### PR TITLE
ares_parse_naptr_reply: make buffer length check more accurate

### DIFF
--- a/ares_parse_naptr_reply.c
+++ b/ares_parse_naptr_reply.c
@@ -110,17 +110,18 @@ ares_parse_naptr_reply (const unsigned char *abuf, int alen,
           status = ARES_EBADRESP;
           break;
         }
-      /* RR must contain at least 7 bytes = 2 x int16 + 3 x name */
-      if (rr_len < 7)
-        {
-          status = ARES_EBADRESP;
-          break;
-        }
 
       /* Check if we are really looking at a NAPTR record */
       if (rr_class == C_IN && rr_type == T_NAPTR)
         {
           /* parse the NAPTR record itself */
+
+          /* RR must contain at least 7 bytes = 2 x int16 + 3 x name */
+          if (rr_len < 7)
+            {
+              status = ARES_EBADRESP;
+              break;
+            }
 
           /* Allocate storage for this NAPTR answer appending it to the list */
           naptr_curr = ares_malloc_data(ARES_DATATYPE_NAPTR_REPLY);


### PR DESCRIPTION
9478908a490a6bf009ba58d81de8c1d06d50a117 introduced a length check for records parsed by `ares_parse_naptr_reply()`. However, that function is designed to parse replies which also contain non-NAPTR records; for A records, the `rr_len > 7` check will fail as there are only 4 bytes of payload.
In particular, parsing ANY replies for NAPTR records was broken by that patch.

Fix that by moving the check into the case in which it is already known that the record is a NAPTR record.