### PR TITLE
Fix CNAME lookup with ares_parse_a_reply()

### DIFF
--- a/ares_parse_a_reply.c
+++ b/ares_parse_a_reply.c
@@ -201,7 +201,7 @@ int ares_parse_a_reply(const unsigned char *abuf, int alen,
         }
     }
 
-  if (status == ARES_SUCCESS && naddrs == 0)
+  if (status == ARES_SUCCESS && naddrs == 0 && naliases == 0)
     status = ARES_ENODATA;
   if (status == ARES_SUCCESS)
     {


### PR DESCRIPTION
Currently fails with ARES_ENODATA. [This thread](http://groups.google.com/group/nodejs/browse_thread/thread/a1268c9ea5e9ad9b) brought it to light,
