### PR TITLE
Added support for Windows DNS Suffix Search List

### DIFF
--- a/ares_init.c
+++ b/ares_init.c
@@ -1323,10 +1323,10 @@ static void replace_comma_by_space(char* str)
 static bool contains_suffix(const char* const searchlist,
                             const char* const suffix, const size_t len)
 {
-  if (!*suffix)
-    return true;
   const char* beg = searchlist;
   const char* end;
+  if (!*suffix)
+    return true;
   for (;;)
   {
     while (*beg && (ISSPACE(*beg) || (*beg == ',')))
@@ -1430,7 +1430,7 @@ static int get_SuffixList_Windows(char **outptr)
       while (len = next_suffix(&pp, len))
       {
         if (!contains_suffix(*outptr, pp, len))
-          commajoin(outptr, pp, len);
+          commanjoin(outptr, pp, len);
       }
       ares_free(p);
       p = NULL;

--- a/ares_init.c
+++ b/ares_init.c
@@ -1421,7 +1421,7 @@ static int get_SuffixList_Windows(char **outptr)
     RegCloseKey(hKey);
   }
   if (!*outptr)
-  return 0;
+    return 0;
 
   /*  b. Interface SearchList, Domain, DhcpDomain */
   if (!RegOpenKeyEx(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY "\\" INTERFACES_KEY, 0,
@@ -1433,10 +1433,10 @@ static int get_SuffixList_Windows(char **outptr)
     if (RegEnumKeyEx(hKey, keyIdx++, keyName, &keyNameBuffSize,
         0, NULL, NULL, NULL)
         != ERROR_SUCCESS)
-    break;
+      break;
     if (RegOpenKeyEx(hKey, keyName, 0, KEY_QUERY_VALUE, &hKeyEnum)
         != ERROR_SUCCESS)
-    continue;
+      continue;
     if (get_REG_SZ(hKeyEnum, SEARCHLIST_KEY, &p) ||
         get_REG_SZ(hKeyEnum, DOMAIN_KEY, &p) ||
         get_REG_SZ(hKeyEnum, DHCPDOMAIN_KEY, &p))

--- a/ares_init.c
+++ b/ares_init.c
@@ -1304,7 +1304,7 @@ static int get_DNS_Windows(char **outptr)
   return get_DNS_Registry(outptr);
 }
 
-static void replaceColonBySpace(char* str)
+static void replace_comma_by_space(char* str)
 {
   /* replace ',' by ' ' to coincide with resolv.conf search parameter */
   char *p;
@@ -1319,8 +1319,9 @@ static void replaceColonBySpace(char* str)
  * otherwise false. 'searchlist' is a comma separated list of domain suffixes,
  * 'suffix' is one domain suffix, 'len' is the length of 'suffix'.
  * The search ignores case. E.g.:
- * contains("abc.def,ghi.jkl", "ghi.JKL") returns true  */
-static bool contains(const char* const searchlist, const char* const suffix, const size_t len)
+ * contains_suffix("abc.def,ghi.jkl", "ghi.JKL") returns true  */
+static bool contains_suffix(const char* const searchlist,
+                            const char* const suffix, const size_t len)
 {
   if (!*suffix)
     return true;
@@ -1389,7 +1390,7 @@ static int get_SuffixList_Windows(char **outptr)
       KEY_READ, &hKey) == ERROR_SUCCESS)
   {
     if (get_REG_SZ(hKey, SEARCHLIST_KEY, outptr))
-      replaceColonBySpace(*outptr);
+      replace_comma_by_space(*outptr);
     RegCloseKey(hKey);
     if (*outptr)
       return 1;
@@ -1428,7 +1429,7 @@ static int get_SuffixList_Windows(char **outptr)
       pp = p;
       while (len = next_suffix(&pp, len))
       {
-        if (!contains(*outptr, pp, len))
+        if (!contains_suffix(*outptr, pp, len))
           commajoin(outptr, pp, len);
       }
       ares_free(p);
@@ -1438,7 +1439,7 @@ static int get_SuffixList_Windows(char **outptr)
   }
   RegCloseKey(hKey);
   if (*outptr)
-    replaceColonBySpace(*outptr);
+    replace_comma_by_space(*outptr);
   return *outptr != NULL;
 }
 

--- a/ares_init.c
+++ b/ares_init.c
@@ -1370,11 +1370,10 @@ static int get_SuffixList_Windows(char **outptr)
     {
       keyNameBuffSize = sizeof(keyName);
       if (RegEnumKeyEx(hKey, keyIdx++, keyName, &keyNameBuffSize,
-          0, NULL, NULL, NULL)
-        != ERROR_SUCCESS)
+          0, NULL, NULL, NULL) != ERROR_SUCCESS)
         break;
-      if (RegOpenKeyEx(hKey, keyName, 0, KEY_QUERY_VALUE, &hKeyEnum)
-        != ERROR_SUCCESS)
+      if (RegOpenKeyEx(hKey, keyName, 0, KEY_QUERY_VALUE, &hKeyEnum) !=
+          ERROR_SUCCESS)
         continue;
       if (get_REG_SZ(hKeyEnum, SEARCHLIST, &p))
       {

--- a/ares_private.h
+++ b/ares_private.h
@@ -54,10 +54,14 @@
 
 #define WIN_NS_9X      "System\\CurrentControlSet\\Services\\VxD\\MSTCP"
 #define WIN_NS_NT_KEY  "System\\CurrentControlSet\\Services\\Tcpip\\Parameters"
+#define WIN_DNSCLIENT  "Software\\Policies\\Microsoft\\System\\DNSClient"
 #define NAMESERVER     "NameServer"
 #define DHCPNAMESERVER "DhcpNameServer"
 #define DATABASEPATH   "DatabasePath"
 #define WIN_PATH_HOSTS  "\\hosts"
+#define SEARCHLIST     "SearchList"
+#define PRIMARYDNSSUFFIX "PrimaryDNSSuffix"
+#define INTERFACES     "Interfaces"
 
 #elif defined(WATT32)
 

--- a/ares_private.h
+++ b/ares_private.h
@@ -59,9 +59,11 @@
 #define DHCPNAMESERVER "DhcpNameServer"
 #define DATABASEPATH   "DatabasePath"
 #define WIN_PATH_HOSTS  "\\hosts"
-#define SEARCHLIST     "SearchList"
-#define PRIMARYDNSSUFFIX "PrimaryDNSSuffix"
-#define INTERFACES     "Interfaces"
+#define SEARCHLIST_KEY "SearchList"
+#define PRIMARYDNSSUFFIX_KEY "PrimaryDNSSuffix"
+#define INTERFACES_KEY "Interfaces"
+#define DOMAIN_KEY     "Domain"
+#define DHCPDOMAIN_KEY "DhcpDomain"
 
 #elif defined(WATT32)
 


### PR DESCRIPTION
This change solves issue #53.

Support for suffix search lists was already built in for Linux. The search list could be set via `set_search`. With this change the suffix search list from Windows is read from the registry and then set into the ares configuration via `set_search`. There are two sources for the search list:

1. The global DNS suffix search list.
2. The primary and connection specific DNS suffixes if the global is not available.