### PR TITLE
allow cmake_debug_postfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,11 @@ PROJECT (c-ares C)
 SET (CARES_LIB_VERSIONINFO "4:0:2")
 
 
-OPTION (CARES_STATIC     "Build as a static library"                                             OFF)
-OPTION (CARES_SHARED     "Build as a shared library"                                             ON)
-OPTION (CARES_INSTALL    "Create installation targets (chain builders may want to disable this)" ON)
-OPTION (CARES_STATIC_PIC "Build the static library as PIC (position independent)"                OFF)
-
+OPTION (CARES_STATIC        "Build as a static library"                                             OFF)
+OPTION (CARES_SHARED        "Build as a shared library"                                             ON)
+OPTION (CARES_INSTALL       "Create installation targets (chain builders may want to disable this)" ON)
+OPTION (CARES_STATIC_PIC    "Build the static library as PIC (position independent)"                OFF)
+OPTION (CARES_DEBUG_POSTFIX "Use 'd' as postfix for debug libraries"                                OFF)
 
 # Keep build organized.
 SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
@@ -50,6 +50,10 @@ SET (TARGETS_INST_DEST
 	ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
 	INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
+IF (CARES_DEBUG_POSTFIX)
+	SET (CMAKE_DEBUG_POSTFIX "d")
+ENDIF ()
 
 # Look for dependent/required libraries
 CHECK_LIBRARY_EXISTS (resolv res_servicename "" HAVE_RES_SERVICENAME_IN_LIBRESOLV)


### PR DESCRIPTION
allow both debug and release versions of the library to be installed simultaneously

it adds a debug postfix (`d`) to the library names (incl. dynamic libraries)
this is an option and it is `OFF` by default.

this is useful for people who work in IDEs like Visual Studio; switching to debug will allow them to debug and step into this project without fuss.