### PR TITLE
Travis: add iOS target built with CMake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,53 +11,53 @@ addons:
 
 matrix:
     include:
-#        - os: linux
-#          compiler: gcc
-#          env: BUILD_TYPE=normal
-#        - os: linux
-#          compiler: clang
-#          env: BUILD_TYPE=normal
-#        - os: linux
-#          compiler: gcc
-#          env: BUILD_TYPE=cmake
-#        - os: linux
-#          compiler: clang
-#          env: BUILD_TYPE=cmake
-#        - os: linux
-#          compiler: gcc
-#          env: BUILD_TYPE=coverage
-#        - os: linux
-#          compiler: clang
-#          env: BUILD_TYPE=ubsan
-#        - os: linux
-#          compiler: clang
-#          env: BUILD_TYPE=asan
-#        - os: linux
-#          compiler: clang
-#          env: BUILD_TYPE=lsan
-#        - os: linux
-#          compiler: clang
-#          env: BUILD_TYPE=analyze
-#        - os: linux
-#          compiler: gcc
-#          env: BUILD_TYPE=valgrind
-#        - os: osx
-#          osx_image: xcode11.4
-#          compiler: gcc
-#          env: BUILD_TYPE=normal
-#        - os: osx
-#          osx_image: xcode11.4
-#          compiler: clang
-#          env: BUILD_TYPE=normal
-#        - os: osx
-#          osx_image: xcode11.4
-#          compiler: clang
-#          env: BUILD_TYPE=cmake
-#        - os: osx
-#          osx_image: xcode11.4
-#          compiler: clang
-#          language: objective-c
-#          env: BUILD_TYPE=ios
+        - os: linux
+          compiler: gcc
+          env: BUILD_TYPE=normal
+        - os: linux
+          compiler: clang
+          env: BUILD_TYPE=normal
+        - os: linux
+          compiler: gcc
+          env: BUILD_TYPE=cmake
+        - os: linux
+          compiler: clang
+          env: BUILD_TYPE=cmake
+        - os: linux
+          compiler: gcc
+          env: BUILD_TYPE=coverage
+        - os: linux
+          compiler: clang
+          env: BUILD_TYPE=ubsan
+        - os: linux
+          compiler: clang
+          env: BUILD_TYPE=asan
+        - os: linux
+          compiler: clang
+          env: BUILD_TYPE=lsan
+        - os: linux
+          compiler: clang
+          env: BUILD_TYPE=analyze
+        - os: linux
+          compiler: gcc
+          env: BUILD_TYPE=valgrind
+        - os: osx
+          osx_image: xcode11.4
+          compiler: gcc
+          env: BUILD_TYPE=normal
+        - os: osx
+          osx_image: xcode11.4
+          compiler: clang
+          env: BUILD_TYPE=normal
+        - os: osx
+          osx_image: xcode11.4
+          compiler: clang
+          env: BUILD_TYPE=cmake
+        - os: osx
+          osx_image: xcode11.4
+          compiler: clang
+          language: objective-c
+          env: BUILD_TYPE=ios
         - os: osx
           osx_image: xcode11.4
           compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,53 +11,58 @@ addons:
 
 matrix:
     include:
-        - os: linux
-          compiler: gcc
-          env: BUILD_TYPE=normal
-        - os: linux
-          compiler: clang
-          env: BUILD_TYPE=normal
-        - os: linux
-          compiler: gcc
-          env: BUILD_TYPE=cmake
-        - os: linux
-          compiler: clang
-          env: BUILD_TYPE=cmake
-        - os: linux
-          compiler: gcc
-          env: BUILD_TYPE=coverage
-        - os: linux
-          compiler: clang
-          env: BUILD_TYPE=ubsan
-        - os: linux
-          compiler: clang
-          env: BUILD_TYPE=asan
-        - os: linux
-          compiler: clang
-          env: BUILD_TYPE=lsan
-        - os: linux
-          compiler: clang
-          env: BUILD_TYPE=analyze
-        - os: linux
-          compiler: gcc
-          env: BUILD_TYPE=valgrind
-        - os: osx
-          osx_image: xcode11.4
-          compiler: gcc
-          env: BUILD_TYPE=normal
-        - os: osx
-          osx_image: xcode11.4
-          compiler: clang
-          env: BUILD_TYPE=normal
-        - os: osx
-          osx_image: xcode11.4
-          compiler: clang
-          env: BUILD_TYPE=cmake
+#        - os: linux
+#          compiler: gcc
+#          env: BUILD_TYPE=normal
+#        - os: linux
+#          compiler: clang
+#          env: BUILD_TYPE=normal
+#        - os: linux
+#          compiler: gcc
+#          env: BUILD_TYPE=cmake
+#        - os: linux
+#          compiler: clang
+#          env: BUILD_TYPE=cmake
+#        - os: linux
+#          compiler: gcc
+#          env: BUILD_TYPE=coverage
+#        - os: linux
+#          compiler: clang
+#          env: BUILD_TYPE=ubsan
+#        - os: linux
+#          compiler: clang
+#          env: BUILD_TYPE=asan
+#        - os: linux
+#          compiler: clang
+#          env: BUILD_TYPE=lsan
+#        - os: linux
+#          compiler: clang
+#          env: BUILD_TYPE=analyze
+#        - os: linux
+#          compiler: gcc
+#          env: BUILD_TYPE=valgrind
+#        - os: osx
+#          osx_image: xcode11.4
+#          compiler: gcc
+#          env: BUILD_TYPE=normal
+#        - os: osx
+#          osx_image: xcode11.4
+#          compiler: clang
+#          env: BUILD_TYPE=normal
+#        - os: osx
+#          osx_image: xcode11.4
+#          compiler: clang
+#          env: BUILD_TYPE=cmake
+#        - os: osx
+#          osx_image: xcode11.4
+#          compiler: clang
+#          language: objective-c
+#          env: BUILD_TYPE=ios
         - os: osx
           osx_image: xcode11.4
           compiler: clang
           language: objective-c
