### PR TITLE
Fix LTO -Wmaybe-uninitialized error with gcc 8.

### DIFF
--- a/ares_query.c
+++ b/ares_query.c
@@ -112,7 +112,7 @@ void ares_query(ares_channel channel, const char *name, int dnsclass,
                 int type, ares_callback callback, void *arg)
 {
   struct qquery *qquery;
-  unsigned char *qbuf;
+  unsigned char *qbuf = NULL;
   int qlen, rd, status;
 
   /* Compose the query. */


### PR DESCRIPTION
Hi,

I have this issue in my own project if I build c-ares with LTO mode enabled (and gcc 8 with -Wall -Werror -Wextra)

```
ares_query.c: In function 'ares_query':
ares_query.c:124:10: error: 'qbuf' may be used uninitialized in this function [-Werror=maybe-uninitialized]
ares_query.c:115:18: note: 'qbuf' was declared here
```

Cheers,
Romain