### PR TITLE
Really fix memory leak when parsing AAAA replies.

### DIFF
--- a/ares_parse_aaaa_reply.c
+++ b/ares_parse_aaaa_reply.c
@@ -236,6 +236,8 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
                   for (i = 0; i < naddrs; i++)
                     hostent->h_addr_list[i] = (char *) &addrs[i];
                   hostent->h_addr_list[naddrs] = NULL;
+                  if (!naddrs && addrs)
+                    free(addrs);
                   *host = hostent;
                   return ARES_SUCCESS;
                 }


### PR DESCRIPTION
bffd67f16a8f42fe6dbf79ab2e39d92eea05c8a6
