### PR TITLE
Fix a bashism in the configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -842,7 +842,7 @@ CARES_PRIVATE_LIBS="$LIBS"
 AC_SUBST(CARES_PRIVATE_LIBS)
 
 CARES_CFLAG_EXTRAS=""
-if test X"$want_werror" == Xyes; then
+if test X"$want_werror" = Xyes; then
   CARES_CFLAG_EXTRAS="-Werror"
 fi
 AC_SUBST(CARES_CFLAG_EXTRAS)


### PR DESCRIPTION
Hi,

Thanks for your work on c-ares!

Here's a minor patch to make the configure script play nice with e.g. FreeBSD's /bin/sh,
which does not understand the bash "test a == b" extension :)

G'luck,
Peter
