### PR TITLE
Fixes for Watt-32 on djgpp + Windows

### DIFF
--- a/Makefile.dj
+++ b/Makefile.dj
@@ -1,80 +1,102 @@
 #
 # c-ares Makefile for djgpp/gcc/Watt-32.
-#   By Gisle Vanem <gvanem@yahoo.no> 2004.
+#   By Gisle Vanem <gvanem@yahoo.no> 2004 - 2020.
 #
+include src/lib/Makefile.inc
 
+CSOURCES := $(addprefix src/lib/, $(CSOURCES))
+CSOURCES := $(filter-out src/lib/windows_port.c, $(CSOURCES))
 
-TOPDIR = ..
+VPATH = src/lib src/tools
 
-DEPEND_PREREQ = ares_config.h
+#
+# Root directory for Waterloo tcp/ip.
+# WATT_ROOT should be set during Watt-32 install.
+#
+WATT32_ROOT = $(realpath $(WATT_ROOT))
+WATT32_LIB  = $(WATT32_ROOT)/lib/libwatt.a
 
-include ../packages/DOS/common.dj
-include Makefile.inc
+OBJ_DIR = djgpp
 
-CFLAGS += -DWATT32 -Dselect=select_s
+CFLAGS = -g -O2 -I./include -I./src/lib \
+         -I$(WATT32_ROOT)/inc -Wall \
+         -DWATT32 -DHAVE_CONFIG_H   \
+         -Dselect=select_s
 
 LDFLAGS = -s
 
-OBJ_HACK = libcares.a
+ifeq ($(OS),Windows_NT)
+  #
+  # Windows hosted djgpp cross compiler. Get it from:
+  #   https://github.com/andrewwutw/build-djgpp/releases
+  #
+  DJ_PREFIX ?= c:/some-path/djgpp/bin/i586-pc-msdosdjgpp-
+  CC = $(DJ_PREFIX)gcc
 
-ifeq ($(USE_SSL),1)
-  EX_LIBS += $(OPENSSL_ROOT)/lib/libssl.a $(OPENSSL_ROOT)/lib/libcrypt.a
+else
+  #
+  # The normal djgpp 'gcc' for MSDOS.
+  #
+  CC = gcc
 endif
 
-ifeq ($(USE_ZLIB),1)
-  EX_LIBS += $(ZLIB_ROOT)/libz.a
-endif
+OBJECTS = $(addprefix $(OBJ_DIR)/, \
+            $(notdir $(CSOURCES:.c=.o)))
 
-ifeq ($(USE_IDNA),1)
-  EX_LIBS += $(LIBIDN_ROOT)/lib/dj_obj/libidn.a -liconv
-endif
+GENERATED = src/lib/ares_config.h \
+            include/ares_build.h
 
-EX_LIBS += $(WATT32_ROOT)/lib/libwatt.a
+TARGETS = libcares.a acountry.exe adig.exe ahost.exe
 
-OBJECTS = $(addprefix $(OBJ_DIR)/, $(CSOURCES:.c=.o))
+.SECONDARY: $(OBJ_DIR)/ares_getopt.o
 
-all: $(OBJ_DIR) ares_config.h libcares.a ahost.exe adig.exe acountry.exe
+all: $(OBJ_DIR) $(GENERATED) $(TARGETS)
 	@echo Welcome to c-ares.
 
 libcares.a: $(OBJECTS)
-	ar rs $@ $?
+	ar rs $@ $(OBJECTS)
 
-ares_config.h: config-dos.h
-	$(COPY) $^ $@
+src/lib/ares_config.h: src/lib/config-dos.h
+	cp --update $< $@
 
-ahost.exe: ahost.c $(OBJ_DIR)/ares_getopt.o $(OBJ_HACK)
-	$(CC) $(LDFLAGS) $(CFLAGS) -o $@ $^ $(EX_LIBS)
+include/ares_build.h: include/ares_build.h.dist
+	cp --update $< $@
 
-adig.exe: adig.c $(OBJ_DIR)/ares_getopt.o $(OBJ_HACK)
-	$(CC) $(LDFLAGS) $(CFLAGS) -o $@ $^ $(EX_LIBS)
+%.exe: src/tools/%.c $(OBJ_DIR)/ares_getopt.o libcares.a
+	$(call compile_and_link, $@, $^ $(WATT32_LIB))
 
-acountry.exe: acountry.c $(OBJ_DIR)/ares_getopt.o $(OBJ_HACK)
-	$(CC) $(LDFLAGS) $(CFLAGS) -o $@ $^ $(EX_LIBS)
-
-# clean generated files
+# Clean generated files and objects.
 #
