### PR TITLE
Rename `ares_getaddrinfo`

### DIFF
--- a/ares.h
+++ b/ares.h
@@ -283,7 +283,7 @@ struct hostent;
 struct timeval;
 struct sockaddr;
 struct ares_channeldata;
-struct ares_addrinfo_result;
+struct ares_addrinfo_ex;
 struct ares_addrinfo;
 
 typedef struct ares_channeldata *ares_channel;
@@ -316,7 +316,7 @@ typedef int  (*ares_sock_config_callback)(ares_socket_t socket_fd,
 typedef void (*ares_addrinfo_callback)(void *arg,
                                    int status,
                                    int timeouts,
-                                   struct ares_addrinfo_result *res);
+                                   struct ares_addrinfo_ex *res);
 
 CARES_EXTERN int ares_library_init(int flags);
 
@@ -388,7 +388,7 @@ CARES_EXTERN void ares_getaddrinfo_ex(ares_channel channel,
                                    ares_addrinfo_callback callback,
                                    void* arg);
 
-CARES_EXTERN void ares_freeaddrinfo(struct ares_addrinfo_result* ai);
+CARES_EXTERN void ares_freeaddrinfo(struct ares_addrinfo_ex* ai);
 
 /*
  * Virtual function set to have user-managed socket IO.
@@ -605,7 +605,7 @@ struct ares_addrinfo_cname {
   struct ares_addrinfo_cname *next;
 };
 
-struct ares_addrinfo_result {
+struct ares_addrinfo_ex {
   struct ares_addrinfo_cname *cnames;
   struct ares_addrinfo  *nodes;
 };

--- a/ares.h
+++ b/ares.h
@@ -283,8 +283,8 @@ struct hostent;
 struct timeval;
 struct sockaddr;
 struct ares_channeldata;
+struct ares_addrinfo_result;
 struct ares_addrinfo;
-struct ares_addrinfo_hints;
 
 typedef struct ares_channeldata *ares_channel;
 
@@ -316,7 +316,7 @@ typedef int  (*ares_sock_config_callback)(ares_socket_t socket_fd,
 typedef void (*ares_addrinfo_callback)(void *arg,
                                    int status,
                                    int timeouts,
-                                   struct ares_addrinfo *res);
+                                   struct ares_addrinfo_result *res);
 
 CARES_EXTERN int ares_library_init(int flags);
 
@@ -384,11 +384,11 @@ CARES_EXTERN int ares_set_sortlist(ares_channel channel,
 CARES_EXTERN void ares_getaddrinfo(ares_channel channel,
                                    const char* node,
                                    const char* service,
-                                   const struct ares_addrinfo_hints* hints,
+                                   const struct ares_addrinfo* hints,
                                    ares_addrinfo_callback callback,
                                    void* arg);
 
-CARES_EXTERN void ares_freeaddrinfo(struct ares_addrinfo* ai);
+CARES_EXTERN void ares_freeaddrinfo(struct ares_addrinfo_result* ai);
 
 /*
  * Virtual function set to have user-managed socket IO.
@@ -582,7 +582,7 @@ struct ares_soa_reply {
 /*
  * Similar to addrinfo, but with extra ttl and missing canonname.
  */
