### PR TITLE
Accept invalid /etc/resolv.conf lookup values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ OPTION (CARES_SHARED     "Build as a shared library"                            
 OPTION (CARES_INSTALL    "Create installation targets (chain builders may want to disable this)" ON)
 OPTION (CARES_STATIC_PIC "Build the static library as PIC (position independent)"                OFF)
 OPTION (CARES_BUILD_TESTS "Build and run tests"                                                  OFF)
+OPTION (CARES_BUILD_CONTAINER_TESTS "Build and run container tests (implies CARES_BUILD_TESTS, Linux only)" OFF)
 OPTION (CARES_BUILD_TOOLS "Build tools"                                                          ON)
 
 # allow linking against the static runtime library in msvc
@@ -644,7 +645,7 @@ IF (CARES_STATIC)
 	ENDIF ()
 ENDIF ()
 
-IF (CARES_BUILD_TESTS)
+IF (CARES_BUILD_TESTS OR CARES_BUILD_CONTAINER_TESTS)
 	ENABLE_TESTING ()
 	ADD_SUBDIRECTORY (test)
 ENDIF ()

--- a/ares_init.c
+++ b/ares_init.c
@@ -2024,6 +2024,7 @@ static int config_lookup(ares_channel channel, const char *str,
 {
   char lookups[3], *l;
   const char *vqualifier p;
+  int found;
 
   if (altbindch == NULL)
     altbindch = bindch;
@@ -2034,17 +2035,21 @@ static int config_lookup(ares_channel channel, const char *str,
    */
   l = lookups;
   p = str;
+  found = 0;
   while (*p)
     {
       if ((*p == *bindch || *p == *altbindch || *p == *filech) && l < lookups + 2) {
         if (*p == *bindch || *p == *altbindch) *l++ = 'b';
         else *l++ = 'f';
+        found = 1;
       }
       while (*p && !ISSPACE(*p) && (*p != ','))
         p++;
       while (*p && (ISSPACE(*p) || (*p == ',')))
         p++;
     }
+  if (!found)
+    return ARES_ENOTINITIALIZED;
   *l = '\0';
   channel->lookups = ares_strdup(lookups);
   return (channel->lookups) ? ARES_SUCCESS : ARES_ENOMEM;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,10 @@ add_executable(arestest ${TESTSOURCES} ${TESTHEADERS})
 target_include_directories(arestest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(arestest PRIVATE caresinternal gmock)
 
+IF (CARES_BUILD_CONTAINER_TESTS)
+  target_compile_definitions(arestest PRIVATE HAVE_USER_NAMESPACE HAVE_UTS_NAMESPACE)
+ENDIF ()
+
 add_executable(aresfuzz ${FUZZSOURCES})
 target_link_libraries(aresfuzz PRIVATE caresinternal)
 

--- a/test/ares-test-init.cc
+++ b/test/ares-test-init.cc
@@ -469,6 +469,24 @@ CONTAINED_TEST_F(LibraryTest, ContainerSvcConfInit,
   return HasFailure();
 }
 
+NameContentList malformedresolvconflookup = {
+  {"/etc/resolv.conf", "nameserver 1.2.3.4\n"
+                       "lookup garbage\n"}};  // malformed line
+CONTAINED_TEST_F(LibraryTest, ContainerMalformedResolvConfLookup,
+                 "myhostname", "mydomainname.org", malformedresolvconflookup) {
+  ares_channel channel = nullptr;
+  EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
+
+  struct ares_options opts;
+  int optmask = 0;
+  ares_save_options(channel, &opts, &optmask);
+  EXPECT_EQ(std::string("fb"), std::string(opts.lookups));
+  ares_destroy_options(&opts);
+
+  ares_destroy(channel);
+  return HasFailure();
+}
+
 // Failures when expected config filenames are inaccessible.
 class MakeUnreadable {
  public:


### PR DESCRIPTION
Before this commit invalid `lookup` values resulted in c-ares not using
any lookups without any clear indication why. After this commit it uses
the default "fb".

(I'm all ears if there is a better way to fix this.)