### PR TITLE
Add Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: c
+
+compiler:
+  - gcc
+  - clang
+
+before_install:
+  - sudo apt-get update
+
+install: 
+  - sudo apt-get install debhelper autotools-dev dh-autoreconf
+
+before_script:
+  - ./buildconf && ./configure
+
+script:
+  - make


### PR DESCRIPTION
This pull request adds an travis CI configuration file to the repository. With some minimal configuration we will get a continuous integration check for the c-ares git tree.

With some minor changes we could also use it to drive the Coverity build.