### PR TITLE
Test build fixes for windows (failures intruduced by virtual IO patch set)

### DIFF
--- a/ares_process.c
+++ b/ares_process.c
@@ -1011,7 +1011,7 @@ static int configure_socket(ares_socket_t s, int family, ares_channel channel)
   return 0;
 }
 
-static int open_socket(ares_channel channel, int af, int type, int protocol)
+static ares_socket_t open_socket(ares_channel channel, int af, int type, int protocol)
 {
   if (channel->sock_funcs != 0)
     return channel->sock_funcs->asocket(af,

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -19,11 +19,9 @@
 
 #ifdef WIN32
 #define BYTE_CAST (char *)
-#define sclose(x) closesocket(x)
 #define mkdir_(d, p) mkdir(d)
 #else
 #define BYTE_CAST
-#define sclose(x) close(x)
 #define mkdir_(d, p) mkdir(d, p)
 #endif
 

--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -2,12 +2,12 @@
 #ifndef ARES_TEST_H
 #define ARES_TEST_H
 
-#include "ares.h"
-
 #include "dns-proto.h"
-
 // Include ares internal file for DNS protocol constants
 #include "nameser.h"
+
+#include "ares_setup.h"
+#include "ares.h"
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"

--- a/test/dns-proto.cc
+++ b/test/dns-proto.cc
@@ -1,6 +1,7 @@
 #include "dns-proto.h"
 
 // Include ares internal file for DNS protocol details
+#include "ares_setup.h"
 #include "ares.h"
 #include "ares_dns.h"
 


### PR DESCRIPTION
* Some test code was not windows-proofed. (i.e. use sclose, not close, no writev, etc)
* Nested lambdas fail due to vs2013 compiler bug. 
* Due to the signature of recvfrom, and consequently its virtual counter part, windows builds require (as all examples have) ares_setup.h first in the include set. (or ares includes at least). Tests however did not follow this rule, so change it so ares_test.h includes this first. 
Not surprisingly, this leads to a little conflict with the ares nameser.h / system nameser.h, so need to change the order here as well. 
All tests should build and run across the platform matrix now however. 