-          env: BUILD_TYPE=ios
+          env: BUILD_TYPE=ios-cmake
 install:
     - if [ "$TRAVIS_OS_NAME" != "osx" ]; then pip install --user cpp-coveralls > /dev/null; fi
     - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew reinstall libtool > /dev/null; fi
@@ -103,6 +108,15 @@ before_script:
              export CONFIG_OPTS="--host=arm-apple-darwin10 --disable-tests"
              export DEVPATH=`xcode-select -print-path`/Platforms/iPhoneOS.platform/Developer
              export IOSFLAGS="-isysroot $DEVPATH/SDKs/iPhoneOS.sdk -arch armv7 -miphoneos-version-min=8.0.0"
+             export CFLAGS=$IOSFLAGS
+             export CXXFLAGS=$IOSFLAGS
+             export LDFLAGS=$IOSFLAGS
+         fi
+    - |
+         if [ "$BUILD_TYPE" = "ios-cmake" ]; then
+             export SYSROOT="$(xcode-select -print-path)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/"
+             export IOSFLAGS="-miphoneos-version-min=10.0"
+             export ARCHITECTURES="armv7;armv7s;arm64"
              export CFLAGS=$IOSFLAGS
              export CXXFLAGS=$IOSFLAGS
              export LDFLAGS=$IOSFLAGS

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -1,12 +1,26 @@
 #!/bin/sh
 set -e
 
-if [ "$BUILD_TYPE" != "cmake" -a "$BUILD_TYPE" != "valgrind" ]; then
+if [ "$BUILD_TYPE" != "cmake" -a "$BUILD_TYPE" != "valgrind" -a "$BUILD_TYPE" != "ios-cmake" ]; then
     ./buildconf
     mkdir atoolsbld
     cd atoolsbld
     $SCAN_WRAP ../configure --disable-symbol-hiding --enable-expose-statics --enable-maintainer-mode --enable-debug $CONFIG_OPTS
     $SCAN_WRAP make
+elif [ "$BUILD_TYPE" = "ios-cmake" ] ; then
+    mkdir cmakebld
+    cd cmakebld
+    cmake \
+      -DCMAKE_BUILD_TYPE=DEBUG                 \
+      -DCARES_STATIC=ON                        \
+      -DCARES_STATIC_PIC=ON                    \
+      -DCARES_BUILD_TESTS=OFF                  \
+      -DCMAKE_C_FLAGS=$CFLAGS                  \
+      -DCMAKE_CXX_FLAGS=$CXXFLAGS              \
+      -DCMAKE_OSX_SYSROOT=$SYSROOT             \
+      -DCMAKE_OSX_ARCHITECTURES=$ARCHITECTURES \
+      ..
+    make
 else
     # Use cmake for valgrind to prevent libtool script wrapping of tests that interfere with valgrind
     mkdir cmakebld

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -6,7 +6,7 @@ set -e
 [ -z "$TEST_FILTER" ] && export TEST_FILTER="--gtest_filter=-*LiveSearchANY*"
 
 # No tests for ios as it is a cross-compile
-if [ "$BUILD_TYPE" = "ios" ] ; then
+if [ "$BUILD_TYPE" = "ios" -o "$BUILD_TYPE" = "ios-cmake" ] ; then
     exit 0
 fi
 


### PR DESCRIPTION
Issue #377 suggested that CMake builds for iOS with c-ares were broken.  This PR adds an automatic Travis build for iOS CMake.
