### PR TITLE
Make gethostbyaddr fail with `ECANCELLED` for `ares_cancel()`

### DIFF
--- a/ares_gethostbyaddr.c
+++ b/ares_gethostbyaddr.c
@@ -157,7 +157,7 @@ static void addr_callback(void *arg, int status, int timeouts,
         }
       end_aquery(aquery, status, host);
     }
-  else if (status == ARES_EDESTRUCTION)
+  else if (status == ARES_EDESTRUCTION || status == ARES_ECANCELLED)
     end_aquery(aquery, status, NULL);
   else
     next_lookup(aquery);

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -883,6 +883,18 @@ TEST_P(MockChannelTest, CancelImmediate) {
   EXPECT_EQ(0, result.timeouts_);
 }
 
+TEST_P(MockChannelTest, CancelImmediateGetHostByAddr) {
+  HostResult result;
+  struct in_addr addr;
+  addr.s_addr = htonl(0x08080808);
+  
+  ares_gethostbyaddr(channel_, &addr, sizeof(addr), AF_INET, HostCallback, &result);
+  ares_cancel(channel_);
+  EXPECT_TRUE(result.done_);
+  EXPECT_EQ(ARES_ECANCELLED, result.status_);
+  EXPECT_EQ(0, result.timeouts_);
+}
+
 // Relies on retries so is UDP-only
 TEST_P(MockUDPChannelTest, CancelLater) {
   std::vector<byte> nothing;


### PR DESCRIPTION
When `ares_cancel()` was invoked, `ares_gethostbyaddr()` queries would fail with `ENOTFOUND` instead of `ECANCELLED`.

It seems appropriate to treat `ares_cancel()` like `ares_destroy()`, but I would appreciate review of the correctness of this change.

Ref: https://github.com/nodejs/node/issues/14814