### PR TITLE
configure.ac: do not check for ar if specified manually

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,10 +59,13 @@ AC_SUBST([EGREP])
 
 dnl AR is mandatory for configure process and libtool.
 dnl This is target dependent, so check it as a tool.
-AC_PATH_TOOL([AR], [ar], [not_found],
-  [$PATH:/usr/bin:/usr/local/bin])
-if test -z "$AR" || test "$AR" = "not_found"; then
-  AC_MSG_ERROR([ar not found in PATH. Cannot continue without ar.])
+if test -z "$AR"; then
+  dnl allow it to be overridden
+  AC_PATH_TOOL([AR], [ar], [not_found],
+    [$PATH:/usr/bin:/usr/local/bin])
+  if test -z "$AR" || test "$AR" = "not_found"; then
+    AC_MSG_ERROR([ar not found in PATH. Cannot continue without ar.])
+  fi
 fi
 AC_SUBST([AR])
 


### PR DESCRIPTION
The `configure` script of c-ares checks for the `ar` binary to use no matter if one was specified manually or not and ignores a manually specified one. With this change it only searches for it in case none was specified manually. This change is identical to what already is done in `configure.ac` of curl.
