### PR TITLE
replace all usages of inet_addr() with ares_inet_pton()

### DIFF
--- a/ares__get_hostent.c
+++ b/ares__get_hostent.c
@@ -138,8 +138,7 @@ int ares__get_hostent(FILE *fp, int family, struct hostent **host)
       addr.addrV4.s_addr = INADDR_NONE;
       if ((family == AF_INET) || (family == AF_UNSPEC))
         {
-          addr.addrV4.s_addr = inet_addr(txtaddr);
-          if (addr.addrV4.s_addr != INADDR_NONE)
+          if (ares_inet_pton(AF_INET, txtaddr, &addr.addrV4) > 0)
             {
               /* Actual network address family and length. */
               addr.family = AF_INET;

--- a/ares__readaddrinfo.c
+++ b/ares__readaddrinfo.c
@@ -170,8 +170,7 @@ int ares__readaddrinfo(FILE *fp,
       if ((hints->ai_family == AF_INET) || (hints->ai_family == AF_UNSPEC))
         {
           addr.sa4.sin_port = htons(port);
-          addr.sa4.sin_addr.s_addr = inet_addr(txtaddr);
-          if (addr.sa4.sin_addr.s_addr != INADDR_NONE)
+          if (ares_inet_pton(AF_INET, txtaddr, &addr.sa4.sin_addr) > 0)
             {
               node = ares__append_addrinfo_node(&nodes);
               if(!node)

--- a/ares_getaddrinfo.c
+++ b/ares_getaddrinfo.c
@@ -313,14 +313,13 @@ static int fake_addrinfo(const char *name,
       memset(&addr, 0, sizeof(addr));
 
       /* if we don't have 3 dots, it is illegal
-       * (although inet_addr doesn't think so).
+       * (although inet_pton doesn't think so).
        */
       if (numdots != 3 || !valid)
         result = 0;
       else
         result =
-            ((addr.sa4.sin_addr.s_addr = inet_addr(name)) == INADDR_NONE ? 0
-                                                                         : 1);
+            (ares_inet_pton(AF_INET, name, &addr.sa4.sin_addr) < 1 ? 0 : 1);
 
       if (result)
         {

--- a/ares_gethostbyname.c
+++ b/ares_gethostbyname.c
@@ -213,7 +213,7 @@ static void host_callback(void *arg, int status, int timeouts,
         }
       if (status == ARES_SUCCESS && host && host->h_addr_list[0] == NULL)
       {
-        /* The query returned something but had no A/AAAA record 
+        /* The query returned something but had no A/AAAA record
            (even after potentially retrying AAAA with A)
            so we should treat this as an error */
         status = ARES_ENODATA;
@@ -274,12 +274,12 @@ static int fake_hostent(const char *name, int family,
         }
 
       /* if we don't have 3 dots, it is illegal
-       * (although inet_addr doesn't think so).
+       * (although inet_pton doesn't think so).
        */
       if (numdots != 3 || !valid)
         result = 0;
       else
-        result = ((in.s_addr = inet_addr(name)) == INADDR_NONE ? 0 : 1);
+        result = (ares_inet_pton(AF_INET, name, &in) < 1 ? 0 : 1);
 
       if (result)
         family = AF_INET;

--- a/ares_init.c
+++ b/ares_init.c
@@ -2297,7 +2297,7 @@ static int set_search(ares_channel channel, const char *str)
     channel->ndomains = -1;
   } /* LCOV_EXCL_STOP */
 
-  channel->domains  = ares_strsplit(str, ", ", 1, &cnt); 
+  channel->domains  = ares_strsplit(str, ", ", 1, &cnt);
   channel->ndomains = (int)cnt;
   if (channel->domains == NULL || channel->ndomains == 0) {
     channel->domains  = NULL;
@@ -2423,9 +2423,9 @@ static int ip_addr(const char *ipbuf, ares_ssize_t len, struct in_addr *addr)
   if (len > 15)
     return -1;
 
-  addr->s_addr = inet_addr(ipbuf);
-  if (addr->s_addr == INADDR_NONE && strcmp(ipbuf, "255.255.255.255") != 0)
+  if (ares_inet_pton(AF_INET, ipbuf, addr) < 1)
     return -1;
+
   return 0;
 }
 


### PR DESCRIPTION
Fixes #309 

Replace usage of inet_addr() with ares_inet_pton() which is more appropriate and fixes issues with legitimate addresses like 255.255.255.0.  IPv6 already used this.