### PR TITLE
Update README.md

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -88,7 +88,7 @@ To fuzz the packet parsing code with libFuzzer, follow the main
    ```console
    % export CFLAGS="-fsanitize=address -fsanitize-coverage=edge"
    % export CC=clang
-   % ./configure --disable-shared && make
+   % ./configure && make
    ```
  - Download and build the libFuzzer code:
 


### PR DESCRIPTION
./configure --disable-shared is incorrect for the libfuzzer section because you need the .libs directory created to build the fuzzers.