### PR TITLE
Add configurability for path to resolv.conf file (#220)

### DIFF
--- a/ares.h
+++ b/ares.h
@@ -164,6 +164,7 @@ extern "C" {
 #define ARES_OPT_ROTATE         (1 << 14)
 #define ARES_OPT_EDNSPSZ        (1 << 15)
 #define ARES_OPT_NOROTATE       (1 << 16)
+#define ARES_OPT_RESOLVCONF     (1 << 17)
 
 /* Nameinfo flag values */
 #define ARES_NI_NOFQDN                  (1 << 0)
@@ -270,6 +271,7 @@ struct ares_options {
   struct apattern *sortlist;
   int nsort;
   int ednspsz;
+  char *resolvconf_path;
 };
 
 struct hostent;

--- a/ares_destroy.c
+++ b/ares_destroy.c
@@ -36,6 +36,8 @@ void ares_destroy_options(struct ares_options *options)
     ares_free(options->sortlist);
   if(options->lookups)
     ares_free(options->lookups);
+  if(options->resolvconf_path)
+    ares_free(options->resolvconf_path);
 }
 
 void ares_destroy(ares_channel channel)
@@ -84,6 +86,9 @@ void ares_destroy(ares_channel channel)
 
   if (channel->lookups)
     ares_free(channel->lookups);
+
+  if (channel->resolvconf_path)
+    ares_free(channel->resolvconf_path);
 
   ares_free(channel);
 }

--- a/ares_init.c
+++ b/ares_init.c
@@ -169,6 +169,7 @@ int ares_init_options(ares_channel *channelptr, struct ares_options *options,
   channel->sock_config_cb_data = NULL;
   channel->sock_funcs = NULL;
   channel->sock_func_cb_data = NULL;
+  channel->resolvconf_path = NULL;
 
   channel->last_server = 0;
   channel->last_timeout_processed = (time_t)now.tv_sec;
@@ -242,6 +243,8 @@ done:
         ares_free(channel->sortlist);
       if(channel->lookups)
         ares_free(channel->lookups);
+      if(channel->resolvconf_path)
+        ares_free(channel->resolvconf_path);
       ares_free(channel);
       return status;
     }
@@ -347,7 +350,7 @@ int ares_save_options(ares_channel channel, struct ares_options *options,
   (*optmask) = (ARES_OPT_FLAGS|ARES_OPT_TRIES|ARES_OPT_NDOTS|
                 ARES_OPT_UDP_PORT|ARES_OPT_TCP_PORT|ARES_OPT_SOCK_STATE_CB|
                 ARES_OPT_SERVERS|ARES_OPT_DOMAINS|ARES_OPT_LOOKUPS|
-                ARES_OPT_SORTLIST|ARES_OPT_TIMEOUTMS);
+                ARES_OPT_SORTLIST|ARES_OPT_TIMEOUTMS|ARES_OPT_RESOLVCONF);
   (*optmask) |= (channel->rotate ? ARES_OPT_ROTATE : ARES_OPT_NOROTATE);
 
   /* Copy easy stuff */
@@ -421,6 +424,13 @@ int ares_save_options(ares_channel channel, struct ares_options *options,
       options->sortlist[i] = channel->sortlist[i];
   }
   options->nsort = channel->nsort;
+
+  /* copy path for resolv.conf file */
+  if (channel->resolvconf_path) {
+    options->resolvconf_path = ares_strdup(channel->resolvconf_path);
+    if (!options->resolvconf_path)
+      return ARES_ENOMEM;
+  }
 
   return ARES_SUCCESS;
 }
@@ -529,6 +539,14 @@ static int init_by_options(ares_channel channel,
     }
     channel->nsort = options->nsort;
   }
+
+  /* Set path for resolv.conf file, if given. */
+  if ((optmask & ARES_OPT_RESOLVCONF) && !channel->resolvconf_path)
+    {
+      channel->resolvconf_path = ares_strdup(options->resolvconf_path);
+      if (!channel->resolvconf_path && options->resolvconf_path)
+        return ARES_ENOMEM;
+    }
 
   channel->optmask = optmask;
 