-struct ares_addrinfo_node {
+struct ares_addrinfo {
   int                        ai_ttl;
   int                        ai_flags;
   int                        ai_family;
@@ -590,7 +590,7 @@ struct ares_addrinfo_node {
   int                        ai_protocol;
   ares_socklen_t             ai_addrlen;
   struct sockaddr           *ai_addr;
-  struct ares_addrinfo_node *ai_next;
+  struct ares_addrinfo *ai_next;
 };
 
 /*
@@ -605,16 +605,9 @@ struct ares_addrinfo_cname {
   struct ares_addrinfo_cname *next;
 };
 
-struct ares_addrinfo {
+struct ares_addrinfo_result {
   struct ares_addrinfo_cname *cnames;
-  struct ares_addrinfo_node  *nodes;
-};
-
-struct ares_addrinfo_hints {
-  int ai_flags;
-  int ai_family;
-  int ai_socktype;
-  int ai_protocol;
+  struct ares_addrinfo  *nodes;
 };
 
 /*

--- a/ares.h
+++ b/ares.h
@@ -121,7 +121,7 @@ extern "C" {
 /* ares_getnameinfo error codes */
 #define ARES_EBADFLAGS          18
 
-/* ares_getaddrinfo error codes */
+/* ares_getaddrinfo_ex error codes */
 #define ARES_ENONAME            19
 #define ARES_EBADHINTS          20
 
@@ -135,7 +135,7 @@ extern "C" {
 /* More error codes */
 #define ARES_ECANCELLED         24          /* introduced in 1.7.0 */
 
-/* More ares_getaddrinfo error codes */
+/* More ares_getaddrinfo_ex error codes */
 #define ARES_ESERVICE           25          /* introduced in 1.?.0 */
 
 /* Flag values */
@@ -381,7 +381,7 @@ CARES_EXTERN void ares_set_socket_configure_callback(ares_channel channel,
 CARES_EXTERN int ares_set_sortlist(ares_channel channel,
                                    const char *sortstr);
 
-CARES_EXTERN void ares_getaddrinfo(ares_channel channel,
+CARES_EXTERN void ares_getaddrinfo_ex(ares_channel channel,
                                    const char* node,
                                    const char* service,
                                    const struct ares_addrinfo* hints,

--- a/ares__parse_into_addrinfo.c
+++ b/ares__parse_into_addrinfo.c
@@ -48,7 +48,7 @@
 int ares__parse_into_addrinfo2(const unsigned char *abuf,
                                int alen,
                                char **question_hostname,
-                               struct ares_addrinfo *ai)
+                               struct ares_addrinfo_result *ai)
 {
   unsigned int qdcount, ancount;
   int status, i, rr_type, rr_class, rr_len, rr_ttl;
@@ -57,7 +57,7 @@ int ares__parse_into_addrinfo2(const unsigned char *abuf,
   const unsigned char *aptr;
   char *hostname, *rr_name = NULL, *rr_data;
   struct ares_addrinfo_cname *cname, *cnames = NULL;
-  struct ares_addrinfo_node *node, *nodes = NULL;
+  struct ares_addrinfo *node, *nodes = NULL;
   struct sockaddr_in *sin;
   struct sockaddr_in6 *sin6;
 
@@ -127,7 +127,7 @@ int ares__parse_into_addrinfo2(const unsigned char *abuf,
             goto failed_stat;
           }  /* LCOV_EXCL_STOP */
 
-          node = ares__append_addrinfo_node(&nodes);
+          node = ares__append_addrinfo(&nodes);
           if (!node)
             {
               status = ARES_ENOMEM;
@@ -163,7 +163,7 @@ int ares__parse_into_addrinfo2(const unsigned char *abuf,
             goto failed_stat;
           }  /* LCOV_EXCL_STOP */
 
-          node = ares__append_addrinfo_node(&nodes);
+          node = ares__append_addrinfo(&nodes);
           if (!node)
             {
               status = ARES_ENOMEM;
@@ -256,7 +256,7 @@ failed_stat:
 
 int ares__parse_into_addrinfo(const unsigned char *abuf,
                               int alen,
-                              struct ares_addrinfo *ai)
+                              struct ares_addrinfo_result *ai)
 {
   int status;
   char *question_hostname;

--- a/ares__parse_into_addrinfo.c
+++ b/ares__parse_into_addrinfo.c
@@ -48,7 +48,7 @@
 int ares__parse_into_addrinfo2(const unsigned char *abuf,
                                int alen,
                                char **question_hostname,
-                               struct ares_addrinfo_result *ai)
+                               struct ares_addrinfo_ex *ai)
 {
   unsigned int qdcount, ancount;
   int status, i, rr_type, rr_class, rr_len, rr_ttl;
@@ -256,7 +256,7 @@ failed_stat:
 
 int ares__parse_into_addrinfo(const unsigned char *abuf,
                               int alen,
-                              struct ares_addrinfo_result *ai)
+                              struct ares_addrinfo_ex *ai)
 {
   int status;
   char *question_hostname;

--- a/ares__readaddrinfo.c
+++ b/ares__readaddrinfo.c
@@ -35,8 +35,8 @@
 int ares__readaddrinfo(FILE *fp,
                        const char *name,
                        unsigned short port,
-                       const struct ares_addrinfo_hints *hints,
-                       struct ares_addrinfo *ai)
+                       const struct ares_addrinfo *hints,
+                       struct ares_addrinfo_result *ai)
 {
   char *line = NULL, *p, *q;
   char *txtaddr, *txthost, *txtalias;
@@ -46,7 +46,7 @@ int ares__readaddrinfo(FILE *fp,
   size_t linesize;
   ares_sockaddr addr;
   struct ares_addrinfo_cname *cname = NULL, *cnames = NULL;
-  struct ares_addrinfo_node *node = NULL, *nodes = NULL;
+  struct ares_addrinfo *node = NULL, *nodes = NULL;
   int match_with_alias, match_with_canonical;
   int want_cname = hints->ai_flags & ARES_AI_CANONNAME;
 
@@ -173,7 +173,7 @@ int ares__readaddrinfo(FILE *fp,
           addr.sa4.sin_addr.s_addr = inet_addr(txtaddr);
           if (addr.sa4.sin_addr.s_addr != INADDR_NONE)
             {
-              node = ares__append_addrinfo_node(&nodes);
+              node = ares__append_addrinfo(&nodes);
               if(!node)
                 {
                   goto enomem;
@@ -194,7 +194,7 @@ int ares__readaddrinfo(FILE *fp,
           addr.sa6.sin6_port = htons(port);
           if (ares_inet_pton(AF_INET6, txtaddr, &addr.sa6.sin6_addr) > 0)
             {
-              node = ares__append_addrinfo_node(&nodes);
+              node = ares__append_addrinfo(&nodes);
               if (!node)
                 {
                   goto enomem;

--- a/ares__readaddrinfo.c
+++ b/ares__readaddrinfo.c
@@ -36,7 +36,7 @@ int ares__readaddrinfo(FILE *fp,
                        const char *name,
                        unsigned short port,
                        const struct ares_addrinfo *hints,
-                       struct ares_addrinfo_result *ai)
+                       struct ares_addrinfo_ex *ai)
 {
   char *line = NULL, *p, *q;
   char *txtaddr, *txthost, *txtalias;

--- a/ares__sortaddrinfo.c
+++ b/ares__sortaddrinfo.c
@@ -54,7 +54,7 @@
 
 struct addrinfo_sort_elem
 {
-  struct ares_addrinfo_node *ai;
+  struct ares_addrinfo *ai;
   int has_src_addr;
   ares_sockaddr src_addr;
   int original_order;
@@ -439,9 +439,9 @@ static int find_src_addr(ares_channel channel,
  * Sort the linked list starting at sentinel->ai_next in RFC6724 order.
  * Will leave the list unchanged if an error occurs.
  */
-int ares__sortaddrinfo(ares_channel channel, struct ares_addrinfo_node *list_sentinel)
+int ares__sortaddrinfo(ares_channel channel, struct ares_addrinfo *list_sentinel)
 {
-  struct ares_addrinfo_node *cur;
+  struct ares_addrinfo *cur;
   int nelem = 0, i;
   int has_src_addr;
   struct addrinfo_sort_elem *elems;

--- a/ares_freeaddrinfo.3
+++ b/ares_freeaddrinfo.3
@@ -20,13 +20,13 @@ ares_freeaddrinfo \- Free addrinfo structure allocated by ares functions
 .nf
 .B #include <ares.h>
 .PP
-.B void ares_freeaddrinfo(struct ares_addrinfo *\fIai\fP)
+.B void ares_freeaddrinfo(struct ares_addrinfo_result *\fIai\fP)
 .fi
 .SH DESCRIPTION
 The
 .B ares_freeaddrinfo
 function frees a
-.B struct ares_addrinfo
+.B struct ares_addrinfo_result
 returned in \fIresult\fP of
 .B ares_addrinfo_callback
 .SH SEE ALSO

--- a/ares_freeaddrinfo.3
+++ b/ares_freeaddrinfo.3
@@ -20,13 +20,13 @@ ares_freeaddrinfo \- Free addrinfo structure allocated by ares functions
 .nf
 .B #include <ares.h>
 .PP
-.B void ares_freeaddrinfo(struct ares_addrinfo_result *\fIai\fP)
+.B void ares_freeaddrinfo(struct ares_addrinfo_ex *\fIai\fP)
 .fi
 .SH DESCRIPTION
 The
 .B ares_freeaddrinfo
 function frees a
-.B struct ares_addrinfo_result
+.B struct ares_addrinfo_ex
 returned in \fIresult\fP of
 .B ares_addrinfo_callback
 .SH SEE ALSO

--- a/ares_freeaddrinfo.3
+++ b/ares_freeaddrinfo.3
@@ -30,7 +30,7 @@ function frees a
 returned in \fIresult\fP of
 .B ares_addrinfo_callback
 .SH SEE ALSO
-.BR ares_getaddrinfo (3),
+.BR ares_getaddrinfo_ex (3),
 .SH AUTHOR
 Christian Ammer
 .BR

--- a/ares_freeaddrinfo.c
+++ b/ares_freeaddrinfo.c
@@ -49,7 +49,7 @@ void ares__freeaddrinfo_nodes(struct ares_addrinfo *head)
     }
 }
 
-void ares_freeaddrinfo(struct ares_addrinfo_result *ai)
+void ares_freeaddrinfo(struct ares_addrinfo_ex *ai)
 {
   ares__freeaddrinfo_cnames(ai->cnames);
   ares__freeaddrinfo_nodes(ai->nodes);

--- a/ares_freeaddrinfo.c
+++ b/ares_freeaddrinfo.c
@@ -37,9 +37,9 @@ void ares__freeaddrinfo_cnames(struct ares_addrinfo_cname *head)
     }
 }
 
-void ares__freeaddrinfo_nodes(struct ares_addrinfo_node *head)
+void ares__freeaddrinfo_nodes(struct ares_addrinfo *head)
 {
-  struct ares_addrinfo_node *current;
+  struct ares_addrinfo *current;
   while (head)
     {
       current = head;
@@ -49,7 +49,7 @@ void ares__freeaddrinfo_nodes(struct ares_addrinfo_node *head)
     }
 }
 
-void ares_freeaddrinfo(struct ares_addrinfo *ai)
+void ares_freeaddrinfo(struct ares_addrinfo_result *ai)
 {
   ares__freeaddrinfo_cnames(ai->cnames);
   ares__freeaddrinfo_nodes(ai->nodes);

--- a/ares_getaddrinfo.3
+++ b/ares_getaddrinfo.3
@@ -21,10 +21,10 @@ ares_getaddrinfo \- Initiate a host query by name and service
 .B #include <ares.h>
 .PP
 .B typedef void (*ares_addrinfo_callback)(void *\fIarg\fP, int \fIstatus\fP,
-.B 	int \fItimeouts\fP, struct ares_addrinfo *\fIresult\fP)
+.B 	int \fItimeouts\fP, struct ares_addrinfo_result *\fIresult\fP)
 .PP
 .B void ares_getaddrinfo(ares_channel \fIchannel\fP, const char *\fIname\fP,
-.B 	const char* \fIservice\fP, const struct ares_addrinfo_hints *\fIhints\fP,
+.B 	const char* \fIservice\fP, const struct ares_addrinfo *\fIhints\fP,
 .B 	ares_addrinfo_callback \fIcallback\fP, void *\fIarg\fP)
 .fi
 .SH DESCRIPTION
@@ -41,12 +41,12 @@ parameters give the hostname and service as NULL-terminated C strings.
 The
 .I hints
 parameter is an
-.BR ares_addrinfo_hints
+.BR ares_addrinfo
 structure:
 .PP
 .IN +4n
 .EX
-struct ares_addrinfo_hints {
+struct ares_addrinfo {
   int ai_flags;
   int ai_family;
   int ai_socktype;
@@ -75,7 +75,7 @@ If this option is set
 field will be treated as a numeric value.
 .TP 19
 .B ARES_AI_CANONNAME
-The ares_addrinfo structure will return a canonical names list.
+The ares_addrinfo_result structure will return a canonical names list.
 .TP 19
 .B ARES_AI_NOSORT
 Result addresses will not be sorted and no connections to resolved addresses will be attempted.
@@ -126,24 +126,24 @@ is being destroyed; the query will not be completed.
 On successful completion of the query, the callback argument
 .I result
 points to a
-.B struct ares_addrinfo
+.B struct ares_addrinfo_result
 which contains two linked lists, one with resolved addresses and another with canonical names.
 .PP
 .IN +4n
 .EX
-struct ares_addrinfo {
+struct ares_addrinfo_result {
   struct ares_addrinfo_cname *cnames;
-  struct ares_addrinfo_node  *nodes;
+  struct ares_addrinfo  *nodes;
 };
 .EE
 .IN
 .PP
-.I ares_addrinfo_node
+.I ares_addrinfo
 structure is similar to RFC3493 addrinfo, but without canonname and with extra ttl field.
 .IN +4n
 .PP
 .EX
-struct ares_addrinfo_node {
+struct ares_addrinfo {
   int                        ai_ttl;
   int                        ai_flags;
   int                        ai_family;
@@ -151,7 +151,7 @@ struct ares_addrinfo_node {
   int                        ai_protocol;
   ares_socklen_t             ai_addrlen;
   struct sockaddr           *ai_addr;
-  struct ares_addrinfo_node *ai_next;
+  struct ares_addrinfo *ai_next;
 };
 .EE
 .IN

--- a/ares_getaddrinfo.3
+++ b/ares_getaddrinfo.3
@@ -42,17 +42,8 @@ The
 .I hints
 parameter is an
 .BR ares_addrinfo
-structure:
+structure which considers following arguments:
 .PP
-.IN +4n
-.EX
-struct ares_addrinfo {
-  int ai_flags;
-  int ai_family;
-  int ai_socktype;
-  int ai_protocol;
-};
-.EE
 .IN
 .TP
 .I ai_family

--- a/ares_getaddrinfo.3
+++ b/ares_getaddrinfo.3
@@ -21,7 +21,7 @@ ares_getaddrinfo_ex \- Initiate a host query by name and service
 .B #include <ares.h>
 .PP
 .B typedef void (*ares_addrinfo_callback)(void *\fIarg\fP, int \fIstatus\fP,
-.B 	int \fItimeouts\fP, struct ares_addrinfo_result *\fIresult\fP)
+.B 	int \fItimeouts\fP, struct ares_addrinfo_ex *\fIresult\fP)
 .PP
 .B void ares_getaddrinfo_ex(ares_channel \fIchannel\fP, const char *\fIname\fP,
 .B 	const char* \fIservice\fP, const struct ares_addrinfo *\fIhints\fP,
@@ -66,7 +66,7 @@ If this option is set
 field will be treated as a numeric value.
 .TP 19
 .B ARES_AI_CANONNAME
-The ares_addrinfo_result structure will return a canonical names list.
+The ares_addrinfo_ex structure will return a canonical names list.
 .TP 19
 .B ARES_AI_NOSORT
 Result addresses will not be sorted and no connections to resolved addresses will be attempted.
@@ -117,12 +117,12 @@ is being destroyed; the query will not be completed.
 On successful completion of the query, the callback argument
 .I result
 points to a
-.B struct ares_addrinfo_result
+.B struct ares_addrinfo_ex
 which contains two linked lists, one with resolved addresses and another with canonical names.
 .PP
 .IN +4n
 .EX
-struct ares_addrinfo_result {
+struct ares_addrinfo_ex {
   struct ares_addrinfo_cname *cnames;
   struct ares_addrinfo  *nodes;
 };

--- a/ares_getaddrinfo.3
+++ b/ares_getaddrinfo.3
@@ -15,7 +15,7 @@
 .\"
 .TH ARES_GETADDRINFO 3 "4 November 2018"
 .SH NAME
-ares_getaddrinfo \- Initiate a host query by name and service
+ares_getaddrinfo_ex \- Initiate a host query by name and service
 .SH SYNOPSIS
 .nf
 .B #include <ares.h>
@@ -23,13 +23,13 @@ ares_getaddrinfo \- Initiate a host query by name and service
 .B typedef void (*ares_addrinfo_callback)(void *\fIarg\fP, int \fIstatus\fP,
 .B 	int \fItimeouts\fP, struct ares_addrinfo_result *\fIresult\fP)
 .PP
-.B void ares_getaddrinfo(ares_channel \fIchannel\fP, const char *\fIname\fP,
+.B void ares_getaddrinfo_ex(ares_channel \fIchannel\fP, const char *\fIname\fP,
 .B 	const char* \fIservice\fP, const struct ares_addrinfo *\fIhints\fP,
 .B 	ares_addrinfo_callback \fIcallback\fP, void *\fIarg\fP)
 .fi
 .SH DESCRIPTION
 The
-.B ares_getaddrinfo
+.B ares_getaddrinfo_ex
 function initiates a host query by name on the name service channel
 identified by
 .IR channel .
@@ -83,7 +83,7 @@ during a later call to \fIares_process(3)\fP, \fIares_destroy(3)\fP or
 The callback argument
 .I arg
 is copied from the
-.B ares_getaddrinfo
+.B ares_getaddrinfo_ex
 argument
 .IR arg .
 The callback argument

--- a/ares_getaddrinfo.c
+++ b/ares_getaddrinfo.c
@@ -75,7 +75,7 @@ struct host_query
   int timeouts;    /* number of timeouts we saw for this request */
   const char *remaining_lookups; /* types of lookup we need to perform ("fb" by
                                     default, file and dns respectively) */
-  struct ares_addrinfo_result *ai;      /* store results between lookups */
+  struct ares_addrinfo_ex *ai;      /* store results between lookups */
   int remaining;   /* number of DNS answers waiting for */
   int next_domain; /* next search domain to try */
 };
@@ -100,7 +100,7 @@ static const struct ares_addrinfo empty_addrinfo = {
 
 static const struct ares_addrinfo* default_hints = &empty_addrinfo;
 
-static const struct ares_addrinfo_result empty_addrinfo_result = {
+static const struct ares_addrinfo_ex empty_addrinfo_result = {
   NULL, /* cnames */
   NULL  /* nodes */
 };
@@ -158,9 +158,9 @@ void ares__addrinfo_cat_cnames(struct ares_addrinfo_cname **head,
   last->next = tail;
 }
 
-struct ares_addrinfo_result *ares__malloc_addrinfo_result()
+struct ares_addrinfo_ex *ares__malloc_addrinfo_result()
 {
-  struct ares_addrinfo_result *ai = ares_malloc(sizeof(struct ares_addrinfo_result));
+  struct ares_addrinfo_ex *ai = ares_malloc(sizeof(struct ares_addrinfo_ex));
   if (!ai)
     return NULL;
 
@@ -277,7 +277,7 @@ static unsigned short lookup_service(const char *service, int flags)
 static int fake_addrinfo(const char *name,
                          unsigned short port,
                          const struct ares_addrinfo *hints,
-                         struct ares_addrinfo_result *ai,
+                         struct ares_addrinfo_ex *ai,
                          ares_addrinfo_callback callback,
                          void *arg)
 {
@@ -579,7 +579,7 @@ void ares_getaddrinfo_ex(ares_channel channel,
   struct host_query *hquery;
   unsigned short port = 0;
   int family;
-  struct ares_addrinfo_result *ai;
+  struct ares_addrinfo_ex *ai;
 
   if (!hints)
     {

--- a/ares_getaddrinfo.c
+++ b/ares_getaddrinfo.c
@@ -571,7 +571,7 @@ static void host_callback(void *arg, int status, int timeouts,
   /* at this point we keep on waiting for the next query to finish */
 }
 
-void ares_getaddrinfo(ares_channel channel,
+void ares_getaddrinfo_ex(ares_channel channel,
                       const char* name, const char* service,
                       const struct ares_addrinfo* hints,
                       ares_addrinfo_callback callback, void* arg)

--- a/ares_parse_a_reply.c
+++ b/ares_parse_a_reply.c
@@ -51,8 +51,8 @@ int ares_parse_a_reply(const unsigned char *abuf, int alen,
                        struct hostent **host,
                        struct ares_addrttl *addrttls, int *naddrttls)
 {
-  struct ares_addrinfo ai;
-  struct ares_addrinfo_node *next;
+  struct ares_addrinfo_result ai;
+  struct ares_addrinfo *next;
   struct ares_addrinfo_cname *next_cname;
   char **aliases = NULL;
   char *question_hostname = NULL;

--- a/ares_parse_a_reply.c
+++ b/ares_parse_a_reply.c
@@ -51,7 +51,7 @@ int ares_parse_a_reply(const unsigned char *abuf, int alen,
                        struct hostent **host,
                        struct ares_addrttl *addrttls, int *naddrttls)
 {
-  struct ares_addrinfo_result ai;
+  struct ares_addrinfo_ex ai;
   struct ares_addrinfo *next;
   struct ares_addrinfo_cname *next_cname;
   char **aliases = NULL;

--- a/ares_parse_aaaa_reply.c
+++ b/ares_parse_aaaa_reply.c
@@ -53,7 +53,7 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
                           struct hostent **host, struct ares_addr6ttl *addrttls,
                           int *naddrttls)
 {
-  struct ares_addrinfo_result ai;
+  struct ares_addrinfo_ex ai;
   struct ares_addrinfo *next;
   struct ares_addrinfo_cname *next_cname;
   char **aliases = NULL;

--- a/ares_parse_aaaa_reply.c
+++ b/ares_parse_aaaa_reply.c
@@ -53,8 +53,8 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
                           struct hostent **host, struct ares_addr6ttl *addrttls,
                           int *naddrttls)
 {
-  struct ares_addrinfo ai;
-  struct ares_addrinfo_node *next;
+  struct ares_addrinfo_result ai;
+  struct ares_addrinfo *next;
   struct ares_addrinfo_cname *next_cname;
   char **aliases = NULL;
   char *question_hostname = NULL;

--- a/ares_private.h
+++ b/ares_private.h
@@ -358,19 +358,19 @@ void ares__destroy_servers_state(ares_channel channel);
 int ares__parse_qtype_reply(const unsigned char* abuf, int alen, int* qtype);
 int ares__single_domain(ares_channel channel, const char *name, char **s);
 int ares__cat_domain(const char *name, const char *domain, char **s);
-int ares__sortaddrinfo(ares_channel channel, struct ares_addrinfo_node *ai_node);
+int ares__sortaddrinfo(ares_channel channel, struct ares_addrinfo *ai_node);
 int ares__readaddrinfo(FILE *fp, const char *name, unsigned short port,
-                       const struct ares_addrinfo_hints *hints,
-                       struct ares_addrinfo *ai);
+                       const struct ares_addrinfo *hints,
+                       struct ares_addrinfo_result *ai);
+
+struct ares_addrinfo_result *ares__malloc_addrinfo_result(void);
 
 struct ares_addrinfo *ares__malloc_addrinfo(void);
+void ares__freeaddrinfo_nodes(struct ares_addrinfo *ai_node);
 
-struct ares_addrinfo_node *ares__malloc_addrinfo_node(void);
-void ares__freeaddrinfo_nodes(struct ares_addrinfo_node *ai_node);
-
-struct ares_addrinfo_node *ares__append_addrinfo_node(struct ares_addrinfo_node **ai_node);
-void ares__addrinfo_cat_nodes(struct ares_addrinfo_node **head,
-                              struct ares_addrinfo_node *tail);
+struct ares_addrinfo *ares__append_addrinfo(struct ares_addrinfo **ai_node);
+void ares__addrinfo_cat_nodes(struct ares_addrinfo **head,
+                              struct ares_addrinfo *tail);
 
 struct ares_addrinfo_cname *ares__malloc_addrinfo_cname(void);
 void ares__freeaddrinfo_cnames(struct ares_addrinfo_cname *ai_cname);
@@ -382,12 +382,12 @@ void ares__addrinfo_cat_cnames(struct ares_addrinfo_cname **head,
 
 int ares__parse_into_addrinfo(const unsigned char *abuf,
                               int alen,
-                              struct ares_addrinfo *ai);
+                              struct ares_addrinfo_result *ai);
 
 int ares__parse_into_addrinfo2(const unsigned char *abuf,
                                int alen,
                                char **question_hostname,
-                               struct ares_addrinfo *ai);
+                               struct ares_addrinfo_result *ai);
 
 #if 0 /* Not used */
 long ares__tvdiff(struct timeval t1, struct timeval t2);

--- a/ares_private.h
+++ b/ares_private.h
@@ -361,9 +361,9 @@ int ares__cat_domain(const char *name, const char *domain, char **s);
 int ares__sortaddrinfo(ares_channel channel, struct ares_addrinfo *ai_node);
 int ares__readaddrinfo(FILE *fp, const char *name, unsigned short port,
                        const struct ares_addrinfo *hints,
-                       struct ares_addrinfo_result *ai);
+                       struct ares_addrinfo_ex *ai);
 
-struct ares_addrinfo_result *ares__malloc_addrinfo_result(void);
+struct ares_addrinfo_ex *ares__malloc_addrinfo_result(void);
 
 struct ares_addrinfo *ares__malloc_addrinfo(void);
 void ares__freeaddrinfo_nodes(struct ares_addrinfo *ai_node);
@@ -382,12 +382,12 @@ void ares__addrinfo_cat_cnames(struct ares_addrinfo_cname **head,
 
 int ares__parse_into_addrinfo(const unsigned char *abuf,
                               int alen,
-                              struct ares_addrinfo_result *ai);
+                              struct ares_addrinfo_ex *ai);
 
 int ares__parse_into_addrinfo2(const unsigned char *abuf,
                                int alen,
                                char **question_hostname,
-                               struct ares_addrinfo_result *ai);
+                               struct ares_addrinfo_ex *ai);
 
 #if 0 /* Not used */
 long ares__tvdiff(struct timeval t1, struct timeval t2);

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -451,7 +451,7 @@ TEST_F(LibraryTest, GetAddrInfoAllocFail) {
     rewind(fp);
     ClearFails();
     SetAllocFail(ii);
-    struct ares_addrinfo_result ai;
+    struct ares_addrinfo_ex ai;
     EXPECT_EQ(ARES_ENOMEM, ares__readaddrinfo(fp, "example.com", port, &hints, &ai)) << ii;
   }
   fclose(fp);

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -368,7 +368,7 @@ TEST_F(DefaultChannelTest, GetAddrInfoHostsPositive) {
   AddrInfoTestResult result = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_CANONNAME | ARES_AI_ENVHOSTS | ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "example.com", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "example.com", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   std::stringstream ss;
@@ -388,7 +388,7 @@ TEST_F(DefaultChannelTest, GetAddrInfoHostsSpaces) {
   AddrInfoTestResult result = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_CANONNAME | ARES_AI_ENVHOSTS | ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "google.com", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "google.com", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   std::stringstream ss;
@@ -408,7 +408,7 @@ TEST_F(DefaultChannelTest, GetAddrInfoHostsByALias) {
   AddrInfoTestResult result = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_CANONNAME | ARES_AI_ENVHOSTS | ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "www2.google.com", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "www2.google.com", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   std::stringstream ss;
@@ -428,7 +428,7 @@ TEST_F(DefaultChannelTest, GetAddrInfoHostsIPV6) {
   AddrInfoTestResult result = {};
   hints.ai_family = AF_INET6;
   hints.ai_flags = ARES_AI_CANONNAME | ARES_AI_ENVHOSTS | ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "ipv6.com", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "ipv6.com", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   std::stringstream ss;

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -364,8 +364,8 @@ TEST_F(DefaultChannelTest, GetAddrInfoHostsPositive) {
                      "1.3.5.7  \n"
                      "::1    ipv6.com");
   EnvValue with_env("CARES_HOSTS", hostsfile.filename());
-  struct ares_addrinfo_hints hints = {};
-  AddrInfoResult result = {};
+  struct ares_addrinfo hints = {};
+  AddrInfoTestResult result = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_CANONNAME | ARES_AI_ENVHOSTS | ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "example.com", NULL, &hints, AddrInfoCallback, &result);
@@ -384,8 +384,8 @@ TEST_F(DefaultChannelTest, GetAddrInfoHostsSpaces) {
                      "1.3.5.7  \n"
                      "::1    ipv6.com");
   EnvValue with_env("CARES_HOSTS", hostsfile.filename());
-  struct ares_addrinfo_hints hints = {};
-  AddrInfoResult result = {};
+  struct ares_addrinfo hints = {};
+  AddrInfoTestResult result = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_CANONNAME | ARES_AI_ENVHOSTS | ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "google.com", NULL, &hints, AddrInfoCallback, &result);
@@ -404,8 +404,8 @@ TEST_F(DefaultChannelTest, GetAddrInfoHostsByALias) {
                      "1.3.5.7  \n"
                      "::1    ipv6.com");
   EnvValue with_env("CARES_HOSTS", hostsfile.filename());
-  struct ares_addrinfo_hints hints = {};
-  AddrInfoResult result = {};
+  struct ares_addrinfo hints = {};
+  AddrInfoTestResult result = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_CANONNAME | ARES_AI_ENVHOSTS | ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "www2.google.com", NULL, &hints, AddrInfoCallback, &result);
@@ -424,8 +424,8 @@ TEST_F(DefaultChannelTest, GetAddrInfoHostsIPV6) {
                      "1.3.5.7  \n"
                      "::1    ipv6.com");
   EnvValue with_env("CARES_HOSTS", hostsfile.filename());
-  struct ares_addrinfo_hints hints = {};
-  AddrInfoResult result = {};
+  struct ares_addrinfo hints = {};
+  AddrInfoTestResult result = {};
   hints.ai_family = AF_INET6;
   hints.ai_flags = ARES_AI_CANONNAME | ARES_AI_ENVHOSTS | ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "ipv6.com", NULL, &hints, AddrInfoCallback, &result);
@@ -438,7 +438,7 @@ TEST_F(DefaultChannelTest, GetAddrInfoHostsIPV6) {
 
 TEST_F(LibraryTest, GetAddrInfoAllocFail) {
   TempFile hostsfile("1.2.3.4 example.com alias1 alias2\n");
-  struct ares_addrinfo_hints hints;
+  struct ares_addrinfo hints;
   unsigned short port = 80;
 
   memset(&hints, 0, sizeof(hints));
@@ -451,7 +451,7 @@ TEST_F(LibraryTest, GetAddrInfoAllocFail) {
     rewind(fp);
     ClearFails();
     SetAllocFail(ii);
-    struct ares_addrinfo ai;
+    struct ares_addrinfo_result ai;
     EXPECT_EQ(ARES_ENOMEM, ares__readaddrinfo(fp, "example.com", port, &hints, &ai)) << ii;
   }
   fclose(fp);

--- a/test/ares-test-live.cc
+++ b/test/ares-test-live.cc
@@ -22,7 +22,7 @@ MATCHER_P(IncludesAtLeastNumAddresses, n, "") {
   if(!arg)
     return false;
   int cnt = 0;
-  for (const ares_addrinfo_node* ai = arg->nodes; ai != NULL; ai = ai->ai_next)
+  for (const ares_addrinfo* ai = arg->nodes; ai != NULL; ai = ai->ai_next)
     cnt++;
   return cnt >= n;
 }
@@ -30,7 +30,7 @@ MATCHER_P(IncludesAtLeastNumAddresses, n, "") {
 MATCHER_P(OnlyIncludesAddrType, addrtype, "") {
   if(!arg)
     return false;
-  for (const ares_addrinfo_node* ai = arg->nodes; ai != NULL; ai = ai->ai_next)
+  for (const ares_addrinfo* ai = arg->nodes; ai != NULL; ai = ai->ai_next)
     if (ai->ai_family != addrtype)
       return false;
   return true;
@@ -39,16 +39,16 @@ MATCHER_P(OnlyIncludesAddrType, addrtype, "") {
 MATCHER_P(IncludesAddrType, addrtype, "") {
   if(!arg)
     return false;
-  for (const ares_addrinfo_node* ai = arg->nodes; ai != NULL; ai = ai->ai_next)
+  for (const ares_addrinfo* ai = arg->nodes; ai != NULL; ai = ai->ai_next)
     if (ai->ai_family == addrtype)
       return true;
   return false;
 }
 
 //VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetAddrInfoV4) {
-  //struct ares_addrinfo_hints hints = {};
+  //struct ares_addrinfo hints = {};
   //hints.ai_family = AF_INET;
-  //AddrInfoResult result;
+  //AddrInfoTestResult result;
   //ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   //Process();
   //EXPECT_TRUE(result.done_);
@@ -58,9 +58,9 @@ MATCHER_P(IncludesAddrType, addrtype, "") {
 //}
 
 //VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetAddrInfoV6) {
-  //struct ares_addrinfo_hints hints = {};
+  //struct ares_addrinfo hints = {};
   //hints.ai_family = AF_INET6;
-  //AddrInfoResult result;
+  //AddrInfoTestResult result;
   //ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   //Process();
   //EXPECT_TRUE(result.done_);
@@ -70,9 +70,9 @@ MATCHER_P(IncludesAddrType, addrtype, "") {
 //}
 
 //VIRT_NONVIRT_TEST_F(DefaultChannelTest, LiveGetAddrInfoUnspec) {
-  //struct ares_addrinfo_hints hints = {};
+  //struct ares_addrinfo hints = {};
   //hints.ai_family = AF_UNSPEC;
-  //AddrInfoResult result;
+  //AddrInfoTestResult result;
   //ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   //Process();
   //EXPECT_TRUE(result.done_);

--- a/test/ares-test-live.cc
+++ b/test/ares-test-live.cc
@@ -49,7 +49,7 @@ MATCHER_P(IncludesAddrType, addrtype, "") {
   //struct ares_addrinfo hints = {};
   //hints.ai_family = AF_INET;
   //AddrInfoTestResult result;
-  //ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
+  //ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   //Process();
   //EXPECT_TRUE(result.done_);
   //EXPECT_EQ(ARES_SUCCESS, result.status_);
@@ -61,7 +61,7 @@ MATCHER_P(IncludesAddrType, addrtype, "") {
   //struct ares_addrinfo hints = {};
   //hints.ai_family = AF_INET6;
   //AddrInfoTestResult result;
-  //ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
+  //ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   //Process();
   //EXPECT_TRUE(result.done_);
   //EXPECT_EQ(ARES_SUCCESS, result.status_);
@@ -73,7 +73,7 @@ MATCHER_P(IncludesAddrType, addrtype, "") {
   //struct ares_addrinfo hints = {};
   //hints.ai_family = AF_UNSPEC;
   //AddrInfoTestResult result;
-  //ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
+  //ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   //Process();
   //EXPECT_TRUE(result.done_);
   //EXPECT_EQ(ARES_SUCCESS, result.status_);

--- a/test/ares-test-misc.cc
+++ b/test/ares-test-misc.cc
@@ -297,8 +297,8 @@ TEST_F(DefaultChannelTest, HostByNameFileOnionDomain) {
 }
 
 TEST_F(DefaultChannelTest, GetAddrinfoOnionDomain) {
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_UNSPEC;
   ares_getaddrinfo(channel_, "dontleak.onion", NULL, &hints, AddrInfoCallback, &result);
   EXPECT_TRUE(result.done_);

--- a/test/ares-test-misc.cc
+++ b/test/ares-test-misc.cc
@@ -300,7 +300,7 @@ TEST_F(DefaultChannelTest, GetAddrinfoOnionDomain) {
   AddrInfoTestResult result;
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_UNSPEC;
-  ares_getaddrinfo(channel_, "dontleak.onion", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "dontleak.onion", NULL, &hints, AddrInfoCallback, &result);
   EXPECT_TRUE(result.done_);
   EXPECT_EQ(ARES_ENOTFOUND, result.status_);
 }

--- a/test/ares-test-mock-ai.cc
+++ b/test/ares-test-mock-ai.cc
@@ -18,7 +18,7 @@ MATCHER_P(IncludesNumAddresses, n, "") {
   if(!arg)
     return false;
   int cnt = 0;
-  for (const ares_addrinfo_node* ai = arg->nodes; ai != NULL; ai = ai->ai_next)
+  for (const ares_addrinfo* ai = arg->nodes; ai != NULL; ai = ai->ai_next)
     cnt++;
   return n == cnt;
 }
@@ -29,7 +29,7 @@ MATCHER_P(IncludesV4Address, address, "") {
   in_addr addressnum = {};
   if (!ares_inet_pton(AF_INET, address, &addressnum))
     return false; // wrong number format?
-  for (const ares_addrinfo_node* ai = arg->nodes; ai != NULL; ai = ai->ai_next) {
+  for (const ares_addrinfo* ai = arg->nodes; ai != NULL; ai = ai->ai_next) {
     if (ai->ai_family != AF_INET)
       continue;
     if (reinterpret_cast<sockaddr_in*>(ai->ai_addr)->sin_addr.s_addr ==
@@ -46,7 +46,7 @@ MATCHER_P(IncludesV6Address, address, "") {
   if (!ares_inet_pton(AF_INET6, address, &addressnum)) {
     return false; // wrong number format?
   }
-  for (const ares_addrinfo_node* ai = arg->nodes; ai != NULL; ai = ai->ai_next) {
+  for (const ares_addrinfo* ai = arg->nodes; ai != NULL; ai = ai->ai_next) {
     if (ai->ai_family != AF_INET6)
       continue;
     if (!memcmp(
@@ -72,14 +72,14 @@ TEST_P(MockUDPChannelTestAI, GetAddrInfoParallelLookups) {
   ON_CALL(server_, OnRequest("www.example.com", ns_t_a))
     .WillByDefault(SetReply(&server_, &rsp2));
 
-  struct ares_addrinfo_hints hints = {};
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  AddrInfoResult result1;
+  AddrInfoTestResult result1;
   ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result1);
-  AddrInfoResult result2;
+  AddrInfoTestResult result2;
   ares_getaddrinfo(channel_, "www.example.com.", NULL, &hints, AddrInfoCallback, &result2);
-  AddrInfoResult result3;
+  AddrInfoTestResult result3;
   ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result3);
   Process();
 
@@ -112,8 +112,8 @@ TEST_P(MockUDPChannelTestAI, TruncationRetry) {
     .WillOnce(SetReply(&server_, &rsptruncated))
     .WillOnce(SetReply(&server_, &rspok));
 
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
@@ -130,8 +130,8 @@ TEST_P(MockTCPChannelTestAI, MalformedResponse) {
   EXPECT_CALL(server_, OnRequest("www.google.com", ns_t_a))
     .WillOnce(SetReplyData(&server_, one));
 
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
@@ -148,8 +148,8 @@ TEST_P(MockTCPChannelTestAI, FormErrResponse) {
   EXPECT_CALL(server_, OnRequest("www.google.com", ns_t_a))
     .WillOnce(SetReply(&server_, &rsp));
 
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
@@ -166,8 +166,8 @@ TEST_P(MockTCPChannelTestAI, ServFailResponse) {
   EXPECT_CALL(server_, OnRequest("www.google.com", ns_t_a))
     .WillOnce(SetReply(&server_, &rsp));
 
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
@@ -185,8 +185,8 @@ TEST_P(MockTCPChannelTestAI, NotImplResponse) {
   EXPECT_CALL(server_, OnRequest("www.google.com", ns_t_a))
     .WillOnce(SetReply(&server_, &rsp));
 
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
@@ -204,8 +204,8 @@ TEST_P(MockTCPChannelTestAI, RefusedResponse) {
   EXPECT_CALL(server_, OnRequest("www.google.com", ns_t_a))
     .WillOnce(SetReply(&server_, &rsp));
 
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
@@ -223,8 +223,8 @@ TEST_P(MockTCPChannelTestAI, YXDomainResponse) {
   EXPECT_CALL(server_, OnRequest("www.google.com", ns_t_a))
     .WillOnce(SetReply(&server_, &rsp));
 
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
@@ -266,8 +266,8 @@ TEST_P(MockExtraOptsTestAI, SimpleQuery) {
   ON_CALL(server_, OnRequest("www.google.com", ns_t_a))
     .WillByDefault(SetReply(&server_, &rsp));
 
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
@@ -307,8 +307,8 @@ TEST_P(MockNoCheckRespChannelTestAI, ServFailResponse) {
   ON_CALL(server_, OnRequest("www.google.com", ns_t_a))
     .WillByDefault(SetReply(&server_, &rsp));
 
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
@@ -325,8 +325,8 @@ TEST_P(MockNoCheckRespChannelTestAI, NotImplResponse) {
   ON_CALL(server_, OnRequest("www.google.com", ns_t_a))
     .WillByDefault(SetReply(&server_, &rsp));
 
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
@@ -343,8 +343,8 @@ TEST_P(MockNoCheckRespChannelTestAI, RefusedResponse) {
   ON_CALL(server_, OnRequest("www.google.com", ns_t_a))
     .WillByDefault(SetReply(&server_, &rsp));
 
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
@@ -362,8 +362,8 @@ TEST_P(MockChannelTestAI, FamilyV6) {
                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x03}));
   ON_CALL(server_, OnRequest("example.com", ns_t_aaaa))
     .WillByDefault(SetReply(&server_, &rsp6));
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET6;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "example.com.", NULL, &hints,
@@ -381,8 +381,8 @@ TEST_P(MockChannelTestAI, FamilyV4) {
     .add_answer(new DNSARR("example.com", 100, {2, 3, 4, 5}));
   ON_CALL(server_, OnRequest("example.com", ns_t_a))
     .WillByDefault(SetReply(&server_, &rsp4));
-  AddrInfoResult result = {};
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result = {};
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "example.com.", NULL, &hints,
@@ -401,8 +401,8 @@ TEST_P(MockChannelTestAI, FamilyV4_MultipleAddresses) {
     .add_answer(new DNSARR("example.com", 100, {7, 8, 9, 0}));
   ON_CALL(server_, OnRequest("example.com", ns_t_a))
     .WillByDefault(SetReply(&server_, &rsp4));
-  AddrInfoResult result = {};
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result = {};
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "example.com.", NULL, &hints,
@@ -429,8 +429,8 @@ TEST_P(MockChannelTestAI, FamilyUnspecified) {
     .add_answer(new DNSARR("example.com", 100, {2, 3, 4, 5}));
   ON_CALL(server_, OnRequest("example.com", ns_t_a))
     .WillByDefault(SetReply(&server_, &rsp4));
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_UNSPEC;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "example.com.", NULL, &hints,
@@ -459,8 +459,8 @@ TEST_P(MockEDNSChannelTestAI, RetryWithoutEDNS) {
     .WillOnce(SetReply(&server_, &rspfail))
     .WillOnce(SetReply(&server_, &rspok));
 
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
@@ -488,8 +488,8 @@ TEST_P(MockChannelTestAI, SearchDomains) {
   ON_CALL(server_, OnRequest("www.third.gov", ns_t_a))
     .WillByDefault(SetReply(&server_, &yesthird));
 
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "www", NULL, &hints, AddrInfoCallback, &result);
@@ -534,8 +534,8 @@ TEST_P(MockChannelTestAI, SearchDomainsServFailOnAAAA) {
   ON_CALL(server_, OnRequest("www.third.gov", ns_t_a))
     .WillByDefault(SetReply(&server_, &failthird4));
 
-  AddrInfoResult result;
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result;
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_UNSPEC;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "www", NULL, &hints, AddrInfoCallback, &result);
@@ -552,8 +552,8 @@ class MockMultiServerChannelTestAI
   MockMultiServerChannelTestAI(bool rotate)
     : MockChannelOptsTest(3, GetParam().first, GetParam().second, nullptr, rotate ? ARES_OPT_ROTATE : ARES_OPT_NOROTATE) {}
   void CheckExample() {
-    AddrInfoResult result;
-    struct ares_addrinfo_hints hints = {};
+    AddrInfoTestResult result;
+    struct ares_addrinfo hints = {};
     hints.ai_family = AF_INET;
     hints.ai_flags = ARES_AI_NOSORT;
     ares_getaddrinfo(channel_, "www.example.com.", NULL, &hints, AddrInfoCallback, &result);
@@ -674,8 +674,8 @@ TEST_P(MockChannelTestAI, FamilyV4ServiceName) {
     .add_answer(new DNSARR("example.com", 100, {2, 2, 2, 2}));
   ON_CALL(server_, OnRequest("example.com", ns_t_a))
     .WillByDefault(SetReply(&server_, &rsp4));
-  AddrInfoResult result = {};
-  struct ares_addrinfo_hints hints = {};
+  AddrInfoTestResult result = {};
+  struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   ares_getaddrinfo(channel_, "example.com", "http", &hints, AddrInfoCallback, &result);

--- a/test/ares-test-mock-ai.cc
+++ b/test/ares-test-mock-ai.cc
@@ -76,11 +76,11 @@ TEST_P(MockUDPChannelTestAI, GetAddrInfoParallelLookups) {
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
   AddrInfoTestResult result1;
-  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result1);
+  ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result1);
   AddrInfoTestResult result2;
-  ares_getaddrinfo(channel_, "www.example.com.", NULL, &hints, AddrInfoCallback, &result2);
+  ares_getaddrinfo_ex(channel_, "www.example.com.", NULL, &hints, AddrInfoCallback, &result2);
   AddrInfoTestResult result3;
-  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result3);
+  ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result3);
   Process();
 
   EXPECT_TRUE(result1.done_);
@@ -116,7 +116,7 @@ TEST_P(MockUDPChannelTestAI, TruncationRetry) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   EXPECT_EQ(result.status_, ARES_SUCCESS);
@@ -134,7 +134,7 @@ TEST_P(MockTCPChannelTestAI, MalformedResponse) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   EXPECT_EQ(ARES_ETIMEOUT, result.status_);
@@ -152,7 +152,7 @@ TEST_P(MockTCPChannelTestAI, FormErrResponse) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   EXPECT_EQ(ARES_EFORMERR, result.status_);
@@ -170,7 +170,7 @@ TEST_P(MockTCPChannelTestAI, ServFailResponse) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   // ARES_FLAG_NOCHECKRESP not set, so SERVFAIL consumed
@@ -189,7 +189,7 @@ TEST_P(MockTCPChannelTestAI, NotImplResponse) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   // ARES_FLAG_NOCHECKRESP not set, so NOTIMPL consumed
@@ -208,7 +208,7 @@ TEST_P(MockTCPChannelTestAI, RefusedResponse) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   // ARES_FLAG_NOCHECKRESP not set, so REFUSED consumed
@@ -227,7 +227,7 @@ TEST_P(MockTCPChannelTestAI, YXDomainResponse) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   EXPECT_EQ(ARES_ENODATA, result.status_);
@@ -270,7 +270,7 @@ TEST_P(MockExtraOptsTestAI, SimpleQuery) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   EXPECT_EQ(ARES_SUCCESS, result.status_);
@@ -311,7 +311,7 @@ TEST_P(MockNoCheckRespChannelTestAI, ServFailResponse) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   EXPECT_EQ(ARES_ESERVFAIL, result.status_);
@@ -329,7 +329,7 @@ TEST_P(MockNoCheckRespChannelTestAI, NotImplResponse) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   EXPECT_EQ(ARES_ENOTIMP, result.status_);
@@ -347,7 +347,7 @@ TEST_P(MockNoCheckRespChannelTestAI, RefusedResponse) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   EXPECT_EQ(ARES_EREFUSED, result.status_);
@@ -366,7 +366,7 @@ TEST_P(MockChannelTestAI, FamilyV6) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET6;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "example.com.", NULL, &hints,
+  ares_getaddrinfo_ex(channel_, "example.com.", NULL, &hints,
                    AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
@@ -385,7 +385,7 @@ TEST_P(MockChannelTestAI, FamilyV4) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "example.com.", NULL, &hints,
+  ares_getaddrinfo_ex(channel_, "example.com.", NULL, &hints,
                    AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
@@ -405,7 +405,7 @@ TEST_P(MockChannelTestAI, FamilyV4_MultipleAddresses) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "example.com.", NULL, &hints,
+  ares_getaddrinfo_ex(channel_, "example.com.", NULL, &hints,
                    AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
@@ -433,7 +433,7 @@ TEST_P(MockChannelTestAI, FamilyUnspecified) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_UNSPEC;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "example.com.", NULL, &hints,
+  ares_getaddrinfo_ex(channel_, "example.com.", NULL, &hints,
                    AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
@@ -463,7 +463,7 @@ TEST_P(MockEDNSChannelTestAI, RetryWithoutEDNS) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "www.google.com.", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   EXPECT_THAT(result.ai_, IncludesNumAddresses(1));
@@ -492,7 +492,7 @@ TEST_P(MockChannelTestAI, SearchDomains) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "www", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "www", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   EXPECT_THAT(result.ai_, IncludesNumAddresses(1));
@@ -538,7 +538,7 @@ TEST_P(MockChannelTestAI, SearchDomainsServFailOnAAAA) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_UNSPEC;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "www", NULL, &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "www", NULL, &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   EXPECT_THAT(result.ai_, IncludesNumAddresses(1));
@@ -556,7 +556,7 @@ class MockMultiServerChannelTestAI
     struct ares_addrinfo hints = {};
     hints.ai_family = AF_INET;
     hints.ai_flags = ARES_AI_NOSORT;
-    ares_getaddrinfo(channel_, "www.example.com.", NULL, &hints, AddrInfoCallback, &result);
+    ares_getaddrinfo_ex(channel_, "www.example.com.", NULL, &hints, AddrInfoCallback, &result);
     Process();
     EXPECT_TRUE(result.done_);
     EXPECT_EQ(result.status_, ARES_SUCCESS);
@@ -678,7 +678,7 @@ TEST_P(MockChannelTestAI, FamilyV4ServiceName) {
   struct ares_addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_flags = ARES_AI_NOSORT;
-  ares_getaddrinfo(channel_, "example.com", "http", &hints, AddrInfoCallback, &result);
+  ares_getaddrinfo_ex(channel_, "example.com", "http", &hints, AddrInfoCallback, &result);
   Process();
   EXPECT_TRUE(result.done_);
   std::stringstream ss;

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -565,7 +565,7 @@ void HostCallback(void *data, int status, int timeouts,
   if (verbose) std::cerr << "HostCallback(" << *result << ")" << std::endl;
 }
 
-std::ostream& operator<<(std::ostream& os, const AddrInfoResult& result) {
+std::ostream& operator<<(std::ostream& os, const AddrInfoTestResult& result) {
   os << '{';
   if (result.done_ && result.ai_) {
     os << StatusToString(result.status_) << " " << result.ai_;
@@ -576,7 +576,7 @@ std::ostream& operator<<(std::ostream& os, const AddrInfoResult& result) {
   return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const AddrInfo& ai) {
+std::ostream& operator<<(std::ostream& os, const AddrInfoResult& ai) {
   os << '{';
   if (ai == nullptr) {
     os << "nullptr}";
@@ -597,7 +597,7 @@ std::ostream& operator<<(std::ostream& os, const AddrInfo& ai) {
       os << " ";
   }
 
-  struct ares_addrinfo_node *next = ai->nodes;
+  struct ares_addrinfo *next = ai->nodes;
   while(next) {
     //if(next->ai_canonname) {
       //os << "'" << next->ai_canonname << "' ";
@@ -628,13 +628,13 @@ std::ostream& operator<<(std::ostream& os, const AddrInfo& ai) {
 }
 
 void AddrInfoCallback(void *data, int status, int timeouts,
-                      struct ares_addrinfo *ai) {
+                      struct ares_addrinfo_result *ai) {
   EXPECT_NE(nullptr, data);
-  AddrInfoResult* result = reinterpret_cast<AddrInfoResult*>(data);
+  AddrInfoTestResult* result = reinterpret_cast<AddrInfoTestResult*>(data);
   result->done_ = true;
   result->status_ = status;
   result->timeouts_= timeouts;
-  result->ai_ = AddrInfo(ai);
+  result->ai_ = AddrInfoResult(ai);
   if (verbose) std::cerr << "AddrInfoCallback(" << *result << ")" << std::endl;
 }
 

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -628,7 +628,7 @@ std::ostream& operator<<(std::ostream& os, const AddrInfoResult& ai) {
 }
 
 void AddrInfoCallback(void *data, int status, int timeouts,
-                      struct ares_addrinfo_result *ai) {
+                      struct ares_addrinfo_ex *ai) {
   EXPECT_NE(nullptr, data);
   AddrInfoTestResult* result = reinterpret_cast<AddrInfoTestResult*>(data);
   result->done_ = true;

--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -280,13 +280,13 @@ struct NameInfoResult {
 std::ostream& operator<<(std::ostream& os, const NameInfoResult& result);
 
 struct AddrInfoResultDeleter {
-  void operator() (ares_addrinfo_result *ptr) {
+  void operator() (ares_addrinfo_ex *ptr) {
     if (ptr) ares_freeaddrinfo(ptr);
   }
 };
 
-// C++ wrapper for struct ares_addrinfo_result.
-using AddrInfoResult = std::unique_ptr<ares_addrinfo_result, AddrInfoResultDeleter>;
+// C++ wrapper for struct ares_addrinfo_ex.
+using AddrInfoResult = std::unique_ptr<ares_addrinfo_ex, AddrInfoResultDeleter>;
 
 std::ostream& operator<<(std::ostream& os, const AddrInfoResult& result);
 
@@ -298,7 +298,7 @@ struct AddrInfoTestResult {
   // Explicitly provided result information.
   int status_;
   int timeouts_;
-  // Contents of the ares_addrinfo_result structure, if provided.
+  // Contents of the ares_addrinfo_ex structure, if provided.
   AddrInfoResult ai_;
 };
 std::ostream& operator<<(std::ostream& os, const AddrInfoTestResult& result);
@@ -312,7 +312,7 @@ void SearchCallback(void *data, int status, int timeouts,
 void NameInfoCallback(void *data, int status, int timeouts,
                       char *node, char *service);
 void AddrInfoCallback(void *data, int status, int timeouts,
-                      struct ares_addrinfo_result *res);
+                      struct ares_addrinfo_ex *res);
 
 // Retrieve the name servers used by a channel.
 std::vector<std::string> GetNameServers(ares_channel channel);

--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -279,29 +279,29 @@ struct NameInfoResult {
 };
 std::ostream& operator<<(std::ostream& os, const NameInfoResult& result);
 
-struct AddrInfoDeleter {
-  void operator() (ares_addrinfo *ptr) {
+struct AddrInfoResultDeleter {
+  void operator() (ares_addrinfo_result *ptr) {
     if (ptr) ares_freeaddrinfo(ptr);
   }
 };
 
-// C++ wrapper for struct ares_addrinfo.
-using AddrInfo = std::unique_ptr<ares_addrinfo, AddrInfoDeleter>;
+// C++ wrapper for struct ares_addrinfo_result.
+using AddrInfoResult = std::unique_ptr<ares_addrinfo_result, AddrInfoResultDeleter>;
 
-std::ostream& operator<<(std::ostream& os, const AddrInfo& result);
+std::ostream& operator<<(std::ostream& os, const AddrInfoResult& result);
 
 // Structure that describes the result of an ares_addrinfo_callback invocation.
-struct AddrInfoResult {
-  AddrInfoResult() : done_(false), status_(-1), timeouts_(0) {}
+struct AddrInfoTestResult {
+  AddrInfoTestResult() : done_(false), status_(-1), timeouts_(0) {}
   // Whether the callback has been invoked.
   bool done_;
   // Explicitly provided result information.
   int status_;
   int timeouts_;
-  // Contents of the ares_addrinfo structure, if provided.
-  AddrInfo ai_;
+  // Contents of the ares_addrinfo_result structure, if provided.
+  AddrInfoResult ai_;
 };
-std::ostream& operator<<(std::ostream& os, const AddrInfoResult& result);
+std::ostream& operator<<(std::ostream& os, const AddrInfoTestResult& result);
 
 // Standard implementation of ares callbacks that fill out the corresponding
 // structures.
@@ -312,7 +312,7 @@ void SearchCallback(void *data, int status, int timeouts,
 void NameInfoCallback(void *data, int status, int timeouts,
                       char *node, char *service);
 void AddrInfoCallback(void *data, int status, int timeouts,
-                      struct ares_addrinfo *res);
+                      struct ares_addrinfo_result *res);
 
 // Retrieve the name servers used by a channel.
 std::vector<std::string> GetNameServers(ares_channel channel);


### PR DESCRIPTION
This PR addresses #286 and is suggesting some renamings regarding the `getaddrinfo` feature. One is the function name `ares_getaddrinfo` itself. I'm suggesting the new name `ares_getaddrinfo_ex` instead. The reason for this renaming is because 
> the only thing we'd accept that would accomplish your actual goal of "RFC Conformance" from an API prototype standpoint would be a wrapper to better emulate getaddrinfo(), and I'd think that wrapper should rely on the system's struct addrinfo if it exists, or the wrapper as a whole would not be available 

The most appropriate name for a future [RFC-3439](https://tools.ietf.org/html/rfc3493 "Basic Socket Interface Extensions for IPv6") conformant wrapper would be `ares_getaddrinfo`. And to have this name reserved, we need this renaming. 

The other renamings are addressing the structures:
- `ares_addrinfo` to `ares_addrinfo_ex` because for the same reason as for the function renaming
- `ares_addrinfo_node` to `ares_addrinfo` to be conformant to the RFC
- replace `ares_addrinfo_hints` by `ares_addrinfo` to be conformant to the RFC

FYI: @bradh352 
