### PR TITLE
Fix: sizeof(sizeof(addr.saX)) -> sizeof(addr.saX) in readaddrinfo

### DIFF
--- a/ares__readaddrinfo.c
+++ b/ares__readaddrinfo.c
@@ -179,7 +179,7 @@ int ares__readaddrinfo(FILE *fp,
                 }
 
               node->ai_family = addr.sa.sa_family = AF_INET;
-              node->ai_addrlen = sizeof(sizeof(addr.sa4));
+              node->ai_addrlen = sizeof(addr.sa4);
               node->ai_addr = ares_malloc(sizeof(addr.sa4));
               if (!node->ai_addr)
                 {
@@ -200,7 +200,7 @@ int ares__readaddrinfo(FILE *fp,
                 }
 
               node->ai_family = addr.sa.sa_family = AF_INET6;
-              node->ai_addrlen = sizeof(sizeof(addr.sa6));
+              node->ai_addrlen = sizeof(addr.sa6);
               node->ai_addr = ares_malloc(sizeof(addr.sa6));
               if (!node->ai_addr)
                 {


### PR DESCRIPTION
Currently it always returns 8 bytes (x64 architecture), so bind `memcpy(dest, ai->ai_addr, ai->ai_addrlen)` is buggy, and instead of relying on `ai_addrlen` field, `ai_addr` should be examined for type before copying; the last approach is a workaround, of course.