### PR TITLE
Android JNI code leaks local references in some cases

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ Frederic Germain
 Geert Uytterhoeven
 George Neill
 Gisle Vanem
+Google LLC
 Gregor Jasny
 Guenter Knauf
 Guilherme Balena Versiani

--- a/ares_android.c
+++ b/ares_android.c
@@ -24,6 +24,19 @@
 static JavaVM *android_jvm = NULL;
 static jobject android_connectivity_manager = NULL;
 
+/* ConnectivityManager.getActiveNetwork */
+static jmethodID android_cm_active_net_mid = NULL;
+/* ConnectivityManager.getLinkProperties */
+static jmethodID android_cm_link_props_mid = NULL;
+/* LinkProperties.getDnsServers */
+static jmethodID android_lp_dns_servers_mid = NULL;
+/* List.size */
+static jmethodID android_list_size_mid = NULL;
+/* List.get */
+static jmethodID android_list_get_mid = NULL;
+/* InetAddress.getHostAddress */
+static jmethodID android_ia_host_addr_mid = NULL;
+
 static jclass jni_get_class(JNIEnv *env, const char *path)
 {
   jclass cls = NULL;
@@ -70,9 +83,11 @@ int ares_library_init_android(jobject connectivity_manager)
   JNIEnv *env = NULL;
   int need_detatch = 0;
   int res;
+  int ret = ARES_ENOTINITIALIZED;
+  jclass obj_cls = NULL;
 
   if (android_jvm == NULL)
-    return ARES_ENOTINITIALIZED;
+    goto fail;
 
   res = (*android_jvm)->GetEnv(android_jvm, (void **)&env, JNI_VERSION_1_6);
   if (res == JNI_EDETACHED)
@@ -82,14 +97,94 @@ int ares_library_init_android(jobject connectivity_manager)
     need_detatch = 1;
   }
   if (res != JNI_OK || env == NULL)
-    return ARES_ENOTINITIALIZED;
+    goto fail;
 
-  android_connectivity_manager = (*env)->NewGlobalRef(env, connectivity_manager);
+  android_connectivity_manager =
+      (*env)->NewGlobalRef(env, connectivity_manager);
+  if (android_connectivity_manager == NULL)
+    goto fail;
 
+  /* ConnectivityManager in API 1. */
+  obj_cls = jni_get_class(env, "android/net/ConnectivityManager");
+  if (obj_cls == NULL)
+    goto fail;
+
+  /* ConnectivityManager.getActiveNetwork in API 23. */
+  android_cm_active_net_mid =
+      jni_get_method_id(env, obj_cls, "getActiveNetwork",
+                        "()Landroid/net/Network;");
+  if (android_cm_active_net_mid == NULL)
+    goto fail;
+
+  /* ConnectivityManager.getLinkProperties in API 21. */
+  android_cm_link_props_mid =
+      jni_get_method_id(env, obj_cls, "getLinkProperties",
+                        "(Landroid/net/Network;)Landroid/net/LinkProperties;");
+  if (android_cm_link_props_mid == NULL)
+    goto fail;
+
+  /* LinkProperties in API 21. */
+  (*env)->DeleteLocalRef(env, obj_cls);
+  obj_cls = jni_get_class(env, "android/net/LinkProperties");
+  if (obj_cls == NULL)
+    goto fail;
+
+  /* getDnsServers in API 21. */
+  android_lp_dns_servers_mid = jni_get_method_id(env, obj_cls, "getDnsServers",
+                                                 "()Ljava/util/List;");
+  if (android_lp_dns_servers_mid == NULL)
+    goto fail;
+
+  (*env)->DeleteLocalRef(env, obj_cls);
+  obj_cls = jni_get_class(env, "java/util/List");
+  if (obj_cls == NULL)
+    goto fail;
+
+  android_list_size_mid = jni_get_method_id(env, obj_cls, "size", "()I");
+  if (android_list_size_mid == NULL)
+    goto fail;
+
+  android_list_get_mid = jni_get_method_id(env, obj_cls, "get",
+                                           "(I)Ljava/lang/Object;");
+  if (android_list_get_mid == NULL)
+    goto fail;
+
+  (*env)->DeleteLocalRef(env, obj_cls);
+  obj_cls = jni_get_class(env, "java/net/InetAddress");
+  if (obj_cls == NULL)
+    goto fail;
+
+  android_ia_host_addr_mid = jni_get_method_id(env, obj_cls, "getHostAddress",
+                                               "()Ljava/lang/String;");
+  if (android_ia_host_addr_mid == NULL)
+    goto fail;
+
+  (*env)->DeleteLocalRef(env, obj_cls);
+  ret = ARES_SUCCESS;
+  goto done;
+
+fail:
+  if (obj_cls != NULL)
+    (*env)->DeleteLocalRef(env, obj_cls);
+
+  android_cm_active_net_mid = NULL;
+  android_cm_link_props_mid = NULL;
+  android_lp_dns_servers_mid = NULL;
+  android_list_size_mid = NULL;
+  android_list_get_mid = NULL;
+  android_ia_host_addr_mid = NULL;
+
+  if (android_connectivity_manager != NULL)
+  {
+    (*env)->DeleteGlobalRef(env, android_connectivity_manager);
+    android_connectivity_manager = NULL;
+  }
+
+done:
   if (need_detatch)
     (*android_jvm)->DetachCurrentThread(android_jvm);
 
