### PR TITLE
Fixed IPv6 parsing

### DIFF
--- a/ares_options.c
+++ b/ares_options.c
@@ -244,6 +244,8 @@ int ares_set_servers_csv(ares_channel channel,
         s->next = NULL;
         if (last) {
           last->next = s;
+          /* need to move last to maintain the linked list */
+          last = last->next;
         }
         else {
           servers = s;


### PR DESCRIPTION
I fixed a bug that caused the last part of an IPv6 address to be parsed as the port number when the last part is all numeric.  I did this in response to [this comment](https://github.com/joyent/node/pull/5435#issuecomment-17636816) on a node.js pull request.
