### PR TITLE
Don't override ARES_OPT_DOMAINS with the values in resolv.conf

### DIFF
--- a/ares_init.c
+++ b/ares_init.c
@@ -853,6 +853,12 @@ DhcpNameServer
     FILE *fp;
     size_t linesize;
     int error;
+    
+    int ignore_domains = 0;
+    
+    /* Don't override ARES_OPT_DOMAINS */
+    if (channel->ndomains != -1)
+        ignore_domains = 1;
 
     /* Don't read resolv.conf and friends if we don't have to */
     if (ARES_CONFIG_CHECK(channel))
@@ -862,11 +868,11 @@ DhcpNameServer
     if (fp) {
       while ((status = ares__read_line(fp, &line, &linesize)) == ARES_SUCCESS)
       {
-        if ((p = try_config(line, "domain", ';')))
+        if ((p = try_config(line, "domain", ';')) && !ignore_domains)
           status = config_domain(channel, p);
         else if ((p = try_config(line, "lookup", ';')) && !channel->lookups)
           status = config_lookup(channel, p, "bind", "file");
-        else if ((p = try_config(line, "search", ';')))
+        else if ((p = try_config(line, "search", ';')) && !ignore_domains)
           status = set_search(channel, p);
         else if ((p = try_config(line, "nameserver", ';')) &&
                  channel->nservers == -1)


### PR DESCRIPTION
I noticed that since commit 125b1a8619eb27556e093fd9c9adf451e896f012, "domains" and "search" lines in resolv.conf are overriding search domains set by the ARES_OPT_DOMAINS option.

This patch fixes init_by_resolv_conf to get the old behaviour back where ARES_OPT_DOMAINS options take priority, but still makes the last "domain" or "search" resolv.conf entry take priority over the first if the user didn't pass in any ARES_OPT_DOMAINS.
