### PR TITLE
Win32 exclude legacy ipv6 subnets

### DIFF
--- a/ares_init.c
+++ b/ares_init.c
@@ -1032,7 +1032,7 @@ static int ares_ipv6_server_blacklisted(const unsigned char ipaddr[16])
 #if 1
     char          addr[128];
     ares_inet_ntop(AF_INET6, ipaddr, addr, sizeof(addr));
-    printf("comparing netmask %s/%d to %s", blacklist[i].netbase, blacklist[i].netmask, addr);
+    printf("comparing netmask %s/%d to %s\n", blacklist[i].netbase, blacklist[i].netmask, addr);
 #endif
 
     if (ares_inet_pton(AF_INET6, blacklist[i].netbase, netbase) != 1)

--- a/ares_init.c
+++ b/ares_init.c
@@ -980,7 +980,6 @@ static int compareAddresses(const void *arg1,
   return 0;
 }
 
-
 /* Validate that the ip address matches the subnet (network base and network
  * mask) specified. Addresses are specified in standard Network Byte Order as
  * 16 bytes, and the netmask is 0 to 128 (bits).
@@ -1012,7 +1011,6 @@ static int ares_ipv6_subnet_matches(const unsigned char netbase[16],
   return 1;
 }
 
-
 static int ares_ipv6_server_blacklisted(const unsigned char ipaddr[16])
 {
   const struct {
@@ -1038,7 +1036,6 @@ static int ares_ipv6_server_blacklisted(const unsigned char ipaddr[16])
   }
   return 0;
 }
-
 
 /* There can be multiple routes to "the Internet".  And there can be different
  * DNS servers associated with each of the interfaces that offer those routes.

--- a/ares_init.c
+++ b/ares_init.c
@@ -1032,14 +1032,16 @@ static int ares_ipv6_server_blacklisted(const unsigned char ipaddr[16])
 #if 1
     char          addr[128];
     ares_inet_ntop(AF_INET6, ipaddr, addr, sizeof(addr));
-    printf("comparing netmask %s/%d to %s\n", blacklist[i].netbase, blacklist[i].netmask, addr);
+    printf("comparing netmask %s/%d to %s\r\n", blacklist[i].netbase, blacklist[i].netmask, addr);
 #endif
 
     if (ares_inet_pton(AF_INET6, blacklist[i].netbase, netbase) != 1)
       continue;
 
-    if (ares_ipv6_subnet_matches(netbase, blacklist[i].netmask, ipaddr))
+    if (ares_ipv6_subnet_matches(netbase, blacklist[i].netmask, ipaddr)) {
+printf("excluding!\r\n");
       return 1;
+    }
   }
   return 0;
 }

--- a/ares_init.c
+++ b/ares_init.c
@@ -980,6 +980,66 @@ static int compareAddresses(const void *arg1,
   return 0;
 }
 
+
+/* Validate that the ip address matches the subnet (network base and network
+ * mask) specified. Addresses are specified in standard Network Byte Order as
+ * 16 bytes, and the netmask is 0 to 128 (bits).
+ */
+static int ares_ipv6_subnet_matches(const unsigned char netbase[16],
+                                    M_uint8 netmask,
+                                    const unsigned char ipaddr[16])
+{
+  const unsigned char mask[16] = { 0 };
+  unsigned char       i;
+
+  /* Misuse */
+  if (netmask > 128)
+    return 0;
+
+  /* Quickly set whole bytes */
+  memset(mask, 0xFF, netmask / 8);
+
+  /* Set remaining bits */
+  for (i=(netmask / 8)*8; i<netmask; i++) {
+    mask[i / 8] |= 1 << ((7-i) % 8);
+  }
+
+  for (i=0; i<sizeof(ipaddr); i++) {
+    if (netbase[i] & mask[i] != ipaddr[i] & mask[i])
+      return 0;
+  }
+
+  return 1;
+}
+
+
+static int ares_ipv6_server_blacklisted(const unsigned char ipaddr[16])
+{
+  const struct {
+    const char *netbase;
+    M_uint8     netmask;
+  } blacklist[] = {
+    /* Deprecated by [RFC3879] in September 2004. Formerly a Site-Local scoped
+     * address prefix. Causes known issues on Windows as these are not valid DNS
+     * servers. */
+    { "fec0::", 10 },
+    { NULL,     0  }
+  };
+  size_t i;
+
+  for (i=0; blacklist[i] != NULL; i++) {
+    unsigned char netbase[16];
+
+    if (ares_inet_pton(AF_INET6, blacklist[i].netbase, netbase) != 1)
+      continue;
+
+    if (ares_ipv6_subnet_matches(netbase, blacklist[i].netmask, ipaddr))
+      return 1;
+  }
+  return 0;
+}
+
+
 /* There can be multiple routes to "the Internet".  And there can be different
  * DNS servers associated with each of the interfaces that offer those routes.
  * We have to assume that any DNS server can serve any request.  But, some DNS
@@ -1197,6 +1257,11 @@ static int get_DNS_AdaptersAddresses(char **outptr)
       {
         if (memcmp(&namesrvr.sa6->sin6_addr, &ares_in6addr_any,
                    sizeof(namesrvr.sa6->sin6_addr)) == 0)
+          continue;
+
+        if (ares_ipv6_server_blacklisted(
+              (const unsigned char[16])&namesrvr.sa6->sin6_addr)
+           )
           continue;
 
         /* Allocate room for another address, if necessary, else skip. */

