### PR TITLE
fix a crash/UB in ares_getnameinfo

### DIFF
--- a/ares_getnameinfo.c
+++ b/ares_getnameinfo.c
@@ -187,7 +187,7 @@ void ares_getnameinfo(ares_channel channel, const struct sockaddr *sa,
         if (sa->sa_family == AF_INET)
           {
             niquery->family = AF_INET;
-            memcpy(&niquery->addr.addr4, addr, sizeof(addr));
+            memcpy(&niquery->addr.addr4, addr, sizeof(struct sockaddr_in));
             ares_gethostbyaddr(channel, &addr->sin_addr,
                                sizeof(struct in_addr), AF_INET,
                                nameinfo_callback, niquery);
@@ -195,7 +195,7 @@ void ares_getnameinfo(ares_channel channel, const struct sockaddr *sa,
         else
           {
             niquery->family = AF_INET6;
-            memcpy(&niquery->addr.addr6, addr6, sizeof(addr6));
+            memcpy(&niquery->addr.addr6, addr6, sizeof(struct sockaddr_in6));
             ares_gethostbyaddr(channel, &addr6->sin6_addr,
                                sizeof(struct ares_in6_addr), AF_INET6,
                                nameinfo_callback, niquery);


### PR DESCRIPTION
if the resulting domain was not found, not all of the original sockaddr structure
was copied into nameinfo_query, resulting in undefined behaviour
