### PR TITLE
Virtual socket IO functions

### DIFF
--- a/ares.h
+++ b/ares.h
@@ -356,6 +356,27 @@ CARES_EXTERN void ares_set_socket_configure_callback(ares_channel channel,
 CARES_EXTERN int ares_set_sortlist(ares_channel channel,
                                    const char *sortstr);
 
+/*
+ * Virtual function set to have user-managed socket IO.
+ * Note that all functions need to be defined, and when
+ * set, the library will not do any bind nor set any
+ * socket options, assuming the client handles these
+ * through either socket creation or the
+ * ares_sock_config_callback call.
+ */
+struct iovec;
+struct ares_socket_functions {
+   ares_socket_t(*asocket)(int, int, int, void *);
+   int(*aclose)(ares_socket_t, void *);
+   int(*aconnect)(ares_socket_t, const struct sockaddr *, socklen_t, void *);
+   ssize_t(*arecvfrom)(ares_socket_t, void *, size_t, int, struct sockaddr *, socklen_t *, void *);
+   ssize_t(*asendv)(ares_socket_t, const struct iovec *, int, void *);
+};
+
+CARES_EXTERN void ares_set_socket_functions(ares_channel channel,
+					    const struct ares_socket_functions * funcs,
+					    void *user_data);
+
 CARES_EXTERN void ares_send(ares_channel channel,
                             const unsigned char *qbuf,
                             int qlen,

--- a/ares__close_sockets.c
+++ b/ares__close_sockets.c
@@ -48,14 +48,14 @@ void ares__close_sockets(ares_channel channel, struct server_state *server)
   if (server->tcp_socket != ARES_SOCKET_BAD)
     {
       SOCK_STATE_CALLBACK(channel, server->tcp_socket, 0, 0);
-      sclose(server->tcp_socket);
+      ares__socket_close(channel, server->tcp_socket);
       server->tcp_socket = ARES_SOCKET_BAD;
       server->tcp_connection_generation = ++channel->tcp_connection_generation;
     }
   if (server->udp_socket != ARES_SOCKET_BAD)
     {
       SOCK_STATE_CALLBACK(channel, server->udp_socket, 0, 0);
-      sclose(server->udp_socket);
+      ares__socket_close(channel, server->udp_socket);
       server->udp_socket = ARES_SOCKET_BAD;
     }
 }

--- a/ares_init.c
+++ b/ares_init.c
@@ -166,6 +166,8 @@ int ares_init_options(ares_channel *channelptr, struct ares_options *options,
   channel->sock_create_cb_data = NULL;
   channel->sock_config_cb = NULL;
   channel->sock_config_cb_data = NULL;
+  channel->sock_funcs = NULL;
+  channel->sock_func_cb_data = NULL;
 
   channel->last_server = 0;
   channel->last_timeout_processed = (time_t)now.tv_sec;
@@ -292,6 +294,8 @@ int ares_dup(ares_channel *dest, ares_channel src)
   (*dest)->sock_create_cb_data = src->sock_create_cb_data;
   (*dest)->sock_config_cb      = src->sock_config_cb;
   (*dest)->sock_config_cb_data = src->sock_config_cb_data;
+  (*dest)->sock_funcs          = src->sock_funcs;
+  (*dest)->sock_func_cb_data   = src->sock_func_cb_data;
 
   strncpy((*dest)->local_dev_name, src->local_dev_name,
           sizeof(src->local_dev_name));
@@ -2101,6 +2105,14 @@ void ares_set_socket_configure_callback(ares_channel channel,
 {
   channel->sock_config_cb = cb;
   channel->sock_config_cb_data = data;
+}
+
+void ares_set_socket_functions(ares_channel channel,
+                               const struct ares_socket_functions * funcs,
+                               void *data)
+{
+  channel->sock_funcs = funcs;
+  channel->sock_func_cb_data = data;
 }
 
 int ares_set_sortlist(ares_channel channel, const char *sortstr)

--- a/ares_private.h
+++ b/ares_private.h
@@ -314,6 +314,9 @@ struct ares_channeldata {
 
   ares_sock_config_callback sock_config_cb;
   void *sock_config_cb_data;
+
+  const struct ares_socket_functions * sock_funcs;
+  void *sock_func_cb_data;
 };
 
 /* Memory management functions */

--- a/ares_private.h
+++ b/ares_private.h
@@ -345,6 +345,8 @@ void ares__destroy_servers_state(ares_channel channel);
 long ares__tvdiff(struct timeval t1, struct timeval t2);
 #endif
 
+void ares__socket_close(ares_channel, ares_socket_t);
+
 #define ARES_SWAP_BYTE(a,b) \
   { unsigned char swapByte = *(a);  *(a) = *(b);  *(b) = swapByte; }
 

--- a/ares_process.c
+++ b/ares_process.c
@@ -175,6 +175,26 @@ static int try_again(int errnum)
   return 0;
 }
 
+static ssize_t socket_writev(ares_channel channel, ares_socket_t s, const struct iovec * vec, int len)
+{
+  if (channel->sock_funcs)
+    return channel->sock_funcs->asendv(s, vec, len, channel->sock_func_cb_data);
+
+  return writev(s, vec, len);
+}
+
+static ssize_t socket_write(ares_channel channel, ares_socket_t s, const void * data, size_t len)
+{
+  if (channel->sock_funcs)
+    {
+      struct iovec vec;
+      vec.iov_base = (void*)data;
+      vec.iov_len = len;
+      return channel->sock_funcs->asendv(s, &vec, 1, channel->sock_func_cb_data);
+    }
+  return swrite(s, data, len);
+}
+
 /* If any TCP sockets select true for writing, write out queued data
  * we have for them.
  */
@@ -238,7 +258,7 @@ static void write_tcp_data(ares_channel channel,
               vec[n].iov_len = sendreq->len;
               n++;
             }
-          wcount = (ssize_t)writev(server->tcp_socket, vec, (int)n);
+          wcount = socket_writev(channel, server->tcp_socket, vec, (int)n);
           ares_free(vec);
           if (wcount < 0)
             {
@@ -255,7 +275,7 @@ static void write_tcp_data(ares_channel channel,
           /* Can't allocate iovecs; just send the first request. */
           sendreq = server->qhead;
 
-          scount = swrite(server->tcp_socket, sendreq->data, sendreq->len);
+          scount = socket_write(channel, server->tcp_socket, sendreq->data, sendreq->len);
           if (scount < 0)
             {
               if (!try_again(SOCKERRNO))
@@ -297,6 +317,38 @@ static void advance_tcp_send_queue(ares_channel channel, int whichserver,
       num_bytes = 0;
     }
   }
+}
+
+static ssize_t socket_recvfrom(ares_channel channel,
+   ares_socket_t s,
+   void * data,
+   size_t data_len,
+   int flags,
+   struct sockaddr *from,
+   socklen_t *from_len)
+{
+   if (channel->sock_funcs)
+      return channel->sock_funcs->arecvfrom(s, data, data_len,
+	 flags, from, from_len,
+	 channel->sock_func_cb_data);
+
+#ifdef HAVE_RECVFROM
+   return recvfrom(s, data, data_len, flags, from, from_len);
+#else
+   return sread(s, data, data_len);
+#endif
+}
+
+static ssize_t socket_recv(ares_channel channel,
+   ares_socket_t s,
+   void * data,
+   size_t data_len)
+{
+   if (channel->sock_funcs)
+      return channel->sock_funcs->arecvfrom(s, data, data_len, 0, 0, 0,
+	 channel->sock_func_cb_data);
+
+   return sread(s, data, data_len);
 }
 
 /* If any TCP socket selects true for reading, read some data,
@@ -343,9 +395,9 @@ static void read_tcp_data(ares_channel channel, fd_set *read_fds,
           /* We haven't yet read a length word, so read that (or
            * what's left to read of it).
            */
-          count = sread(server->tcp_socket,
-                        server->tcp_lenbuf + server->tcp_lenbuf_pos,
-                        2 - server->tcp_lenbuf_pos);
+          count = socket_recv(channel, server->tcp_socket,
+			      server->tcp_lenbuf + server->tcp_lenbuf_pos,
+			      2 - server->tcp_lenbuf_pos);
           if (count <= 0)
             {
               if (!(count == -1 && try_again(SOCKERRNO)))
@@ -373,9 +425,9 @@ static void read_tcp_data(ares_channel channel, fd_set *read_fds,
       else
         {
           /* Read data into the allocated buffer. */
-          count = sread(server->tcp_socket,
-                        server->tcp_buffer + server->tcp_buffer_pos,
-                        server->tcp_length - server->tcp_buffer_pos);
+          count = socket_recv(channel, server->tcp_socket,
+			      server->tcp_buffer + server->tcp_buffer_pos,
+			      server->tcp_length - server->tcp_buffer_pos);
           if (count <= 0)
             {
               if (!(count == -1 && try_again(SOCKERRNO)))
@@ -453,16 +505,12 @@ static void read_udp_packets(ares_channel channel, fd_set *read_fds,
           count = 0;
 
         else {
-#ifdef HAVE_RECVFROM
           if (server->addr.family == AF_INET)
             fromlen = sizeof(from.sa4);
           else
             fromlen = sizeof(from.sa6);
-          count = (ssize_t)recvfrom(server->udp_socket, (void *)buf,
-                                    sizeof(buf), 0, &from.sa, &fromlen);
-#else
-          count = sread(server->udp_socket, buf, sizeof(buf));
-#endif
+          count = socket_recvfrom(channel, server->udp_socket, (void *)buf,
+                                  sizeof(buf), 0, &from.sa, &fromlen);
         }
 
         if (count == -1 && try_again(SOCKERRNO))
@@ -812,7 +860,7 @@ void ares__send_query(ares_channel channel, struct query *query,
               return;
             }
         }
-      if (swrite(server->udp_socket, query->qbuf, query->qlen) == -1)
+      if (socket_write(channel, server->udp_socket, query->qbuf, query->qlen) == -1)
         {
           /* FIXME: Handle EAGAIN here since it likely can happen. */
           skip_server(channel, query, query->server);
@@ -898,6 +946,10 @@ static int setsocknonblock(ares_socket_t sockfd,    /* operate on this */
 
 static int configure_socket(ares_socket_t s, int family, ares_channel channel)
 {
+  /* do not set options for user-managed sockets */
+  if (channel->sock_funcs)
+    return 0;
+
   union {
     struct sockaddr     sa;
     struct sockaddr_in  sa4;
@@ -959,6 +1011,30 @@ static int configure_socket(ares_socket_t s, int family, ares_channel channel)
   return 0;
 }
 
+static int open_socket(ares_channel channel, int af, int type, int protocol)
+{
+  if (channel->sock_funcs != 0)
+    return channel->sock_funcs->asocket(af,
+                                        type,
+                                        protocol,
+                                        channel->sock_func_cb_data);
+
+  return socket(af, type, protocol);
+}
+
+static int connect_socket(ares_channel channel, ares_socket_t sockfd,
+			  const struct sockaddr * addr,
+	                  socklen_t addrlen)
+{
+   if (channel->sock_funcs != 0)
+      return channel->sock_funcs->aconnect(sockfd,
+	                                   addr,
+	                                   addrlen,
+	                                   channel->sock_func_cb_data);
+
+   return connect(sockfd, addr, addrlen);
+}
+
 static int open_tcp_socket(ares_channel channel, struct server_state *server)
 {
   ares_socket_t s;
@@ -1003,14 +1079,14 @@ static int open_tcp_socket(ares_channel channel, struct server_state *server)
     }
 
   /* Acquire a socket. */
-  s = socket(server->addr.family, SOCK_STREAM, 0);
+  s = open_socket(channel, server->addr.family, SOCK_STREAM, 0);
   if (s == ARES_SOCKET_BAD)
     return -1;
 
   /* Configure it. */
   if (configure_socket(s, server->addr.family, channel) < 0)
     {
-       sclose(s);
+       ares__socket_close(channel, s);
        return -1;
     }
 
@@ -1022,10 +1098,12 @@ static int open_tcp_socket(ares_channel channel, struct server_state *server)
    * so batching isn't very interesting.
    */
   opt = 1;
-  if (setsockopt(s, IPPROTO_TCP, TCP_NODELAY,
-                 (void *)&opt, sizeof(opt)) == -1)
+  if (channel->sock_funcs == 0
+     &&
+     setsockopt(s, IPPROTO_TCP, TCP_NODELAY,
+                (void *)&opt, sizeof(opt)) == -1)
     {
-       sclose(s);
+       ares__socket_close(channel, s);
        return -1;
     }
 #endif
@@ -1036,19 +1114,19 @@ static int open_tcp_socket(ares_channel channel, struct server_state *server)
                                         channel->sock_config_cb_data);
       if (err < 0)
         {
-          sclose(s);
+          ares__socket_close(channel, s);
           return err;
         }
     }
 
   /* Connect to the server. */
-  if (connect(s, sa, salen) == -1)
+  if (connect_socket(channel, s, sa, salen) == -1)
     {
       int err = SOCKERRNO;
 
       if (err != EINPROGRESS && err != EWOULDBLOCK)
         {
-          sclose(s);
+          ares__socket_close(channel, s);
           return -1;
         }
     }
@@ -1059,7 +1137,7 @@ static int open_tcp_socket(ares_channel channel, struct server_state *server)
                                         channel->sock_create_cb_data);
       if (err < 0)
         {
-          sclose(s);
+          ares__socket_close(channel, s);
           return err;
         }
     }
@@ -1114,14 +1192,14 @@ static int open_udp_socket(ares_channel channel, struct server_state *server)
     }
 
   /* Acquire a socket. */
-  s = socket(server->addr.family, SOCK_DGRAM, 0);
+  s = open_socket(channel, server->addr.family, SOCK_DGRAM, 0);
   if (s == ARES_SOCKET_BAD)
     return -1;
 
   /* Set the socket non-blocking. */
   if (configure_socket(s, server->addr.family, channel) < 0)
     {
-       sclose(s);
+       ares__socket_close(channel, s);
        return -1;
     }
 
@@ -1131,19 +1209,19 @@ static int open_udp_socket(ares_channel channel, struct server_state *server)
                                         channel->sock_config_cb_data);
       if (err < 0)
         {
-          sclose(s);
+          ares__socket_close(channel, s);
           return err;
         }
     }
 
   /* Connect to the server. */
-  if (connect(s, sa, salen) == -1)
+  if (connect_socket(channel, s, sa, salen) == -1)
     {
       int err = SOCKERRNO;
 
       if (err != EINPROGRESS && err != EWOULDBLOCK)
         {
-          sclose(s);
+          ares__socket_close(channel, s);
           return -1;
         }
     }
@@ -1154,7 +1232,7 @@ static int open_udp_socket(ares_channel channel, struct server_state *server)
                                         channel->sock_create_cb_data);
       if (err < 0)
         {
-          sclose(s);
+          ares__socket_close(channel, s);
           return err;
         }
     }
@@ -1356,4 +1434,12 @@ void ares__free_query(struct query *query)
   ares_free(query->tcpbuf);
   ares_free(query->server_info);
   ares_free(query);
+}
+
+void ares__socket_close(ares_channel channel, ares_socket_t s)
+{
+  if (channel->sock_funcs)
+    channel->sock_funcs->aclose(s, channel->sock_func_cb_data);
+  else
+    sclose(s);
 }

