### PR TITLE
windows: only look for ancient compilers

### DIFF
--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -87,11 +87,10 @@ USE_WATT32 = 0
 !ENDIF
 
 # ------------------------------------------------------------------
-# Base subdir is the common root from which other subdirs will hang,
-# the name depends on MSVC version being used when building c-ares.
+# Base subdir is the common root from which other subdirs will hang.
 # ------------------------------------------------------------------
 
-BASE_DIR = .\$(CC_VERS_STR)
+BASE_DIR = .\msvc
 
 # ----------------------------------------
 # Subdir holding sources for all projects
@@ -189,9 +188,9 @@ EX_LIBS_REL = ws2_32.lib advapi32.lib kernel32.lib
 EX_LIBS_DBG = ws2_32.lib advapi32.lib kernel32.lib
 !ENDIF
 
-# -----------------------------------------
-# Switches that depend on compiler version
-# -----------------------------------------
+# -------------------------------------------------
+# Switches that depend on ancient compiler versions
+# -------------------------------------------------
 
 !IF $(CC_VERS_NUM) == 60
 PDB_NONE            = /pdb:none

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,4 +12,4 @@ build_script:
   - cd test
   - if "%platform%" == "mingw" ( mingw32-make.exe -f Makefile.m32 ) else ( nmake /f Makefile.msvc vtest )
   - if "%platform%" == "mingw" ( mingw32-make.exe -f Makefile.m32 aresfuzz.exe aresfuzzname.exe dnsdump.exe ) else ( nmake /f Makefile.msvc aresfuzz aresfuzzname dnsdump )
-  - if "%platform%" == "mingw" ( .\dnsdump.exe fuzzinput\answer_a fuzzinput\answer_aaaa ) else ( .\msvc120\arestest\lib-debug\dnsdump.exe fuzzinput\answer_a fuzzinput\answer_aaaa )
+  - if "%platform%" == "mingw" ( .\dnsdump.exe fuzzinput\answer_a fuzzinput\answer_aaaa ) else ( .\msvc\arestest\lib-debug\dnsdump.exe fuzzinput\answer_a fuzzinput\answer_aaaa )

--- a/msvc_ver.inc
+++ b/msvc_ver.inc
@@ -1,6 +1,6 @@
-# -------------------------------------------
-# Detect NMAKE version deducing MSVC version
-# -------------------------------------------
+# -----------------------------------------------
+# Detect NMAKE version deducing old MSVC versions
+# -----------------------------------------------
 
 !IFNDEF _NMAKE_VER
 !  MESSAGE Macro _NMAKE_VER not defined.
@@ -18,63 +18,7 @@ CC_VERS_NUM = 70
 CC_VERS_NUM = 70
 !ELSEIF "$(_NMAKE_VER)" == "7.00.9955"
 CC_VERS_NUM = 70
