### PR TITLE
Simple changes to appease stricter compilers.

### DIFF
--- a/ares_getnameinfo.c
+++ b/ares_getnameinfo.c
@@ -356,12 +356,9 @@ static void append_scopeid(struct sockaddr_in6 *addr6, unsigned int flags,
 #ifdef HAVE_IF_INDEXTONAME
   int is_ll, is_mcll;
 #endif
-  static const char fmt_u[] = "%u";
-  static const char fmt_lu[] = "%lu";
   char tmpbuf[IF_NAMESIZE + 2];
   size_t bufl;
-  const char *fmt = (sizeof(addr6->sin6_scope_id) > sizeof(unsigned int))?
-    fmt_lu:fmt_u;
+  int is_scope_long = sizeof(addr6->sin6_scope_id) > sizeof(unsigned int);
 
   tmpbuf[0] = '%';
 
@@ -371,15 +368,38 @@ static void append_scopeid(struct sockaddr_in6 *addr6, unsigned int flags,
   if ((flags & ARES_NI_NUMERICSCOPE) ||
       (!is_ll && !is_mcll))
     {
-       sprintf(&tmpbuf[1], fmt, addr6->sin6_scope_id);
+      if (is_scope_long)
+        {
+          sprintf(&tmpbuf[1], "%lu", (unsigned long)addr6->sin6_scope_id);
+        }
+      else
+        {
+          sprintf(&tmpbuf[1], "%u", (unsigned int)addr6->sin6_scope_id);
+        }
     }
   else
     {
       if (if_indextoname(addr6->sin6_scope_id, &tmpbuf[1]) == NULL)
-        sprintf(&tmpbuf[1], fmt, addr6->sin6_scope_id);
+        {
+          if (is_scope_long)
+            {
+              sprintf(&tmpbuf[1], "%lu", (unsigned long)addr6->sin6_scope_id);
+            }
+          else
+            {
+              sprintf(&tmpbuf[1], "%u", (unsigned int)addr6->sin6_scope_id);
+            }
+        }
     }
 #else
-  sprintf(&tmpbuf[1], fmt, addr6->sin6_scope_id);
+  if (is_scope_long)
+    {
+      sprintf(&tmpbuf[1], "%lu", (unsigned long)addr6->sin6_scope_id);
+    }
+  else
+    {
+      sprintf(&tmpbuf[1], "%u", (unsigned int)addr6->sin6_scope_id);
+    }
   (void) flags;
 #endif
   tmpbuf[IF_NAMESIZE + 1] = '\0';

--- a/ares_process.c
+++ b/ares_process.c
@@ -29,6 +29,9 @@
 #ifdef HAVE_NETDB_H
 #  include <netdb.h>
 #endif
+#ifdef HAVE_ARPA_INET_H
+#  include <arpa/inet.h>
+#endif
 #ifdef HAVE_ARPA_NAMESER_H
 #  include <arpa/nameser.h>
 #else


### PR DESCRIPTION
ares_process.c uses htonl, which needs <arpa/inet.h> included.
ares_getnameinfo.c uses a dynamically selected format string for
sprintf, which -Wformat-literal doesn't like. Usually one would use
inttypes.h and a format string "%" PRIu32, but C99 is too new for some
supported platforms.