### PR TITLE
Fixes for Watt-32 on Windows and MSDOS

### DIFF
--- a/src/lib/ares_gethostbyaddr.c
+++ b/src/lib/ares_gethostbyaddr.c
@@ -208,7 +208,6 @@ static int file_lookup(struct ares_addr *addr, struct hostent **host)
   strcat(PATH_HOSTS, WIN_PATH_HOSTS);
 
 #elif defined(WATT32)
-  extern const char *_w32_GetHostsFile (void);
   const char *PATH_HOSTS = _w32_GetHostsFile();
 
   if (!PATH_HOSTS)


### PR DESCRIPTION
Move the prototype to 'ares_private.h'.