### PR TITLE
add ares_process_timeouts

### DIFF
--- a/ares.h
+++ b/ares.h
@@ -420,6 +420,8 @@ CARES_EXTERN void ares_process_fd(ares_channel channel,
                                   ares_socket_t read_fd,
                                   ares_socket_t write_fd);
 
+CARES_EXTERN void ares_process_timeouts(ares_channel channel);
+
 CARES_EXTERN int ares_create_query(const char *name,
                                    int dnsclass,
                                    int type,

--- a/ares_process.c
+++ b/ares_process.c
@@ -148,6 +148,15 @@ void ares_process_fd(ares_channel channel,
   processfds(channel, NULL, read_fd, NULL, write_fd);
 }
 
+/* Closing process 
+*/
+void ares_process_timeouts(ares_channel channel)
+{
+  struct timeval now = ares__tvnow();
+  process_timeouts(channel, &now);
+  process_broken_connections(channel, &now);
+}
+
 
 /* Return 1 if the specified error number describes a readiness error, or 0
  * otherwise. This is mostly for HP-UX, which could return EAGAIN or


### PR DESCRIPTION
If you have two libraries c-ares and libev needed feature that extra ends the process.
The result was a situation that libev library comes ev_timer event (eg maximum time-out) and in the library of c-ares works ares_process function and there was no way to correctly close the connection.

example: https://github.com/Garik-/crawler/blob/libev/ev_ares.c