@@ -1652,43 +1670,90 @@ static int init_by_resolv_conf(ares_channel channel)
     /* Only update search domains if they're not already specified */
     update_domains = (channel->ndomains == -1);
 
-    fp = fopen(PATH_RESOLV_CONF, "r");
-    if (fp) {
-      while ((status = ares__read_line(fp, &line, &linesize)) == ARES_SUCCESS)
-      {
-        if ((p = try_config(line, "domain", ';')) && update_domains)
-          status = config_domain(channel, p);
-        else if ((p = try_config(line, "lookup", ';')) && !channel->lookups)
-          status = config_lookup(channel, p, "bind", NULL, "file");
-        else if ((p = try_config(line, "search", ';')) && update_domains)
-          status = set_search(channel, p);
-        else if ((p = try_config(line, "nameserver", ';')) &&
-                 channel->nservers == -1)
-          status = config_nameserver(&servers, &nservers, p);
-        else if ((p = try_config(line, "sortlist", ';')) &&
-                 channel->nsort == -1)
-          status = config_sortlist(&sortlist, &nsort, p);
-        else if ((p = try_config(line, "options", ';')))
-          status = set_options(channel, p);
-        else
-          status = ARES_SUCCESS;
-        if (status != ARES_SUCCESS)
-          break;
+    /* Support path for resolvconf filename set by ares_init_options */
+    if (channel->resolvconf_path) {
+      fp = fopen(channel->resolvconf_path, "r");
+      if (fp) {
+        while ((status = ares__read_line(fp, &line, &linesize)) == ARES_SUCCESS)
+        {
+          if ((p = try_config(line, "domain", ';')) && update_domains)
+            status = config_domain(channel, p);
+          else if ((p = try_config(line, "lookup", ';')) && !channel->lookups)
+            status = config_lookup(channel, p, "bind", NULL, "file");
+          else if ((p = try_config(line, "search", ';')) && update_domains)
+            status = set_search(channel, p);
+          else if ((p = try_config(line, "nameserver", ';')) &&
+                  channel->nservers == -1)
+            status = config_nameserver(&servers, &nservers, p);
+          else if ((p = try_config(line, "sortlist", ';')) &&
+                  channel->nsort == -1)
+            status = config_sortlist(&sortlist, &nsort, p);
+          else if ((p = try_config(line, "options", ';')))
+            status = set_options(channel, p);
+          else
+            status = ARES_SUCCESS;
+          if (status != ARES_SUCCESS)
+            break;
+        }
+        fclose(fp);
       }
-      fclose(fp);
+      else {
+        error = ERRNO;
+        switch(error) {
+        case ENOENT:
+        case ESRCH:
+          status = ARES_EOF;
+          break;
+        default:
+          DEBUGF(fprintf(stderr, "fopen() failed with error: %d %s\n",
+                        error, strerror(error)));
+          DEBUGF(fprintf(stderr, "Error opening file: %s\n", PATH_RESOLV_CONF));
+          status = ARES_EFILE;
+        }
+      }
     }
-    else {
-      error = ERRNO;
-      switch(error) {
-      case ENOENT:
-      case ESRCH:
-        status = ARES_EOF;
-        break;
-      default:
-        DEBUGF(fprintf(stderr, "fopen() failed with error: %d %s\n",
-                       error, strerror(error)));
-        DEBUGF(fprintf(stderr, "Error opening file: %s\n", PATH_RESOLV_CONF));
-        status = ARES_EFILE;
+
+    if ((channel->resolvconf_path && status == ARES_EFILE) ||
+        !(channel->resolvconf_path))
+    {
+      fp = fopen(PATH_RESOLV_CONF, "r");
+      if (fp) {
+        while ((status = ares__read_line(fp, &line, &linesize)) == ARES_SUCCESS)
+        {
+          if ((p = try_config(line, "domain", ';')) && update_domains)
+            status = config_domain(channel, p);
+          else if ((p = try_config(line, "lookup", ';')) && !channel->lookups)
+            status = config_lookup(channel, p, "bind", NULL, "file");
+          else if ((p = try_config(line, "search", ';')) && update_domains)
+            status = set_search(channel, p);
+          else if ((p = try_config(line, "nameserver", ';')) &&
+                  channel->nservers == -1)
+            status = config_nameserver(&servers, &nservers, p);
+          else if ((p = try_config(line, "sortlist", ';')) &&
+                  channel->nsort == -1)
+            status = config_sortlist(&sortlist, &nsort, p);
+          else if ((p = try_config(line, "options", ';')))
+            status = set_options(channel, p);
+          else
+            status = ARES_SUCCESS;
+          if (status != ARES_SUCCESS)
+            break;
+        }
+        fclose(fp);
+      }
+      else {
+        error = ERRNO;
+        switch(error) {
+        case ENOENT:
+        case ESRCH:
+          status = ARES_EOF;
+          break;
+        default:
+          DEBUGF(fprintf(stderr, "fopen() failed with error: %d %s\n",
+                        error, strerror(error)));
+          DEBUGF(fprintf(stderr, "Error opening file: %s\n", PATH_RESOLV_CONF));
+          status = ARES_EFILE;
+        }
       }
     }
 
@@ -1953,6 +2018,11 @@ static int init_by_defaults(ares_channel channel)
     if(channel->lookups) {
       ares_free(channel->lookups);
       channel->lookups = NULL;
+    }
+
+    if(channel->resolvconf_path) {
+      ares_free(channel->resolvconf_path);
+      channel->resolvconf_path = NULL;
     }
   }
 

--- a/ares_init_options.3
+++ b/ares_init_options.3
@@ -40,6 +40,7 @@ struct ares_options {
   struct apattern *sortlist;
   int nsort;
   int ednspsz;
+  char *resolvconf_path;
 };
 
 int ares_init_options(ares_channel *\fIchannelptr\fP,
@@ -181,6 +182,15 @@ The receive buffer size to set for the socket.
 .B ARES_OPT_EDNSPSZ
 .B int \fIednspsz\fP;
 .br
+.TP 18
+.B ARES_OPT_RESOLVCONF
+.B char *\fIresolvconf_path\fP;
+The path to use for reading the resolv.conf file. The
+.I resolvconf_path
+should be set to a path string, and will be honoured on *nix like systems. The
+default is
+.B /etc/resolv.conf
+.br
 The message size to be advertized in EDNS; only takes effect if the
 .B ARES_FLAG_EDNS
 flag is set.
@@ -259,6 +269,9 @@ c-ares library initialization not yet performed.
 .SH NOTES
 When initializing from
 .B /etc/resolv.conf,
+(or, alternatively when specified by the
+.I resolvconf_path
+path location)
 \fBares_init_options(3)\fP reads the \fIdomain\fP and \fIsearch\fP directives
 to allow lookups of short names relative to the domains specified. The
 \fIdomain\fP and \fIsearch\fP directives override one another. If more that

--- a/ares_private.h
+++ b/ares_private.h
@@ -325,6 +325,9 @@ struct ares_channeldata {
 
   const struct ares_socket_functions * sock_funcs;
   void *sock_func_cb_data;
+
+  /* Path for resolv.conf file, configurable via ares_options */
+  char *resolvconf_path;
 };
 
 /* Memory management functions */


### PR DESCRIPTION
- [x] By extending `struct ares_options` and `struct ares_channeldata`, and similarly `ares_init_options()`, `ares_save_options()`, and `init_by_resolv_conf()`
- [x] Added test case, for *nix, within `CONTAINED_TEST_F` (could not test locally, as local machine is darwin, which does not support linux LXC)
- [ ] Add support for windows (How? also, cannot test locally)
- [x] No new warnings with `--enable-maintainer-mode` and `--enable-debug`
- [ ] Documentation needs to be updated.

Fixes #220 