### PR TITLE
Force using the ANSI versions of WinAPI functions

### DIFF
--- a/ares_gethostbyaddr.c
+++ b/ares_gethostbyaddr.c
@@ -190,18 +190,18 @@ static int file_lookup(struct ares_addr *addr, struct hostent **host)
     char tmp[MAX_PATH];
     HKEY hkeyHosts;
 
-    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY, 0, KEY_READ,
+    if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY, 0, KEY_READ,
                      &hkeyHosts) == ERROR_SUCCESS)
     {
       DWORD dwLength = MAX_PATH;
-      RegQueryValueEx(hkeyHosts, DATABASEPATH, NULL, NULL, (LPBYTE)tmp,
+      RegQueryValueExA(hkeyHosts, DATABASEPATH, NULL, NULL, (LPBYTE)tmp,
                       &dwLength);
-      ExpandEnvironmentStrings(tmp, PATH_HOSTS, MAX_PATH);
+      ExpandEnvironmentStringsA(tmp, PATH_HOSTS, MAX_PATH);
       RegCloseKey(hkeyHosts);
     }
   }
   else if (platform == WIN_9X)
-    GetWindowsDirectory(PATH_HOSTS, MAX_PATH);
+    GetWindowsDirectoryA(PATH_HOSTS, MAX_PATH);
   else
     return ARES_ENOTFOUND;
 

--- a/ares_gethostbyname.c
+++ b/ares_gethostbyname.c
@@ -351,18 +351,18 @@ static int file_lookup(const char *name, int family, struct hostent **host)
     char tmp[MAX_PATH];
     HKEY hkeyHosts;
 
-    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY, 0, KEY_READ,
+    if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY, 0, KEY_READ,
                      &hkeyHosts) == ERROR_SUCCESS)
     {
       DWORD dwLength = MAX_PATH;
-      RegQueryValueEx(hkeyHosts, DATABASEPATH, NULL, NULL, (LPBYTE)tmp,
+      RegQueryValueExA(hkeyHosts, DATABASEPATH, NULL, NULL, (LPBYTE)tmp,
                       &dwLength);
-      ExpandEnvironmentStrings(tmp, PATH_HOSTS, MAX_PATH);
+      ExpandEnvironmentStringsA(tmp, PATH_HOSTS, MAX_PATH);
       RegCloseKey(hkeyHosts);
     }
   }
   else if (platform == WIN_9X)
-    GetWindowsDirectory(PATH_HOSTS, MAX_PATH);
+    GetWindowsDirectoryA(PATH_HOSTS, MAX_PATH);
   else
     return ARES_ENOTFOUND;
 

--- a/ares_init.c
+++ b/ares_init.c
@@ -585,7 +585,7 @@ static int get_REG_SZ(HKEY hKey, const char *leafKeyName, char **outptr)
   *outptr = NULL;
 
   /* Find out size of string stored in registry */
-  res = RegQueryValueEx(hKey, leafKeyName, 0, NULL, NULL, &size);
+  res = RegQueryValueExA(hKey, leafKeyName, 0, NULL, NULL, &size);
   if ((res != ERROR_SUCCESS && res != ERROR_MORE_DATA) || !size)
     return 0;
 
@@ -596,7 +596,7 @@ static int get_REG_SZ(HKEY hKey, const char *leafKeyName, char **outptr)
     return 0;
 
   /* Get the value for real */