--- a/ares_set_socket_functions.3
+++ b/ares_set_socket_functions.3
@@ -1,0 +1,99 @@
+.\"
+.TH ARES_SET_SOCKET_FUNCTIONS 3 "13 Dec 2016"
+.SH NAME
+ares_set_socket_functions \- Set socket io callbacks
+.SH SYNOPSIS
+.nf
+.B #include <ares.h>
+.PP
+.B struct ares_socket_functions {
+	ares_socket_t(*\fIasocket\fP)(int, int, int, void *);
+	int(*\fIaclose\fP)(ares_socket_t, void *);
+	int(*\fIaconnect\fP)(ares_socket_t, const struct sockaddr *, socklen_t, void *);
+	ssize_t(*\fIarecvfrom\fP)(ares_socket_t, void *, size_t, int, struct sockaddr *, socklen_t *, void *);
+	ssize_t(*\fIasendv\fP)(ares_socket_t, const struct iovec *, int, void *);
+   };
+
+.PP
+.B void ares_set_socket_functions(ares_channel \fIchannel\fP,
+				  const struct ares_socket_functions * \fIfunctions\fP,
+				  void *\fIuser_data\fP);
+
+.fi
+.SH DESCRIPTION
+.PP
+This function sets a set of callback \fIfunctions\fP in the given ares channel handle. 
+These callback functions will be invoked to create/destroy socket objects and perform
+io, instead of the normal system calls. A client application can override normal network
+operation fully through this functionality, and provide its own transport layer.
+.PP 
+All callback functions are expected to operate like their system equivalents, and to 
+set 
+.BR errno(3) 
+to an appropriate error code on failure. C-ares also expects all io functions to behave 
+asynchronously, i.e. as if the socket object has been set to non-blocking mode. Thus 
+read/write calls (for TCP connections) are expected to often generate 
+.BR EAGAIN 
+or 
+.BR EWOULDBLOCK.
+
+.PP
+The \fIuser_data\fP value is provided to each callback function invocation to serve as 
+context. 
+.PP
+The 
+.B ares_socket_functions 
+must provide the following callbacks:
+.TP 18
+.B \fIasocket\fP
+.B ares_socket_t(*)(int \fIdomain\fP, int \fItype\fP, int \fIprotocol\fP, void * \fIuser_data\fP)
+.br
+Creates an endpoint for communication and returns a descriptor. \fIdomain\fP, \fItype\fP, and \fIprotocol\fP
+each correspond to the parameters of 
+.BR socket(2).
+Returns ahandle to the newly created socket, or -1 on error. 
+.TP 18
+.B \fIaclose\fP
+.B int(*)(ares_socket_t \fIfd\fP, void * \fIuser_data\fP)
+.br
+Closes the socket endpoint indicated by \fIfd\fP. See
+.BR close(2)
+.TP 18
+.B \fIaconnect\fP
+.B int(*)(ares_socket_t \fIfd\fP, const struct sockaddr * \fIaddr\fP, socklen_t \fIaddr_len\fP, void * \fIuser_data\fP)
+.br
+Initiate a connection to the address indicated by \fIaddr\fP on a socket. See
+.BR connect(2)
+
+.TP 18
+.B \fIarecvfrom\fP
+.B ssize_t(*)(ares_socket_t \fIfd\fP, void * \fIbuffer\fP, size_t \fIbuf_size\fP, int \fIflags\fP, struct sockaddr * \fIaddr\fP, socklen_t * \fIaddr_len\fP, void * \fIuser_data\fP)
+.br 
+Receives data from remote socket endpoint, if available. If the \fIaddr\fP parameter is not NULL and the connection protocol provides the source address, the callback should fill this in. See
+.BR recvfrom(2)
+
+.TP 18
+.B \fIasendv\fP
+.B ssize_t(*)(ares_socket_t \fIfd\fP, const struct iovec * \fIdata\fP, int \fIlen\fP, void * \fIuser_data\fP)
+.br 
+Send data, as provided by the iovec array \fIdata\fP, to the socket endpoint. See
+.BR writev(2),
+
+.PP
+The 
+.B ares_socket_functions 
+struct provided is not copied but directly referenced, 
+and must thus remain valid through out the channels and any created socket's lifetime. 
+
+.SH SEE ALSO
+.BR ares_init_options (3), 
+.BR socket(2), 
+.BR close(2), 
+.BR connect(2), 
+.BR recv(2), 
+.BR recvfrom(2), 
+.BR send(2), 
+.BR writev(2)
+.SH AUTHOR
+Carl Wilund
+

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -2,6 +2,8 @@
 #include "dns-proto.h"
 
 #include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
 
 extern "C" {
 // Remove command-line defines of package variables for the test project...
@@ -19,6 +21,9 @@ extern "C" {
 
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
+#endif
+#ifdef HAVE_SYS_UIO_H
+#  include <sys/uio.h>
 #endif
 }
 
@@ -382,6 +387,72 @@ TEST_F(DefaultChannelTest, SaveInvalidChannel) {
   EXPECT_EQ(ARES_ENODATA, ares_save_options(channel_, &opts, &optmask));
   channel_->nservers = saved;
 }
+
+// TODO: This should not really be in this file, but we need ares config 
+// flags, and here they are available. 
+const struct ares_socket_functions VirtualizeIO::default_functions = {
+  [](int af, int type, int protocol, void *) {
+    auto s = ::socket(af, type, protocol);
+    if (s < 0) {
+      return s;
+    }
+    auto res = [s] {
+    // transposed from ares-process, simplified non-block setter. 
+#if defined(USE_BLOCKING_SOCKETS)
+    return 0; /* returns success */
+#elif defined(HAVE_FCNTL_O_NONBLOCK)
+  /* most recent unix versions */
+    int flags;
+    flags = fcntl(s, F_GETFL, 0);
+    return fcntl(s, F_SETFL, flags | O_NONBLOCK);
+#elif defined(HAVE_IOCTL_FIONBIO)
+    /* older unix versions */
+    int flags = 1;
+    return ioctl(s, FIONBIO, &flags);
+#elif defined(HAVE_IOCTLSOCKET_FIONBIO)    
+#ifdef WATT32
+    char flags = 1;
+#else
+    /* Windows */
+    unsigned long flags = 1UL;
+#endif
+    return ioctlsocket(s, FIONBIO, &flags);
+#elif defined(HAVE_IOCTLSOCKET_CAMEL_FIONBIO)    
+    /* Amiga */
+    long flags = 1L;
+    return IoctlSocket(s, FIONBIO, flags);
+#elif defined(HAVE_SETSOCKOPT_SO_NONBLOCK)
+    /* BeOS */
+    long b = 1L;
+    return setsockopt(s, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
+#else
+#  error "no non-blocking method was found/used/set"
+#endif
+    }();
+    if (res != 0) {
+      ::close(s);
+      return -1;
+    }
+    return s;
+  },
+  [](ares_socket_t s, void * p) {
+    return ::close(s);
+  },
+  [](ares_socket_t s, const struct sockaddr * addr, socklen_t len, void *) {
+    return ::connect(s, addr, len);
+  },
+  [](ares_socket_t s, void * dst, size_t len, int flags, struct sockaddr * addr, socklen_t * alen, void *) {
+#ifdef HAVE_RECVFROM
+    return ::recvfrom(s, dst, len, flags, addr, alen);
+#else
+    return sread(s, dst, len);
+#endif
+  },
+  [](ares_socket_t s, const struct iovec * vec, int len, void *) {
+    return :: writev(s, vec, len);
+  }
+};
+
 
 }  // namespace test
 }  // namespace ares

