### PR TITLE
Restore working Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,4 +114,5 @@ before_script:
              export LDFLAGS=$IOSFLAGS
          fi
 script:
-    - ./travis/build.sh && ./travis/test.sh && ./travis/distcheck.sh && ./travis/covupload.sh
+    - ./travis/build.sh && ./travis/test.sh
+    - if [ "$BUILD_TYPE" = "normal" ]; then ./travis/distcheck.sh && ./travis/covupload.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,7 @@ matrix:
           language: objective-c
           env: BUILD_TYPE=ios
 install:
-    - pip install --user 'requests[security]<2.9.1'
-    - pip install --user cpp-coveralls
+    - if [ "$TRAVIS_OS_NAME" != "osx" ]; then pip install --user cpp-coveralls > /dev/null; fi
     - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew reinstall libtool > /dev/null; fi
 before_script:
     - |

--- a/test/ares-test-main.cc
+++ b/test/ares-test-main.cc
@@ -11,6 +11,12 @@ int main(int argc, char* argv[]) {
     } else if ((strcmp(argv[ii], "-p") == 0) && (ii + 1 < argc)) {
       ii++;
       ares::test::mock_port = atoi(argv[ii]);
+    } else if (strcmp(argv[ii], "-4") == 0) {
+      ares::test::families = ares::test::ipv4_family;
+      ares::test::families_modes = ares::test::ipv4_family_both_modes;
+    } else if (strcmp(argv[ii], "-6") == 0) {
+      ares::test::families = ares::test::ipv6_family;
+      ares::test::families_modes = ares::test::ipv6_family_both_modes;
     } else {
       gtest_argv.push_back(argv[ii]);
     }

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -1138,48 +1138,21 @@ TEST_P(NoRotateMultiMockTest, ThirdServer) {
   CheckExample();
 }
 
+INSTANTIATE_TEST_CASE_P(AddressFamilies, MockChannelTest, ::testing::ValuesIn(ares::test::families_modes));
 
-INSTANTIATE_TEST_CASE_P(AddressFamilies, MockChannelTest,
-                        ::testing::Values(std::make_pair<int, bool>(AF_INET, false),
-                                          std::make_pair<int, bool>(AF_INET, true),
-                                          std::make_pair<int, bool>(AF_INET6, false),
-                                          std::make_pair<int, bool>(AF_INET6, true)));
+INSTANTIATE_TEST_CASE_P(AddressFamilies, MockUDPChannelTest, ::testing::ValuesIn(ares::test::families));
 
-INSTANTIATE_TEST_CASE_P(AddressFamilies, MockUDPChannelTest,
-                        ::testing::Values(AF_INET, AF_INET6));
+INSTANTIATE_TEST_CASE_P(AddressFamilies, MockTCPChannelTest, ::testing::ValuesIn(ares::test::families));
 
-INSTANTIATE_TEST_CASE_P(AddressFamilies, MockTCPChannelTest,
-                        ::testing::Values(AF_INET, AF_INET6));
+INSTANTIATE_TEST_CASE_P(AddressFamilies, MockExtraOptsTest, ::testing::ValuesIn(ares::test::families_modes));
 
-INSTANTIATE_TEST_CASE_P(AddressFamilies, MockExtraOptsTest,
-                        ::testing::Values(std::make_pair<int, bool>(AF_INET, false),
-                                          std::make_pair<int, bool>(AF_INET, true),
-                                          std::make_pair<int, bool>(AF_INET6, false),
-                                          std::make_pair<int, bool>(AF_INET6, true)));
+INSTANTIATE_TEST_CASE_P(AddressFamilies, MockNoCheckRespChannelTest, ::testing::ValuesIn(ares::test::families_modes));
 
-INSTANTIATE_TEST_CASE_P(AddressFamilies, MockNoCheckRespChannelTest,
-                        ::testing::Values(std::make_pair<int, bool>(AF_INET, false),
-                                          std::make_pair<int, bool>(AF_INET, true),
-                                          std::make_pair<int, bool>(AF_INET6, false),
-                                          std::make_pair<int, bool>(AF_INET6, true)));
+INSTANTIATE_TEST_CASE_P(AddressFamilies, MockEDNSChannelTest, ::testing::ValuesIn(ares::test::families_modes));
 
