### PR TITLE
Include sys/time.h for fd_set.

### DIFF
--- a/ares.h
+++ b/ares.h
@@ -31,6 +31,7 @@
 #  define WIN32
 #endif
 
+#include <sys/time.h>
 #include <sys/types.h>
 
 /* HP-UX systems version 9, 10 and 11 lack sys/select.h and so does oldish


### PR DESCRIPTION
Fixes 'ares.h:387: error: expected declaration specifiers or ‘...’ before ‘fd_set’' when compiling with `gcc -ansi`.
