### PR TITLE
Fixing name resolution under win10 x64

### DIFF
--- a/ares_expand_name.c
+++ b/ares_expand_name.c
@@ -73,6 +73,8 @@ int ares_expand_name(const unsigned char *encoded, const unsigned char *abuf,
      size_t uns;
   } nlen;
 
+  memset(&nlen, 0, sizeof(nlen));
+
   nlen.sig = name_length(encoded, abuf, alen);
   if (nlen.sig < 0)
     return ARES_EBADNAME;


### PR DESCRIPTION
While using c-ares for internal project, got a problem of names not resolving on Windows 10 x64 native (Linux/Mac/.NET x86&x64 worked fine).

It turned out, some compilers just do not null the high part of the `size_t uns` in `nlen` union leading to ares_malloc failure (nlen.uns gets too big).

Simple memset fixes the problem.