### PR TITLE
Update ares.h to support compiling with QNX

### DIFF
--- a/ares.h
+++ b/ares.h
@@ -38,7 +38,8 @@
    require it! */
 #if defined(_AIX) || defined(__NOVELL_LIBC__) || defined(__NetBSD__) || \
     defined(__minix) || defined(__SYMBIAN32__) || defined(__INTEGRITY) || \
-    defined(ANDROID) || defined(__ANDROID__) || defined(__OpenBSD__)
+    defined(ANDROID) || defined(__ANDROID__) || defined(__OpenBSD__) || \
+    defined(__QNXNTO__)
 #include <sys/select.h>
 #endif
 #if (defined(NETWARE) && !defined(__NOVELL_LIBC__))


### PR DESCRIPTION
QNX compilation of curl 7.54.1 with c-ares support is failing with the following lines in the config.log:

configure:40519: checking that c-ares is good and recent enough
configure:40546: ntoarmv7-gcc -o conftest -Werror-implicit-function-declaration -O2 -Wno-system-headers   -I/home/osboxes/ares-install-arm/include   -L/home/osboxes/ares-install-arm/lib conftest.c -lcares -lssl -lcrypto -lz -lsocket  >&5
In file included from conftest.c:294:0:
/home/osboxes/ares-install-arm/include/ares.h:405:27: error: unknown type name 'fd_set'
/home/osboxes/ares-install-arm/include/ares.h:406:27: error: unknown type name 'fd_set'
/home/osboxes/ares-install-arm/include/ares.h:417:32: error: unknown type name 'fd_set'
/home/osboxes/ares-install-arm/include/ares.h:418:32: error: unknown type name 'fd_set'

I have added checking for QNX to include the <sys/select.h> header file to get rid of this error.  I have tested this patch on my system with compiling and it is working as expected.