### PR TITLE
Fixing LoadLibrary in the case the application is using UNICODE.

### DIFF
--- a/ares_library_init.c
+++ b/ares_library_init.c
@@ -45,7 +45,7 @@ static int ares_win32_init(void)
 #ifdef USE_WINSOCK
 
   hnd_iphlpapi = 0;
-  hnd_iphlpapi = LoadLibrary("iphlpapi.dll");
+  hnd_iphlpapi = LoadLibraryW(L"iphlpapi.dll");
   if (!hnd_iphlpapi)
     return ARES_ELOADIPHLPAPI;
 
@@ -73,7 +73,7 @@ static int ares_win32_init(void)
    */
 
   hnd_advapi32 = 0;
-  hnd_advapi32 = LoadLibrary("advapi32.dll");
+  hnd_advapi32 = LoadLibraryW(L"advapi32.dll");
   if (hnd_advapi32)
     {
       ares_fpSystemFunction036 = (fpSystemFunction036_t)


### PR DESCRIPTION
The current code is assuming the library is compiled and used in ANSI, by always passing an ANSI string to LoadLibrary. It means that if the library is in fact compiled in UNICODE, the LoadLibrary call will assume you're passing a widechar string, and will ultimately fail.

This commit fixes it by forcing the usage of the UNICODE version of the API, and ignoring the compilation settings of the library.

This is mostly relevant if the library is compiled statically within another application.