### PR TITLE
Fixing clang-5.0 compilation errors

### DIFF
--- a/ares__get_hostent.c
+++ b/ares__get_hostent.c
@@ -164,8 +164,7 @@ int ares__get_hostent(FILE *fp, int family, struct hostent **host)
       */
 
       /* Allocate memory for the hostent structure. */
-      void* tempPtr = ares_malloc(sizeof(struct hostent));
-      hostent_ptr = (hostent*)tempPtr;
+      hostent_ptr = (hostent*)ares_malloc(sizeof(struct hostent));
       if (!hostent_ptr)
         break;
 

--- a/ares__get_hostent.c
+++ b/ares__get_hostent.c
@@ -164,7 +164,7 @@ int ares__get_hostent(FILE *fp, int family, struct hostent **host)
       */
 
       /* Allocate memory for the hostent structure. */
-      hostent_ptr = (hostent*)ares_malloc(sizeof(struct hostent));
+      hostent_ptr = (struct hostent*)ares_malloc(sizeof(struct hostent));
       if (!hostent_ptr)
         break;
 

--- a/ares__read_line.c
+++ b/ares__read_line.c
@@ -36,7 +36,7 @@ int ares__read_line(FILE *fp, char **buf, size_t *bufsize)
 
   if (*buf == NULL)
     {
-      *buf = ares_malloc(128);
+      *buf = (char*)ares_malloc(128);
       if (!*buf)
         return ARES_ENOMEM;
       *bufsize = 128;
@@ -59,7 +59,7 @@ int ares__read_line(FILE *fp, char **buf, size_t *bufsize)
         continue;
 
       /* Allocate more space. */
-      newbuf = ares_realloc(*buf, *bufsize * 2);
+      newbuf = (char*)ares_realloc(*buf, *bufsize * 2);
       if (!newbuf)
         {
           ares_free(*buf);

--- a/ares_cancel.c
+++ b/ares_cancel.c
@@ -25,7 +25,7 @@
  */
 void ares_cancel(ares_channel channel)
 {
-  struct query *query;
+  struct query *query_ptr;
   struct list_node list_head_copy;
   struct list_node* list_head;
   struct list_node* list_node;
@@ -46,10 +46,10 @@ void ares_cancel(ares_channel channel)
     list_head->next = list_head;
     for (list_node = list_head_copy.next; list_node != &list_head_copy; )
     {
-      query = list_node->data;
+      query_ptr = (query*)list_node->data;
       list_node = list_node->next;  /* since we're deleting the query */
-      query->callback(query->arg, ARES_ECANCELLED, 0, NULL, 0);
-      ares__free_query(query);
+      query_ptr->callback(query_ptr->arg, ARES_ECANCELLED, 0, NULL, 0);
+      ares__free_query(query_ptr);
     }
   }
   if (!(channel->flags & ARES_FLAG_STAYOPEN) && ares__is_list_empty(&(channel->all_queries)))

--- a/ares_cancel.c
+++ b/ares_cancel.c
@@ -46,7 +46,7 @@ void ares_cancel(ares_channel channel)
     list_head->next = list_head;
     for (list_node = list_head_copy.next; list_node != &list_head_copy; )
     {
-      query_ptr = (query*)list_node->data;
+      query_ptr = (struct query*)list_node->data;
       list_node = list_node->next;  /* since we're deleting the query */
       query_ptr->callback(query_ptr->arg, ARES_ECANCELLED, 0, NULL, 0);
       ares__free_query(query_ptr);

--- a/ares_create_query.c
+++ b/ares_create_query.c
@@ -104,7 +104,7 @@ int ares_create_query(const char *name, int dnsclass, int type,
    */
   len = strlen(name) + 2 + HFIXEDSZ + QFIXEDSZ +
     (max_udp_size ? EDNSFIXEDSZ : 0);
-  buf = ares_malloc(len);
+  buf = (unsigned char *)ares_malloc(len);
   if (!buf)
     return ARES_ENOMEM;
 

--- a/ares_data.c
+++ b/ares_data.c
@@ -50,7 +50,7 @@ void ares_free_data(void *dataptr)
    /* 1684: conversion from pointer to same-sized integral type */
 #endif
 
-    ptr = (void *)((char *)dataptr - offsetof(struct ares_data, data));
+    ptr = (ares_data *)((char *)dataptr - offsetof(struct ares_data, data));
 
 #ifdef __INTEL_COMPILER
 #  pragma warning(pop)
@@ -144,7 +144,7 @@ void *ares_malloc_data(ares_datatype type)
 {
   struct ares_data *ptr;
 
-  ptr = ares_malloc(sizeof(struct ares_data));
+  ptr = (ares_data*)ares_malloc(sizeof(struct ares_data));
   if (!ptr)
     return NULL;
 

--- a/ares_data.c
+++ b/ares_data.c
@@ -50,7 +50,7 @@ void ares_free_data(void *dataptr)
    /* 1684: conversion from pointer to same-sized integral type */
 #endif
 
-    ptr = (ares_data *)((char *)dataptr - offsetof(struct ares_data, data));
+    ptr = (struct ares_data *)((char *)dataptr - offsetof(struct ares_data, data));
 
 #ifdef __INTEL_COMPILER
 #  pragma warning(pop)
@@ -144,7 +144,7 @@ void *ares_malloc_data(ares_datatype type)
 {
   struct ares_data *ptr;
 
-  ptr = (ares_data*)ares_malloc(sizeof(struct ares_data));
+  ptr = (struct ares_data*)ares_malloc(sizeof(struct ares_data));
   if (!ptr)
     return NULL;
 

--- a/ares_destroy.c
+++ b/ares_destroy.c
@@ -51,7 +51,7 @@ void ares_destroy(ares_channel channel)
   list_head = &(channel->all_queries);
   for (list_node = list_head->next; list_node != list_head; )
     {
-      query_ptr = (query*)list_node->data;
+      query_ptr = (struct query*)list_node->data;
       list_node = list_node->next;  /* since we're deleting the query */
       query_ptr->callback(query_ptr->arg, ARES_EDESTRUCTION, 0, NULL, 0);
       ares__free_query(query_ptr);

--- a/ares_destroy.c
+++ b/ares_destroy.c
@@ -41,7 +41,7 @@ void ares_destroy_options(struct ares_options *options)
 void ares_destroy(ares_channel channel)
 {
   int i;
-  struct query *query;
+  struct query *query_ptr;
   struct list_node* list_head;
   struct list_node* list_node;
   
@@ -51,10 +51,10 @@ void ares_destroy(ares_channel channel)
   list_head = &(channel->all_queries);
   for (list_node = list_head->next; list_node != list_head; )
     {
-      query = list_node->data;
+      query_ptr = (query*)list_node->data;
       list_node = list_node->next;  /* since we're deleting the query */
-      query->callback(query->arg, ARES_EDESTRUCTION, 0, NULL, 0);
-      ares__free_query(query);
+      query_ptr->callback(query_ptr->arg, ARES_EDESTRUCTION, 0, NULL, 0);
+      ares__free_query(query_ptr);
     }
 #ifndef NDEBUG
   /* Freeing the query should remove it from all the lists in which it sits,

--- a/ares_expand_name.c
+++ b/ares_expand_name.c
@@ -77,7 +77,7 @@ int ares_expand_name(const unsigned char *encoded, const unsigned char *abuf,
   if (nlen.sig < 0)
     return ARES_EBADNAME;
 
-  *s = ares_malloc(nlen.uns + 1);
+  *s = (char*)ares_malloc(nlen.uns + 1);
   if (!*s)
     return ARES_ENOMEM;
   q = *s;

--- a/ares_expand_string.c
+++ b/ares_expand_string.c
@@ -54,7 +54,7 @@ int ares_expand_string(const unsigned char *encoded,
 
   encoded++;
 
-  *s = ares_malloc(elen.uns+1);
+  *s = (unsigned char*)ares_malloc(elen.uns+1);
   if (*s == NULL)
     return ARES_ENOMEM;
   q = *s;

--- a/ares_gethostbyaddr.c
+++ b/ares_gethostbyaddr.c
@@ -79,7 +79,7 @@ void ares_gethostbyaddr(ares_channel channel, const void *addr, int addrlen,
       return;
     }
 
-  aquery = ares_malloc(sizeof(struct addr_query));
+  aquery = (addr_query*)ares_malloc(sizeof(struct addr_query));
   if (!aquery)
     {
       callback(arg, ARES_ENOMEM, 0, NULL);

--- a/ares_gethostbyaddr.c
+++ b/ares_gethostbyaddr.c
@@ -79,7 +79,7 @@ void ares_gethostbyaddr(ares_channel channel, const void *addr, int addrlen,
       return;
     }
 
-  aquery = (addr_query*)ares_malloc(sizeof(struct addr_query));
+  aquery = (struct addr_query*)ares_malloc(sizeof(struct addr_query));
   if (!aquery)
     {
       callback(arg, ARES_ENOMEM, 0, NULL);

--- a/ares_gethostbyname.c
+++ b/ares_gethostbyname.c
@@ -99,7 +99,7 @@ void ares_gethostbyname(ares_channel channel, const char *name, int family,
     return;
 
   /* Allocate and fill in the host query structure. */
-  hquery = (host_query*)ares_malloc(sizeof(struct host_query));
+  hquery = (struct host_query*)ares_malloc(sizeof(struct host_query));
   if (!hquery)
     {
       callback(arg, ARES_ENOMEM, 0, NULL);

--- a/ares_gethostbyname.c
+++ b/ares_gethostbyname.c
@@ -99,7 +99,7 @@ void ares_gethostbyname(ares_channel channel, const char *name, int family,
     return;
 
   /* Allocate and fill in the host query structure. */
-  hquery = ares_malloc(sizeof(struct host_query));
+  hquery = (host_query*)ares_malloc(sizeof(struct host_query));
   if (!hquery)
     {
       callback(arg, ARES_ENOMEM, 0, NULL);

--- a/ares_getnameinfo.c
+++ b/ares_getnameinfo.c
@@ -163,7 +163,7 @@ void ares_getnameinfo(ares_channel channel, const struct sockaddr *sa,
     /* This is where a DNS lookup becomes necessary */
     else
       {
-        niquery = ares_malloc(sizeof(struct nameinfo_query));
+        niquery = (nameinfo_query*)ares_malloc(sizeof(struct nameinfo_query));
         if (!niquery)
           {
             callback(arg, ARES_ENOMEM, 0, NULL, NULL);
@@ -303,7 +303,7 @@ static char *lookup_service(unsigned short port, int flags,
           sep = &se;
           memset(tmpbuf, 0, sizeof(tmpbuf));
 #if GETSERVBYPORT_R_ARGS == 6
-          if (getservbyport_r(port, proto, &se, (void *)tmpbuf,
+          if (getservbyport_r(port, proto, &se, (char *)tmpbuf,
                               sizeof(tmpbuf), &sep) != 0)
             sep = NULL;  /* LCOV_EXCL_LINE: buffer large so this never fails */
 #elif GETSERVBYPORT_R_ARGS == 5

--- a/ares_getnameinfo.c
+++ b/ares_getnameinfo.c
@@ -163,7 +163,7 @@ void ares_getnameinfo(ares_channel channel, const struct sockaddr *sa,
     /* This is where a DNS lookup becomes necessary */
     else
       {
-        niquery = (nameinfo_query*)ares_malloc(sizeof(struct nameinfo_query));
+        niquery = (struct nameinfo_query*)ares_malloc(sizeof(struct nameinfo_query));
         if (!niquery)
           {
             callback(arg, ARES_ENOMEM, 0, NULL, NULL);

--- a/ares_getopt.c
+++ b/ares_getopt.c
@@ -81,7 +81,7 @@ ares_getopt(int nargc, char * const nargv[], const char *ostr)
         }
     }                                         /* option letter okay? */
     if ((optopt = (int)*place++) == (int)':' ||
-        (oli = strchr(ostr, optopt)) == NULL) {
+        (oli = (char*)strchr(ostr, optopt)) == NULL) {
         /*
          * if the user didn't specify '-' as an option,
          * assume it means EOF.

--- a/ares_init.c
+++ b/ares_init.c
@@ -132,7 +132,7 @@ int ares_init_options(ares_channel *channelptr, struct ares_options *options,
   if (ares_library_initialized() != ARES_SUCCESS)
     return ARES_ENOTINITIALIZED;  /* LCOV_EXCL_LINE: n/a on non-WinSock */
 
-  channel = ares_malloc(sizeof(struct ares_channeldata));
+  channel = (ares_channeldata*)ares_malloc(sizeof(struct ares_channeldata));
   if (!channel) {
     *channelptr = NULL;
     return ARES_ENOMEM;
@@ -377,7 +377,7 @@ int ares_save_options(ares_channel channel, struct ares_options *options,
         ipv4_nservers++;
     }
     if (ipv4_nservers) {
-      options->servers = ares_malloc(ipv4_nservers * sizeof(struct in_addr));
+      options->servers = (in_addr*)ares_malloc(ipv4_nservers * sizeof(struct in_addr));
       if (!options->servers)
         return ARES_ENOMEM;
       for (i = j = 0; i < channel->nservers; i++)
@@ -395,7 +395,7 @@ int ares_save_options(ares_channel channel, struct ares_options *options,
 
   /* copy domains */
   if (channel->ndomains) {
-    options->domains = ares_malloc(channel->ndomains * sizeof(char *));
+    options->domains = (char**)ares_malloc(channel->ndomains * sizeof(char *));
     if (!options->domains)
       return ARES_ENOMEM;
 
@@ -418,7 +418,7 @@ int ares_save_options(ares_channel channel, struct ares_options *options,
 
   /* copy sortlist */
   if (channel->nsort) {
-    options->sortlist = ares_malloc(channel->nsort * sizeof(struct apattern));
+    options->sortlist = (apattern*)ares_malloc(channel->nsort * sizeof(struct apattern));
     if (!options->sortlist)
       return ARES_ENOMEM;
     for (i = 0; i < channel->nsort; i++)
@@ -476,7 +476,7 @@ static int init_by_options(ares_channel channel,
       if (options->nservers > 0)
         {
           channel->servers =
-            ares_malloc(options->nservers * sizeof(struct server_state));
+            (server_state*)ares_malloc(options->nservers * sizeof(struct server_state));
           if (!channel->servers)
             return ARES_ENOMEM;
           for (i = 0; i < options->nservers; i++)
@@ -500,7 +500,7 @@ static int init_by_options(ares_channel channel,
       /* Avoid zero size allocations at any cost */
       if (options->ndomains > 0)
       {
-        channel->domains = ares_malloc(options->ndomains * sizeof(char *));
+        channel->domains = (char**)ares_malloc(options->ndomains * sizeof(char *));
         if (!channel->domains)
           return ARES_ENOMEM;
         for (i = 0; i < options->ndomains; i++)
@@ -525,7 +525,7 @@ static int init_by_options(ares_channel channel,
   /* copy sortlist */
   if ((optmask & ARES_OPT_SORTLIST) && (channel->nsort == -1)) {
     if (options->nsort > 0) {
-      channel->sortlist = ares_malloc(options->nsort * sizeof(struct apattern));
+      channel->sortlist = (apattern*)ares_malloc(options->nsort * sizeof(struct apattern));
       if (!channel->sortlist)
         return ARES_ENOMEM;
       for (i = 0; i < options->nsort; i++)
@@ -1873,7 +1873,7 @@ static int init_by_defaults(ares_channel channel)
 
   if (channel->nservers == -1) {
     /* If nobody specified servers, try a local named. */
-    channel->servers = ares_malloc(sizeof(struct server_state));
+    channel->servers = (server_state*)ares_malloc(sizeof(struct server_state));
     if (!channel->servers) {
       rc = ARES_ENOMEM;
       goto error;
@@ -1906,7 +1906,7 @@ static int init_by_defaults(ares_channel channel)
     int res;
     channel->ndomains = 0; /* default to none */
 
-    hostname = ares_malloc(len);
+    hostname = (char*)ares_malloc(len);
     if(!hostname) {
       rc = ARES_ENOMEM;
       goto error;
@@ -1919,7 +1919,7 @@ static int init_by_defaults(ares_channel channel)
         char *p;
         len *= 2;
         lenv *= 2;
-        p = ares_realloc(hostname, len);
+        p = (char*)ares_realloc(hostname, len);
         if(!p) {
           rc = ARES_ENOMEM;
           goto error;
@@ -1939,7 +1939,7 @@ static int init_by_defaults(ares_channel channel)
     dot = strchr(hostname, '.');
     if (dot) {
       /* a dot was found */
-      channel->domains = ares_malloc(sizeof(char *));
+      channel->domains = (char**)ares_malloc(sizeof(char *));
       if (!channel->domains) {
         rc = ARES_ENOMEM;
         goto error;
@@ -2160,7 +2160,7 @@ static int config_nameserver(struct server_state **servers, int *nservers,
         continue;
 
       /* Resize servers state array. */
-      newserv = ares_realloc(*servers, (*nservers + 1) *
+      newserv = (server_state*)ares_realloc(*servers, (*nservers + 1) *
                              sizeof(struct server_state));
       if (!newserv)
         return ARES_ENOMEM;
@@ -2308,7 +2308,7 @@ static int set_search(ares_channel channel, const char *str)
       return ARES_SUCCESS;
     }
 
-  channel->domains = ares_malloc(n * sizeof(char *));
+  channel->domains = (char**)ares_malloc(n * sizeof(char *));
   if (!channel->domains)
     return ARES_ENOMEM;
 
@@ -2321,7 +2321,7 @@ static int set_search(ares_channel channel, const char *str)
       q = p;
       while (*q && !ISSPACE(*q))
         q++;
-      channel->domains[n] = ares_malloc(q - p + 1);
+      channel->domains[n] = (char*)ares_malloc(q - p + 1);
       if (!channel->domains[n])
         return ARES_ENOMEM;
       memcpy(channel->domains[n], p, q - p);
@@ -2482,7 +2482,7 @@ static int sortlist_alloc(struct apattern **sortlist, int *nsort,
                           struct apattern *pat)
 {
   struct apattern *newsort;
-  newsort = ares_realloc(*sortlist, (*nsort + 1) * sizeof(struct apattern));
+  newsort = (apattern*)ares_realloc(*sortlist, (*nsort + 1) * sizeof(struct apattern));
   if (!newsort)
     return 0;
   newsort[*nsort] = *pat;
@@ -2534,7 +2534,7 @@ static int init_id_key(rc4_key* key,int key_data_len)
   short counter;
   unsigned char *key_data_ptr = 0;
 
-  key_data_ptr = ares_malloc(key_data_len);
+  key_data_ptr = (unsigned char*)ares_malloc(key_data_len);
   if (!key_data_ptr)
     return ARES_ENOMEM;
   memset(key_data_ptr, 0, key_data_len);

--- a/ares_init.c
+++ b/ares_init.c
@@ -1873,7 +1873,7 @@ static int init_by_defaults(ares_channel channel)
 
   if (channel->nservers == -1) {
     /* If nobody specified servers, try a local named. */
-    channel->servers = (server_state*)ares_malloc(sizeof(struct server_state));
+    channel->servers = (struct server_state*)ares_malloc(sizeof(struct server_state));
     if (!channel->servers) {
       rc = ARES_ENOMEM;
       goto error;
@@ -2482,7 +2482,7 @@ static int sortlist_alloc(struct apattern **sortlist, int *nsort,
                           struct apattern *pat)
 {
   struct apattern *newsort;
-  newsort = (apattern*)ares_realloc(*sortlist, (*nsort + 1) * sizeof(struct apattern));
+  newsort = (struct apattern*)ares_realloc(*sortlist, (*nsort + 1) * sizeof(struct apattern));
   if (!newsort)
     return 0;
   newsort[*nsort] = *pat;

--- a/ares_init.c
+++ b/ares_init.c
@@ -476,7 +476,7 @@ static int init_by_options(ares_channel channel,
       if (options->nservers > 0)
         {
           channel->servers =
-            (server_state*)ares_malloc(options->nservers * sizeof(struct server_state));
+            (struct server_state*)ares_malloc(options->nservers * sizeof(struct server_state));
           if (!channel->servers)
             return ARES_ENOMEM;
           for (i = 0; i < options->nservers; i++)

--- a/ares_init.c
+++ b/ares_init.c
@@ -132,7 +132,7 @@ int ares_init_options(ares_channel *channelptr, struct ares_options *options,
   if (ares_library_initialized() != ARES_SUCCESS)
     return ARES_ENOTINITIALIZED;  /* LCOV_EXCL_LINE: n/a on non-WinSock */
 
-  channel = (ares_channeldata*)ares_malloc(sizeof(struct ares_channeldata));
+  channel = (struct ares_channeldata*)ares_malloc(sizeof(struct ares_channeldata));
   if (!channel) {
     *channelptr = NULL;
     return ARES_ENOMEM;
@@ -377,7 +377,7 @@ int ares_save_options(ares_channel channel, struct ares_options *options,
         ipv4_nservers++;
     }
     if (ipv4_nservers) {
-      options->servers = (in_addr*)ares_malloc(ipv4_nservers * sizeof(struct in_addr));
+      options->servers = (struct in_addr*)ares_malloc(ipv4_nservers * sizeof(struct in_addr));
       if (!options->servers)
         return ARES_ENOMEM;
       for (i = j = 0; i < channel->nservers; i++)
@@ -418,7 +418,7 @@ int ares_save_options(ares_channel channel, struct ares_options *options,
 
   /* copy sortlist */
   if (channel->nsort) {
-    options->sortlist = (apattern*)ares_malloc(channel->nsort * sizeof(struct apattern));
+    options->sortlist = (struct apattern*)ares_malloc(channel->nsort * sizeof(struct apattern));
     if (!options->sortlist)
       return ARES_ENOMEM;
     for (i = 0; i < channel->nsort; i++)
@@ -525,7 +525,7 @@ static int init_by_options(ares_channel channel,
   /* copy sortlist */
   if ((optmask & ARES_OPT_SORTLIST) && (channel->nsort == -1)) {
     if (options->nsort > 0) {
-      channel->sortlist = (apattern*)ares_malloc(options->nsort * sizeof(struct apattern));
+      channel->sortlist = (struct apattern*)ares_malloc(options->nsort * sizeof(struct apattern));
       if (!channel->sortlist)
         return ARES_ENOMEM;
       for (i = 0; i < options->nsort; i++)
@@ -2160,7 +2160,7 @@ static int config_nameserver(struct server_state **servers, int *nservers,
         continue;
 
       /* Resize servers state array. */
-      newserv = (server_state*)ares_realloc(*servers, (*nservers + 1) *
+      newserv = (struct server_state*)ares_realloc(*servers, (*nservers + 1) *
                              sizeof(struct server_state));
       if (!newserv)
         return ARES_ENOMEM;

--- a/ares_options.c
+++ b/ares_options.c
@@ -43,7 +43,7 @@ int ares_get_servers(ares_channel channel,
   for (i = 0; i < channel->nservers; i++)
     {
       /* Allocate storage for this server node appending it to the list */
-      srvr_curr = ares_malloc_data(ARES_DATATYPE_ADDR_NODE);
+      srvr_curr = (ares_addr_node*)ares_malloc_data(ARES_DATATYPE_ADDR_NODE);
       if (!srvr_curr)
         {
           status = ARES_ENOMEM;
@@ -98,7 +98,7 @@ int ares_get_servers_ports(ares_channel channel,
   for (i = 0; i < channel->nservers; i++)
     {
       /* Allocate storage for this server node appending it to the list */
-      srvr_curr = ares_malloc_data(ARES_DATATYPE_ADDR_PORT_NODE);
+      srvr_curr = (ares_addr_port_node*)ares_malloc_data(ARES_DATATYPE_ADDR_PORT_NODE);
       if (!srvr_curr)
         {
           status = ARES_ENOMEM;
@@ -166,7 +166,7 @@ int ares_set_servers(ares_channel channel,
   if (num_srvrs > 0)
     {
       /* Allocate storage for servers state */
-      channel->servers = ares_malloc(num_srvrs * sizeof(struct server_state));
+      channel->servers = (server_state*)ares_malloc(num_srvrs * sizeof(struct server_state));
       if (!channel->servers)
         {
           return ARES_ENOMEM;
@@ -218,7 +218,7 @@ int ares_set_servers_ports(ares_channel channel,
   if (num_srvrs > 0)
     {
       /* Allocate storage for servers state */
-      channel->servers = ares_malloc(num_srvrs * sizeof(struct server_state));
+      channel->servers = (server_state*)ares_malloc(num_srvrs * sizeof(struct server_state));
       if (!channel->servers)
         {
           return ARES_ENOMEM;
@@ -268,7 +268,7 @@ static int set_servers_csv(ares_channel channel,
   if (i == 0)
      return ARES_SUCCESS; /* blank all servers */
 
-  csv = ares_malloc(i + 2);
+  csv = (char*)ares_malloc(i + 2);
   if (!csv)
     return ARES_ENOMEM;
 
@@ -339,7 +339,7 @@ static int set_servers_csv(ares_channel channel,
           goto out;
         }
         /* was ipv6, add new server */
-        s = ares_malloc(sizeof(*s));
+        s = (ares_addr_port_node*)ares_malloc(sizeof(*s));
         if (!s) {
           rv = ARES_ENOMEM;
           goto out;
@@ -349,7 +349,7 @@ static int set_servers_csv(ares_channel channel,
       }
       else {
         /* was ipv4, add new server */
-        s = ares_malloc(sizeof(*s));
+        s = (ares_addr_port_node*)ares_malloc(sizeof(*s));
         if (!s) {
           rv = ARES_ENOMEM;
           goto out;

--- a/ares_options.c
+++ b/ares_options.c
@@ -43,7 +43,7 @@ int ares_get_servers(ares_channel channel,
   for (i = 0; i < channel->nservers; i++)
     {
       /* Allocate storage for this server node appending it to the list */
-      srvr_curr = (ares_addr_node*)ares_malloc_data(ARES_DATATYPE_ADDR_NODE);
+      srvr_curr = (struct ares_addr_node*)ares_malloc_data(ARES_DATATYPE_ADDR_NODE);
       if (!srvr_curr)
         {
           status = ARES_ENOMEM;
@@ -98,7 +98,7 @@ int ares_get_servers_ports(ares_channel channel,
   for (i = 0; i < channel->nservers; i++)
     {
       /* Allocate storage for this server node appending it to the list */
-      srvr_curr = (ares_addr_port_node*)ares_malloc_data(ARES_DATATYPE_ADDR_PORT_NODE);
+      srvr_curr = (struct ares_addr_port_node*)ares_malloc_data(ARES_DATATYPE_ADDR_PORT_NODE);
       if (!srvr_curr)
         {
           status = ARES_ENOMEM;
@@ -166,7 +166,7 @@ int ares_set_servers(ares_channel channel,
   if (num_srvrs > 0)
     {
       /* Allocate storage for servers state */
-      channel->servers = (server_state*)ares_malloc(num_srvrs * sizeof(struct server_state));
+      channel->servers = (struct server_state*)ares_malloc(num_srvrs * sizeof(struct server_state));
       if (!channel->servers)
         {
           return ARES_ENOMEM;
@@ -218,7 +218,7 @@ int ares_set_servers_ports(ares_channel channel,
   if (num_srvrs > 0)
     {
       /* Allocate storage for servers state */
-      channel->servers = (server_state*)ares_malloc(num_srvrs * sizeof(struct server_state));
+      channel->servers = (struct server_state*)ares_malloc(num_srvrs * sizeof(struct server_state));
       if (!channel->servers)
         {
           return ARES_ENOMEM;
@@ -339,7 +339,7 @@ static int set_servers_csv(ares_channel channel,
           goto out;
         }
         /* was ipv6, add new server */
-        s = (ares_addr_port_node*)ares_malloc(sizeof(*s));
+        s = (struct ares_addr_port_node*)ares_malloc(sizeof(*s));
         if (!s) {
           rv = ARES_ENOMEM;
           goto out;
@@ -349,7 +349,7 @@ static int set_servers_csv(ares_channel channel,
       }
       else {
         /* was ipv4, add new server */
-        s = (ares_addr_port_node*)ares_malloc(sizeof(*s));
+        s = (struct ares_addr_port_node*)ares_malloc(sizeof(*s));
         if (!s) {
           rv = ARES_ENOMEM;
           goto out;

--- a/ares_parse_a_reply.c
+++ b/ares_parse_a_reply.c
@@ -94,7 +94,7 @@ int ares_parse_a_reply(const unsigned char *abuf, int alen,
     {
       /* Allocate addresses and aliases; ancount gives an upper bound for
          both. */
-      addrs = (in_addr*)ares_malloc(ancount * sizeof(struct in_addr));
+      addrs = (struct in_addr*)ares_malloc(ancount * sizeof(struct in_addr));
       if (!addrs)
         {
           ares_free(hostname);
@@ -228,7 +228,7 @@ int ares_parse_a_reply(const unsigned char *abuf, int alen,
       if (host)
         {
           /* Allocate memory to build the host entry. */
-          hostent_ptr = (hostent*)ares_malloc(sizeof(struct hostent));
+          hostent_ptr = (struct hostent*)ares_malloc(sizeof(struct hostent));
           if (hostent_ptr)
             {
               hostent_ptr->h_addr_list = (char**)ares_malloc((naddrs + 1) * sizeof(char *));

--- a/ares_parse_a_reply.c
+++ b/ares_parse_a_reply.c
@@ -58,7 +58,7 @@ int ares_parse_a_reply(const unsigned char *abuf, int alen,
   const unsigned char *aptr;
   char *hostname, *rr_name, *rr_data, **aliases;
   struct in_addr *addrs;
-  struct hostent *hostent;
+  struct hostent *hostent_ptr;
   const int max_addr_ttls = (addrttls && naddrttls) ? *naddrttls : 0;
 
   /* Set *host to NULL for all failure cases. */
@@ -94,13 +94,13 @@ int ares_parse_a_reply(const unsigned char *abuf, int alen,
     {
       /* Allocate addresses and aliases; ancount gives an upper bound for
          both. */
-      addrs = ares_malloc(ancount * sizeof(struct in_addr));
+      addrs = (in_addr*)ares_malloc(ancount * sizeof(struct in_addr));
       if (!addrs)
         {
           ares_free(hostname);
           return ARES_ENOMEM;
         }
-      aliases = ares_malloc((ancount + 1) * sizeof(char *));
+      aliases = (char**)ares_malloc((ancount + 1) * sizeof(char *));
       if (!aliases)
         {
           ares_free(hostname);
@@ -228,26 +228,26 @@ int ares_parse_a_reply(const unsigned char *abuf, int alen,
       if (host)
         {
           /* Allocate memory to build the host entry. */
-          hostent = ares_malloc(sizeof(struct hostent));
-          if (hostent)
+          hostent_ptr = (hostent*)ares_malloc(sizeof(struct hostent));
+          if (hostent_ptr)
             {
-              hostent->h_addr_list = ares_malloc((naddrs + 1) * sizeof(char *));
-              if (hostent->h_addr_list)
+              hostent_ptr->h_addr_list = (char**)ares_malloc((naddrs + 1) * sizeof(char *));
+              if (hostent_ptr->h_addr_list)
                 {
                   /* Fill in the hostent and return successfully. */
-                  hostent->h_name = hostname;
-                  hostent->h_aliases = aliases;
-                  hostent->h_addrtype = AF_INET;
-                  hostent->h_length = sizeof(struct in_addr);
+                  hostent_ptr->h_name = hostname;
+                  hostent_ptr->h_aliases = aliases;
+                  hostent_ptr->h_addrtype = AF_INET;
+                  hostent_ptr->h_length = sizeof(struct in_addr);
                   for (i = 0; i < naddrs; i++)
-                    hostent->h_addr_list[i] = (char *) &addrs[i];
-                  hostent->h_addr_list[naddrs] = NULL;
+                    hostent_ptr->h_addr_list[i] = (char *) &addrs[i];
+                  hostent_ptr->h_addr_list[naddrs] = NULL;
                   if (!naddrs && addrs)
                     ares_free(addrs);
-                  *host = hostent;
+                  *host = hostent_ptr;
                   return ARES_SUCCESS;
                 }
-              ares_free(hostent);
+              ares_free(hostent_ptr);
             }
           status = ARES_ENOMEM;
         }

--- a/ares_parse_aaaa_reply.c
+++ b/ares_parse_aaaa_reply.c
@@ -95,7 +95,7 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
   /* Allocate addresses and aliases; ancount gives an upper bound for both. */
   if (host)
     {
-      addrs = (ares_in6_addr*)ares_malloc(ancount * sizeof(struct ares_in6_addr));
+      addrs = (struct ares_in6_addr*)ares_malloc(ancount * sizeof(struct ares_in6_addr));
       if (!addrs)
         {
           ares_free(hostname);
@@ -228,7 +228,7 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
       if (host)
         {
           /* Allocate memory to build the host entry. */
-          hostent_ptr = (hostent*)ares_malloc(sizeof(struct hostent));
+          hostent_ptr = (struct hostent*)ares_malloc(sizeof(struct hostent));
           if (hostent_ptr)
             {
               hostent_ptr->h_addr_list = (char**)ares_malloc((naddrs + 1) * sizeof(char *));

--- a/ares_parse_aaaa_reply.c
+++ b/ares_parse_aaaa_reply.c
@@ -60,7 +60,7 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
   const unsigned char *aptr;
   char *hostname, *rr_name, *rr_data, **aliases;
   struct ares_in6_addr *addrs;
-  struct hostent *hostent;
+  struct hostent *hostent_ptr;
   const int max_addr_ttls = (addrttls && naddrttls) ? *naddrttls : 0;
 
   /* Set *host to NULL for all failure cases. */
@@ -95,13 +95,13 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
   /* Allocate addresses and aliases; ancount gives an upper bound for both. */
   if (host)
     {
-      addrs = ares_malloc(ancount * sizeof(struct ares_in6_addr));
+      addrs = (ares_in6_addr*)ares_malloc(ancount * sizeof(struct ares_in6_addr));
       if (!addrs)
         {
           ares_free(hostname);
           return ARES_ENOMEM;
         }
-      aliases = ares_malloc((ancount + 1) * sizeof(char *));
+      aliases = (char**)ares_malloc((ancount + 1) * sizeof(char *));
       if (!aliases)
         {
           ares_free(hostname);
@@ -228,26 +228,26 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
       if (host)
         {
           /* Allocate memory to build the host entry. */
-          hostent = ares_malloc(sizeof(struct hostent));
-          if (hostent)
+          hostent_ptr = (hostent*)ares_malloc(sizeof(struct hostent));
+          if (hostent_ptr)
             {
-              hostent->h_addr_list = ares_malloc((naddrs + 1) * sizeof(char *));
-              if (hostent->h_addr_list)
+              hostent_ptr->h_addr_list = (char**)ares_malloc((naddrs + 1) * sizeof(char *));
+              if (hostent_ptr->h_addr_list)
                 {
                   /* Fill in the hostent and return successfully. */
-                  hostent->h_name = hostname;
-                  hostent->h_aliases = aliases;
-                  hostent->h_addrtype = AF_INET6;
-                  hostent->h_length = sizeof(struct ares_in6_addr);
+                  hostent_ptr->h_name = hostname;
+                  hostent_ptr->h_aliases = aliases;
+                  hostent_ptr->h_addrtype = AF_INET6;
+                  hostent_ptr->h_length = sizeof(struct ares_in6_addr);
                   for (i = 0; i < naddrs; i++)
-                    hostent->h_addr_list[i] = (char *) &addrs[i];
-                  hostent->h_addr_list[naddrs] = NULL;
+                    hostent_ptr->h_addr_list[i] = (char *) &addrs[i];
+                  hostent_ptr->h_addr_list[naddrs] = NULL;
                   if (!naddrs && addrs)
                     ares_free(addrs);
-                  *host = hostent;
+                  *host = hostent_ptr;
                   return ARES_SUCCESS;
                 }
-              ares_free(hostent);
+              ares_free(hostent_ptr);
             }
           status = ARES_ENOMEM;
         }

--- a/ares_parse_mx_reply.c
+++ b/ares_parse_mx_reply.c
@@ -117,7 +117,7 @@ ares_parse_mx_reply (const unsigned char *abuf, int alen,
             }
 
           /* Allocate storage for this MX answer appending it to the list */
-          mx_curr = ares_malloc_data(ARES_DATATYPE_MX_REPLY);
+          mx_curr = (ares_mx_reply*)(ARES_DATATYPE_MX_REPLY);
           if (!mx_curr)
             {
               status = ARES_ENOMEM;

--- a/ares_parse_mx_reply.c
+++ b/ares_parse_mx_reply.c
@@ -117,7 +117,7 @@ ares_parse_mx_reply (const unsigned char *abuf, int alen,
             }
 
           /* Allocate storage for this MX answer appending it to the list */
-          mx_curr = (ares_mx_reply*)(ARES_DATATYPE_MX_REPLY);
+          mx_curr = (struct ares_mx_reply*)(ARES_DATATYPE_MX_REPLY);
           if (!mx_curr)
             {
               status = ARES_ENOMEM;

--- a/ares_parse_naptr_reply.c
+++ b/ares_parse_naptr_reply.c
@@ -124,7 +124,7 @@ ares_parse_naptr_reply (const unsigned char *abuf, int alen,
             }
 
           /* Allocate storage for this NAPTR answer appending it to the list */
-          naptr_curr = ares_malloc_data(ARES_DATATYPE_NAPTR_REPLY);
+          naptr_curr = (ares_naptr_reply*)ares_malloc_data(ARES_DATATYPE_NAPTR_REPLY);
           if (!naptr_curr)
             {
               status = ARES_ENOMEM;

--- a/ares_parse_naptr_reply.c
+++ b/ares_parse_naptr_reply.c
@@ -124,7 +124,7 @@ ares_parse_naptr_reply (const unsigned char *abuf, int alen,
             }
 
           /* Allocate storage for this NAPTR answer appending it to the list */
-          naptr_curr = (ares_naptr_reply*)ares_malloc_data(ARES_DATATYPE_NAPTR_REPLY);
+          naptr_curr = (struct ares_naptr_reply*)ares_malloc_data(ARES_DATATYPE_NAPTR_REPLY);
           if (!naptr_curr)
             {
               status = ARES_ENOMEM;

--- a/ares_parse_ns_reply.c
+++ b/ares_parse_ns_reply.c
@@ -156,7 +156,7 @@ int ares_parse_ns_reply( const unsigned char* abuf, int alen,
   {
     /* We got our answer.  Allocate memory to build the host entry. */
     nameservers[nameservers_num] = NULL;
-    hostent_ptr = (hostent*)ares_malloc( sizeof( struct hostent ) );
+    hostent_ptr = (struct hostent*)ares_malloc( sizeof( struct hostent ) );
     if ( hostent_ptr )
     {
       hostent_ptr->h_addr_list = (char**)ares_malloc( 1 * sizeof( char * ) );

--- a/ares_parse_ns_reply.c
+++ b/ares_parse_ns_reply.c
@@ -51,7 +51,7 @@ int ares_parse_ns_reply( const unsigned char* abuf, int alen,
   long len;
   const unsigned char *aptr;
   char* hostname, *rr_name, *rr_data, **nameservers;
-  struct hostent *hostent;
+  struct hostent *hostent_ptr;
 
   /* Set *host to NULL for all failure cases. */
   *host = NULL;
@@ -79,7 +79,7 @@ int ares_parse_ns_reply( const unsigned char* abuf, int alen,
   aptr += len + QFIXEDSZ;
 
   /* Allocate nameservers array; ancount gives an upper bound */
-  nameservers = ares_malloc( ( ancount + 1 ) * sizeof( char * ) );
+  nameservers = (char**)ares_malloc( ( ancount + 1 ) * sizeof( char * ) );
   if ( !nameservers )
   {
     ares_free( hostname );
@@ -123,7 +123,7 @@ int ares_parse_ns_reply( const unsigned char* abuf, int alen,
         break;
       }
 
-      nameservers[nameservers_num] = ares_malloc(strlen(rr_data)+1);
+      nameservers[nameservers_num] = (char*)ares_malloc(strlen(rr_data)+1);
 
       if (nameservers[nameservers_num]==NULL)
       {
@@ -156,22 +156,22 @@ int ares_parse_ns_reply( const unsigned char* abuf, int alen,
   {
     /* We got our answer.  Allocate memory to build the host entry. */
     nameservers[nameservers_num] = NULL;
-    hostent = ares_malloc( sizeof( struct hostent ) );
-    if ( hostent )
+    hostent_ptr = (hostent*)ares_malloc( sizeof( struct hostent ) );
+    if ( hostent_ptr )
     {
-      hostent->h_addr_list = ares_malloc( 1 * sizeof( char * ) );
-      if ( hostent->h_addr_list )
+      hostent_ptr->h_addr_list = (char**)ares_malloc( 1 * sizeof( char * ) );
+      if ( hostent_ptr->h_addr_list )
       {
         /* Fill in the hostent and return successfully. */
-        hostent->h_name = hostname;
-        hostent->h_aliases = nameservers;
-        hostent->h_addrtype = AF_INET;
-        hostent->h_length = sizeof( struct in_addr );
-        hostent->h_addr_list[0] = NULL;
-        *host = hostent;
+        hostent_ptr->h_name = hostname;
+        hostent_ptr->h_aliases = nameservers;
+        hostent_ptr->h_addrtype = AF_INET;
+        hostent_ptr->h_length = sizeof( struct in_addr );
+        hostent_ptr->h_addr_list[0] = NULL;
+        *host = hostent_ptr;
         return ARES_SUCCESS;
       }
-      ares_free( hostent );
+      ares_free( hostent_ptr );
     }
     status = ARES_ENOMEM;
   }

--- a/ares_parse_ptr_reply.c
+++ b/ares_parse_ptr_reply.c
@@ -174,7 +174,7 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
   if (status == ARES_SUCCESS)
     {
       /* We got our answer.  Allocate memory to build the host entry. */
-      hostent_ptr = (hostent*)ares_malloc(sizeof(struct hostent));
+      hostent_ptr = (struct hostent*)ares_malloc(sizeof(struct hostent));
       if (hostent_ptr)
         {
           hostent_ptr->h_addr_list = (char**)ares_malloc(2 * sizeof(char *));

--- a/ares_parse_ptr_reply.c
+++ b/ares_parse_ptr_reply.c
@@ -48,7 +48,7 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
   long len;
   const unsigned char *aptr;
   char *ptrname, *hostname, *rr_name, *rr_data;
-  struct hostent *hostent;
+  struct hostent *hostent_ptr;
   int aliascnt = 0;
   int alias_alloc = 8;
   char ** aliases;
@@ -80,7 +80,7 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
 
   /* Examine each answer resource record (RR) in turn. */
   hostname = NULL;
-  aliases = ares_malloc(alias_alloc * sizeof(char *));
+  aliases = (char**)ares_malloc(alias_alloc * sizeof(char *));
   if (!aliases)
     {
       ares_free(ptrname);
@@ -124,7 +124,7 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
           if (hostname)
             ares_free(hostname);
           hostname = rr_data;
-          aliases[aliascnt] = ares_malloc((strlen(rr_data)+1) * sizeof(char));
+          aliases[aliascnt] = (char*)ares_malloc((strlen(rr_data)+1) * sizeof(char));
           if (!aliases[aliascnt])
             {
               ares_free(rr_name);
@@ -136,7 +136,7 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
           if (aliascnt >= alias_alloc) {
             char **ptr;
             alias_alloc *= 2;
-            ptr = ares_realloc(aliases, alias_alloc * sizeof(char *));
+            ptr = (char**)ares_realloc(aliases, alias_alloc * sizeof(char *));
             if(!ptr) {
               ares_free(rr_name);
               status = ARES_ENOMEM;
@@ -174,37 +174,37 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
   if (status == ARES_SUCCESS)
     {
       /* We got our answer.  Allocate memory to build the host entry. */
-      hostent = ares_malloc(sizeof(struct hostent));
-      if (hostent)
+      hostent_ptr = (hostent*)ares_malloc(sizeof(struct hostent));
+      if (hostent_ptr)
         {
-          hostent->h_addr_list = ares_malloc(2 * sizeof(char *));
-          if (hostent->h_addr_list)
+          hostent_ptr->h_addr_list = (char**)ares_malloc(2 * sizeof(char *));
+          if (hostent_ptr->h_addr_list)
             {
-              hostent->h_addr_list[0] = ares_malloc(addrlen);
-              if (hostent->h_addr_list[0])
+              hostent_ptr->h_addr_list[0] = (char*)ares_malloc(addrlen);
+              if (hostent_ptr->h_addr_list[0])
                 {
-                  hostent->h_aliases = ares_malloc((aliascnt+1) * sizeof (char *));
-                  if (hostent->h_aliases)
+                  hostent_ptr->h_aliases = (char**)ares_malloc((aliascnt+1) * sizeof (char *));
+                  if (hostent_ptr->h_aliases)
                     {
                       /* Fill in the hostent and return successfully. */
-                      hostent->h_name = hostname;
+                      hostent_ptr->h_name = hostname;
                       for (i=0 ; i<aliascnt ; i++)
-                        hostent->h_aliases[i] = aliases[i];
-                      hostent->h_aliases[aliascnt] = NULL;
-                      hostent->h_addrtype = aresx_sitoss(family);
-                      hostent->h_length = aresx_sitoss(addrlen);
-                      memcpy(hostent->h_addr_list[0], addr, addrlen);
-                      hostent->h_addr_list[1] = NULL;
-                      *host = hostent;
+                        hostent_ptr->h_aliases[i] = aliases[i];
+                      hostent_ptr->h_aliases[aliascnt] = NULL;
+                      hostent_ptr->h_addrtype = aresx_sitoss(family);
+                      hostent_ptr->h_length = aresx_sitoss(addrlen);
+                      memcpy(hostent_ptr->h_addr_list[0], addr, addrlen);
+                      hostent_ptr->h_addr_list[1] = NULL;
+                      *host = hostent_ptr;
                       ares_free(aliases);
                       ares_free(ptrname);
                       return ARES_SUCCESS;
                     }
-                  ares_free(hostent->h_addr_list[0]);
+                  ares_free(hostent_ptr->h_addr_list[0]);
                 }
-              ares_free(hostent->h_addr_list);
+              ares_free(hostent_ptr->h_addr_list);
             }
-          ares_free(hostent);
+          ares_free(hostent_ptr);
         }
       status = ARES_ENOMEM;
     }

--- a/ares_parse_soa_reply.c
+++ b/ares_parse_soa_reply.c
@@ -84,7 +84,7 @@ ares_parse_soa_reply(const unsigned char *abuf, int alen,
   aptr += RRFIXEDSZ;
 
   /* allocate result struct */
-  soa = ares_malloc_data(ARES_DATATYPE_SOA_REPLY);
+  soa = (ares_soa_reply*)ares_malloc_data(ARES_DATATYPE_SOA_REPLY);
   if (!soa)
     {
       status = ARES_ENOMEM;

--- a/ares_parse_soa_reply.c
+++ b/ares_parse_soa_reply.c
@@ -84,7 +84,7 @@ ares_parse_soa_reply(const unsigned char *abuf, int alen,
   aptr += RRFIXEDSZ;
 
   /* allocate result struct */
-  soa = (ares_soa_reply*)ares_malloc_data(ARES_DATATYPE_SOA_REPLY);
+  soa = (struct ares_soa_reply*)ares_malloc_data(ARES_DATATYPE_SOA_REPLY);
   if (!soa)
     {
       status = ARES_ENOMEM;

--- a/ares_parse_srv_reply.c
+++ b/ares_parse_srv_reply.c
@@ -122,7 +122,7 @@ ares_parse_srv_reply (const unsigned char *abuf, int alen,
             }
 
           /* Allocate storage for this SRV answer appending it to the list */
-          srv_curr = ares_malloc_data(ARES_DATATYPE_SRV_REPLY);
+          srv_curr = (ares_srv_reply*)ares_malloc_data(ARES_DATATYPE_SRV_REPLY);
           if (!srv_curr)
             {
               status = ARES_ENOMEM;

--- a/ares_parse_srv_reply.c
+++ b/ares_parse_srv_reply.c
@@ -122,7 +122,7 @@ ares_parse_srv_reply (const unsigned char *abuf, int alen,
             }
 
           /* Allocate storage for this SRV answer appending it to the list */
-          srv_curr = (ares_srv_reply*)ares_malloc_data(ARES_DATATYPE_SRV_REPLY);
+          srv_curr = (struct ares_srv_reply*)ares_malloc_data(ARES_DATATYPE_SRV_REPLY);
           if (!srv_curr)
             {
               status = ARES_ENOMEM;

--- a/ares_parse_txt_reply.c
+++ b/ares_parse_txt_reply.c
@@ -134,7 +134,7 @@ ares__parse_txt_reply (const unsigned char *abuf, int alen,
                 }
 
               /* Allocate storage for this TXT answer appending it to the list */
-              txt_curr = ares_malloc_data(ex ? ARES_DATATYPE_TXT_EXT :
+              txt_curr = (ares_txt_ext*)ares_malloc_data(ex ? ARES_DATATYPE_TXT_EXT :
                                                ARES_DATATYPE_TXT_REPLY);
               if (!txt_curr)
                 {
@@ -154,7 +154,7 @@ ares__parse_txt_reply (const unsigned char *abuf, int alen,
               if (ex)
                 txt_curr->record_start = (strptr == aptr);
               txt_curr->length = substr_len;
-              txt_curr->txt = ares_malloc (substr_len + 1/* Including null byte */);
+              txt_curr->txt = (unsigned char*)ares_malloc (substr_len + 1/* Including null byte */);
               if (txt_curr->txt == NULL)
                 {
                   status = ARES_ENOMEM;

--- a/ares_parse_txt_reply.c
+++ b/ares_parse_txt_reply.c
@@ -134,7 +134,7 @@ ares__parse_txt_reply (const unsigned char *abuf, int alen,
                 }
 
               /* Allocate storage for this TXT answer appending it to the list */
-              txt_curr = (ares_txt_ext*)ares_malloc_data(ex ? ARES_DATATYPE_TXT_EXT :
+              txt_curr = (struct ares_txt_ext*)ares_malloc_data(ex ? ARES_DATATYPE_TXT_EXT :
                                                ARES_DATATYPE_TXT_REPLY);
               if (!txt_curr)
                 {

--- a/ares_process.c
+++ b/ares_process.c
@@ -251,7 +251,7 @@ static void write_tcp_data(ares_channel channel,
         n++;
 
       /* Allocate iovecs so we can send all our data at once. */
-      vec = (iovec*)ares_malloc(n * sizeof(struct iovec));
+      vec = (struct iovec*)ares_malloc(n * sizeof(struct iovec));
       if (vec)
         {
           /* Fill in the iovecs and send. */
@@ -552,7 +552,7 @@ static void process_timeouts(ares_channel channel, struct timeval *now)
       list_head = &(channel->queries_by_timeout[t % ARES_TIMEOUT_TABLE_SIZE]);
       for (list_node = list_head->next; list_node != list_head; )
         {
-          query_ptr = (query*)list_node->data;
+          query_ptr = (struct query*)list_node->data;
           list_node = list_node->next;  /* in case the query gets deleted */
           if (query_ptr->timeout.tv_sec && ares__timedout(now, &query_ptr->timeout))
             {
@@ -732,7 +732,7 @@ static void handle_error(ares_channel channel, int whichserver,
   swap_lists(&list_head, &(server->queries_to_server));
   for (list_node = list_head.next; list_node != &list_head; )
     {
-      query_ptr = (query*)list_node->data;
+      query_ptr = (struct query*)list_node->data;
       list_node = list_node->next;  /* in case the query gets deleted */
       assert(query_ptr->server == whichserver);
       skip_server(channel, query_ptr, whichserver);
@@ -825,7 +825,7 @@ void ares__send_query(ares_channel channel, struct query *query,
               return;
             }
         }
-      sendreq = (send_request*)ares_malloc(sizeof(struct send_request));
+      sendreq = (struct send_request*)ares_malloc(sizeof(struct send_request));
       if (!sendreq)
         {
         end_query(channel, query, ARES_ENOMEM, NULL, 0);
@@ -1078,7 +1078,7 @@ static int open_tcp_socket(ares_channel channel, struct server_state *server)
   switch (server->addr.family)
     {
       case AF_INET:
-        sa = (sockaddr *)&saddr.sa4;
+        sa = (struct sockaddr *)&saddr.sa4;
         salen = sizeof(saddr.sa4);
         memset(sa, 0, salen);
         saddr.sa4.sin_family = AF_INET;
@@ -1091,7 +1091,7 @@ static int open_tcp_socket(ares_channel channel, struct server_state *server)
                sizeof(server->addr.addrV4));
         break;
       case AF_INET6:
-        sa = (sockaddr *)&saddr.sa6;
+        sa = (struct sockaddr *)&saddr.sa6;
         salen = sizeof(saddr.sa6);
         memset(sa, 0, salen);
         saddr.sa6.sin6_family = AF_INET6;
@@ -1191,7 +1191,7 @@ static int open_udp_socket(ares_channel channel, struct server_state *server)
   switch (server->addr.family)
     {
       case AF_INET:
-        sa = (sockaddr *)&saddr.sa4;
+        sa = (struct sockaddr *)&saddr.sa4;
         salen = sizeof(saddr.sa4);
         memset(sa, 0, salen);
         saddr.sa4.sin_family = AF_INET;
@@ -1204,7 +1204,7 @@ static int open_udp_socket(ares_channel channel, struct server_state *server)
                sizeof(server->addr.addrV4));
         break;
       case AF_INET6:
-        sa = (sockaddr *)&saddr.sa6;
+        sa = (struct sockaddr *)&saddr.sa6;
         salen = sizeof(saddr.sa6);
         memset(sa, 0, salen);
         saddr.sa6.sin6_family = AF_INET6;

--- a/ares_process.c
+++ b/ares_process.c
@@ -597,7 +597,7 @@ static void process_answer(ares_channel channel, unsigned char *abuf,
   for (list_node = list_head->next; list_node != list_head;
        list_node = list_node->next)
     {
-      struct query *q = (query*)list_node->data;
+      struct query *q = (struct query*)list_node->data;
       if ((q->qid == id) && same_questions(q->qbuf, q->qlen, abuf, alen))
         {
           query_ptr = q;

--- a/ares_query.c
+++ b/ares_query.c
@@ -129,7 +129,7 @@ void ares_query(ares_channel channel, const char *name, int dnsclass,
   channel->next_id = generate_unique_id(channel);
 
   /* Allocate and fill in the query structure. */
-  qquery_ptr = (qquery*)ares_malloc(sizeof(struct qquery));
+  qquery_ptr = (struct qquery*)ares_malloc(sizeof(struct qquery));
   if (!qquery_ptr)
     {
       ares_free_string(qbuf);

--- a/ares_query.c
+++ b/ares_query.c
@@ -77,7 +77,7 @@ static struct query* find_query_by_id(ares_channel channel, unsigned short id)
   for (list_node = list_head->next; list_node != list_head;
        list_node = list_node->next)
     {
-       struct query *q = list_node->data;
+       struct query *q = (query*)list_node->data;
        if (q->qid == qid)
 	  return q;
     }
@@ -111,7 +111,7 @@ unsigned short ares__generate_new_id(rc4_key* key)
 void ares_query(ares_channel channel, const char *name, int dnsclass,
                 int type, ares_callback callback, void *arg)
 {
-  struct qquery *qquery;
+  struct qquery *qquery_ptr;
   unsigned char *qbuf;
   int qlen, rd, status;
 
@@ -129,18 +129,18 @@ void ares_query(ares_channel channel, const char *name, int dnsclass,
   channel->next_id = generate_unique_id(channel);
 
   /* Allocate and fill in the query structure. */
-  qquery = ares_malloc(sizeof(struct qquery));
-  if (!qquery)
+  qquery_ptr = (qquery*)ares_malloc(sizeof(struct qquery));
+  if (!qquery_ptr)
     {
       ares_free_string(qbuf);
       callback(arg, ARES_ENOMEM, 0, NULL, 0);
       return;
     }
-  qquery->callback = callback;
-  qquery->arg = arg;
+  qquery_ptr->callback = callback;
+  qquery_ptr->arg = arg;
 
   /* Send it off.  qcallback will be called when we get an answer. */
-  ares_send(channel, qbuf, qlen, qcallback, qquery);
+  ares_send(channel, qbuf, qlen, qcallback, qquery_ptr);
   ares_free_string(qbuf);
 }
 

--- a/ares_query.c
+++ b/ares_query.c
@@ -77,7 +77,7 @@ static struct query* find_query_by_id(ares_channel channel, unsigned short id)
   for (list_node = list_head->next; list_node != list_head;
        list_node = list_node->next)
     {
-       struct query *q = (query*)list_node->data;
+       struct query *q = (struct query*)list_node->data;
        if (q->qid == qid)
 	  return q;
     }

--- a/ares_search.c
+++ b/ares_search.c
@@ -73,7 +73,7 @@ void ares_search(ares_channel channel, const char *name, int dnsclass,
   /* Allocate a search_query structure to hold the state necessary for
    * doing multiple lookups.
    */
-  squery = (search_query*)ares_malloc(sizeof(struct search_query));
+  squery = (struct search_query*)ares_malloc(sizeof(struct search_query));
   if (!squery)
     {
       callback(arg, ARES_ENOMEM, 0, NULL, 0);

--- a/ares_search.c
+++ b/ares_search.c
@@ -73,7 +73,7 @@ void ares_search(ares_channel channel, const char *name, int dnsclass,
   /* Allocate a search_query structure to hold the state necessary for
    * doing multiple lookups.
    */
-  squery = ares_malloc(sizeof(struct search_query));
+  squery = (search_query*)ares_malloc(sizeof(struct search_query));
   if (!squery)
     {
       callback(arg, ARES_ENOMEM, 0, NULL, 0);
@@ -211,7 +211,7 @@ static int cat_domain(const char *name, const char *domain, char **s)
   size_t nlen = strlen(name);
   size_t dlen = strlen(domain);
 
-  *s = ares_malloc(nlen + 1 + dlen + 1);
+  *s = (char*)ares_malloc(nlen + 1 + dlen + 1);
   if (!*s)
     return ARES_ENOMEM;
   memcpy(*s, name, nlen);
@@ -268,7 +268,7 @@ STATIC_TESTABLE int single_domain(ares_channel channel, const char *name, char *
                       q = p + 1;
                       while (*q && !ISSPACE(*q))
                         q++;
-                      *s = ares_malloc(q - p + 1);
+                      *s = (char*)ares_malloc(q - p + 1);
                       if (*s)
                         {
                           memcpy(*s, p, q - p);

--- a/ares_send.c
+++ b/ares_send.c
@@ -35,7 +35,7 @@
 void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
                ares_callback callback, void *arg)
 {
-  struct query *query;
+  struct query *query_ptr;
   int i, packetsz;
   struct timeval now;
 
@@ -47,91 +47,91 @@ void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
     }
 
   /* Allocate space for query and allocated fields. */
-  query = ares_malloc(sizeof(struct query));
-  if (!query)
+  query_ptr = (query*)ares_malloc(sizeof(struct query));
+  if (!query_ptr)
     {
       callback(arg, ARES_ENOMEM, 0, NULL, 0);
       return;
     }
-  query->tcpbuf = ares_malloc(qlen + 2);
-  if (!query->tcpbuf)
+  query_ptr->tcpbuf = (unsigned char*)ares_malloc(qlen + 2);
+  if (!query_ptr->tcpbuf)
     {
-      ares_free(query);
+      ares_free(query_ptr);
       callback(arg, ARES_ENOMEM, 0, NULL, 0);
       return;
     }
   if (channel->nservers < 1)
     {
-      ares_free(query);
+      ares_free(query_ptr);
       callback(arg, ARES_ESERVFAIL, 0, NULL, 0);
       return;
     }
-  query->server_info = ares_malloc(channel->nservers *
-                                   sizeof(query->server_info[0]));
-  if (!query->server_info)
+  query_ptr->server_info = (query_server_info*)ares_malloc(channel->nservers *
+                                   sizeof(query_ptr->server_info[0]));
+  if (!query_ptr->server_info)
     {
-      ares_free(query->tcpbuf);
-      ares_free(query);
+      ares_free(query_ptr->tcpbuf);
+      ares_free(query_ptr);
       callback(arg, ARES_ENOMEM, 0, NULL, 0);
       return;
     }
 
   /* Compute the query ID.  Start with no timeout. */
-  query->qid = DNS_HEADER_QID(qbuf);
-  query->timeout.tv_sec = 0;
-  query->timeout.tv_usec = 0;
+  query_ptr->qid = DNS_HEADER_QID(qbuf);
+  query_ptr->timeout.tv_sec = 0;
+  query_ptr->timeout.tv_usec = 0;
 
   /* Form the TCP query buffer by prepending qlen (as two
    * network-order bytes) to qbuf.
    */
-  query->tcpbuf[0] = (unsigned char)((qlen >> 8) & 0xff);
-  query->tcpbuf[1] = (unsigned char)(qlen & 0xff);
-  memcpy(query->tcpbuf + 2, qbuf, qlen);
-  query->tcplen = qlen + 2;
+  query_ptr->tcpbuf[0] = (unsigned char)((qlen >> 8) & 0xff);
+  query_ptr->tcpbuf[1] = (unsigned char)(qlen & 0xff);
+  memcpy(query_ptr->tcpbuf + 2, qbuf, qlen);
+  query_ptr->tcplen = qlen + 2;
 
   /* Fill in query arguments. */
-  query->qbuf = query->tcpbuf + 2;
-  query->qlen = qlen;
-  query->callback = callback;
-  query->arg = arg;
+  query_ptr->qbuf = query_ptr->tcpbuf + 2;
+  query_ptr->qlen = qlen;
+  query_ptr->callback = callback;
+  query_ptr->arg = arg;
 
   /* Initialize query status. */
-  query->try_count = 0;
+  query_ptr->try_count = 0;
 
   /* Choose the server to send the query to. If rotation is enabled, keep track
    * of the next server we want to use. */
-  query->server = channel->last_server;
+  query_ptr->server = channel->last_server;
   if (channel->rotate == 1)
     channel->last_server = (channel->last_server + 1) % channel->nservers;
 
   for (i = 0; i < channel->nservers; i++)
     {
-      query->server_info[i].skip_server = 0;
-      query->server_info[i].tcp_connection_generation = 0;
+      query_ptr->server_info[i].skip_server = 0;
+      query_ptr->server_info[i].tcp_connection_generation = 0;
     }
 
   packetsz = (channel->flags & ARES_FLAG_EDNS) ? channel->ednspsz : PACKETSZ;
-  query->using_tcp = (channel->flags & ARES_FLAG_USEVC) || qlen > packetsz;
+  query_ptr->using_tcp = (channel->flags & ARES_FLAG_USEVC) || qlen > packetsz;
 
-  query->error_status = ARES_ECONNREFUSED;
-  query->timeouts = 0;
+  query_ptr->error_status = ARES_ECONNREFUSED;
+  query_ptr->timeouts = 0;
 
   /* Initialize our list nodes. */
-  ares__init_list_node(&(query->queries_by_qid),     query);
-  ares__init_list_node(&(query->queries_by_timeout), query);
-  ares__init_list_node(&(query->queries_to_server),  query);
-  ares__init_list_node(&(query->all_queries),        query);
+  ares__init_list_node(&(query_ptr->queries_by_qid),     query_ptr);
+  ares__init_list_node(&(query_ptr->queries_by_timeout), query_ptr);
+  ares__init_list_node(&(query_ptr->queries_to_server),  query_ptr);
+  ares__init_list_node(&(query_ptr->all_queries),        query_ptr);
 
   /* Chain the query into the list of all queries. */
-  ares__insert_in_list(&(query->all_queries), &(channel->all_queries));
+  ares__insert_in_list(&(query_ptr->all_queries), &(channel->all_queries));
   /* Keep track of queries bucketed by qid, so we can process DNS
    * responses quickly.
    */
   ares__insert_in_list(
-    &(query->queries_by_qid),
-    &(channel->queries_by_qid[query->qid % ARES_QID_TABLE_SIZE]));
+    &(query_ptr->queries_by_qid),
+    &(channel->queries_by_qid[query_ptr->qid % ARES_QID_TABLE_SIZE]));
 
   /* Perform the first query action. */
   now = ares__tvnow();
-  ares__send_query(channel, query, &now);
+  ares__send_query(channel, query_ptr, &now);
 }

--- a/ares_send.c
+++ b/ares_send.c
@@ -47,7 +47,7 @@ void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
     }
 
   /* Allocate space for query and allocated fields. */
-  query_ptr = (query*)ares_malloc(sizeof(struct query));
+  query_ptr = (struct query*)ares_malloc(sizeof(struct query));
   if (!query_ptr)
     {
       callback(arg, ARES_ENOMEM, 0, NULL, 0);
@@ -66,7 +66,7 @@ void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
       callback(arg, ARES_ESERVFAIL, 0, NULL, 0);
       return;
     }
-  query_ptr->server_info = (query_server_info*)ares_malloc(channel->nservers *
+  query_ptr->server_info = (struct query_server_info*)ares_malloc(channel->nservers *
                                    sizeof(query_ptr->server_info[0]));
   if (!query_ptr->server_info)
     {

--- a/ares_strdup.c
+++ b/ares_strdup.c
@@ -36,7 +36,7 @@ char *ares_strdup(const char *s1)
       if(sz < (size_t)-1) {
         sz++;
         if(sz < ((size_t)-1) / sizeof(char)) {
-          s2 = ares_malloc(sz * sizeof(char));
+          s2 = (char*)ares_malloc(sz * sizeof(char));
           if(s2) {
             memcpy(s2, s1, sz * sizeof(char));
             return s2;

--- a/ares_timeout.c
+++ b/ares_timeout.c
@@ -38,7 +38,7 @@ static long timeoffset(struct timeval *now, struct timeval *check)
 struct timeval *ares_timeout(ares_channel channel, struct timeval *maxtv,
                              struct timeval *tvbuf)
 {
-  struct query *query;
+  struct query *query_ptr;
   struct list_node* list_head;
   struct list_node* list_node;
   struct timeval now;
@@ -57,10 +57,10 @@ struct timeval *ares_timeout(ares_channel channel, struct timeval *maxtv,
   for (list_node = list_head->next; list_node != list_head;
        list_node = list_node->next)
     {
-      query = list_node->data;
-      if (query->timeout.tv_sec == 0)
+      query_ptr = (query*)list_node->data;
+      if (query_ptr->timeout.tv_sec == 0)
         continue;
-      offset = timeoffset(&now, &query->timeout);
+      offset = timeoffset(&now, &query_ptr->timeout);
       if (offset < 0)
         offset = 0;
       if (min_offset == -1 || offset < min_offset)

--- a/ares_timeout.c
+++ b/ares_timeout.c
@@ -57,7 +57,7 @@ struct timeval *ares_timeout(ares_channel channel, struct timeval *maxtv,
   for (list_node = list_head->next; list_node != list_head;
        list_node = list_node->next)
     {
-      query_ptr = (query*)list_node->data;
+      query_ptr = (struct query*)list_node->data;
       if (query_ptr->timeout.tv_sec == 0)
         continue;
       offset = timeoffset(&now, &query_ptr->timeout);

--- a/inet_net_pton.c
+++ b/inet_net_pton.c
@@ -409,9 +409,9 @@ ares_inet_net_pton(int af, const char *src, void *dst, size_t size)
 {
   switch (af) {
   case AF_INET:
-    return (inet_net_pton_ipv4(src, dst, size));
+    return (inet_net_pton_ipv4(src, (unsigned char*)dst, size));
   case AF_INET6:
-    return (inet_net_pton_ipv6(src, dst, size));
+    return (inet_net_pton_ipv6(src, (unsigned char*)dst, size));
   default:
     SET_ERRNO(EAFNOSUPPORT);
     return (-1);


### PR DESCRIPTION
Mainly adding explicit c style casts and renaming some of variables (the happened to have the same name as type).