-  res = RegQueryValueEx(hKey, leafKeyName, 0, NULL,
+  res = RegQueryValueExA(hKey, leafKeyName, 0, NULL,
                         (unsigned char *)*outptr, &size);
   if ((res != ERROR_SUCCESS) || (size == 1))
   {
@@ -627,7 +627,7 @@ static int get_REG_SZ_9X(HKEY hKey, const char *leafKeyName, char **outptr)
   *outptr = NULL;
 
   /* Find out size of string stored in registry */
-  res = RegQueryValueEx(hKey, leafKeyName, 0, &dataType, NULL, &size);
+  res = RegQueryValueExA(hKey, leafKeyName, 0, &dataType, NULL, &size);
   if ((res != ERROR_SUCCESS && res != ERROR_MORE_DATA) || !size)
     return 0;
 
@@ -638,7 +638,7 @@ static int get_REG_SZ_9X(HKEY hKey, const char *leafKeyName, char **outptr)
     return 0;
 
   /* Get the value for real */
-  res = RegQueryValueEx(hKey, leafKeyName, 0, &dataType,
+  res = RegQueryValueExA(hKey, leafKeyName, 0, &dataType,
                         (unsigned char *)*outptr, &size);
   if ((res != ERROR_SUCCESS) || (size == 1))
   {
@@ -683,11 +683,11 @@ static int get_enum_REG_SZ(HKEY hKeyParent, const char *leafKeyName,
   for(;;)
   {
     enumKeyNameBuffSize = sizeof(enumKeyName);
-    res = RegEnumKeyEx(hKeyParent, enumKeyIdx++, enumKeyName,
+    res = RegEnumKeyExA(hKeyParent, enumKeyIdx++, enumKeyName,
                        &enumKeyNameBuffSize, 0, NULL, NULL, NULL);
     if (res != ERROR_SUCCESS)
       break;
-    res = RegOpenKeyEx(hKeyParent, enumKeyName, 0, KEY_QUERY_VALUE,
+    res = RegOpenKeyExA(hKeyParent, enumKeyName, 0, KEY_QUERY_VALUE,
                        &hKeyEnum);
     if (res != ERROR_SUCCESS)
       continue;
@@ -718,7 +718,7 @@ static int get_DNS_Registry_9X(char **outptr)
 
   *outptr = NULL;
 
-  res = RegOpenKeyEx(HKEY_LOCAL_MACHINE, WIN_NS_9X, 0, KEY_READ,
+  res = RegOpenKeyExA(HKEY_LOCAL_MACHINE, WIN_NS_9X, 0, KEY_READ,
                      &hKey_VxD_MStcp);
   if (res != ERROR_SUCCESS)
     return 0;
@@ -750,7 +750,7 @@ static int get_DNS_Registry_NT(char **outptr)
 
   *outptr = NULL;
 
-  res = RegOpenKeyEx(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY, 0, KEY_READ,
+  res = RegOpenKeyExA(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY, 0, KEY_READ,
                      &hKey_Tcpip_Parameters);
   if (res != ERROR_SUCCESS)
     return 0;
@@ -772,7 +772,7 @@ static int get_DNS_Registry_NT(char **outptr)
     goto done;
 
   /* Try adapter specific parameters */
-  res = RegOpenKeyEx(hKey_Tcpip_Parameters, "Interfaces", 0,
+  res = RegOpenKeyExA(hKey_Tcpip_Parameters, "Interfaces", 0,
                      KEY_QUERY_VALUE | KEY_ENUMERATE_SUB_KEYS,
                      &hKey_Interfaces);
   if (res != ERROR_SUCCESS)
@@ -1401,7 +1401,7 @@ static int get_SuffixList_Windows(char **outptr)
     return 0;
 
   /* 1. Global DNS Suffix Search List */
-  if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY, 0,
+  if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY, 0,
       KEY_READ, &hKey) == ERROR_SUCCESS)
   {
     if (get_REG_SZ(hKey, SEARCHLIST_KEY, outptr))
@@ -1413,7 +1413,7 @@ static int get_SuffixList_Windows(char **outptr)
 
   /* 2. Connection Specific Search List composed of:
    *  a. Primary DNS Suffix */
-  if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, WIN_DNSCLIENT, 0,
+  if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, WIN_DNSCLIENT, 0,
       KEY_READ, &hKey) == ERROR_SUCCESS)
   {
     get_REG_SZ(hKey, PRIMARYDNSSUFFIX_KEY, outptr);
@@ -1423,17 +1423,17 @@ static int get_SuffixList_Windows(char **outptr)
     return 0;
 
   /*  b. Interface SearchList, Domain, DhcpDomain */
-  if (!RegOpenKeyEx(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY "\\" INTERFACES_KEY, 0,
+  if (!RegOpenKeyExA(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY "\\" INTERFACES_KEY, 0,
       KEY_READ, &hKey) == ERROR_SUCCESS)
     return 0;
   for(;;)
   {
     keyNameBuffSize = sizeof(keyName);
-    if (RegEnumKeyEx(hKey, keyIdx++, keyName, &keyNameBuffSize,
+    if (RegEnumKeyExA(hKey, keyIdx++, keyName, &keyNameBuffSize,
         0, NULL, NULL, NULL)
         != ERROR_SUCCESS)
       break;
-    if (RegOpenKeyEx(hKey, keyName, 0, KEY_QUERY_VALUE, &hKeyEnum)
+    if (RegOpenKeyExA(hKey, keyName, 0, KEY_QUERY_VALUE, &hKeyEnum)
         != ERROR_SUCCESS)
       continue;
     if (get_REG_SZ(hKeyEnum, SEARCHLIST_KEY, &p) ||


### PR DESCRIPTION
When compiling c-ares with a build system that defines UNICODE,
bad versions of WinAPI functions are used causing failures or even
crashes. When windows.h is included in MBCS mode (like in the default
build system), the ..A versions are the same as using the one without
any suffix.