### PR TITLE
test: fix bad expectation in ipv6 localhost test

### DIFF
--- a/test/ares-test-live.cc
+++ b/test/ares-test-live.cc
@@ -167,8 +167,9 @@ TEST_P(DefaultChannelModeTest, LiveGetLocalhostByAddrV6) {
     EXPECT_EQ(ARES_SUCCESS, result.status_);
     EXPECT_LT(0, (int)result.host_.addrs_.size());
     EXPECT_EQ(AF_INET6, result.host_.addrtype_);
-    EXPECT_NE(std::string::npos,
-              result.host_.name_.find("localhost"));
+    const std::string& name = result.host_.name_;
+    EXPECT_TRUE(std::string::npos != name.find("localhost") ||
+                std::string::npos != name.find("ip6-loopback"));
   }
 }
 


### PR DESCRIPTION
The LiveGetLocalhostByAddrV6 test expected to see "localhost" in the
result when doing an address-to-name lookup for ::1 but on my system
that resolves to "ip6-loopback" because of this stanza in /etc/hosts:

    $ grep ^::1 /etc/hosts
    ::1     ip6-localhost ip6-loopback