### PR TITLE
Return ENODATA if no valid A or AAAA record found

### DIFF
--- a/ares_gethostbyname.c
+++ b/ares_gethostbyname.c
@@ -211,6 +211,13 @@ static void host_callback(void *arg, int status, int timeouts,
           if (host && channel->nsort)
             sort6_addresses(host, channel->sortlist, channel->nsort);
         }
+      if (status == ARES_SUCCESS && host && host->h_addr_list[0] == NULL)
+      {
+        /* The query returned something but had no A/AAAA record 
+           (even after potentially retrying AAAA with A)
+           so we should treat this as an error */
+        status = ARES_ENODATA;
+      }
       end_hquery(hquery, status, host);
     }
   else if ((status == ARES_ENODATA || status == ARES_EBADRESP ||

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -936,6 +936,21 @@ TEST_P(MockChannelTest, GetHostByNameDestroyRelative) {
   EXPECT_EQ(0, result.timeouts_);
 }
 
+TEST_P(MockChannelTest, GetHostByNameCNAMENoData) {
+  DNSPacket response;
+  response.set_response().set_aa()
+    .add_question(new DNSQuestion("cname.first.com", ns_t_a))
+    .add_answer(new DNSCnameRR("cname.first.com", 100, "a.first.com"));
+  ON_CALL(server_, OnRequest("cname.first.com", ns_t_a))
+    .WillByDefault(SetReply(&server_, &response));
+
+  HostResult result;
+  ares_gethostbyname(channel_, "cname.first.com", AF_INET, HostCallback, &result);
+  Process();
+  EXPECT_TRUE(result.done_);
+  EXPECT_EQ(ARES_ENODATA, result.status_);
+}
+
 TEST_P(MockChannelTest, GetHostByAddrDestroy) {
   unsigned char gdns_addr4[4] = {0x08, 0x08, 0x08, 0x08};
   HostResult result;

--- a/test/ares-test-parse-a.cc
+++ b/test/ares-test-parse-a.cc
@@ -140,6 +140,7 @@ TEST_F(LibraryTest, ParseAReplyNoData) {
   std::stringstream ss;
   ss << HostEnt(host);
   EXPECT_EQ("{'c.example.com' aliases=[example.com] addrs=[]}", ss.str());
+  ares_free_hostent(host);
 }
 
 TEST_F(LibraryTest, ParseAReplyVariantA) {

--- a/test/ares-test-parse-a.cc
+++ b/test/ares-test-parse-a.cc
@@ -131,10 +131,15 @@ TEST_F(LibraryTest, ParseAReplyNoData) {
 
   // Again but with a CNAME.
   pkt.add_answer(new DNSCnameRR("example.com", 200, "c.example.com"));
-  EXPECT_EQ(ARES_ENODATA, ares_parse_a_reply(data.data(), data.size(),
+  data = pkt.data();
+  // Expect success as per https://github.com/c-ares/c-ares/commit/2c63440127feed70ccefb148b8f938a2df6c15f8
+  EXPECT_EQ(ARES_SUCCESS, ares_parse_a_reply(data.data(), data.size(),
                                              &host, info, &count));
   EXPECT_EQ(0, count);
-  EXPECT_EQ(nullptr, host);
+  EXPECT_NE(nullptr, host);
+  std::stringstream ss;
+  ss << HostEnt(host);
+  EXPECT_EQ("{'c.example.com' aliases=[example.com] addrs=[]}", ss.str());
 }
 
 TEST_F(LibraryTest, ParseAReplyVariantA) {


### PR DESCRIPTION
Leave `ares_parse_a_reply` behaviour unchanged.
Update tests to check for the now intended behaviour.
Fixes #303.