### PR TITLE
Fix comment in ares_rules.h

### DIFF
--- a/ares_rules.h
+++ b/ares_rules.h
@@ -83,7 +83,7 @@
 
 /*
  * Verify that the size previously defined and expected for
- * ares_socklen_t is actually the the same as the one reported
+ * ares_socklen_t is actually the same as the one reported
  * by sizeof() at compile time.
  */
 


### PR DESCRIPTION
This is a trivial change fixing a comment in `ares_rules.h`.