### PR TITLE
Fix warnings emitted by MSVC when using -W4

### DIFF
--- a/ares_create_query.c
+++ b/ares_create_query.c
@@ -188,7 +188,7 @@ int ares_create_query(const char *name, int dnsclass, int type,
    * specified in RFC 1035 ("To simplify implementations, the total length of
    * a domain name (i.e., label octets and label length octets) is restricted
    * to 255 octets or less."). */
-  if (buflen > (MAXCDNAME + HFIXEDSZ + QFIXEDSZ +
+  if (buflen > (size_t)(MAXCDNAME + HFIXEDSZ + QFIXEDSZ +
                 (max_udp_size ? EDNSFIXEDSZ : 0))) {
     ares_free (buf);
     return ARES_EBADNAME;

--- a/ares_init.c
+++ b/ares_init.c
@@ -1257,7 +1257,7 @@ static int get_DNS_AdaptersAddresses(char **outptr)
         }
         else
         {
-          addresses[addressesIndex].metric = -1;
+          addresses[addressesIndex].metric = (ULONG)-1;
         }
 
         /* Record insertion index to make qsort stable */
@@ -1304,7 +1304,7 @@ static int get_DNS_AdaptersAddresses(char **outptr)
         }
         else
         {
-          addresses[addressesIndex].metric = -1;
+          addresses[addressesIndex].metric = (ULONG)-1;
         }
 
         /* Record insertion index to make qsort stable */
@@ -1405,24 +1405,24 @@ static void replace_comma_by_space(char* str)
  * 'suffix' is one domain suffix, 'len' is the length of 'suffix'.
  * The search ignores case. E.g.:
  * contains_suffix("abc.def,ghi.jkl", "ghi.JKL") returns true  */
-static bool contains_suffix(const char* const searchlist,
+static BOOL contains_suffix(const char* const searchlist,
                             const char* const suffix, const size_t len)
 {
   const char* beg = searchlist;
   const char* end;
   if (!*suffix)
-    return true;
+    return TRUE;
   for (;;)
   {
     while (*beg && (ISSPACE(*beg) || (*beg == ',')))
       ++beg;
     if (!*beg)
-      return false;
+      return FALSE;
     end = beg;
     while (*end && !ISSPACE(*end) && (*end != ','))
       ++end;
-    if (len == (end - beg) && !strnicmp(beg, suffix, len))
-      return true;
+    if (len == (size_t)(end - beg) && !strnicmp(beg, suffix, len))
+      return TRUE;
     beg = end;
   }
 }

--- a/ares_library_init.c
+++ b/ares_library_init.c
@@ -40,9 +40,19 @@ static unsigned int ares_initialized;
 static int          ares_init_flags;
 
 /* library-private global vars with visibility across the whole library */
-void *(*ares_malloc)(size_t size) = malloc;
-void *(*ares_realloc)(void *ptr, size_t size) = realloc;
-void (*ares_free)(void *ptr) = free;
+#if defined(WIN32)
+/* We need indirections to handle Windows DLL rules. */
+static void *default_malloc(size_t size) { return malloc(size); }
+static void *default_realloc(void *p, size_t size) { return realloc(p, size); }
+static void default_free(void *p) { free(p); }
+#else
+# define default_malloc malloc
+# define default_realloc realloc
+# define default_free free
+#endif
+void *(*ares_malloc)(size_t size) = default_malloc;
+void *(*ares_realloc)(void *ptr, size_t size) = default_realloc;
+void (*ares_free)(void *ptr) = default_free;
 
 #ifdef USE_WINSOCK
 static HMODULE hnd_iphlpapi;


### PR DESCRIPTION
These changes fix a few warnings emitted by recent versions of MSVC when compiling with -W4.  Half of the changes are in Windows-specific code, and the other half should be safe no matter the compiler or OS.

The allocation function change is probably the only one that needs explanation.  MSVC gives warnings about the function pointers not being stable across DLL boundaries or something to that effect, so for Windows, I've made them be called indirectly, which at least made the compiler happy.  I can't say I've tested every linking combination on Windows with them before or after the change, but it seems harmless.