### PR TITLE
support most recent Visual Studio 2017

### DIFF
--- a/msvc_ver.inc
+++ b/msvc_ver.inc
@@ -70,6 +70,8 @@ CC_VERS_NUM = 140
 CC_VERS_NUM = 140
 !ELSEIF "$(_NMAKE_VER)" == "14.11.25506.0"
 CC_VERS_NUM = 140
+!ELSEIF "$(_NMAKE_VER)" == "14.11.25507.1"
+CC_VERS_NUM = 140
 !ELSE
 !  MESSAGE Unknown value for _NMAKE_VER macro: "$(_NMAKE_VER)"
 !  MESSAGE Please, report this condition on the c-ares development


### PR DESCRIPTION
Surely there must be a better way than having to update this all the time?

It's not obvious to me how to do better, because string-manipulation inside MSVC makefiles doesn't seem to be a thing.  

However, so far as I can see, the only places where we actually care what the version number is, are here:

```
Makefile.msvc:196:!IF $(CC_VERS_NUM) == 60
Makefile.msvc:204:!IF $(CC_VERS_NUM) <= 70
```

... which, if I read wikipedia right, takes us back to 2002.  Is it out of the question simply to remove support for these compilers?  

Or, maybe anything later than that could just be treated as RECENT, without having to differentiate every last minor release?