### PR TITLE
Parallel DNS requests in `ares_getaddrinfo`

### DIFF
--- a/ares_getaddrinfo.c
+++ b/ares_getaddrinfo.c
@@ -76,6 +76,8 @@ struct host_query
   const char *remaining_lookups; /* types of lookup we need to perform ("fb" by
                                     default, file and dns respectively) */
   struct ares_addrinfo *ai;      /* store results between lookups */
+  int remaining;   /* number of DNS answers waiting for */
+  int next_domain; /* next search domain to try */
 };
 
 static const struct ares_addrinfo_hints default_hints = {
@@ -108,8 +110,11 @@ static const struct ares_addrinfo empty_addrinfo = {
   NULL  /* nodes */
 };
 
+/* forward declarations */
 static void host_callback(void *arg, int status, int timeouts,
                           unsigned char *abuf, int alen);
+static int as_is_first(const struct host_query *hquery);
+static int next_dns_lookup(struct host_query *hquery);
 
 struct ares_addrinfo_cname *ares__malloc_addrinfo_cname()
 {
@@ -500,91 +505,75 @@ static int file_lookup(struct host_query *hquery)
   return status;
 }
 
-static void next_lookup(struct host_query *hquery, int status_code)
+static void next_lookup(struct host_query *hquery, int status)
 {
-  const char *p;
-  int status = status_code;
-
-  for (p = hquery->remaining_lookups; *p; p++)
+  switch (*hquery->remaining_lookups)
     {
-      switch (*p)
-        {
-        case 'b':
+      case 'b':
           /* DNS lookup */
-          hquery->remaining_lookups = p + 1;
-          if ((hquery->hints.ai_family == AF_INET6) ||
-              (hquery->hints.ai_family == AF_UNSPEC)) {
-            /* if inet6 or unspec, start out with AAAA */
-            hquery->sent_family = AF_INET6;
-            ares_search(hquery->channel, hquery->name, C_IN, T_AAAA,
-                        host_callback, hquery);
-          }
-          else {
-            hquery->sent_family = AF_INET;
-            ares_search(hquery->channel, hquery->name, C_IN, T_A,
-                        host_callback, hquery);
-          }
-          return;
-
-        case 'f':
-          /* Host file lookup */
-          status = file_lookup(hquery);
-
-          /* this status check below previously checked for !ARES_ENOTFOUND,
-             but we should not assume that this single error code is the one
-             that can occur, as that is in fact no longer the case */
-          if (status == ARES_SUCCESS)
-            {
-              end_hquery(hquery, status);
-              return;
-            }
-          status = status_code;   /* Use original status code */
+          if (next_dns_lookup(hquery))
+            break;
+          hquery->remaining_lookups++;
+          next_lookup(hquery, status);
           break;
-        }
+
+      case 'f':
+          /* Host file lookup */
+          if (file_lookup(hquery) == ARES_SUCCESS)
+            {
+              end_hquery(hquery, ARES_SUCCESS);
+              break;
+            }
+          hquery->remaining_lookups++;
+          next_lookup(hquery, status);
+          break;
+      default:
+          /* No lookup left */
+         end_hquery(hquery, status);
+         break;
     }
-  end_hquery(hquery, status);
 }
 
 static void host_callback(void *arg, int status, int timeouts,
                           unsigned char *abuf, int alen)
 {
-  struct host_query *hquery = (struct host_query *) arg;
+  struct host_query *hquery = (struct host_query*)arg;
+  int addinfostatus = ARES_SUCCESS;
   hquery->timeouts += timeouts;
+  hquery->remaining--;
+
   if (status == ARES_SUCCESS)
     {
-      if (hquery->sent_family == AF_INET)
-        {
-          status = ares__parse_into_addrinfo(abuf, alen, hquery->ai);
-        }
-      else if (hquery->sent_family == AF_INET6)
-        {
-          status = ares__parse_into_addrinfo(abuf, alen, hquery->ai);
-          if (hquery->hints.ai_family == AF_UNSPEC)
-            {
-              /* Now look for A records and append them to existing results. */
-              hquery->sent_family = AF_INET;
-              ares_search(hquery->channel, hquery->name, C_IN, T_A,
-                          host_callback, hquery);
-              return;
-            }
-        }
-      end_hquery(hquery, status);
-    }
-  else if ((status == ARES_ENODATA || status == ARES_ESERVFAIL ||
-            status == ARES_ECONNREFUSED || status == ARES_EBADRESP ||
-            status == ARES_ETIMEOUT) &&
-           (hquery->sent_family == AF_INET6 &&
-            hquery->hints.ai_family == AF_UNSPEC))
-    {
-      /* The AAAA query yielded no useful result.  Now look up an A instead. */
-      hquery->sent_family = AF_INET;
-      ares_search(hquery->channel, hquery->name, C_IN, T_A, host_callback,
-                  hquery);
+      addinfostatus = ares__parse_into_addrinfo(abuf, alen, hquery->ai);
     }
   else if (status == ARES_EDESTRUCTION)
-    end_hquery(hquery, status);
-  else
-    next_lookup(hquery, status);
+    {
+      end_hquery(hquery, status);
+    }
+
+  if (!hquery->remaining)
+    {
+      if (addinfostatus != ARES_SUCCESS)
+        {
+          /* error in parsing result e.g. no memory */
+          end_hquery(hquery, addinfostatus);
+        }
+      else if (hquery->ai->nodes)
+        {
+          /* at least one query ended with ARES_SUCCESS */
+          end_hquery(hquery, ARES_SUCCESS);
+        }
+      else if (status == ARES_ENOTFOUND)
+        {
+          next_lookup(hquery, status);
+        }
+      else
+        {
+          end_hquery(hquery, status);
+        }
+    }
+
+  /* at this point we keep on waiting for the next query to finish */
 }
 
 void ares_getaddrinfo(ares_channel channel,
@@ -611,6 +600,12 @@ void ares_getaddrinfo(ares_channel channel,
       family != AF_UNSPEC)
     {
       callback(arg, ARES_ENOTIMP, 0, NULL);
+      return;
+    }
+
+  if (ares__is_onion_domain(name))
+    {
+      callback(arg, ARES_ENOTFOUND, 0, NULL);
       return;
     }
 
@@ -679,7 +674,92 @@ void ares_getaddrinfo(ares_channel channel,
   hquery->remaining_lookups = channel->lookups;
   hquery->timeouts = 0;
   hquery->ai = ai;
+  hquery->next_domain = -1;
+  hquery->remaining = 0;
 
   /* Start performing lookups according to channel->lookups. */
   next_lookup(hquery, ARES_ECONNREFUSED /* initial error code */);
+}
+
+static int next_dns_lookup(struct host_query *hquery)
+{
+  char *s = NULL;
+  int is_s_allocated = 0;
+  int status;
+
+  /* if next_domain == -1 and as_is_first is true, try hquery->name */
+  if (hquery->next_domain == -1)
+    {
+      if (as_is_first(hquery))
+        {
+          s = hquery->name;
+        }
+      hquery->next_domain = 0;
+    }
+
+  /* if as_is_first is false, try hquery->name at last */
+  if (!s && hquery->next_domain == hquery->channel->ndomains) {
+    if (!as_is_first(hquery))
+      {
+        s = hquery->name;
+      }
+    hquery->next_domain++;
+  }
+
+  if (!s && hquery->next_domain < hquery->channel->ndomains)
+    {
+      status = ares__cat_domain(
+          hquery->name,
+          hquery->channel->domains[hquery->next_domain++],
+          &s);
+      if (status == ARES_SUCCESS)
+        {
+          is_s_allocated = 1;
+        }
+    }
+
+  if (s)
+    {
+      switch (hquery->hints.ai_family)
+        {
+          case AF_INET:
+            hquery->remaining += 1;
+            ares_query(hquery->channel, s, C_IN, T_A, host_callback, hquery);
+            break;
+          case AF_INET6:
+            hquery->remaining += 1;
+            ares_query(hquery->channel, s, C_IN, T_AAAA, host_callback, hquery);
+            break;
+          case AF_UNSPEC:
+            hquery->remaining += 2;
+            ares_query(hquery->channel, s, C_IN, T_A, host_callback, hquery);
+            ares_query(hquery->channel, s, C_IN, T_AAAA, host_callback, hquery);
+            break;
+          default: break;
+        }
+      if (is_s_allocated)
+        {
+          ares_free(s);
+        }
+      return 1;
+    }
+  else
+    {
+      assert(!hquery->ai->nodes);
+      return 0;
+    }
+}
+
+static int as_is_first(const struct host_query* hquery)
+{
+  char* p;
+  int ndots = 0;
+  for (p = hquery->name; *p; p++)
+    {
+      if (*p == '.')
+        {
+          ndots++;
+        }
+    }
+  return ndots >= hquery->channel->ndots;
 }

--- a/test/ares-test-misc.cc
+++ b/test/ares-test-misc.cc
@@ -296,6 +296,15 @@ TEST_F(DefaultChannelTest, HostByNameFileOnionDomain) {
             ares_gethostbyname_file(channel_, "dontleak.onion", AF_INET, &h));
 }
 
+TEST_F(DefaultChannelTest, GetAddrinfoOnionDomain) {
+  AddrInfoResult result;
+  struct ares_addrinfo_hints hints = {};
+  hints.ai_family = AF_UNSPEC;
+  ares_getaddrinfo(channel_, "dontleak.onion", NULL, &hints, AddrInfoCallback, &result);
+  EXPECT_TRUE(result.done_);
+  EXPECT_EQ(ARES_ENOTFOUND, result.status_);
+}
+
 // Interesting question: should tacking on a search domain let the query
 // through? It seems safer to reject it because "supersecret.onion.search"
 // still leaks information about the query to malicious resolvers.


### PR DESCRIPTION
This PR addresses issue #285. For this change `ares_search` was removed from `ares_getaddrinfo`. Instead `ares_query` in combination with `next_dns_lookup` performs the suffix search.

Adding support for `.onion` addresses which are tested by `TEST_F(DefaultChannelTest, GetAddrinfoOnionDomain)`.

Following test shows that the queries for A and AAAA are tried for one domain before switching to the next domain:
```
~/github/ChristianAmmer/c-ares/test$ ./arestest -v --gtest_filter=AddressFamiliesAI/MockChannelTestAI.SearchDomainsServFailOnAAAA/0
Note: Google Test filter = AddressFamiliesAI/MockChannelTestAI.SearchDomainsServFailOnAAAA/0
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from AddressFamiliesAI/MockChannelTestAI
[ RUN      ] AddressFamiliesAI/MockChannelTestAI.SearchDomainsServFailOnAAAA/0
Configured IPv4 mock server with TCP socket 3 on port 5300 and UDP socket 4 on port 5300
Configured library with servers: 127.0.0.1:5300
received UDP request REQ QRY RD  Q:{'www.first.com' IN A} on port 5300
ProcessRequest(34391, 'www.first.com', A)
sending reply RSP QRY AA NXDOMAIN Q:{'www.first.com' IN A} on port 5300
received UDP request REQ QRY RD  Q:{'www.first.com' IN AAAA} on port 5300
ProcessRequest(57573, 'www.first.com', AAAA)
sending reply RSP QRY AA NXDOMAIN Q:{'www.first.com' IN AAAA} on port 5300
received UDP request REQ QRY RD  Q:{'www.second.org' IN A} on port 5300
ProcessRequest(44444, 'www.second.org', A)
sending reply RSP QRY AA NOERROR Q:{'www.second.org' IN A} A:{'www.second.org' IN A TTL=512 2.3.4.5} on port 5300
received UDP request REQ QRY RD  Q:{'www.second.org' IN AAAA} on port 5300
ProcessRequest(8828, 'www.second.org', AAAA)
sending reply RSP QRY AA NXDOMAIN Q:{'www.second.org' IN AAAA} on port 5300
AddrInfoCallback({ARES_SUCCESS {addr=[2.3.4.5]}})
[       OK ] AddressFamiliesAI/MockChannelTestAI.SearchDomainsServFailOnAAAA/0 (1 ms)
[----------] 1 test from AddressFamiliesAI/MockChannelTestAI (1 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1 ms total)
[  PASSED  ] 1 test.
```