### PR TITLE
Report ARES_ENOTFOUND for .onion domain names.

### DIFF
--- a/ares_create_query.3
+++ b/ares_create_query.3
@@ -58,6 +58,13 @@ can return any of the following values:
 .B ARES_SUCCESS
 Construction of the DNS query succeeded.
 .TP 15
+.B ARES_ENOTFOUND
+The query name
+.I name
+refers to a
+.I .onion
+domain name. See RFC 7686.
+.TP 15
 .B ARES_EBADNAME
 The query name
 .I name

--- a/ares_create_query.c
+++ b/ares_create_query.c
@@ -94,6 +94,10 @@ int ares_create_query(const char *name, int dnsclass, int type,
   size_t buflen;
   unsigned char *buf;
 
+  /* Per RFC 7686, reject queries for ".onion" domain names with NXDOMAIN. */
+  if (ares__is_onion_domain(name))
+    return ARES_ENOTFOUND;
+
   /* Set our results early, in case we bail out early with an error. */
   *buflenp = 0;
   *bufp = NULL;

--- a/ares_gethostbyname.c
+++ b/ares_gethostbyname.c
@@ -95,6 +95,13 @@ void ares_gethostbyname(ares_channel channel, const char *name, int family,
     return;
   }
 
+  /* Per RFC 7686, reject queries for ".onion" domain names with NXDOMAIN. */
+  if (ares__is_onion_domain(name))
+    {
+      callback(arg, ARES_ENOTFOUND, 0, NULL);
+      return;
+    }
+
   if (fake_hostent(name, family, callback, arg))
     return;
 
@@ -338,6 +345,10 @@ static int file_lookup(const char *name, int family, struct hostent **host)
   char **alias;
   int status;
   int error;
+
+  /* Per RFC 7686, reject queries for ".onion" domain names with NXDOMAIN. */
+  if (ares__is_onion_domain(name))
+    return ARES_ENOTFOUND;
 
 #ifdef WIN32
   char PATH_HOSTS[MAX_PATH];

--- a/ares_getnameinfo.c
+++ b/ares_getnameinfo.c
@@ -440,3 +440,14 @@ STATIC_TESTABLE char *ares_striendstr(const char *s1, const char *s2)
     }
   return (char *)c1_begin;
 }
+
+int ares__is_onion_domain(const char *name)
+{
+  if (ares_striendstr(name, ".onion"))
+    return 1;
+
+  if (ares_striendstr(name, ".onion."))
+    return 1;
+
+  return 0;
+}

--- a/ares_mkquery.3
+++ b/ares_mkquery.3
@@ -64,6 +64,13 @@ can return any of the following values:
 .B ARES_SUCCESS
 Construction of the DNS query succeeded.
 .TP 15
+.B ARES_ENOTFOUND
+The query name
+.I name
+refers to a
+.I .onion
+domain name. See RFC 7686.
+.TP 15
 .B ARES_EBADNAME
 The query name
 .I name

--- a/ares_private.h
+++ b/ares_private.h
@@ -330,6 +330,9 @@ struct ares_channeldata {
   char *resolvconf_path;
 };
 
+/* Does the domain end in ".onion" or ".onion."? Case-insensitive. */
+int ares__is_onion_domain(const char *name);
+
 /* Memory management functions */
 extern void *(*ares_malloc)(size_t size);
 extern void *(*ares_realloc)(void *ptr, size_t size);

--- a/ares_search.c
+++ b/ares_search.c
@@ -54,6 +54,13 @@ void ares_search(ares_channel channel, const char *name, int dnsclass,
   const char *p;
   int status, ndots;
 
+  /* Per RFC 7686, reject queries for ".onion" domain names with NXDOMAIN. */
+  if (ares__is_onion_domain(name))
+    {
+      callback(arg, ARES_ENOTFOUND, 0, NULL, 0);
+      return;
+    }
+
   /* If name only yields one domain to search, then we don't have
    * to keep extra state, so just do an ares_query().
    */

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -355,6 +355,17 @@ TEST_F(LibraryTest, GetHostentAllocFail) {
   }
   fclose(fp);
 }
+
+TEST(Misc, OnionDomain) {
+  EXPECT_EQ(0, ares__is_onion_domain("onion.no"));
+  EXPECT_EQ(0, ares__is_onion_domain(".onion.no"));
+  EXPECT_EQ(1, ares__is_onion_domain(".onion"));
+  EXPECT_EQ(1, ares__is_onion_domain(".onion."));
+  EXPECT_EQ(1, ares__is_onion_domain("yes.onion"));
+  EXPECT_EQ(1, ares__is_onion_domain("yes.onion."));
+  EXPECT_EQ(1, ares__is_onion_domain("YES.ONION"));
+  EXPECT_EQ(1, ares__is_onion_domain("YES.ONION."));
+}
 #endif
 
 #ifdef CARES_EXPOSE_STATICS

--- a/test/ares-test-misc.cc
+++ b/test/ares-test-misc.cc
@@ -275,6 +275,38 @@ TEST_F(LibraryTest, CreateQueryFailures) {
   if (p) ares_free_string(p);
 }
 
+TEST_F(LibraryTest, CreateQueryOnionDomain) {
+  byte* p;
+  int len;
+  EXPECT_EQ(ARES_ENOTFOUND,
+            ares_create_query("dontleak.onion", ns_c_in, ns_t_a, 0x1234, 0,
+                              &p, &len, 0));
+}
+
+TEST_F(DefaultChannelTest, HostByNameOnionDomain) {
+  HostResult result;
+  ares_gethostbyname(channel_, "dontleak.onion", AF_INET, HostCallback, &result);
+  EXPECT_TRUE(result.done_);
+  EXPECT_EQ(ARES_ENOTFOUND, result.status_);
+}
+
+TEST_F(DefaultChannelTest, HostByNameFileOnionDomain) {
+  struct hostent *h;
+  EXPECT_EQ(ARES_ENOTFOUND,
+            ares_gethostbyname_file(channel_, "dontleak.onion", AF_INET, &h));
+}
+
+// Interesting question: should tacking on a search domain let the query
+// through? It seems safer to reject it because "supersecret.onion.search"
+// still leaks information about the query to malicious resolvers.
+TEST_F(DefaultChannelTest, SearchOnionDomain) {
+  SearchResult result;
+  ares_search(channel_, "dontleak.onion", ns_c_in, ns_t_a,
+              SearchCallback, &result);
+  EXPECT_TRUE(result.done_);
+  EXPECT_EQ(ARES_ENOTFOUND, result.status_);
+}
+
 TEST_F(DefaultChannelTest, SendFailure) {
   unsigned char buf[2];
   SearchResult result;


### PR DESCRIPTION
Quoting RFC 7686:

    Name Resolution APIs and Libraries (...) MUST either respond
    to requests for .onion names by resolving them according to
    [tor-rendezvous] or by responding with NXDOMAIN.

    A legacy client may inadvertently attempt to resolve a .onion
    name through the DNS. This causes a disclosure that the client
    is attempting to use Tor to reach a specific service. Malicious
    resolvers could be engineered to capture and record such leaks,
    which might have very adverse consequences for the well-being
    of the user.

Bug: #196