### PR TITLE
Fix for CURLDEBUG code

### DIFF
--- a/ares_init.c
+++ b/ares_init.c
@@ -119,13 +119,13 @@ int ares_init_options(ares_channel *channelptr, struct ares_options *options,
   const char *env = getenv("CARES_MEMDEBUG");
 
   if (env)
-    curl_memdebug(env);
+    curl_dbg_memdebug(env);
   env = getenv("CARES_MEMLIMIT");
   if (env) {
     char *endptr;
     long num = strtol(env, &endptr, 10);
     if((endptr != env) && (endptr == env + strlen(env)) && (num > 0))
-      curl_memlimit(num);
+      curl_dbg_memlimit(num);
   }
 #endif
 


### PR DESCRIPTION
Since libcurl's changed some names in `memdebug.[ch]`.

Ref. https://github.com/curl/curl/commit/76b63489495ee1d49182a20525d7e6629cbab493