### PR TITLE
fix stringop-overflow warning of GCC

### DIFF
--- a/ares_parse_ptr_reply.c
+++ b/ares_parse_ptr_reply.c
@@ -52,6 +52,7 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
   int aliascnt = 0;
   int alias_alloc = 8;
   char ** aliases;
+  size_t rr_data_len;
 
   /* Set *host to NULL for all failure cases. */
   *host = NULL;
@@ -124,14 +125,15 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
           if (hostname)
             ares_free(hostname);
           hostname = rr_data;
-          aliases[aliascnt] = ares_malloc((strlen(rr_data)+1) * sizeof(char));
+          rr_data_len = strlen(rr_data)+1;
+          aliases[aliascnt] = ares_malloc(rr_data_len * sizeof(char));
           if (!aliases[aliascnt])
             {
               ares_free(rr_name);
               status = ARES_ENOMEM;
               break;
             }
-          strncpy(aliases[aliascnt], rr_data, strlen(rr_data)+1);
+          strncpy(aliases[aliascnt], rr_data, rr_data_len);
           aliascnt++;
           if (aliascnt >= alias_alloc) {
             char **ptr;


### PR DESCRIPTION
When using a modern GCC to compile c-ares, there is a stringop-overflow warning as follows:
```
c-ares/ares_parse_ptr_reply.c: In function ‘ares_parse_ptr_reply’:
c-ares/ares_parse_ptr_reply.c:134:11: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
           strncpy(aliases[aliascnt], rr_data, strlen(rr_data)+1);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
c-ares/ares_parse_ptr_reply.c:134:47: note: length computed here
           strncpy(aliases[aliascnt], rr_data, strlen(rr_data)+1);
                                               ^~~~~~~~~~~~~~~
```
This patch fixes this issue... 
