### PR TITLE
Add WSAStartup/WSACleanup into library init/cleanup procedure on Windows.

### DIFF
--- a/ares.h
+++ b/ares.h
@@ -135,6 +135,9 @@ extern "C" {
 /* More error codes */
 #define ARES_ECANCELLED         24          /* introduced in 1.7.0 */
 
+/* ares_library_init error codes */
+#define ARES_EWSASTARTUP             25
+
 /* Flag values */
 #define ARES_FLAG_USEVC         (1 << 0)
 #define ARES_FLAG_PRIMARY       (1 << 1)

--- a/ares_strerror.c
+++ b/ares_strerror.c
@@ -46,7 +46,8 @@ const char *ares_strerror(int code)
     "c-ares library initialization not yet performed",
     "Error loading iphlpapi.dll",
     "Could not find GetNetworkParams function",
-    "DNS query cancelled"
+    "DNS query cancelled",
+    "Windows socket WSAStartup failure"
   };
 
   if(code >= 0 && code < (int)(sizeof(errtext) / sizeof(*errtext)))


### PR DESCRIPTION
See issue #157