-  return ARES_SUCCESS;
+  return ret;
 }
 
 int ares_library_android_initialized(void)
@@ -118,6 +213,13 @@ void ares_library_cleanup_android(void)
   if (res != JNI_OK || env == NULL)
     return;
 
+  android_cm_active_net_mid = NULL;
+  android_cm_link_props_mid = NULL;
+  android_lp_dns_servers_mid = NULL;
+  android_list_size_mid = NULL;
+  android_list_get_mid = NULL;
+  android_ia_host_addr_mid = NULL;
+
   (*env)->DeleteGlobalRef(env, android_connectivity_manager);
   android_connectivity_manager = NULL;
 
@@ -133,11 +235,7 @@ char **ares_get_android_server_list(size_t max_servers,
   jobject link_properties = NULL;
   jobject server_list = NULL;
   jobject server = NULL;
-  jstring str;
-  jclass obj_cls;
-  jmethodID obj_mid;
-  jclass list_cls;
-  jmethodID list_mid;
+  jstring str = NULL;
   jint nserv;
   const char *ch_server_address;
   int res;
@@ -178,84 +276,50 @@ char **ares_get_android_server_list(size_t max_servers,
        String ha = ia.getHostAddress();
      }
 
-     Note: The JNI ConnectivityManager object was previously initialized in
-           ares_library_init_android.
+     Note: The JNI ConnectivityManager object and all method IDs were previously
+           initialized in ares_library_init_android.
    */
 
-  /* ConnectivityManager in API 1. */
-  obj_cls = jni_get_class(env, "android/net/ConnectivityManager");
-  if (obj_cls == NULL)
-    goto done;
-  /* ConnectivityManager.getActiveNetwork in API 23. */
-  obj_mid = jni_get_method_id(env, obj_cls, "getActiveNetwork",
-                              "()Landroid/net/Network;");
-  if (obj_mid == NULL)
-    goto done;
   active_network = (*env)->CallObjectMethod(env, android_connectivity_manager,
-                                            obj_mid);
+                                            android_cm_active_net_mid);
   if (active_network == NULL)
     goto done;
 
-  /* ConnectivityManager.getLinkProperties in API 21. */
-  obj_mid = jni_get_method_id(env, obj_cls, "getLinkProperties",
-            "(Landroid/net/Network;)Landroid/net/LinkProperties;");
-  if (obj_mid == NULL)
-    goto done;
-  link_properties = (*env)->CallObjectMethod(env, android_connectivity_manager,
-                                             obj_mid, active_network);
+  link_properties =
+      (*env)->CallObjectMethod(env, android_connectivity_manager,
+                               android_cm_link_props_mid, active_network);
   if (link_properties == NULL)
     goto done;
 
-  /* LinkProperties in API 21. */
-  obj_cls = jni_get_class(env, "android/net/LinkProperties");
-  if (obj_cls == NULL)
-    goto done;
-  /* getDnsServers in API 21. */
-  obj_mid = jni_get_method_id(env, obj_cls, "getDnsServers",
-                              "()Ljava/util/List;");
-  if (obj_mid == NULL)
-    goto done;
-  server_list = (*env)->CallObjectMethod(env, link_properties, obj_mid);
+  server_list = (*env)->CallObjectMethod(env, link_properties,
+                                         android_lp_dns_servers_mid);
   if (server_list == NULL)
     goto done;
 
-  list_cls = jni_get_class(env, "java/util/List");
-  if (list_cls == NULL)
-    goto done;
-  list_mid = jni_get_method_id(env, list_cls, "size", "()I");
-  if (list_mid == NULL)
-    goto done;
-  nserv = (*env)->CallIntMethod(env, server_list, list_mid);
+  nserv = (*env)->CallIntMethod(env, server_list, android_list_size_mid);
   if (nserv > (jint)max_servers)
     nserv = (jint)max_servers;
   if (nserv <= 0)
     goto done;
   *num_servers = (size_t)nserv;
