### PR TITLE
Harden and rationalize c-ares timeout computation

### DIFF
--- a/ares_process.c
+++ b/ares_process.c
@@ -898,18 +898,6 @@ void ares__send_query(ares_channel channel, struct query *query,
       }
     }
 
-    /* Add a small random amount (between 0 and 511 ms) to the the timeout to
-     * help avoid sending many requests packets at the same time if timeouts
-     * all align.
-     *
-     * Do not _shrink_ the timeout because that will break user expectations
-     * and can lead to spurious failures.  Don't increase the timeout by too
-     * much because that will also break user expectations.
-     *
-     * Even a weak non-uniform random source will do for this purpose.
-     */
-    timeplus += rand() & 0x1ff;
-
     query->timeout = *now;
     timeadd(&query->timeout, timeplus);
     /* Keep track of queries bucketed by timeout, so we can process

--- a/ares_process.c
+++ b/ares_process.c
@@ -53,6 +53,7 @@
 
 #include <assert.h>
 #include <fcntl.h>
+#include <limits.h>
 
 #include "ares.h"
 #include "ares_dns.h"
@@ -871,8 +872,44 @@ void ares__send_query(ares_channel channel, struct query *query,
           return;
         }
     }
-    timeplus = channel->timeout << (query->try_count / channel->nservers);
-    timeplus = (timeplus * (9 + (rand () & 7))) / 16;
+
+    /* For each trip through the entire server list, double the channel's
+     * assigned timeout, avoiding overflow.  If channel->timeout is negative,
+     * leave it as-is, even though that should be impossible here.
+     */
+    timeplus = channel->timeout;
+    {
+      /* How many times do we want to double it?  Presume sane values here. */
+      const int shift = query->try_count / channel->nservers;
+
+      /* Is there enough room to shift timeplus left that many times?
+       *
+       * To find out, confirm that all of the bits we'll shift away are zero.
+       * Stop considering a shift if we get to the point where we could shift
+       * a 1 into the sign bit (i.e. when shift is within two of the bit
+       * count).
+       *
+       * This has the side benefit of leaving negative numbers unchanged.
+       */
+      if(shift <= (int)(sizeof(int) * CHAR_BIT - 1)
+         && (timeplus >> (sizeof(int) * CHAR_BIT - 1 - shift)) == 0)
+      {
+        timeplus <<= shift;
+      }
+    }
+
+    /* Add a small random amount (between 0 and 511 ms) to the the timeout to
+     * help avoid sending many requests packets at the same time if timeouts
+     * all align.
+     *
+     * Do not _shrink_ the timeout because that will break user expectations
+     * and can lead to spurious failures.  Don't increase the timeout by too
+     * much because that will also break user expectations.
+     *
+     * Even a weak non-uniform random source will do for this purpose.
+     */
+    timeplus += rand() & 0x1ff;
+
     query->timeout = *now;
     timeadd(&query->timeout, timeplus);
     /* Keep track of queries bucketed by timeout, so we can process


### PR DESCRIPTION
(This should be a clean version of PR #186.  Sorry about the noise.)

When c-ares sends a DNS query, it computes the timeout for that request as follows:

    timeplus = channel->timeout << (query->try_count / channel->nservers);
    timeplus = (timeplus * (9 + (rand () & 7))) / 16;

I see two issues with this code.  Firstly, when either `try_count` or `channel->timeout` are large enough, this can end up as an illegal shift.

Secondly, the algorithm for adding the random timeout ([added in 2009](https://github.com/c-ares/c-ares/commit/977de8c7780eeb43efeabbbfa6bac82161ceeaaa)) is surprising.  The original commit that introduced this algorithm says it was done to avoid a "packet storm".    But, the algorithm appears to only _reduce_ the timeout by an amount proportional to the scaled timeout's magnitude.  It isn't clear to me that, for example, cutting a 30 second timeout almost in half to roughly 17  seconds is appropriate.  Even with the default timeout of 5000 ms, this algorithm computes values between 2812 ms and 5000 ms, which is enough to cause a slightly latent DNS response to get spuriously dropped.

If preventing the timers from all expiring at the same time really is desirable, then it seems better to _extend_ the timeout by a small factor so that the application gets at least the timeout it asked for, and maybe a little more.  In my experience, this is common practice for timeouts: applications expect that a timeout will happen at or _after_ the designated time (but not before), allowing for delay in detecting and reporting the timeout.   Furthermore, it seems like the timeout shouldn't be extended by very much (we don't want a 30 second timeout changing into a 45 second timeout, either).

Consider also [the documentation](https://c-ares.haxx.se/ares_init_options.html) of `channel->timeout` in `ares_init_options()`:

>  The number of milliseconds each name server is given to respond to a query on the first try. (After the first try, the timeout algorithm becomes more complicated, but scales linearly with the value of timeout.) The default is five seconds.

In the current implementation, even the _first_ try does not use the value that the user supplies; it will use anywhere between 56% and 100% of that value.

The attached patch attempts to address all of these concerns without trying to make the algorithm much more sophisticated. After performing a safe shift, this patch simply _adds_ a small random timeout to the computed value of between 0 ms and 511 ms.  I could see limiting the random amount to be no _greater_ than a proportion of the configured magnitude, but I can't see scaling the random with the overall computed timeout.  As far as I understand, the goal is just to schedule retries "not at the same exact time", so a small difference seems sufficient.

It might be useful to add an option that disables the timeout randomization.  I'm not even sure I understand what problems it addresses, exactly.  UDP packet loss?

What do you think?