--- a/ares_init.c
+++ b/ares_init.c
@@ -1028,20 +1028,11 @@ static int ares_ipv6_server_blacklisted(const unsigned char ipaddr[16])
   for (i=0; blacklist[i].netbase != NULL; i++) {
     unsigned char netbase[16];
 
-/* Debugging */
-#if 1
-    char          addr[128];
-    ares_inet_ntop(AF_INET6, ipaddr, addr, sizeof(addr));
-    printf("comparing netmask %s/%d to %s\r\n", blacklist[i].netbase, blacklist[i].netmask, addr);
-#endif
-
     if (ares_inet_pton(AF_INET6, blacklist[i].netbase, netbase) != 1)
       continue;
 
-    if (ares_ipv6_subnet_matches(netbase, blacklist[i].netmask, ipaddr)) {
-printf("excluding!\r\n");
+    if (ares_ipv6_subnet_matches(netbase, blacklist[i].netmask, ipaddr))
       return 1;
-    }
   }
   return 0;
 }

--- a/ares_init.c
+++ b/ares_init.c
@@ -988,8 +988,8 @@ static int ares_ipv6_subnet_matches(const unsigned char netbase[16],
                                     unsigned char netmask,
                                     const unsigned char ipaddr[16])
 {
-  const unsigned char mask[16] = { 0 };
-  unsigned char       i;
+  unsigned char mask[16] = { 0 };
+  unsigned char i;
 
   /* Misuse */
   if (netmask > 128)
@@ -1004,7 +1004,7 @@ static int ares_ipv6_subnet_matches(const unsigned char netbase[16],
   }
 
   for (i=0; i<sizeof(ipaddr); i++) {
-    if (netbase[i] & mask[i] != ipaddr[i] & mask[i])
+    if ((netbase[i] & mask[i]) != (ipaddr[i] & mask[i]))
       return 0;
   }
 
@@ -1025,8 +1025,15 @@ static int ares_ipv6_server_blacklisted(const unsigned char ipaddr[16])
   };
   size_t i;
 
-  for (i=0; blacklist[i] != NULL; i++) {
+  for (i=0; blacklist[i].netbase != NULL; i++) {
     unsigned char netbase[16];
+
+/* Debugging */
+#if 1
+    char          addr[128];
+    ares_inet_ntop(AF_INET6, ipaddr, addr, sizeof(addr));
+    printf("comparing netmask %s/%d to %s", blacklist[i].netbase, blacklist[i].netmask, addr);
+#endif
 
     if (ares_inet_pton(AF_INET6, blacklist[i].netbase, netbase) != 1)
       continue;
@@ -1257,7 +1264,7 @@ static int get_DNS_AdaptersAddresses(char **outptr)
           continue;
 
         if (ares_ipv6_server_blacklisted(
-              (const unsigned char[16])&namesrvr.sa6->sin6_addr)
+              (const unsigned char *)&namesrvr.sa6->sin6_addr)
            )
           continue;
 

--- a/ares_init.c
+++ b/ares_init.c
@@ -985,7 +985,7 @@ static int compareAddresses(const void *arg1,
  * 16 bytes, and the netmask is 0 to 128 (bits).
  */
 static int ares_ipv6_subnet_matches(const unsigned char netbase[16],
-                                    M_uint8 netmask,
+                                    unsigned char netmask,
                                     const unsigned char ipaddr[16])
 {
   const unsigned char mask[16] = { 0 };
@@ -1014,8 +1014,8 @@ static int ares_ipv6_subnet_matches(const unsigned char netbase[16],
 static int ares_ipv6_server_blacklisted(const unsigned char ipaddr[16])
 {
   const struct {
-    const char *netbase;
-    M_uint8     netmask;
+    const char   *netbase;
+    unsigned char netmask;
   } blacklist[] = {
     /* Deprecated by [RFC3879] in September 2004. Formerly a Site-Local scoped
      * address prefix. Causes known issues on Windows as these are not valid DNS

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -230,7 +230,7 @@ TEST(Misc, Bitncmp) {
 }
 
 TEST_F(LibraryTest, Casts) {
-  ssize_t ssz = 100;
+  ares_ssize_t ssz = 100;
   unsigned int u = 100;
   int i = 100;
   long l = 100;
@@ -447,7 +447,7 @@ const struct ares_socket_functions VirtualizeIO::default_functions = {
   [](ares_socket_t s, const struct sockaddr * addr, socklen_t len, void *) {
     return ::connect(s, addr, len);
   },
-  [](ares_socket_t s, void * dst, size_t len, int flags, struct sockaddr * addr, socklen_t * alen, void *) -> ssize_t {
+  [](ares_socket_t s, void * dst, size_t len, int flags, struct sockaddr * addr, socklen_t * alen, void *) -> ares_ssize_t {
 #ifdef HAVE_RECVFROM
     return ::recvfrom(s, reinterpret_cast<RECV_TYPE_ARG2>(dst), len, flags, addr, alen);
 #else


### PR DESCRIPTION
win32 ipv6: add infrastructure to exclude ipv6 subnets that are known to cause issues
Fixes issue #134 



