### PR TITLE
Win32: Fix build with autotools out of source tree

### DIFF
--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -8,7 +8,8 @@ ACLOCAL_AMFLAGS = -I m4 --install
 
 AM_CPPFLAGS = -I$(top_builddir)/include \
               -I$(top_builddir)/src/lib \
-              -I$(top_srcdir)/include
+              -I$(top_srcdir)/include \
+              -I$(top_srcdir)/src/lib
 
 lib_LTLIBRARIES = libcares.la
 


### PR DESCRIPTION
Add missing include directory, which fixes the build with autotools in separated build directory.