### PR TITLE
[ares_getenv] Return NULL in all cases.

### DIFF
--- a/ares_getenv.c
+++ b/ares_getenv.c
@@ -22,9 +22,7 @@
 
 char *ares_getenv(const char *name)
 {
-#ifdef _WIN32_WCE
   return NULL;
-#endif
 }
 
 #endif


### PR DESCRIPTION
In my tricky example HAVE_GETENV check did not work, so I got ares_getenv() call on linux, but there's no return value.
And I get trash and crashes further.

This PR removes _WIN32_WCE ifdef, so all platforms return NULL here.