--- a/test/ares-test-live.cc
+++ b/test/ares-test-live.cc
@@ -18,7 +18,7 @@ unsigned char gdns_addr4[4] = {0x08, 0x08, 0x08, 0x08};
 unsigned char gdns_addr6[16] = {0x20, 0x01, 0x48, 0x60, 0x48, 0x60, 0x00, 0x00,
                                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x88, 0x88};
 
-TEST_F(DefaultChannelTest, LiveGetHostByNameV4) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetHostByNameV4) {
   HostResult result;
   ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback, &result);
   Process();
@@ -28,7 +28,7 @@ TEST_F(DefaultChannelTest, LiveGetHostByNameV4) {
   EXPECT_EQ(AF_INET, result.host_.addrtype_);
 }
 
-TEST_F(DefaultChannelTest, LiveGetHostByNameV6) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetHostByNameV6) {
   HostResult result;
   ares_gethostbyname(channel_, "www.google.com.", AF_INET6, HostCallback, &result);
   Process();
@@ -38,7 +38,7 @@ TEST_F(DefaultChannelTest, LiveGetHostByNameV6) {
   EXPECT_EQ(AF_INET6, result.host_.addrtype_);
 }
 
-TEST_F(DefaultChannelTest, LiveGetHostByAddrV4) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetHostByAddrV4) {
   HostResult result;
   ares_gethostbyaddr(channel_, gdns_addr4, sizeof(gdns_addr4), AF_INET, HostCallback, &result);
   Process();
@@ -48,7 +48,7 @@ TEST_F(DefaultChannelTest, LiveGetHostByAddrV4) {
   EXPECT_EQ(AF_INET, result.host_.addrtype_);
 }
 
-TEST_F(DefaultChannelTest, LiveGetHostByAddrV6) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetHostByAddrV6) {
   HostResult result;
   ares_gethostbyaddr(channel_, gdns_addr6, sizeof(gdns_addr6), AF_INET6, HostCallback, &result);
   Process();
@@ -58,7 +58,7 @@ TEST_F(DefaultChannelTest, LiveGetHostByAddrV6) {
   EXPECT_EQ(AF_INET6, result.host_.addrtype_);
 }
 
-TEST_F(DefaultChannelTest, LiveGetHostByNameFile) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetHostByNameFile) {
   struct hostent *host = nullptr;
 
   // Still need a channel even to query /etc/hosts.
@@ -203,7 +203,7 @@ TEST_P(DefaultChannelModeTest, LiveGetHostByAddrFailAlloc) {
 INSTANTIATE_TEST_CASE_P(Modes, DefaultChannelModeTest,
                         ::testing::Values("f", "b", "fb", "bf"));
 
-TEST_F(DefaultChannelTest, LiveSearchA) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveSearchA) {
   SearchResult result;
   ares_search(channel_, "www.youtube.com.", ns_c_in, ns_t_a,
               SearchCallback, &result);
@@ -212,7 +212,7 @@ TEST_F(DefaultChannelTest, LiveSearchA) {
   EXPECT_EQ(ARES_SUCCESS, result.status_);
 }
 
-TEST_F(DefaultChannelTest, LiveSearchEmptyA) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveSearchEmptyA) {
   SearchResult result;
   ares_search(channel_, "", ns_c_in, ns_t_a,
               SearchCallback, &result);
@@ -221,7 +221,7 @@ TEST_F(DefaultChannelTest, LiveSearchEmptyA) {
   EXPECT_NE(ARES_SUCCESS, result.status_);
 }
 
-TEST_F(DefaultChannelTest, LiveSearchNS) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveSearchNS) {
   SearchResult result;
   ares_search(channel_, "google.com.", ns_c_in, ns_t_ns,
               SearchCallback, &result);
@@ -230,7 +230,7 @@ TEST_F(DefaultChannelTest, LiveSearchNS) {
   EXPECT_EQ(ARES_SUCCESS, result.status_);
 }
 
-TEST_F(DefaultChannelTest, LiveSearchMX) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveSearchMX) {
   SearchResult result;
   ares_search(channel_, "google.com.", ns_c_in, ns_t_mx,
               SearchCallback, &result);
@@ -239,7 +239,7 @@ TEST_F(DefaultChannelTest, LiveSearchMX) {
   EXPECT_EQ(ARES_SUCCESS, result.status_);
 }
 
-TEST_F(DefaultChannelTest, LiveSearchTXT) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveSearchTXT) {
   SearchResult result;
   ares_search(channel_, "google.com.", ns_c_in, ns_t_txt,
               SearchCallback, &result);
@@ -248,7 +248,7 @@ TEST_F(DefaultChannelTest, LiveSearchTXT) {
   EXPECT_EQ(ARES_SUCCESS, result.status_);
 }
 
-TEST_F(DefaultChannelTest, LiveSearchSOA) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveSearchSOA) {
   SearchResult result;
   ares_search(channel_, "google.com.", ns_c_in, ns_t_soa,
               SearchCallback, &result);
@@ -257,7 +257,7 @@ TEST_F(DefaultChannelTest, LiveSearchSOA) {
   EXPECT_EQ(ARES_SUCCESS, result.status_);
 }
 
-TEST_F(DefaultChannelTest, LiveSearchSRV) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveSearchSRV) {
   SearchResult result;
   ares_search(channel_, "_imap._tcp.gmail.com.", ns_c_in, ns_t_srv,
               SearchCallback, &result);
@@ -266,7 +266,7 @@ TEST_F(DefaultChannelTest, LiveSearchSRV) {
   EXPECT_EQ(ARES_SUCCESS, result.status_);
 }
 
-TEST_F(DefaultChannelTest, LiveSearchANY) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveSearchANY) {
   SearchResult result;
   ares_search(channel_, "google.com.", ns_c_in, ns_t_any,
               SearchCallback, &result);
@@ -275,7 +275,7 @@ TEST_F(DefaultChannelTest, LiveSearchANY) {
   EXPECT_EQ(ARES_SUCCESS, result.status_);
 }
 
-TEST_F(DefaultChannelTest, LiveGetNameInfoV4) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetNameInfoV4) {
   NameInfoResult result;
   struct sockaddr_in sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -291,7 +291,7 @@ TEST_F(DefaultChannelTest, LiveGetNameInfoV4) {
   if (verbose) std::cerr << "8.8.8.8:53 => " << result.node_ << "/" << result.service_ << std::endl;
 }
 
-TEST_F(DefaultChannelTest, LiveGetNameInfoV4NoPort) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetNameInfoV4NoPort) {
   NameInfoResult result;
   struct sockaddr_in sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -307,7 +307,7 @@ TEST_F(DefaultChannelTest, LiveGetNameInfoV4NoPort) {
   if (verbose) std::cerr << "8.8.8.8:0 => " << result.node_ << "/" << result.service_ << std::endl;
 }
 
-TEST_F(DefaultChannelTest, LiveGetNameInfoV4UnassignedPort) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetNameInfoV4UnassignedPort) {
   NameInfoResult result;
   struct sockaddr_in sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -323,7 +323,7 @@ TEST_F(DefaultChannelTest, LiveGetNameInfoV4UnassignedPort) {
   if (verbose) std::cerr << "8.8.8.8:4 => " << result.node_ << "/" << result.service_ << std::endl;
 }
 
-TEST_F(DefaultChannelTest, LiveGetNameInfoV6Both) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetNameInfoV6Both) {
   NameInfoResult result;
   struct sockaddr_in6 sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -339,7 +339,7 @@ TEST_F(DefaultChannelTest, LiveGetNameInfoV6Both) {
   if (verbose) std::cerr << "[2001:4860:4860::8888]:53 => " << result.node_ << "/" << result.service_ << std::endl;
 }
 
-TEST_F(DefaultChannelTest, LiveGetNameInfoV6Neither) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetNameInfoV6Neither) {
   NameInfoResult result;
   struct sockaddr_in6 sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -355,7 +355,7 @@ TEST_F(DefaultChannelTest, LiveGetNameInfoV6Neither) {
   if (verbose) std::cerr << "[2001:4860:4860::8888]:53 => " << result.node_ << "/" << result.service_ << std::endl;
 }
 
-TEST_F(DefaultChannelTest, LiveGetNameInfoV4Numeric) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetNameInfoV4Numeric) {
   NameInfoResult result;
   struct sockaddr_in sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -372,7 +372,7 @@ TEST_F(DefaultChannelTest, LiveGetNameInfoV4Numeric) {
   if (verbose) std::cerr << "8.8.8.8:53 => " << result.node_ << "/" << result.service_ << std::endl;
 }
 
-TEST_F(DefaultChannelTest, LiveGetNameInfoV6Numeric) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetNameInfoV6Numeric) {
   NameInfoResult result;
   struct sockaddr_in6 sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -389,7 +389,7 @@ TEST_F(DefaultChannelTest, LiveGetNameInfoV6Numeric) {
   if (verbose) std::cerr << "[2001:4860:4860::8888]:53 => " << result.node_ << "/" << result.service_ << std::endl;
 }
 
-TEST_F(DefaultChannelTest, LiveGetNameInfoV6LinkLocal) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetNameInfoV6LinkLocal) {
   NameInfoResult result;
   struct sockaddr_in6 sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -408,7 +408,7 @@ TEST_F(DefaultChannelTest, LiveGetNameInfoV6LinkLocal) {
   if (verbose) std::cerr << "[fe80:102:102::304]:53 => " << result.node_ << "/" << result.service_ << std::endl;
 }
 
-TEST_F(DefaultChannelTest, LiveGetNameInfoV4NotFound) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetNameInfoV4NotFound) {
   NameInfoResult result;
   struct sockaddr_in sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -426,7 +426,7 @@ TEST_F(DefaultChannelTest, LiveGetNameInfoV4NotFound) {
   if (verbose) std::cerr << "192.0.2.0:53 => " << result.node_ << "/" << result.service_ << std::endl;
 }
 
-TEST_F(DefaultChannelTest, LiveGetNameInfoV4NotFoundFail) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetNameInfoV4NotFoundFail) {
   NameInfoResult result;
   struct sockaddr_in sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -442,7 +442,7 @@ TEST_F(DefaultChannelTest, LiveGetNameInfoV4NotFoundFail) {
   EXPECT_EQ(ARES_ENOTFOUND, result.status_);
 }
 
-TEST_F(DefaultChannelTest, LiveGetNameInfoV6NotFound) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetNameInfoV6NotFound) {
   NameInfoResult result;
   struct sockaddr_in6 sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -462,7 +462,7 @@ TEST_F(DefaultChannelTest, LiveGetNameInfoV6NotFound) {
   if (verbose) std::cerr << "[2001:db8:102::304]:53 => " << result.node_ << "/" << result.service_ << std::endl;
 }
 
-TEST_F(DefaultChannelTest, LiveGetNameInvalidFamily) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetNameInvalidFamily) {
   NameInfoResult result;
   struct sockaddr_in6 sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -477,7 +477,7 @@ TEST_F(DefaultChannelTest, LiveGetNameInvalidFamily) {
   EXPECT_EQ(ARES_ENOTIMP, result.status_);
 }
 
-TEST_F(DefaultChannelTest, LiveGetNameInvalidFlags) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetNameInvalidFlags) {
   NameInfoResult result;
   struct sockaddr_in6 sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -493,7 +493,7 @@ TEST_F(DefaultChannelTest, LiveGetNameInvalidFlags) {
   EXPECT_EQ(ARES_EBADFLAGS, result.status_);
 }
 
-TEST_F(DefaultChannelTest, LiveGetServiceInfo) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetServiceInfo) {
   NameInfoResult result;
   struct sockaddr_in sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -510,7 +510,7 @@ TEST_F(DefaultChannelTest, LiveGetServiceInfo) {
   EXPECT_EQ("", result.node_);
 }
 
-TEST_F(DefaultChannelTest, LiveGetServiceInfoNumeric) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetServiceInfoNumeric) {
   NameInfoResult result;
   struct sockaddr_in sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -528,7 +528,7 @@ TEST_F(DefaultChannelTest, LiveGetServiceInfoNumeric) {
   EXPECT_EQ("53", result.service_);
 }
 
-TEST_F(DefaultChannelTest, LiveGetNameInfoAllocFail) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetNameInfoAllocFail) {
   NameInfoResult result;
   struct sockaddr_in sockaddr;
   memset(&sockaddr, 0, sizeof(sockaddr));
@@ -544,7 +544,7 @@ TEST_F(DefaultChannelTest, LiveGetNameInfoAllocFail) {
   EXPECT_EQ(ARES_ENOMEM, result.status_);
 }
 
-TEST_F(DefaultChannelTest, GetSock) {
+VIRT_NONVIRT_TEST_F(DefaultChannelTest, GetSock) {
   ares_socket_t socks[3] = {-1, -1, -1};
   int bitmask = ares_getsock(channel_, socks, 3);
   EXPECT_EQ(0, bitmask);
@@ -589,6 +589,45 @@ TEST_F(LibraryTest, GetTCPSock) {
 
   ares_destroy(channel);
 }
+
+TEST_F(DefaultChannelTest, VerifySocketFunctionCallback) {
+  VirtualizeIO vio(channel_);
+
+  auto my_functions = VirtualizeIO::default_functions;
+  size_t count = 0;
+
+  my_functions.asocket = [](int af, int type, int protocol, void * p) {
+    EXPECT_NE(nullptr, p);
+    (*reinterpret_cast<size_t *>(p))++;
+    return ::socket(af, type, protocol);
+  };
+
+  ares_set_socket_functions(channel_, &my_functions, &count);
+
+  {
+    count = 0;
+    HostResult result;
+    ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback, &result);
+    Process();
+    EXPECT_TRUE(result.done_);
+    EXPECT_NE(0, count);
+  }
+
+  {
+    count = 0;
+    ares_channel copy;
+    EXPECT_EQ(ARES_SUCCESS, ares_dup(&copy, channel_));
+
+    HostResult result;
+    ares_gethostbyname(copy, "www.google.com.", AF_INET, HostCallback, &result);
+    ProcessWork(copy, NoExtraFDs, nullptr);
+    EXPECT_TRUE(result.done_);
+    ares_destroy(copy);
+    EXPECT_NE(0, count);
+  }
+
+}
+
 
 }  // namespace test
 }  // namespace ares

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -663,5 +663,15 @@ TempFile::TempFile(const std::string& contents)
 
 }
 
+VirtualizeIO::VirtualizeIO(ares_channel c)
+  : channel_(c)
+{
+  ares_set_socket_functions(channel_, &default_functions, 0);
+}
+
+VirtualizeIO::~VirtualizeIO() {
+  ares_set_socket_functions(channel_, 0, 0);
+}
+
 }  // namespace test
 }  // namespace ares


### PR DESCRIPTION
To integrate the C-ares library with [seastar](https://github.com/scylladb/seastar), we need to be able to control the way socket IO is performed, since 

1.) We optionally use our own network stack (virtio/dpdk)
2.) We do asynchronous even more asynchronous. 

This patch set adds a virtual socket function struct to c-ares, which can be attached to an individual channel using a setter function. The socket IO code is modified to use these bound functions if set (which in turn forgoes a lot of socket options etc, with the assumption that the provider deals with such matters. 

