### PR TITLE
ares_init_options: only propagate init failures from options

### DIFF
--- a/test/ares-test-init.cc
+++ b/test/ares-test-init.cc
@@ -451,8 +451,8 @@ CONTAINED_TEST_F(LibraryTest, ContainerResolvConfNotReadable,
                  "myhostname", "mydomainname.org", filelist) {
   ares_channel channel = nullptr;
   MakeUnreadable hide("/etc/resolv.conf");
-  // Unavailable /etc/resolv.conf fails initialization.
-  EXPECT_EQ(ARES_EFILE, ares_init(&channel));
+  // Unavailable /etc/resolv.conf falls back to defaults
+  EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
   return HasFailure();
 }
 CONTAINED_TEST_F(LibraryTest, ContainerNsswitchConfNotReadable,


### PR DESCRIPTION
Commit 46bb820be3a8 ("ares_init_options: don't lose init failure")
changed init behaviour so that earlier errors in initialization
weren't lost.  In particular, if the user passes in specific
options but they are not applied (e.g. because of an allocation
failure), that failure needs to be reported back to the user; this
also applies when duplicating a channel with ares_dup().

However, other initialization failures can be ignored and
overridden -- in particular, if init_by_resolv_conf() or
init_by_environment() fail, then falling back to default values
is OK.

So only preserve failures from the init_by_options() stage, not
from all initialization stages.

Fixes issue 60.