### PR TITLE
Improve domain search suffixes extracting from WinNT registry

### DIFF
--- a/ares_init.c
+++ b/ares_init.c
@@ -1380,6 +1380,21 @@ static size_t next_suffix(const char** list, const size_t advance)
   return end - beg;
 }
 
+/* Appends suffixes from 'tail' to 'searchlist' if not contains yet.
+ * Arguments are comma separated lists of domain suffixes. */
+static void append_suffixes(char** searchlist, const char* const tail)
+{
+  const char *suffix = tail;
+  size_t len = 0;
+  if (!tail || !*tail)
+    return;
+  while (len = next_suffix(&suffix, len))
+  {
+    if (!*searchlist || !contains_suffix(*searchlist, suffix, len))
+      commanjoin(searchlist, suffix, len);
+  }
+}
+
 /*
  * get_SuffixList_Windows()
  *
@@ -1400,8 +1415,6 @@ static int get_SuffixList_Windows(char **outptr)
   DWORD keyNameBuffSize;
   DWORD keyIdx = 0;
   char *p = NULL;
-  const char *pp;
-  size_t len = 0;
 
   *outptr = NULL;
 
@@ -1412,11 +1425,26 @@ static int get_SuffixList_Windows(char **outptr)
   if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY, 0,
       KEY_READ, &hKey) == ERROR_SUCCESS)
   {
-    if (get_REG_SZ(hKey, SEARCHLIST_KEY, outptr))
-      replace_comma_by_space(*outptr);
+    get_REG_SZ(hKey, SEARCHLIST_KEY, outptr);
+    if (get_REG_SZ(hKey, DOMAIN_KEY, &p))
+    {
+      append_suffixes(outptr, p);
+      ares_free(p);
+      p = NULL;
+    }
     RegCloseKey(hKey);
-    if (*outptr)
-      return 1;
+  }
+
+  if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, WIN_NT_DNSCLIENT, 0,
+      KEY_READ, &hKey) == ERROR_SUCCESS)
+  {
+    if (get_REG_SZ(hKey, SEARCHLIST_KEY, &p))
+    {
+      append_suffixes(outptr, p);
+      ares_free(p);
+      p = NULL;
+    }
+    RegCloseKey(hKey);
   }
 
   /* 2. Connection Specific Search List composed of:
@@ -1424,45 +1452,56 @@ static int get_SuffixList_Windows(char **outptr)
   if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, WIN_DNSCLIENT, 0,
       KEY_READ, &hKey) == ERROR_SUCCESS)
   {
-    get_REG_SZ(hKey, PRIMARYDNSSUFFIX_KEY, outptr);
-    RegCloseKey(hKey);
-  }
-  if (!*outptr)
-    return 0;
-
-  /*  b. Interface SearchList, Domain, DhcpDomain */
-  if (!RegOpenKeyExA(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY "\\" INTERFACES_KEY, 0,
-      KEY_READ, &hKey) == ERROR_SUCCESS)
-    return 0;
-  for(;;)
-  {
-    keyNameBuffSize = sizeof(keyName);
-    if (RegEnumKeyExA(hKey, keyIdx++, keyName, &keyNameBuffSize,
-        0, NULL, NULL, NULL)
-        != ERROR_SUCCESS)
-      break;
-    if (RegOpenKeyExA(hKey, keyName, 0, KEY_QUERY_VALUE, &hKeyEnum)
-        != ERROR_SUCCESS)
-      continue;
-    if (get_REG_SZ(hKeyEnum, SEARCHLIST_KEY, &p) ||
-        get_REG_SZ(hKeyEnum, DOMAIN_KEY, &p) ||
-        get_REG_SZ(hKeyEnum, DHCPDOMAIN_KEY, &p))
+    if (get_REG_SZ(hKey, PRIMARYDNSSUFFIX_KEY, &p))
     {
-      /* p can be comma separated (SearchList) */
-      pp = p;
-      while ((len = next_suffix(&pp, len)) != 0)
-      {
-        if (!contains_suffix(*outptr, pp, len))
-          commanjoin(outptr, pp, len);
-      }
+      append_suffixes(outptr, p);
       ares_free(p);
       p = NULL;
     }
-    RegCloseKey(hKeyEnum);
+    RegCloseKey(hKey);
   }
