### PR TITLE
Use unbuffered stdio for /dev/urandom to read exactly as much data as requested.

### DIFF
--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -2473,6 +2473,7 @@ static void randomize_key(unsigned char* key,int key_data_len)
 #ifdef RANDOM_FILE
   FILE *f = fopen(RANDOM_FILE, "rb");
   if(f) {
+    setvbuf(f, NULL, _IONBF, 0);
     counter = aresx_uztosi(fread(key, 1, key_data_len, f));
     fclose(f);
   }


### PR DESCRIPTION
Buffered fread() reads 4096 bytes which is completely unnecessary and potentially may cause problems.
I discovered this on private linux configuration where custom /dev/urandom implementation has poor performance.