### PR TITLE
Add support for Windows DNS Suffix Search List

### DIFF
--- a/ares_init.c
+++ b/ares_init.c
@@ -1131,7 +1131,7 @@ static int get_SuffixList_Windows(char **outptr)
     goto done;
   }
 
-  if (get_REG_SZ(hKey_Tcpip_Parameters, DHCPDOMAIN, outptr))
+  if (get_REG_SZ(hKey_Tcpip_Parameters, DOMAIN, outptr))
     goto done;
 
 done:

--- a/ares_init.c
+++ b/ares_init.c
@@ -1128,13 +1128,12 @@ static int get_SuffixList_Windows(char **outptr)
       if (*p == ',')
         *p = ' ';
     }
-    goto done;
+  }
+  else
+  {
+    get_REG_SZ(hKey_Tcpip_Parameters, DOMAIN, outptr);
   }
 
-  if (get_REG_SZ(hKey_Tcpip_Parameters, DOMAIN, outptr))
-    goto done;
-
-done:
   RegCloseKey(hKey_Tcpip_Parameters);
   return *outptr == NULL ? 0 : 1;
 }

--- a/ares_private.h
+++ b/ares_private.h
@@ -58,6 +58,8 @@
 #define DHCPNAMESERVER "DhcpNameServer"
 #define DATABASEPATH   "DatabasePath"
 #define WIN_PATH_HOSTS  "\\hosts"
+#define DHCPDOMAIN     "DhcpDomain"
+#define SEARCHLIST     "SearchList"
 
 #elif defined(WATT32)
 

--- a/ares_private.h
+++ b/ares_private.h
@@ -58,7 +58,7 @@
 #define DHCPNAMESERVER "DhcpNameServer"
 #define DATABASEPATH   "DatabasePath"
 #define WIN_PATH_HOSTS  "\\hosts"
-#define DHCPDOMAIN     "DhcpDomain"
+#define DOMAIN         "Domain"
 #define SEARCHLIST     "SearchList"
 
 #elif defined(WATT32)


### PR DESCRIPTION
This change should solve issue #53. Support for suffix lists in c-ares was already built-in for Linux. With this code change the function `get_SuffixList_Windows` was added which reads the search list from the registry key:
> HKLM\System\CurrentControlSet\Services\TCPIP\Parameters\SearchList

and latter updates the configuration with `set_search`.

The registry key `SearchList` should be [available since Windows 2000](https://support.microsoft.com/de-at/help/275553/how-to-configure-a-domain-suffix-search-list-on-the-domain-name-system-clients). If the `SearchList` could not be read or is empty, then the content from the registry key `Domain` is returned (the Primary DNS suffix).