-INSTANTIATE_TEST_CASE_P(AddressFamilies, MockEDNSChannelTest,
-                        ::testing::Values(std::make_pair<int, bool>(AF_INET, false),
-                                          std::make_pair<int, bool>(AF_INET, true),
-                                          std::make_pair<int, bool>(AF_INET6, false),
-                                          std::make_pair<int, bool>(AF_INET6, true)));
+INSTANTIATE_TEST_CASE_P(TransportModes, RotateMultiMockTest, ::testing::ValuesIn(ares::test::families_modes));
 
-INSTANTIATE_TEST_CASE_P(TransportModes, RotateMultiMockTest,
-                        ::testing::Values(std::make_pair<int, bool>(AF_INET, false),
-                                          std::make_pair<int, bool>(AF_INET, true),
-                                          std::make_pair<int, bool>(AF_INET6, false),
-                                          std::make_pair<int, bool>(AF_INET6, true)));
-
-INSTANTIATE_TEST_CASE_P(TransportModes, NoRotateMultiMockTest,
-                        ::testing::Values(std::make_pair<int, bool>(AF_INET, false),
-                                          std::make_pair<int, bool>(AF_INET, true),
-                                          std::make_pair<int, bool>(AF_INET6, false),
-                                          std::make_pair<int, bool>(AF_INET6, true)));
+INSTANTIATE_TEST_CASE_P(TransportModes, NoRotateMultiMockTest, ::testing::ValuesIn(ares::test::families_modes));
 
 }  // namespace test
 }  // namespace ares

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -31,6 +31,29 @@ namespace test {
 bool verbose = false;
 int mock_port = 5300;
 
+const std::vector<int> both_families = {AF_INET, AF_INET6};
+const std::vector<int> ipv4_family = {AF_INET};
+const std::vector<int> ipv6_family = {AF_INET6};
+
+const std::vector<std::pair<int, bool>> both_families_both_modes = {
+  std::make_pair<int, bool>(AF_INET, false),
+  std::make_pair<int, bool>(AF_INET, true),
+  std::make_pair<int, bool>(AF_INET6, false),
+  std::make_pair<int, bool>(AF_INET6, true)
+};
+const std::vector<std::pair<int, bool>> ipv4_family_both_modes = {
+  std::make_pair<int, bool>(AF_INET, false),
+  std::make_pair<int, bool>(AF_INET, true)
+};
+const std::vector<std::pair<int, bool>> ipv6_family_both_modes = {
+  std::make_pair<int, bool>(AF_INET6, false),
+  std::make_pair<int, bool>(AF_INET6, true)
+};
+
+// Which parameters to use in tests
+std::vector<int> families = both_families;
+std::vector<std::pair<int, bool>> families_modes = both_families_both_modes;
+
 unsigned long long LibraryTest::fails_ = 0;
 std::map<size_t, int> LibraryTest::size_fails_;
 

--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -36,6 +36,17 @@ namespace test {
 
 extern bool verbose;
 extern int mock_port;
+extern const std::vector<int> both_families;
+extern const std::vector<int> ipv4_family;
+extern const std::vector<int> ipv6_family;
+
+extern const std::vector<std::pair<int, bool>> both_families_both_modes;
+extern const std::vector<std::pair<int, bool>> ipv4_family_both_modes;
+extern const std::vector<std::pair<int, bool>> ipv6_family_both_modes;
+
+// Which parameters to use in tests
+extern std::vector<int> families;
+extern std::vector<std::pair<int, bool>> families_modes;
 
 // Process all pending work on ares-owned file descriptors, plus
 // optionally the given set-of-FDs + work function.

--- a/travis/distcheck.sh
+++ b/travis/distcheck.sh
@@ -10,7 +10,7 @@ if [ "$BUILD_TYPE" = "normal" -a "$TRAVIS_OS_NAME" = "linux" ]; then
 
     cd test
     make
-    $TEST_WRAP ./arestest -v $TEST_FILTER
+    $TEST_WRAP ./arestest -4 -v $TEST_FILTER
     cd ..
 
     cd ..

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -6,7 +6,7 @@ if [ "$BUILD_TYPE" != "ios" -a "$BUILD_TYPE" != "analyse" -a "$BUILD_TYPE" != "c
     $TEST_WRAP ./ahost www.google.com
     cd test
     make
-    $TEST_WRAP ./arestest -v $TEST_FILTER
+    $TEST_WRAP ./arestest -4 -v $TEST_FILTER
     ./fuzzcheck.sh
     ./dnsdump  fuzzinput/answer_a fuzzinput/answer_aaaa
     cd ..


### PR DESCRIPTION
The upgrade of Travis Linux servers to Trusty appears to have dropped IPv6 support.
Also drop `pip` stuff from OSX build.