### PR TITLE
fix statement like #define

### DIFF
--- a/ares_build.h.dist
+++ b/ares_build.h.dist
@@ -199,7 +199,7 @@
 #    define CARES_TYPEOF_ARES_SSIZE_T long
 #  endif
 #else
-#  define CARES_TYPEOF_ARES_SSIZE_T ssize_t;
+#  define CARES_TYPEOF_ARES_SSIZE_T ssize_t
 #endif
 
 typedef CARES_TYPEOF_ARES_SSIZE_T ares_ssize_t;


### PR DESCRIPTION
If `ares_build.h.dist` is bundled in the distribution zip as `ares_build.h` this should solve #119. @bradh352 can you please review this Pull-Request. Thank you!