### PR TITLE
Fix computation of IPv6 blacklist mask for values of netmask > 8.

### DIFF
--- a/ares_init.c
+++ b/ares_init.c
@@ -1009,8 +1009,8 @@ static int ares_ipv6_subnet_matches(const unsigned char netbase[16],
   memset(mask, 0xFF, netmask / 8);
 
   /* Set remaining bits */
-  for (i=(netmask / 8)*8; i<netmask; i++) {
-    mask[i / 8] |= (1 << ((7-i) % 8)) & 0xFF;
+  if(netmask % 8) {
+    mask[netmask / 8] = (unsigned char)(0xff << (8 - (netmask % 8)));
   }
 
   for (i=0; i<16; i++) {


### PR DESCRIPTION
Upstream c-ares PR #144 attempts to filter out certain blacklisted IPv6 DNS resolver addresses from those returned by Windows.

The `ares_ipv6_subnet_matches` function computes the full netmask from a bit count argument via a loop.  However, this loop gives the wrong answer when mask > 8. It needn't even be a loop.  This PR fixes the code so it should compute the right netmask for all values from 0 to 128.

BTW, I discovered that the same bad IPv6 resolver addresses ("fec0::") can also appear in Android simulators.  Perhaps these addresses should be generally blacklisted for all operating systems?
