### PR TITLE
fix: T_OPT undeclared

### DIFF
--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -50,6 +50,9 @@
 #ifdef NETWARE
 #  include <sys/filio.h>
 #endif
+#ifndef T_OPT
+#  define T_OPT  41 /* EDNS0 option (meta-RR) */
+#endif
 
 #include <assert.h>
 #include <fcntl.h>


### PR DESCRIPTION
T_OPT undeclared error during make.
`
ares_process.c: In function ‘has_opt_rr’:
ares_process.c:1424:32: error: ‘T_OPT’ undeclared (first use in this function)
       if (DNS_RR_TYPE(aptr) == T_OPT)
`