### PR TITLE
Avoid overflow in RC4 loop comparison

### DIFF
--- a/ares_query.c
+++ b/ares_query.c
@@ -45,7 +45,7 @@ static void rc4(rc4_key* key, unsigned char *buffer_ptr, int buffer_len)
   unsigned char y;
   unsigned char* state;
   unsigned char xorIndex;
-  short counter;
+  int counter;
 
   x = key->x;
   y = key->y;


### PR DESCRIPTION
The `rc4` function iterates over a buffer of size `buffer_len` who's maximum
value is `INT_MAX` with a counter of type `short` that is not guaranteed to
have maximum size `INT_MAX`.

In circumstances where `short` is narrower than `int` and where `buffer_len`
is larger than the maximum value of a `short`, it may be possible to loop
infinitely as `counter` will overflow and never be greater than or equal
to `buffer_len`.

The solution is to make the comparison be between types of equal width.
This commit defines `counter` as an `int`.