### PR TITLE
CMake: fix compile error when RANDOM_FILE is defined

### DIFF
--- a/src/lib/ares_config.h.cmake
+++ b/src/lib/ares_config.h.cmake
@@ -347,7 +347,7 @@
 #cmakedefine NEED_MEMORY_H
 
 /* a suitable file/device to read random data from */
-#cmakedefine RANDOM_FILE
+#cmakedefine RANDOM_FILE "@RANDOM_FILE@"
 
 /* Define to the type qualifier pointed by arg 5 for recvfrom. */
 #define RECVFROM_QUAL_ARG5 @RECVFROM_QUAL_ARG5@


### PR DESCRIPTION
When `RANDOM_FILE` is defined in CMake, compile error occurs:
> /home/demian51/cares/src/lib/ares_init.c: In function ‘randomize_key’:
/home/demian51/cares/src/lib/ares_init.c:2474:30: error: expected expression before ‘,’ token
2474 |   FILE *f = fopen(RANDOM_FILE, "rb");
      |                              ^

`RANDOM_FILE` is used as file path(e.g., "dev/urandom") but it defined as empty value in `ares_config.h.cmake`. As a result the code is preprocessed like `FILE *f = fopen(, "rb");` and compile error occurs.

So fixed the macro to be defined as a string.