### PR TITLE
Add missing limits.h include from ares_getaddrinfo.c

### DIFF
--- a/ares_getaddrinfo.c
+++ b/ares_getaddrinfo.c
@@ -48,6 +48,10 @@
 #endif
 #include <assert.h>
 
+#ifdef HAVE_LIMITS_H
+#include <limits.h>
+#endif
+
 #include "ares.h"
 #include "bitncmp.h"
 #include "ares_private.h"


### PR DESCRIPTION
This files references INT_MAX, but does not include limits.h. This can cause a build failure on some platforms. Include limits.h if we have it.

Tested by building and running existing c-ARES tests. `./configure --enable-debug --enable-maintainer-mode` build shows no new warnings.

Signed-off-by: Dan Noé <dpn@google.com>