-  RegCloseKey(hKey);
+
+  /*  b. Interface SearchList, Domain, DhcpDomain */
+  if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY "\\" INTERFACES_KEY, 0,
+      KEY_READ, &hKey) == ERROR_SUCCESS)
+  {
+    for(;;)
+    {
+      keyNameBuffSize = sizeof(keyName);
+      if (RegEnumKeyExA(hKey, keyIdx++, keyName, &keyNameBuffSize,
+          0, NULL, NULL, NULL)
+          != ERROR_SUCCESS)
+        break;
+      if (RegOpenKeyExA(hKey, keyName, 0, KEY_QUERY_VALUE, &hKeyEnum)
+          != ERROR_SUCCESS)
+        continue;
+      /* p can be comma separated (SearchList) */
+      if (get_REG_SZ(hKeyEnum, SEARCHLIST_KEY, &p))
+      {
+        append_suffixes(outptr, p);
+        ares_free(p);
+        p = NULL;
+      }
+      if (get_REG_SZ(hKeyEnum, DOMAIN_KEY, &p))
+      {
+        append_suffixes(outptr, p);
+        ares_free(p);
+        p = NULL;
+      }
+      if (get_REG_SZ(hKeyEnum, DHCPDOMAIN_KEY, &p))
+      {
+        append_suffixes(outptr, p);
+        ares_free(p);
+        p = NULL;
+      }
+      RegCloseKey(hKeyEnum);
+    }
+    RegCloseKey(hKey);
+  }
+
   if (*outptr)
     replace_comma_by_space(*outptr);
+
   return *outptr != NULL;
 }
 

--- a/ares_private.h
+++ b/ares_private.h
@@ -52,18 +52,19 @@
 
 #if defined(WIN32) && !defined(WATT32)
 
-#define WIN_NS_9X      "System\\CurrentControlSet\\Services\\VxD\\MSTCP"
-#define WIN_NS_NT_KEY  "System\\CurrentControlSet\\Services\\Tcpip\\Parameters"
-#define WIN_DNSCLIENT  "Software\\Policies\\Microsoft\\System\\DNSClient"
-#define NAMESERVER     "NameServer"
-#define DHCPNAMESERVER "DhcpNameServer"
-#define DATABASEPATH   "DatabasePath"
-#define WIN_PATH_HOSTS  "\\hosts"
-#define SEARCHLIST_KEY "SearchList"
+#define WIN_NS_9X            "System\\CurrentControlSet\\Services\\VxD\\MSTCP"
+#define WIN_NS_NT_KEY        "System\\CurrentControlSet\\Services\\Tcpip\\Parameters"
+#define WIN_DNSCLIENT        "Software\\Policies\\Microsoft\\System\\DNSClient"
+#define WIN_NT_DNSCLIENT     "Software\\Policies\\Microsoft\\Windows NT\\DNSClient"
+#define NAMESERVER           "NameServer"
+#define DHCPNAMESERVER       "DhcpNameServer"
+#define DATABASEPATH         "DatabasePath"
+#define WIN_PATH_HOSTS       "\\hosts"
+#define SEARCHLIST_KEY       "SearchList"
 #define PRIMARYDNSSUFFIX_KEY "PrimaryDNSSuffix"
-#define INTERFACES_KEY "Interfaces"
-#define DOMAIN_KEY     "Domain"
-#define DHCPDOMAIN_KEY "DhcpDomain"
+#define INTERFACES_KEY       "Interfaces"
+#define DOMAIN_KEY           "Domain"
+#define DHCPDOMAIN_KEY       "DhcpDomain"
 
 #elif defined(WATT32)
 


### PR DESCRIPTION
1. Join all global and connection specific suffix lists
2. Use 'HKLM\Software\Policies\Microsoft\Windows NT\DNSClient\SearchList', 'HKLM\System\CurrentControlSet\Services\Tcpip\Parameters\Domain' as global suffix lists