### PR TITLE
ares-test.cc: Handle nullptr in AddrInfo ostream.

### DIFF
--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -578,6 +578,11 @@ std::ostream& operator<<(std::ostream& os, const AddrInfoResult& result) {
 
 std::ostream& operator<<(std::ostream& os, const AddrInfo& ai) {
   os << '{';
+  if (ai == nullptr) {
+    os << "nullptr}";
+    return os;
+  }
+
   struct ares_addrinfo_cname *next_cname = ai->cnames;
   while(next_cname) {
     if(next_cname->alias) {


### PR DESCRIPTION
The `const AddrInfo&` argument to `operator<<` overload for AddrInfo can be a `nullptr` `unique_ptr`. Handle this explicitly by printing `{nullptr}` if the rest of the function cannot be safely executed. This makes it much easier to debug tests.

Signed-off-by: Dan Noé <dpn@google.com>