### PR TITLE
Use "resolve" as synonym of "dns" in nsswitch.conf

### DIFF
--- a/ares_init.c
+++ b/ares_init.c
@@ -90,7 +90,8 @@ static void natural_mask(struct apattern *pat);
     !defined(ANDROID) && !defined(__ANDROID__) && !defined(CARES_USE_LIBRESOLV)
 static int config_domain(ares_channel channel, char *str);
 static int config_lookup(ares_channel channel, const char *str,
-                         const char *bindch, const char *filech);
+                         const char *bindch, const char *altbindch,
+                         const char *filech);
 static char *try_config(char *s, const char *opt, char scc);
 #endif
 
@@ -1264,7 +1265,7 @@ static int init_by_resolv_conf(ares_channel channel)
         if ((p = try_config(line, "domain", ';')) && update_domains)
           status = config_domain(channel, p);
         else if ((p = try_config(line, "lookup", ';')) && !channel->lookups)
-          status = config_lookup(channel, p, "bind", "file");
+          status = config_lookup(channel, p, "bind", NULL, "file");
         else if ((p = try_config(line, "search", ';')) && update_domains)
           status = set_search(channel, p);
         else if ((p = try_config(line, "nameserver", ';')) &&
@@ -1305,8 +1306,7 @@ static int init_by_resolv_conf(ares_channel channel)
                ARES_SUCCESS)
         {
           if ((p = try_config(line, "hosts:", '\0')) && !channel->lookups)
-            /* ignore errors */
-            (void)config_lookup(channel, p, "dns", "files");
+            (void)config_lookup(channel, p, "dns", "resolve", "files");
         }
         fclose(fp);
       }
@@ -1337,7 +1337,7 @@ static int init_by_resolv_conf(ares_channel channel)
         {
           if ((p = try_config(line, "order", '\0')) && !channel->lookups)
             /* ignore errors */
-            (void)config_lookup(channel, p, "bind", "hosts");
+            (void)config_lookup(channel, p, "bind", NULL, "hosts");
         }
         fclose(fp);
       }
@@ -1368,7 +1368,7 @@ static int init_by_resolv_conf(ares_channel channel)
         {
           if ((p = try_config(line, "hosts=", '\0')) && !channel->lookups)
             /* ignore errors */
-            (void)config_lookup(channel, p, "bind", "local");
+            (void)config_lookup(channel, p, "bind", NULL, "local");
         }
         fclose(fp);
       }
@@ -1589,10 +1589,14 @@ static int config_domain(ares_channel channel, char *str)
 #endif
 
 static int config_lookup(ares_channel channel, const char *str,
-                         const char *bindch, const char *filech)
+                         const char *bindch, const char *altbindch,
+                         const char *filech)
 {
   char lookups[3], *l;
   const char *vqualifier p;
+
+  if (altbindch == NULL)
+    altbindch = bindch;
 
   /* Set the lookup order.  Only the first letter of each work
    * is relevant, and it has to be "b" for DNS or "f" for the
@@ -1602,8 +1606,8 @@ static int config_lookup(ares_channel channel, const char *str,
   p = str;
   while (*p)
     {
-      if ((*p == *bindch || *p == *filech) && l < lookups + 2) {
-        if (*p == *bindch) *l++ = 'b';
+      if ((*p == *bindch || *p == *altbindch || *p == *filech) && l < lookups + 2) {
+        if (*p == *bindch || *p == *altbindch) *l++ = 'b';
         else *l++ = 'f';
       }
       while (*p && !ISSPACE(*p) && (*p != ','))

--- a/test/ares-test-init.cc
+++ b/test/ares-test-init.cc
@@ -493,6 +493,25 @@ CONTAINED_TEST_F(LibraryTest, ContainerMultiResolvInit,
   return HasFailure();
 }
 
+NameContentList systemdresolv = {
+  {"/etc/resolv.conf", "nameserver 1.2.3.4\n"
+                       "domain first.com\n"},
+  {"/etc/nsswitch.conf", "hosts: junk resolve files\n"}};
+CONTAINED_TEST_F(LibraryTest, ContainerSystemdResolvInit,
+                 "myhostname", "mydomainname.org", systemdresolv) {
+  ares_channel channel = nullptr;
+  EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
+
+  struct ares_options opts;
+  int optmask = 0;
+  ares_save_options(channel, &opts, &optmask);
+  EXPECT_EQ(std::string("bf"), std::string(opts.lookups));
+  ares_destroy_options(&opts);
+
+  ares_destroy(channel);
+  return HasFailure();
+}
+
 NameContentList empty = {};  // no files
 CONTAINED_TEST_F(LibraryTest, ContainerEmptyInit,
                  "host.domain.org", "domain.org", empty) {


### PR DESCRIPTION
Modern Linux systems may have libnss_resolve from systemd as the
resolver, which is then configured in /etc/nsswitch.conf with
the "resolve" keyword rather than "dns".

Fixes #33