### PR TITLE
fix: windows LPCWSTR/LPWSTR cast incompatibilities

### DIFF
--- a/ares_getaddrinfo.c
+++ b/ares_getaddrinfo.c
@@ -456,18 +456,18 @@ static int file_lookup(struct host_query *hquery)
           char tmp[MAX_PATH];
           HKEY hkeyHosts;
 
-          if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY, 0, KEY_READ,
+          if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, WIN_NS_NT_KEY, 0, KEY_READ,
                            &hkeyHosts) == ERROR_SUCCESS)
             {
               DWORD dwLength = MAX_PATH;
-              RegQueryValueEx(hkeyHosts, DATABASEPATH, NULL, NULL, (LPBYTE)tmp,
+              RegQueryValueExA(hkeyHosts, DATABASEPATH, NULL, NULL, (LPBYTE)tmp,
                               &dwLength);
-              ExpandEnvironmentStrings(tmp, PATH_HOSTS, MAX_PATH);
+              ExpandEnvironmentStringsA(tmp, PATH_HOSTS, MAX_PATH);
               RegCloseKey(hkeyHosts);
             }
         }
       else if (platform == WIN_9X)
-        GetWindowsDirectory(PATH_HOSTS, MAX_PATH);
+        GetWindowsDirectoryA(PATH_HOSTS, MAX_PATH);
       else
         return ARES_ENOTFOUND;
 


### PR DESCRIPTION
Closes https://github.com/c-ares/c-ares/issues/327.

Fixes the following compatibility and casting issues:
* Use [`RegQueryValueExA`](https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regqueryvalueexa) instead of `RegQueryValueEx`
* Use [`ExpandEnvironmentStringsA`](https://docs.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-expandenvironmentstringsa) instead of `ExpandEnvironmentStrings`
* Use [`RegOpenKeyExA`](https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regopenkeyexa) instead of `RegOpenKeyExA`
* Use [`GetWindowsDirectoryA`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getwindowsdirectorya) instead of `GetWindowsDirectoryA`

Previous build errors can be [seen here](https://ci.appveyor.com/project/electron-bot/electron-ia32-testing/builds/32537988).

