### PR TITLE
ares_expand_name bug

### DIFF
--- a/ares_expand_name.c
+++ b/ares_expand_name.c
@@ -87,7 +87,12 @@ int ares_expand_name(const unsigned char *encoded, const unsigned char *abuf,
      * Since this function strips trailing dots though, it becomes ""
      */
     q[0] = '\0';
-    *enclen = 1;  /* the caller should move one byte to get past this */
+    /* indirect root label (like 0xc0 0x0c) is 2 bytes long (stupid, but valid) */
+    if ((*encoded & INDIR_MASK) == INDIR_MASK) {
+      *enclen = 2;
+    } else {
+      *enclen = 1;  /* the caller should move one byte to get past this */
+    }
     return ARES_SUCCESS;
   }
 


### PR DESCRIPTION
Hi,

c-ares has a bug in ares_expand_name: it assumes the encoded length of 
"." is always 1 (as it should be a single null byte), but it could be 
an indirect "." too, which is 2 bytes long (in most cases 0xc0 0x0c, 
referring to the question name).

So it cannot parse responses to queries like (dig) "NS ."

Btw: I think there are many ugly casts in the source, like

  char _buf;
  unsigned short x = ntohs(_(unsigned short*) buf);

These should be fixed (with memcpy for example), as not all platform support
unaligned memory access.
