### PR TITLE
Change the mailman links

### DIFF
--- a/docs/acountry.1
+++ b/docs/acountry.1
@@ -24,7 +24,8 @@ Display this help and exit.
 Be more verbose. Print extra information.
 .SH "REPORTING BUGS"
 Report bugs to the c-ares mailing list:
-\fBhttp://cool.haxx.se/mailman/listinfo/c-ares\fR
+.br
+\fBhttps://cool.haxx.se/mailman/listinfo/c-ares\fR
 .SH "SEE ALSO"
 .PP
 adig(1), ahost(1).

--- a/docs/adig.1
+++ b/docs/adig.1
@@ -48,7 +48,8 @@ PTR, PX, RP, RT, SIG, SOA, SRV, TXT, WKS, X25,
 Use specified UDP port to connect to DNS server.
 .SH "REPORTING BUGS"
 Report bugs to the c-ares mailing list:
-\fBhttp://cool.haxx.se/mailman/listinfo/c-ares\fR
+.br
+\fBhttps://cool.haxx.se/mailman/listinfo/c-ares\fR
 .SH "SEE ALSO"
 .PP
 acountry(1), ahost(1).

--- a/docs/ahost.1
+++ b/docs/ahost.1
@@ -35,7 +35,8 @@ for DNS configuration; it has no effect on other platforms (such as Win32
 or Android).
 .SH "REPORTING BUGS"
 Report bugs to the c-ares mailing list:
-\fBhttp://cool.haxx.se/mailman/listinfo/c-ares\fR
+.br
+\fBhttps://cool.haxx.se/mailman/listinfo/c-ares\fR
 .SH "SEE ALSO"
 .PP
 acountry(1), adig(1).


### PR DESCRIPTION
On a narrow terminal, a link with a hyphen is misleading;
`http://cool.haxx.se/mail-
  man/listinfo/c-ares`.

Besides, the redirects to the `https` link.