### PR TITLE
configure.ac: Allow AR to be overidden

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,10 +59,12 @@ AC_SUBST([EGREP])
 
 dnl AR is mandatory for configure process and libtool.
 dnl This is target dependent, so check it as a tool.
-AC_PATH_TOOL([AR], [ar], [not_found],
-  [$PATH:/usr/bin:/usr/local/bin])
-if test -z "$AR" || test "$AR" = "not_found"; then
-  AC_MSG_ERROR([ar not found in PATH. Cannot continue without ar.])
+if test -z "$AR"; then
+  AC_PATH_TOOL([AR], [ar], [not_found],
+    [$PATH:/usr/bin:/usr/local/bin])
+  if test -z "$AR" || test "$AR" = "not_found"; then
+    AC_MSG_ERROR([ar not found in PATH. Cannot continue without ar.])
+  fi
 fi
 AC_SUBST([AR])
 


### PR DESCRIPTION
If an archiver is configured in with AR in the shell environment, it will be overidden by AC_PATH_TOOL's resolved archiver. This is normally based on the configure option --host alternatively TARGET_SYS. However there are cases when these two differ and configure should not ignore the archiver specified with AR. Corresponding fix has already been made in libcurl.