### PR TITLE
RFC: CMake: Fix 2.8 incompatibilty

### DIFF
--- a/c-ares-config.cmake.in
+++ b/c-ares-config.cmake.in
@@ -7,11 +7,11 @@ include("${CMAKE_CURRENT_LIST_DIR}/c-ares-targets.cmake")
 set(c-ares_LIBRARY c-ares::cares)
 
 if(@CARES_SHARED@)
-	add_library(c-ares::cares_shared INTERFACE IMPORTED)
+	add_library(c-ares::cares_shared SHARED IMPORTED)
 	set_target_properties(c-ares::cares_shared PROPERTIES INTERFACE_LINK_LIBRARIES "c-ares::cares")
 	set(c-ares_SHARED_LIBRARY c-ares::cares_shared)
 elseif(@CARES_STATIC@)
-	add_library(c-ares::cares_static INTERFACE IMPORTED)
+	add_library(c-ares::cares_static SHARED IMPORTED)
 	set_target_properties(c-ares::cares_static PROPERTIES INTERFACE_LINK_LIBRARIES "c-ares::cares")
 endif()
 


### PR DESCRIPTION
Request for comments:

I have very limited CMake knowledge, so most likely my patch doesn't make any sense.

In our project we use CMake 2.8.12 which should be supported according to the CMakeLists.txt file: "CMAKE_MINIMUM_REQUIRED (VERSION 2.8.12)".
But when I build the c-ares using CMake it fails on the INTERFACE targets in the c-ares-config.cmake.in file: CMake 2.8.12 does not support INTERFACE targets (afaik they were introduced with CMake 3.0)

Therefore I used the SHARED target instead, that worked for me. But is this correct, or does it work by accident? I doubt if I did the correct thing for the "CARES_STATIC" case where I also used the SHARED target. Should I have used the STATIC target there?

Thanks in advance for your comments.