### PR TITLE
build: Install c-ares-config.cmake in Autotools build.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,9 @@ SUBDIRS = @BUILD_SUBDIRS@
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libcares.pc
 
+cmakedir = $(libdir)/cmake/c-ares
+cmake_DATA = c-ares-config.cmake
+
 CARES_VERSION_INFO = -version-info 6:1:4
 # This flag accepts an argument of the form current[:revision[:age]]. So,
 # passing -version-info 3:12:1 sets current to 3, revision to 12, and age to

--- a/configure.ac
+++ b/configure.ac
@@ -893,7 +893,8 @@ AC_CONFIG_FILES([Makefile           \
                  src/lib/Makefile   \
                  src/tools/Makefile \
                  docs/Makefile      \
-                 libcares.pc ])
+                 libcares.pc        \
+                 c-ares-config.cmake])
 
 AC_OUTPUT
 XC_AMEND_DISTCLEAN(['.'])


### PR DESCRIPTION
This file is useful for other CMake-based projects that use the
find_package directive to locate C-ares.

* configure.ac: Generate c-ares-config.cmake from c-ares-config.cmake.in.
* Makefile.am (cmake_DATA): Install c-ares-config.cmake.