### PR TITLE
fix segfault when parsing wrong type of record

### DIFF
--- a/ares_parse_aaaa_reply.c
+++ b/ares_parse_aaaa_reply.c
@@ -127,6 +127,11 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
       goto enomem;
     }
 
+  for (i = 0; i < naddrs + 1; ++i)
+    {
+      hostent->h_addr_list[i] = NULL;
+    }
+
   if (ai.cnames)
     {
       hostent->h_name = strdup(ai.cnames->name);
@@ -149,25 +154,32 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
           goto enomem;
         }
 
+      i = 0;
       next = ai.nodes;
-      for (i = 0; i < naddrs; i++)
+      while (next)
         {
-          hostent->h_addr_list[i] = (char*)&addrs[i];
-          memcpy(hostent->h_addr_list[i], &(((struct sockaddr_in6 *)next->ai_addr)->sin6_addr), sizeof(struct ares_in6_addr));
-          if (naddrttls)
+          if(next->ai_family == AF_INET6)
             {
-                if(next->ai_ttl > cname_ttl)
-                  addrttls[i].ttl = cname_ttl;
-                else
-                  addrttls[i].ttl = next->ai_ttl;
+              hostent->h_addr_list[i] = (char*)&addrs[i];
+              memcpy(hostent->h_addr_list[i],
+                     &(((struct sockaddr_in6 *)next->ai_addr)->sin6_addr),
+                     sizeof(struct ares_in6_addr));
+              if (naddrttls)
+                {
+                    if(next->ai_ttl > cname_ttl)
+                      addrttls[i].ttl = cname_ttl;
+                    else
+                      addrttls[i].ttl = next->ai_ttl;
 
-                memcpy(&addrttls[i].ip6addr, &(((struct sockaddr_in6 *)next->ai_addr)->sin6_addr), sizeof(struct ares_in6_addr));
+                    memcpy(&addrttls[i].ip6addr,
+                           &(((struct sockaddr_in6 *)next->ai_addr)->sin6_addr),
+                           sizeof(struct ares_in6_addr));
+                }
+              ++i;
             }
           next = next->ai_next;
         }
     }
-
-  hostent->h_addr_list[naddrs] = NULL;
 
   if (host)
     {


### PR DESCRIPTION
Fixes segfault when trying to ares_parse_aaaa with AF_INET and vise versa.