### PR TITLE
ares_set_socket_callback: make manpage match code

### DIFF
--- a/ares_set_socket_callback.3
+++ b/ares_set_socket_callback.3
@@ -17,8 +17,8 @@ ares_set_socket_callback \- Set a socket creation callback
 This function sets a \fIcallback\fP in the given ares channel handle. This
 callback function will be invoked after the socket has been created, and
 connected to the remote server. The callback must return ARES_SUCCESS if
-things are fine, or use the standard ares error codes to signal errors
-back. Returned errors will abort the ares operation.
+things are fine, or return -1 to signal an error. A returned error will
+abort the ares operation.
 .SH SEE ALSO
 .BR ares_init_options (3)
 .SH AVAILABILITY


### PR DESCRIPTION
Figure it's best to make the man-page reflect the code rather than vice versa, for back-compatibility.