### PR TITLE
Handle CNAME-only replies in ares_parse_aaaa_reply()

### DIFF
--- a/ares_parse_aaaa_reply.c
+++ b/ares_parse_aaaa_reply.c
@@ -204,7 +204,9 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
         }
     }
 
-  if (status == ARES_SUCCESS && naddrs == 0)
+  if (status == ARES_SUCCESS && naddrs == 0 && naliases == 0)
+    /* the check for naliases to be zero is to make sure CNAME responses
+       don't get caught here */
     status = ARES_ENODATA;
   if (status == ARES_SUCCESS)
     {


### PR DESCRIPTION
- Port logic for doing the same from ares_parse_a_reply().
