### PR TITLE
Refresh dns servers

### DIFF
--- a/ares.h
+++ b/ares.h
@@ -618,6 +618,8 @@ CARES_EXTERN int ares_set_servers_csv(ares_channel channel,
 CARES_EXTERN int ares_set_servers_ports_csv(ares_channel channel,
                                             const char* servers);
 
+CARES_EXTERN int ares_refresh_servers(ares_channel channel);
+
 CARES_EXTERN int ares_get_servers(ares_channel channel,
                                   struct ares_addr_node **servers);
 CARES_EXTERN int ares_get_servers_ports(ares_channel channel,

--- a/ares_init.c
+++ b/ares_init.c
@@ -68,7 +68,7 @@ static int init_by_options(ares_channel channel,
                            const struct ares_options *options,
                            int optmask);
 static int init_by_environment(ares_channel channel);
-static int init_by_resolv_conf(ares_channel channel);
+int init_by_resolv_conf(ares_channel channel);
 static int init_by_defaults(ares_channel channel);
 
 #ifndef WATT32
@@ -1091,7 +1091,7 @@ static int get_DNS_Windows(char **outptr)
 }
 #endif
 
-static int init_by_resolv_conf(ares_channel channel)
+int init_by_resolv_conf(ares_channel channel)
 {
 #if !defined(ANDROID) && !defined(__ANDROID__) && !defined(WATT32) && \
     !defined(CARES_USE_LIBRESOLV)

--- a/ares_options.c
+++ b/ares_options.c
@@ -27,6 +27,17 @@
 #include "ares_inet_net_pton.h"
 #include "ares_private.h"
 
+int ares_refresh_servers(ares_channel channel) {
+
+	channel->nservers = -1;
+
+	int status = init_by_resolv_conf(channel);
+	if (status != ARES_SUCCESS)
+		DEBUGF(fprintf(stderr, "Error: init_by_resolv_conf failed: %s\n",
+			ares_strerror(status)));
+
+	return status;
+}
 
 int ares_get_servers(ares_channel channel,
                      struct ares_addr_node **servers)


### PR DESCRIPTION
c-ares currently reads system DNS servers only on init therefore any changes by system settings or by other apps made to them after it's been initialized won't be reflected in `ares_get_servers` function.

I've run into this issue in Node.js that's using c-ares for some of its DNS functionality. See my issue there nodejs/help#408

What this pull does is it introduces a simple public function `ares_refresh_servers` that will reload the DNS servers for a given channel by using `init_by_resolv_conf`. Therefore this doesn't change any current behavior and it's up to the user to implement it if they need it.

On the other hand I'd say this is a bug and a correct behavior for `ares_get_servers` is to always return the up to date server list. Which could be achieved by calling the `ares_refresh_servers` at the beginning of `ares_get_servers`.

I'd appreciate some thoughts on what you think is a better solution.