-genclean:
-	- $(DELETE) ares_config.h
+clean:
+	- rm -f depend.dj $(GENERATED) $(OBJ_DIR)/*.o
+	- rmdir $(OBJ_DIR)
 
-# clean object files and subdir
-#
-objclean: genclean
-	- $(DELETE) $(OBJ_DIR)$(DS)*.o
-	- $(RMDIR) $(OBJ_DIR)
-
-# clean without removing built library and programs
-#
-clean: objclean
-	- $(DELETE) depend.dj
-
-# clean everything
+# Clean everything
 #
 realclean vclean: clean
-	- $(DELETE) libcares.a
-	- $(DELETE) acountry.exe
-	- $(DELETE) adig.exe
-	- $(DELETE) ahost.exe
-	- $(DELETE) libcares.a
+	- rm -f $(TARGETS) $(TARGETS:.exe=.map)
+
+$(OBJ_DIR):
+	- mkdir $@
+
+$(OBJ_DIR)/%.o: %.c
+	$(CC) $(CFLAGS) -o $@ -c $<
+	@echo
+
+define compile_and_link
+  $(CC) -o $(1) $(CFLAGS) $(LDFLAGS) -Wl,--print-map,--sort-common $(2) > $(1:.exe=.map)
+  @echo
+endef
+
+DEP_REPLACE = sed -e 's@\(.*\)\.o: @\n$$(OBJ_DIR)\/\1.o: @' \
+                  -e 's@$(WATT32_ROOT)@$$(WATT32_ROOT)@g'
+
+#
+# One may have to do 'make -f Makefile.dj clean' first in case
+# a foreign 'curl_config.h' is making trouble.
+#
+depend: $(GENERATED) Makefile.dj
+	$(CC) -MM $(CFLAGS) $(CSOURCES) | $(DEP_REPLACE) > depend.dj
 
 -include depend.dj
 

--- a/src/lib/ares_gethostbyaddr.c
+++ b/src/lib/ares_gethostbyaddr.c
@@ -208,7 +208,6 @@ static int file_lookup(struct ares_addr *addr, struct hostent **host)
   strcat(PATH_HOSTS, WIN_PATH_HOSTS);
 
 #elif defined(WATT32)
-  extern const char *_w32_GetHostsFile (void);
   const char *PATH_HOSTS = _w32_GetHostsFile();
 
   if (!PATH_HOSTS)

--- a/src/lib/ares_gethostbyname.c
+++ b/src/lib/ares_gethostbyname.c
@@ -386,7 +386,6 @@ static int file_lookup(const char *name, int family, struct hostent **host)
   strcat(PATH_HOSTS, WIN_PATH_HOSTS);
 
 #elif defined(WATT32)
-  extern const char *_w32_GetHostsFile (void);
   const char *PATH_HOSTS = _w32_GetHostsFile();
 
   if (!PATH_HOSTS)

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -74,6 +74,7 @@
 #elif defined(WATT32)
 
 #define PATH_RESOLV_CONF "/dev/ENV/etc/resolv.conf"
+W32_FUNC const char *_w32_GetHostsFile (void);
 
 #elif defined(NETWARE)
 

--- a/src/lib/config-dos.h
+++ b/src/lib/config-dos.h
@@ -28,6 +28,7 @@
 #define HAVE_SYS_TYPES_H       1
 #define HAVE_TIME_H            1
 #define HAVE_UNISTD_H          1
+#define HAVE_WRITEV            1
 
 #define NEED_MALLOC_H          1
 
@@ -63,6 +64,9 @@
 /* Target HAVE_x section */
 
 #if defined(DJGPP)
+  #undef _SSIZE_T
+  #include <sys/types.h>               /* For 'ssize_t' */
+
   #define HAVE_STRCASECMP           1
   #define HAVE_STRNCASECMP          1
   #define HAVE_SYS_TIME_H           1
@@ -99,6 +103,9 @@
   #define HAVE_SYS_UIO_H                   1
   #define NS_INADDRSZ                      4
   #define HAVE_STRUCT_SOCKADDR_IN6         1
+
+  #define HAVE_GETSERVBYPORT_R             1
+  #define GETSERVBYPORT_R_ARGS             5
 #endif
 
 #undef word


### PR DESCRIPTION
* Rewritten / simplified the `Makefile.dj`:
   no longer any relation to `packages/DOS/common.dj` in libcurl.

* Added some needed defines to `src/lib/config-dos.h`.  
  It seems `_SSIZE_T` is already defined. Causing djgpp's `<sys/types.h>` to no define it. 

* Moved the prototype for `*_w32_GetHostsFile()` to `src/lib/ares_private.h`.