### PR TITLE
travis: use VM not container for {L,A}SAN builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,11 @@ matrix:
         - os: linux
           compiler: clang
           env: BUILD_TYPE=asan
+          sudo: true  # ASAN requires ptrace which is disabled in containers (https://github.com/travis-ci/travis-ci/issues/9033)
         - os: linux
           compiler: clang
           env: BUILD_TYPE=lsan
+          sudo: true  # LSAN requires ptrace which is disabled in containers (https://github.com/travis-ci/travis-ci/issues/9033)
         - os: linux
           compiler: clang
           env: BUILD_TYPE=analyse


### PR DESCRIPTION
As per https://github.com/travis-ci/travis-ci/issues/9033, container
based builds do not currently allow ptrace, which is used by LSAN and
ASAN.