### PR TITLE
gethostbyname: reload resolv.conf values if file changed

### DIFF
--- a/ares.h
+++ b/ares.h
@@ -339,6 +339,8 @@ CARES_EXTERN const char *ares_version(int *version);
 
 CARES_EXTERN int ares_init(ares_channel *channelptr);
 
+CARES_EXTERN int ares_reinit_by_resolv_conf_file(ares_channel channel);
+
 CARES_EXTERN int ares_init_options(ares_channel *channelptr,
                                    struct ares_options *options,
                                    int optmask);

--- a/ares_gethostbyname.c
+++ b/ares_gethostbyname.c
@@ -83,6 +83,10 @@ void ares_gethostbyname(ares_channel channel, const char *name, int family,
 {
   struct host_query *hquery;
 
+  /* nameserver list migh have changed since ares_init,
+     check if this is the case, if yes then reload it */
+  ares_reinit_by_resolv_conf_file(channel);
+
   /* Right now we only know how to look up Internet addresses - and unspec
      means try both basically. */
   switch (family) {

--- a/ares_private.h
+++ b/ares_private.h
@@ -30,6 +30,10 @@
 #include <netinet/in.h>
 #endif
 
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+
 #ifdef WATT32
 #include <tcp.h>
 #include <sys/ioctl.h>
@@ -328,6 +332,10 @@ struct ares_channeldata {
 
   /* Path for resolv.conf file, configurable via ares_options */
   char *resolvconf_path;
+  struct timespec resolvconf_mtime;
+  struct timespec resolvconf_ctime;
+  off_t resolvconf_size;
+  ino_t resolvconf_ino;
 };
 
 /* Does the domain end in ".onion" or ".onion."? Case-insensitive. */


### PR DESCRIPTION
There is unhandled ares use case when we call ares_init when /etc/resolv.conf
is empty and later do the DNS request when it is filled in.
The bug is that ares does not detect change of resolv.conf.
The result is that default DNS IP is used, which is 127.0.0.1

Solution for this problem is that we check if resolv.conf file changed
each time we call ares_gethostbyname function.
Similar solution is done in libc.

Another unhandled use case is that system changes resolve.conf for some reason
and ares would not be aware of this change silently doing wrong DNS requests.

Signed-off-by: Nayana Topolsky <nayana.topolsky@streamunlimited.com>