-  list_mid = jni_get_method_id(env, list_cls, "get", "(I)Ljava/lang/Object;");
-  if (list_mid == NULL)
-    goto done;
 
-  obj_cls = jni_get_class(env, "java/net/InetAddress");
-  if (obj_cls == NULL)
-    goto done;
-  obj_mid = jni_get_method_id(env, obj_cls, "getHostAddress",
-                              "()Ljava/lang/String;");
-  if (obj_mid == NULL)
-    goto done;
   dns_list = ares_malloc(sizeof(*dns_list)*(*num_servers));
   for (i=0; i<*num_servers; i++)
   {
-    server = (*env)->CallObjectMethod(env, server_list, list_mid, (jint)i);
+    server = (*env)->CallObjectMethod(env, server_list, android_list_get_mid,
+                                      (jint)i);
     dns_list[i] = ares_malloc(64);
     dns_list[i][0] = 0;
     if (server == NULL)
     {
       continue;
     }
-    str = (*env)->CallObjectMethod(env, server, obj_mid);
+    str = (*env)->CallObjectMethod(env, server, android_ia_host_addr_mid);
     ch_server_address = (*env)->GetStringUTFChars(env, str, 0);
     strncpy(dns_list[i], ch_server_address, 64);
     (*env)->ReleaseStringUTFChars(env, str, ch_server_address);
+    (*env)->DeleteLocalRef(env, str);
+    (*env)->DeleteLocalRef(env, server);
   }
 
 done:


### PR DESCRIPTION
The current Android JNI code does not explicitly delete all of the local references it creates. This works in cases where DetachLocalThread is called because that function will delete all local references that were created. However, in cases where DetachLocalThread is not called, the local references accumulate, which eventually causes the process to abort. Sample code and crash are below.

While fixing that issue, I noticed that the JNI method IDs were being looked up every time through ares_get_android_server_list. Those can be cached, so I also moved those lookups to ares_library_init_android. See also: https://www.ibm.com/developerworks/library/j-jni/#notc

This does change the behavior of ares_library_init_android slightly. For older Android API versions that don't have these classes or methods, previously ares_library_init_android would return ARES_SUCCESS (although subsequent calls to ares_get_android_server_list would always return NULL). With this change, ares_library_init_android will return ARES_ENOTINITIALIZED (ares_get_android_server_list continues to return NULL). That seems more truthful to me, but we can keep the original semantics if needed.

This code snippet will crash when run in an Android app:

`/* ares_library_init, ares_library_init_jvm, and ares_library_android_init must be called first. */
void test_ares_android_jni(JavaVM *android_jvm) {
  JNIEnv *env = NULL;
  int need_detatch = 0;
  int res;
  int i;
  ares_channel channel;

  res = (*android_jvm)->GetEnv(android_jvm, (void **)&env, JNI_VERSION_1_6);
  if (res == JNI_EDETACHED)
  {
    env = NULL;
    res = (*android_jvm)->AttachCurrentThread(android_jvm, &env, NULL);
    need_detatch = 1;
  }
  if (res != JNI_OK || env == NULL)
    abort();

  for (i = 0; i < 1000; i++)
  {
    ares_init(&channel);
    ares_destroy(channel);
  }

  if (need_detatch)
    (*android_jvm)->DetachCurrentThread(android_jvm);
}
`

The crash will look something like this:

JNI ERROR (app bug): local reference table overflow (max=512)
local reference table dump:
  Last 10 entries (of 509):
      508: 0x12d3fae0 java.lang.String "8.8.4.4"
      507: 0x12d383e0 java.net.Inet4Address
      506: 0x12d3fac0 java.lang.String "8.8.8.8"
      505: 0x12d383c0 java.net.Inet4Address
      504: 0x12d33dd0 java.lang.String "2001:4860:4860::... (20 chars)
      503: 0x12d39240 java.net.Inet6Address
      502: 0x12d33d98 java.lang.String "2001:4860:4860::... (20 chars)
      501: 0x12d39218 java.net.Inet6Address
      500: 0x70925de8 java.lang.Class<java.net.InetAddress>
      499: 0x70940e88 java.lang.Class<java.util.List>
  Summary:
      170 of java.lang.Class (6 unique instances)
      169 of java.lang.String (169 unique instances)
       84 of java.net.Inet4Address (84 unique instances)
       84 of java.net.Inet6Address (84 unique instances)
