### PR TITLE
test: Separate live tests from SetServers* tests

### DIFF
--- a/test/ares-test-live.cc
+++ b/test/ares-test-live.cc
@@ -693,6 +693,54 @@ TEST_F(DefaultChannelTest, VerifySocketFunctionCallback) {
 
 }
 
+TEST_F(DefaultChannelTest, LiveSetServers) {
+  struct ares_addr_node server1;
+  struct ares_addr_node server2;
+  server1.next = &server2;
+  server1.family = AF_INET;
+  server1.addr.addr4.s_addr = htonl(0x01020304);
+  server2.next = nullptr;
+  server2.family = AF_INET;
+  server2.addr.addr4.s_addr = htonl(0x02030405);
+
+  // Change not allowed while request is pending
+  HostResult result;
+  ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback, &result);
+  EXPECT_EQ(ARES_ENOTIMP, ares_set_servers(channel_, &server1));
+  ares_cancel(channel_);
+}
+
+TEST_F(DefaultChannelTest, LiveSetServersPorts) {
+  struct ares_addr_port_node server1;
+  struct ares_addr_port_node server2;
+  server1.next = &server2;
+  server1.family = AF_INET;
+  server1.addr.addr4.s_addr = htonl(0x01020304);
+  server1.udp_port = 111;
+  server1.tcp_port = 111;
+  server2.next = nullptr;
+  server2.family = AF_INET;
+  server2.addr.addr4.s_addr = htonl(0x02030405);
+  server2.udp_port = 0;
+  server2.tcp_port = 0;;
+  EXPECT_EQ(ARES_ENODATA, ares_set_servers_ports(nullptr, &server1));
+
+  // Change not allowed while request is pending
+  HostResult result;
+  ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback, &result);
+  EXPECT_EQ(ARES_ENOTIMP, ares_set_servers_ports(channel_, &server1));
+  ares_cancel(channel_);
+}
+
+TEST_F(DefaultChannelTest, LiveSetServersCSV) {
+  // Change not allowed while request is pending
+  HostResult result;
+  ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback, &result);
+  EXPECT_EQ(ARES_ENOTIMP, ares_set_servers_csv(channel_, "1.2.3.4,2.3.4.5"));
+  EXPECT_EQ(ARES_ENOTIMP, ares_set_servers_ports_csv(channel_, "1.2.3.4:56,2.3.4.5:67"));
+  ares_cancel(channel_);
+}
+
 
 }  // namespace test
 }  // namespace ares

--- a/test/ares-test-misc.cc
+++ b/test/ares-test-misc.cc
@@ -45,12 +45,6 @@ TEST_F(DefaultChannelTest, SetServers) {
   EXPECT_EQ(ARES_SUCCESS, ares_set_servers(channel_, &server1));
   std::vector<std::string> expected = {"1.2.3.4", "2.3.4.5"};
   EXPECT_EQ(expected, GetNameServers(channel_));
-
-  // Change not allowed while request is pending
-  HostResult result;
-  ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback, &result);
-  EXPECT_EQ(ARES_ENOTIMP, ares_set_servers(channel_, &server1));
-  ares_cancel(channel_);
 }
 
 TEST_F(DefaultChannelTest, SetServersPorts) {
@@ -75,12 +69,6 @@ TEST_F(DefaultChannelTest, SetServersPorts) {
   EXPECT_EQ(ARES_SUCCESS, ares_set_servers_ports(channel_, &server1));
   std::vector<std::string> expected = {"1.2.3.4:111", "2.3.4.5"};
   EXPECT_EQ(expected, GetNameServers(channel_));
-
-  // Change not allowed while request is pending
-  HostResult result;
-  ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback, &result);
-  EXPECT_EQ(ARES_ENOTIMP, ares_set_servers_ports(channel_, &server1));
-  ares_cancel(channel_);
 }
 
 TEST_F(DefaultChannelTest, SetServersCSV) {
@@ -107,13 +95,6 @@ TEST_F(DefaultChannelTest, SetServersCSV) {
             ares_set_servers_ports_csv(channel_, "1.2.3.4:54,[0102:0304:0506:0708:0910:1112:1314:1516]:80,2.3.4.5:55"));
   std::vector<std::string> expected2 = {"1.2.3.4:54", "[0102:0304:0506:0708:0910:1112:1314:1516]:80", "2.3.4.5:55"};
   EXPECT_EQ(expected2, GetNameServers(channel_));
-
-  // Change not allowed while request is pending
-  HostResult result;
-  ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback, &result);
-  EXPECT_EQ(ARES_ENOTIMP, ares_set_servers_csv(channel_, "1.2.3.4,2.3.4.5"));
-  EXPECT_EQ(ARES_ENOTIMP, ares_set_servers_ports_csv(channel_, "1.2.3.4:56,2.3.4.5:67"));
-  ares_cancel(channel_);
 
   // Should survive duplication
   ares_channel channel2;


### PR DESCRIPTION
Before this change, SetServers, SetServersPorts and SetServersCSV
contained test cases trying to make DNS queries with the google.com
hostname, which requires Internet connectivity. Tests with that
requirement should be defined in the ares-test-live.cc file and contain
"Live" prefix to filter them out with `--gtest_filter=-*.Live*` on
machines without Internet connectivity.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>