-!ELSEIF "$(_NMAKE_VER)" == "7.10.2240.8"
-CC_VERS_NUM = 71
-!ELSEIF "$(_NMAKE_VER)" == "7.10.3077"
-CC_VERS_NUM = 71
-!ELSEIF "$(_NMAKE_VER)" == "8.00.40607.16"
-CC_VERS_NUM = 80
-!ELSEIF "$(_NMAKE_VER)" == "8.00.50727.42"
-CC_VERS_NUM = 80
-!ELSEIF "$(_NMAKE_VER)" == "8.00.50727.762"
-CC_VERS_NUM = 80
-!ELSEIF "$(_NMAKE_VER)" == "9.00.20706.01"
-CC_VERS_NUM = 90
-!ELSEIF "$(_NMAKE_VER)" == "9.00.21022.08"
-CC_VERS_NUM = 90
-!ELSEIF "$(_NMAKE_VER)" == "9.00.30729.01"
-CC_VERS_NUM = 90
-!ELSEIF "$(_NMAKE_VER)" == "10.00.20506.01"
-CC_VERS_NUM = 100
-!ELSEIF "$(_NMAKE_VER)" == "10.00.21003.01"
-CC_VERS_NUM = 100
-!ELSEIF "$(_NMAKE_VER)" == "10.00.30128.01"
-CC_VERS_NUM = 100
-!ELSEIF "$(_NMAKE_VER)" == "10.00.30319.01"
-CC_VERS_NUM = 100
-!ELSEIF "$(_NMAKE_VER)" == "10.00.40219.01"
-CC_VERS_NUM = 100
-!ELSEIF "$(_NMAKE_VER)" == "11.00.50522.1"
-CC_VERS_NUM = 110
-!ELSEIF "$(_NMAKE_VER)" == "11.00.50727.1"
-CC_VERS_NUM = 110
-!ELSEIF "$(_NMAKE_VER)" == "11.00.51106.1"
-CC_VERS_NUM = 110
-!ELSEIF "$(_NMAKE_VER)" == "11.00.60315.1"
-CC_VERS_NUM = 110
-!ELSEIF "$(_NMAKE_VER)" == "11.00.61030.0"
-CC_VERS_NUM = 110
-!ELSEIF "$(_NMAKE_VER)" == "12.00.21005.1"
-CC_VERS_NUM = 120
-!ELSEIF "$(_NMAKE_VER)" == "14.00.23026.0"
-CC_VERS_NUM = 140
-!ELSEIF "$(_NMAKE_VER)" == "14.00.23506.0"
-CC_VERS_NUM = 140
-!ELSEIF "$(_NMAKE_VER)" == "14.00.23918.0"
-CC_VERS_NUM = 140
-!ELSEIF "$(_NMAKE_VER)" == "14.00.24210.0"
-CC_VERS_NUM = 140
-!ELSEIF "$(_NMAKE_VER)" == "14.10.25017.0"
-CC_VERS_NUM = 140
-!ELSEIF "$(_NMAKE_VER)" == "14.10.25019.0"
-CC_VERS_NUM = 140
-!ELSEIF "$(_NMAKE_VER)" == "14.11.25506.0"
-CC_VERS_NUM = 140
 !ELSE
-!  MESSAGE Unknown value for _NMAKE_VER macro: "$(_NMAKE_VER)"
-!  MESSAGE Please, report this condition on the c-ares development
-!  MESSAGE mailing list: http://cool.haxx.se/mailman/listinfo/c-ares/
-!  ERROR   See previous message.
+# Pick an arbitrary bigger number for all later versions
+CC_VERS_NUM = 199
 !ENDIF
-
-CC_VERS_STR = msvc$(CC_VERS_NUM)

--- a/test/Makefile.msvc
+++ b/test/Makefile.msvc
@@ -79,9 +79,9 @@ RTLIBD = /MTd
 # the name depends on MSVC version being used when building c-ares.
 # ------------------------------------------------------------------
 
-BASE_DIR = .\$(CC_VERS_STR)
+BASE_DIR = .\msvc
 # Look for a built library of the same configuration in the directory above.
-LIB_BASE_DIR = ..\$(CC_VERS_STR)
+LIB_BASE_DIR = ..\msvc
 
 # ----------------------------------------
 # Subdir holding sources for all projects
@@ -146,9 +146,9 @@ CFLAGS  = /DWIN32
 EX_LIBS_REL = ws2_32.lib advapi32.lib kernel32.lib
 EX_LIBS_DBG = ws2_32.lib advapi32.lib kernel32.lib
 
-# -----------------------------------------
-# Switches that depend on compiler version
-# -----------------------------------------
+# -------------------------------------------------
+# Switches that depend on ancient compiler versions
+# -------------------------------------------------
 
 !IF $(CC_VERS_NUM) == 60
 PDB_NONE            = /pdb:none


### PR DESCRIPTION
Also drop the use of a versioned output directory; just use
.\msvc