### PR TITLE
Prevent changing name servers while queries are outstanding

### DIFF
--- a/ares_options.c
+++ b/ares_options.c
@@ -153,6 +153,9 @@ int ares_set_servers(ares_channel channel,
   if (!channel)
     return ARES_ENODATA;
 
+  if (!ares__is_list_empty(&channel->all_queries))
+    return ARES_ENOTIMP;
+
   ares__destroy_servers_state(channel);
 
   for (srvr = servers; srvr; srvr = srvr->next)
@@ -201,6 +204,9 @@ int ares_set_servers_ports(ares_channel channel,
 
   if (!channel)
     return ARES_ENODATA;
+
+  if (!ares__is_list_empty(&channel->all_queries))
+    return ARES_ENOTIMP;
 
   ares__destroy_servers_state(channel);
 

--- a/ares_set_servers.3
+++ b/ares_set_servers.3
@@ -72,6 +72,9 @@ was invalid.
 .TP 15
 .B ARES_ENOTINITIALIZED
 c-ares library initialization not yet performed.
+.TP 15
+.B ARES_ENOTIMP
+Changing name servers configuration while queries are outstanding is not implemented.
 .SH SEE ALSO
 .BR ares_set_servers_csv (3),
 .BR ares_get_servers (3),

--- a/ares_set_servers_csv.3
+++ b/ares_set_servers_csv.3
@@ -55,6 +55,9 @@ was invalid.
 .TP 15
 .B ARES_ENOTINITIALIZED
 c-ares library initialization not yet performed.
+.TP 15
+.B ARES_ENOTIMP
+Changing name servers configuration while queries are outstanding is not implemented.
 .SH SEE ALSO
 .BR ares_set_servers (3)
 .SH AVAILABILITY

--- a/test/ares-test-misc.cc
+++ b/test/ares-test-misc.cc
@@ -45,6 +45,12 @@ TEST_F(DefaultChannelTest, SetServers) {
   EXPECT_EQ(ARES_SUCCESS, ares_set_servers(channel_, &server1));
   std::vector<std::string> expected = {"1.2.3.4", "2.3.4.5"};
   EXPECT_EQ(expected, GetNameServers(channel_));
+
+  // Change not allowed while request is pending
+  HostResult result;
+  ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback, &result);
+  EXPECT_EQ(ARES_ENOTIMP, ares_set_servers(channel_, &server1));
+  ares_cancel(channel_);
 }
 
 TEST_F(DefaultChannelTest, SetServersPorts) {
@@ -69,6 +75,12 @@ TEST_F(DefaultChannelTest, SetServersPorts) {
   EXPECT_EQ(ARES_SUCCESS, ares_set_servers_ports(channel_, &server1));
   std::vector<std::string> expected = {"1.2.3.4:111", "2.3.4.5"};
   EXPECT_EQ(expected, GetNameServers(channel_));
+
+  // Change not allowed while request is pending
+  HostResult result;
+  ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback, &result);
+  EXPECT_EQ(ARES_ENOTIMP, ares_set_servers_ports(channel_, &server1));
+  ares_cancel(channel_);
 }
 
 TEST_F(DefaultChannelTest, SetServersCSV) {
@@ -95,6 +107,13 @@ TEST_F(DefaultChannelTest, SetServersCSV) {
             ares_set_servers_ports_csv(channel_, "1.2.3.4:54,[0102:0304:0506:0708:0910:1112:1314:1516]:80,2.3.4.5:55"));
   std::vector<std::string> expected2 = {"1.2.3.4:54", "[0102:0304:0506:0708:0910:1112:1314:1516]:80", "2.3.4.5:55"};
   EXPECT_EQ(expected2, GetNameServers(channel_));
+
+  // Change not allowed while request is pending
+  HostResult result;
+  ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback, &result);
+  EXPECT_EQ(ARES_ENOTIMP, ares_set_servers_csv(channel_, "1.2.3.4,2.3.4.5"));
+  EXPECT_EQ(ARES_ENOTIMP, ares_set_servers_ports_csv(channel_, "1.2.3.4:56,2.3.4.5:67"));
+  ares_cancel(channel_);
 
   // Should survive duplication
   ares_channel channel2;


### PR DESCRIPTION
It doesn't work, per #41.  Probably it simply isn't intended usage.  Better to return an error code than to crash.

`ARES_ENOTIMP` seems the most appropriate of the existing error codes.  I did consider introducing a new one just for this, but it seemed a bit much.  Happy to be change if you think otherwise.