### PR TITLE
Ignore `fopen` errors to use default values

### DIFF
--- a/ares_init.c
+++ b/ares_init.c
@@ -1315,15 +1315,16 @@ static int init_by_resolv_conf(ares_channel channel)
         switch(error) {
         case ENOENT:
         case ESRCH:
-          status = ARES_EOF;
           break;
         default:
           DEBUGF(fprintf(stderr, "fopen() failed with error: %d %s\n",
                          error, strerror(error)));
           DEBUGF(fprintf(stderr, "Error opening file: %s\n",
                          "/etc/nsswitch.conf"));
-          status = ARES_EFILE;
         }
+
+        /* ignore error, maybe we will get luck in next if clause */
+        status = ARES_EOF;
       }
     }
 
@@ -1345,15 +1346,16 @@ static int init_by_resolv_conf(ares_channel channel)
         switch(error) {
         case ENOENT:
         case ESRCH:
-          status = ARES_EOF;
           break;
         default:
           DEBUGF(fprintf(stderr, "fopen() failed with error: %d %s\n",
                          error, strerror(error)));
           DEBUGF(fprintf(stderr, "Error opening file: %s\n",
                          "/etc/host.conf"));
-          status = ARES_EFILE;
         }
+
+        /* ignore error, maybe we will get luck in next if clause */
+        status = ARES_EOF;
       }
     }
 
@@ -1375,14 +1377,15 @@ static int init_by_resolv_conf(ares_channel channel)
         switch(error) {
         case ENOENT:
         case ESRCH:
-          status = ARES_EOF;
           break;
         default:
           DEBUGF(fprintf(stderr, "fopen() failed with error: %d %s\n",
                          error, strerror(error)));
           DEBUGF(fprintf(stderr, "Error opening file: %s\n", "/etc/svc.conf"));
-          status = ARES_EFILE;
         }
+
+        /* ignore error, default value will be chosen for `channel->lookups` */
+        status = ARES_EOF;
       }
     }
 


### PR DESCRIPTION
After 46bb820be3a83520e70e6c5f0c5133253fcd69cd `init_by_resolv_conf`
errors are no longer swallowed in `ares_init_options`. This has exposed
a previously unknown bug in `lookups` initialization code.

If there is no lookup configuration in `resolv.conf`,
`init_by_resolv_conf` will attempt to read it from other files available
on the system. However, some of these files may have restricted
permissions (like `600`), which will lead to `EACCESS` errno, which in
turn is handled like a fatal error by `init_by_resolv_conf`.

However, it sounds illogical that this error should be handled as a
fatal. There is a `init_by_defaults` call that overrides `lookups` with
default value, and certainly possible absence of lookup information is
the reason why this function exists in a first place!

I suggest handling any `fopen` errors as non-fatal ones, allowing to
pick up the `lookups` value from different config files, or to pick up
default value.