### PR TITLE
travis: do coverage in "coverage" build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,4 +110,5 @@ before_script:
          fi
 script:
     - ./travis/build.sh && ./travis/test.sh
-    - if [ "$BUILD_TYPE" = "normal" ]; then ./travis/distcheck.sh && ./travis/covupload.sh; fi
+    - if [ "$BUILD_TYPE" = "normal" ]; then ./travis/distcheck.sh ; fi
+    - if [ "$BUILD_TYPE" = "coverage" ]; then ./travis/covupload.sh ; fi


### PR DESCRIPTION
Fixes #194, a mistake from commit a255081f2c3c ("travis: Only do
coverage/distcheck on normal build")