### PR TITLE
ares_getsock and ares_fds can take a const channel

### DIFF
--- a/ares.h
+++ b/ares.h
@@ -422,11 +422,11 @@ CARES_EXTERN void ares_getnameinfo(ares_channel channel,
                                    ares_nameinfo_callback callback,
                                    void *arg);
 
-CARES_EXTERN int ares_fds(ares_channel channel,
+CARES_EXTERN int ares_fds(const struct ares_channeldata *channel,
                           fd_set *read_fds,
                           fd_set *write_fds);
 
-CARES_EXTERN int ares_getsock(ares_channel channel,
+CARES_EXTERN int ares_getsock(const struct ares_channeldata *channel,
                               ares_socket_t *socks,
                               int numsocks);
 

--- a/ares_fds.c
+++ b/ares_fds.c
@@ -20,7 +20,7 @@
 #include "ares_nowarn.h"
 #include "ares_private.h"
 
-int ares_fds(ares_channel channel, fd_set *read_fds, fd_set *write_fds)
+int ares_fds(const struct ares_channeldata *channel, fd_set *read_fds, fd_set *write_fds)
 {
   struct server_state *server;
   ares_socket_t nfds;

--- a/ares_getsock.c
+++ b/ares_getsock.c
@@ -17,7 +17,7 @@
 #include "ares.h"
 #include "ares_private.h"
 
-int ares_getsock(ares_channel channel,
+int ares_getsock(const struct ares_channeldata *channel,
                  ares_socket_t *socks,
                  int numsocks) /* size of the 'socks' array */
 {

--- a/ares_llist.c
+++ b/ares_llist.c
@@ -38,7 +38,7 @@ void ares__init_list_node(struct list_node* node, void* d) {
 }
 
 /* Returns true iff the given list is empty */
-int ares__is_list_empty(struct list_node* head) {
+int ares__is_list_empty(const struct list_node* head) {
   return ((head->next == head) && (head->prev == head));
 }
 

--- a/ares_llist.h
+++ b/ares_llist.h
@@ -29,7 +29,7 @@ void ares__init_list_head(struct list_node* head);
 
 void ares__init_list_node(struct list_node* node, void* d);
 
-int ares__is_list_empty(struct list_node* head);
+int ares__is_list_empty(const struct list_node* head);
 
 void ares__insert_in_list(struct list_node* new_node,
                           struct list_node* old_node);


### PR DESCRIPTION
This tweak makes the API a little more precise (in a back-compatible way): the functions `ares_getsock` and `ares_fds` are read-only and can safely take a const channel.

My interest in this is for my Rust wrapper around c-ares: in Rust the distinction between a regular reference and a mutable reference is more meaningful than in C - and more important to get right.

I've been sitting on this for a while because I suspect you're not going to like changing parameter types from `ares_channel` to `const struct ares_channeldata *`.  Alas, the obvious `const ares_channel` makes the const apply to the pointer rather than the structure, so doesn't work.  I'd be happy instead to introduce a second typedef `ares_const_channel` or similar, if that would be acceptable?