### PR TITLE
support for system-assigned ports during test

### DIFF
--- a/ares__sortaddrinfo.c
+++ b/ares__sortaddrinfo.c
@@ -427,7 +427,7 @@ static int find_src_addr(ares_channel channel,
       return 0;
     }
 
-  if (getsockname(sock, src_addr, &len) == -1)
+  if (getsockname(sock, src_addr, &len) != 0)
     {
       ares__close_socket(channel, sock);
       return -1;

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -171,7 +171,7 @@ void DefaultChannelModeTest::Process() {
 }
 
 MockServer::MockServer(int family, int port)
-  : udpport_(port), tcpport_(udpport_), qid_(-1) {
+  : udpport_(port), tcpport_(port), qid_(-1) {
   // Create a TCP socket to receive data on.
   tcpfd_ = socket(family, SOCK_STREAM, 0);
   EXPECT_NE(-1, tcpfd_);

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -200,7 +200,7 @@ MockServer::MockServer(int family, int port, int tcpport)
     // retrieve system-assigned port
     if (udpport_ == 0) {
         int len = sizeof(addr);
-        int result = getsockname(udpfd_, (struct sockaddr*) & addr, &len);
+        int result = getsockname(udpfd_, (struct sockaddr*)&addr, &len);
         EXPECT_NE(SOCKET_ERROR, result);
         udpport_ = ntohs(addr.sin_port);
         EXPECT_NE(0, udpport_);
@@ -208,7 +208,7 @@ MockServer::MockServer(int family, int port, int tcpport)
     if (tcpport_ == 0)
     {
        int len = sizeof(addr);
-       int result = getsockname(tcpfd_, (struct sockaddr*) &addr, &len);
+       int result = getsockname(tcpfd_, (struct sockaddr*)&addr, &len);
        EXPECT_NE(SOCKET_ERROR, result);
        tcpport_ = ntohs(addr.sin_port);
        EXPECT_NE(0, tcpport_);
@@ -236,7 +236,7 @@ MockServer::MockServer(int family, int port, int tcpport)
     if (tcpport_ == 0)
     {
        int len = sizeof(addr);
-       int result = getsockname(tcpfd_, (struct sockaddr*) &addr, &len);
+       int result = getsockname(tcpfd_, (struct sockaddr*)&addr, &len);
        EXPECT_NE(SOCKET_ERROR, result);
        tcpport_ = ntohs(addr.sin6_port);
        EXPECT_NE(0, tcpport_);

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -200,7 +200,7 @@ MockServer::MockServer(int family, int port, int tcpport)
     // retrieve system-assigned port
     if (udpport_ == 0) {
         int len = sizeof(addr);
-        int result = getsockname(udpfd_, (struct sockaddr*)&addr, &len);
+        auto result = getsockname(udpfd_, (struct sockaddr*)&addr, &len);
         EXPECT_NE(SOCKET_ERROR, result);
         udpport_ = ntohs(addr.sin_port);
         EXPECT_NE(0, udpport_);
@@ -208,7 +208,7 @@ MockServer::MockServer(int family, int port, int tcpport)
     if (tcpport_ == 0)
     {
        int len = sizeof(addr);
-       int result = getsockname(tcpfd_, (struct sockaddr*)&addr, &len);
+       auto result = getsockname(tcpfd_, (struct sockaddr*)&addr, &len);
        EXPECT_NE(SOCKET_ERROR, result);
        tcpport_ = ntohs(addr.sin_port);
        EXPECT_NE(0, tcpport_);

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -30,7 +30,8 @@ namespace ares {
 namespace test {
 
 bool verbose = false;
-int mock_port = 5300;
+static constexpr int dynamic_port = 0;
+int mock_port = dynamic_port;
 
 const std::vector<int> both_families = {AF_INET, AF_INET6};
 const std::vector<int> ipv4_family = {AF_INET};
@@ -169,8 +170,8 @@ void DefaultChannelModeTest::Process() {
   ProcessWork(channel_, NoExtraFDs, nullptr);
 }
 
-MockServer::MockServer(int family, int port, int tcpport)
-  : udpport_(port), tcpport_(tcpport ? tcpport : udpport_), qid_(-1) {
+MockServer::MockServer(int family, int port)
+  : udpport_(port), tcpport_(udpport_), qid_(-1) {
   // Create a TCP socket to receive data on.
   tcpfd_ = socket(family, SOCK_STREAM, 0);
   EXPECT_NE(-1, tcpfd_);
@@ -198,19 +199,19 @@ MockServer::MockServer(int family, int port, int tcpport)
     int udprc = bind(udpfd_, (struct sockaddr*)&addr, sizeof(addr));
     EXPECT_EQ(0, udprc) << "Failed to bind AF_INET to UDP port " << udpport_;
     // retrieve system-assigned port
-    if (udpport_ == 0) {
+    if (udpport_ == dynamic_port) {
       ares_socklen_t len = sizeof(addr);
       auto result = getsockname(udpfd_, (struct sockaddr*)&addr, &len);
       EXPECT_EQ(0, result);
       udpport_ = ntohs(addr.sin_port);
-      EXPECT_NE(0, udpport_);
+      EXPECT_NE(dynamic_port, udpport_);
     }
-    if (tcpport_ == 0) {
+    if (tcpport_ == dynamic_port) {
       ares_socklen_t len = sizeof(addr);
       auto result = getsockname(tcpfd_, (struct sockaddr*)&addr, &len);
       EXPECT_EQ(0, result);
       tcpport_ = ntohs(addr.sin_port);
-      EXPECT_NE(0, tcpport_);
+      EXPECT_NE(dynamic_port, tcpport_);
     }
   } else {
     EXPECT_EQ(AF_INET6, family);
@@ -225,19 +226,19 @@ MockServer::MockServer(int family, int port, int tcpport)
     int udprc = bind(udpfd_, (struct sockaddr*)&addr, sizeof(addr));
     EXPECT_EQ(0, udprc) << "Failed to bind AF_INET6 to UDP port " << udpport_;
     // retrieve system-assigned port
-    if (udpport_ == 0) {
+    if (udpport_ == dynamic_port) {
       ares_socklen_t len = sizeof(addr);
       auto result = getsockname(udpfd_, (struct sockaddr*)&addr, &len);
       EXPECT_EQ(0, result);
       udpport_ = ntohs(addr.sin6_port);
-      EXPECT_NE(0, udpport_);
+      EXPECT_NE(dynamic_port, udpport_);
     }
-    if (tcpport_ == 0) {
+    if (tcpport_ == dynamic_port) {
       ares_socklen_t len = sizeof(addr);
       auto result = getsockname(tcpfd_, (struct sockaddr*)&addr, &len);
       EXPECT_EQ(0, result);
       tcpport_ = ntohs(addr.sin6_port);
-      EXPECT_NE(0, tcpport_);
+      EXPECT_NE(dynamic_port, tcpport_);
     }
   }
   if (verbose) std::cerr << "Configured "
@@ -411,7 +412,8 @@ MockChannelOptsTest::NiceMockServers MockChannelOptsTest::BuildServers(int count
   NiceMockServers servers;
   assert(count > 0);
   for (int ii = 0; ii < count; ii++) {
-    std::unique_ptr<NiceMockServer> server(new NiceMockServer(family, base_port ? base_port + ii : 0));
+    int port = base_port == dynamic_port ? dynamic_port : base_port + ii;
+    std::unique_ptr<NiceMockServer> server(new NiceMockServer(family, port));
     servers.push_back(std::move(server));
   }
   return servers;

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -411,7 +411,7 @@ MockChannelOptsTest::NiceMockServers MockChannelOptsTest::BuildServers(int count
   NiceMockServers servers;
   assert(count > 0);
   for (int ii = 0; ii < count; ii++) {
-    std::unique_ptr<NiceMockServer> server(new NiceMockServer(family, base_port + ii));
+    std::unique_ptr<NiceMockServer> server(new NiceMockServer(family, base_port ? base_port + ii : 0));
     servers.push_back(std::move(server));
   }
   return servers;

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -228,7 +228,7 @@ MockServer::MockServer(int family, int port, int tcpport)
     // retrieve system-assigned port
     if (udpport_ == 0) {
         int len = sizeof(addr);
-        int result = getsockname(udpfd_, (struct sockaddr*)&addr, &len);
+        auto result = getsockname(udpfd_, (struct sockaddr*)&addr, &len);
         EXPECT_NE(SOCKET_ERROR, result);
         udpport_ = ntohs(addr.sin6_port);
         EXPECT_NE(0, udpport_);
@@ -236,7 +236,7 @@ MockServer::MockServer(int family, int port, int tcpport)
     if (tcpport_ == 0)
     {
        int len = sizeof(addr);
-       int result = getsockname(tcpfd_, (struct sockaddr*)&addr, &len);
+       auto result = getsockname(tcpfd_, (struct sockaddr*)&addr, &len);
        EXPECT_NE(SOCKET_ERROR, result);
        tcpport_ = ntohs(addr.sin6_port);
        EXPECT_NE(0, tcpport_);

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -199,19 +199,18 @@ MockServer::MockServer(int family, int port, int tcpport)
     EXPECT_EQ(0, udprc) << "Failed to bind AF_INET to UDP port " << udpport_;
     // retrieve system-assigned port
     if (udpport_ == 0) {
-        int len = sizeof(addr);
-        auto result = getsockname(udpfd_, (struct sockaddr*)&addr, &len);
-        EXPECT_NE(SOCKET_ERROR, result);
-        udpport_ = ntohs(addr.sin_port);
-        EXPECT_NE(0, udpport_);
+      ares_socklen_t len = sizeof(addr);
+      auto result = getsockname(udpfd_, (struct sockaddr*)&addr, &len);
+      EXPECT_EQ(0, result);
+      udpport_ = ntohs(addr.sin_port);
+      EXPECT_NE(0, udpport_);
     }
-    if (tcpport_ == 0)
-    {
-       int len = sizeof(addr);
-       auto result = getsockname(tcpfd_, (struct sockaddr*)&addr, &len);
-       EXPECT_NE(SOCKET_ERROR, result);
-       tcpport_ = ntohs(addr.sin_port);
-       EXPECT_NE(0, tcpport_);
+    if (tcpport_ == 0) {
+      ares_socklen_t len = sizeof(addr);
+      auto result = getsockname(tcpfd_, (struct sockaddr*)&addr, &len);
+      EXPECT_EQ(0, result);
+      tcpport_ = ntohs(addr.sin_port);
+      EXPECT_NE(0, tcpport_);
     }
   } else {
     EXPECT_EQ(AF_INET6, family);
@@ -227,19 +226,18 @@ MockServer::MockServer(int family, int port, int tcpport)
     EXPECT_EQ(0, udprc) << "Failed to bind AF_INET6 to UDP port " << udpport_;
     // retrieve system-assigned port
     if (udpport_ == 0) {
-        int len = sizeof(addr);
-        auto result = getsockname(udpfd_, (struct sockaddr*)&addr, &len);
-        EXPECT_NE(SOCKET_ERROR, result);
-        udpport_ = ntohs(addr.sin6_port);
-        EXPECT_NE(0, udpport_);
+      ares_socklen_t len = sizeof(addr);
+      auto result = getsockname(udpfd_, (struct sockaddr*)&addr, &len);
+      EXPECT_EQ(0, result);
+      udpport_ = ntohs(addr.sin6_port);
+      EXPECT_NE(0, udpport_);
     }
-    if (tcpport_ == 0)
-    {
-       int len = sizeof(addr);
-       auto result = getsockname(tcpfd_, (struct sockaddr*)&addr, &len);
-       EXPECT_NE(SOCKET_ERROR, result);
-       tcpport_ = ntohs(addr.sin6_port);
-       EXPECT_NE(0, tcpport_);
+    if (tcpport_ == 0) {
+      ares_socklen_t len = sizeof(addr);
+      auto result = getsockname(tcpfd_, (struct sockaddr*)&addr, &len);
+      EXPECT_EQ(0, result);
+      tcpport_ = ntohs(addr.sin6_port);
+      EXPECT_NE(0, tcpport_);
     }
   }
   if (verbose) std::cerr << "Configured "

--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -136,7 +136,7 @@ class DefaultChannelModeTest
 // Mock DNS server to allow responses to be scripted by tests.
 class MockServer {
  public:
-  MockServer(int family, int port, int tcpport = 0);
+  MockServer(int family, int port);
   ~MockServer();
 
   // Mock method indicating the processing of a particular <name, RRtype>


### PR DESCRIPTION
Allow ares-test to use a system-assigned port (by passing port value 0) which will use the next available port assigned by the system.
Context: In a unit test sandbox environment, it is difficult to control what ports will be available at the time of running the test, and a default or manually-selected port can fail to bind if it is in use. The binding to a system-assigned port guarantees the port is available. 