### PR TITLE
Makefile.m32: add support for CARES_{LD,C}FLAG_EXTRAS envvar

### DIFF
--- a/Makefile.m32
+++ b/Makefile.m32
@@ -17,9 +17,9 @@ RANLIB	= ranlib
 #RM	= rm -f
 CP	= cp -afv
 
-CFLAGS	= -O2 -Wall -I.
+CFLAGS	= $(CARES_CFLAG_EXTRAS) -O2 -Wall -I.
 CFLAGS	+= -DCARES_STATICLIB
-LDFLAGS	= -s
+LDFLAGS	= $(CARES_LDFLAG_EXTRAS) -s
 LIBS	= -lwsock32
 
 # Makefile.inc provides the CSOURCES and HHEADERS defines
@@ -74,4 +74,3 @@ distclean: clean
 ifeq "$(wildcard ares_build.h.dist)" "ares_build.h.dist"
 	$(RM) ares_build.h
 endif
-


### PR DESCRIPTION
This makes it possible to build it like `libssh2` and `curl`, even with dual-target mingw toolchains.
