### PR TITLE
Fix wrappers for sock_funcs in ares__sortaddrinfo

### DIFF
--- a/ares__close_sockets.c
+++ b/ares__close_sockets.c
@@ -48,14 +48,14 @@ void ares__close_sockets(ares_channel channel, struct server_state *server)
   if (server->tcp_socket != ARES_SOCKET_BAD)
     {
       SOCK_STATE_CALLBACK(channel, server->tcp_socket, 0, 0);
-      ares__socket_close(channel, server->tcp_socket);
+      ares__close_socket(channel, server->tcp_socket);
       server->tcp_socket = ARES_SOCKET_BAD;
       server->tcp_connection_generation = ++channel->tcp_connection_generation;
     }
   if (server->udp_socket != ARES_SOCKET_BAD)
     {
       SOCK_STATE_CALLBACK(channel, server->udp_socket, 0, 0);
-      ares__socket_close(channel, server->udp_socket);
+      ares__close_socket(channel, server->udp_socket);
       server->udp_socket = ARES_SOCKET_BAD;
     }
 }

--- a/ares__sortaddrinfo.c
+++ b/ares__sortaddrinfo.c
@@ -401,7 +401,7 @@ static int find_src_addr(ares_channel channel,
       return 0;
     }
 
-  sock = channel->sock_funcs->asocket(addr->sa_family, SOCK_DGRAM, IPPROTO_UDP, channel->sock_func_cb_data);
+  sock = ares__open_socket(channel, addr->sa_family, SOCK_DGRAM, IPPROTO_UDP);
   if (sock == -1)
     {
       if (errno == EAFNOSUPPORT)
@@ -416,23 +416,22 @@ static int find_src_addr(ares_channel channel,
 
   do
     {
-      ret = channel->sock_funcs->aconnect(sock, addr, len, channel->sock_func_cb_data);
+      ret = ares__connect_socket(channel, sock, addr, len);
     }
   while (ret == -1 && errno == EINTR);
 
   if (ret == -1)
     {
-      channel->sock_funcs->aclose(sock, channel->sock_func_cb_data);
+      ares__close_socket(channel, sock);
       return 0;
     }
 
   if (getsockname(sock, src_addr, &len) == -1)
     {
-      channel->sock_funcs->aclose(sock, channel->sock_func_cb_data);
+      ares__close_socket(channel, sock);
       return -1;
     }
-
-  channel->sock_funcs->aclose(sock, channel->sock_func_cb_data);
+  ares__close_socket(channel, sock);
   return 1;
 }
 

--- a/ares_private.h
+++ b/ares_private.h
@@ -364,7 +364,13 @@ int ares__sortaddrinfo(ares_channel channel, struct ares_addrinfo *ai);
 long ares__tvdiff(struct timeval t1, struct timeval t2);
 #endif
 
-void ares__socket_close(ares_channel, ares_socket_t);
+ares_socket_t ares__open_socket(ares_channel channel,
+                                int af, int type, int protocol);
+void ares__close_socket(ares_channel, ares_socket_t);
+int ares__connect_socket(ares_channel channel,
+                         ares_socket_t sockfd,
+                         const struct sockaddr *addr,
+                         ares_socklen_t addrlen);
 
 #define ARES_SWAP_BYTE(a,b) \
   { unsigned char swapByte = *(a);  *(a) = *(b);  *(b) = swapByte; }


### PR DESCRIPTION
I have missed wrappers for sock_funcs in ares__sortaddrinfo, so I have used those from ares_process.c:
- open_socket renamed to ares__open_socket
- connect_socket renamed to ares__connect_socket
- ares__socket_close renamed to ares__close_socket
