### PR TITLE
CMake: RANDOM_FILE not defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,6 +387,10 @@ SET (CMAKE_REQUIRED_DEFINITIONS)
 SET (CMAKE_REQUIRED_LIBRARIES)
 
 
+find_file(CARES_RANDOM_FILE urandom /dev)
+mark_as_advanced(CARES_RANDOM_FILE)
+
+
 ################################################################################
 # recv, recvfrom, send, getnameinfo, gethostname
 # ARGUMENTS AND RETURN VALUES

--- a/configure.ac
+++ b/configure.ac
@@ -850,22 +850,22 @@ dnl Check for user-specified random device
 AC_ARG_WITH(random,
 AC_HELP_STRING([--with-random=FILE],
                [read randomness from FILE (default=/dev/urandom)]),
-    [ RANDOM_FILE="$withval" ],
+    [ CARES_RANDOM_FILE="$withval" ],
     [
         dnl Check for random device.  If we're cross compiling, we can't
         dnl check, and it's better to assume it doesn't exist than it is
         dnl to fail on AC_CHECK_FILE or later.
         if test "$cross_compiling" = "no"; then
-          AC_CHECK_FILE("/dev/urandom", [ RANDOM_FILE="/dev/urandom"] )
+          AC_CHECK_FILE("/dev/urandom", [ CARES_RANDOM_FILE="/dev/urandom"] )
         else
           AC_MSG_WARN([cannot check for /dev/urandom while cross compiling; assuming none])
         fi
 
     ]
 )
-if test -n "$RANDOM_FILE" && test X"$RANDOM_FILE" != Xno ; then
-        AC_SUBST(RANDOM_FILE)
-        AC_DEFINE_UNQUOTED(RANDOM_FILE, "$RANDOM_FILE",
+if test -n "$CARES_RANDOM_FILE" && test X"$CARES_RANDOM_FILE" != Xno ; then
+        AC_SUBST(CARES_RANDOM_FILE)
+        AC_DEFINE_UNQUOTED(CARES_RANDOM_FILE, "$CARES_RANDOM_FILE",
         [a suitable file/device to read random data from])
 fi
 

--- a/src/lib/ares_config.h.cmake
+++ b/src/lib/ares_config.h.cmake
@@ -1,4 +1,4 @@
-/* Generated from ares_config.h.cmake*/
+/* Generated from ares_config.h.cmake */
 
 /* Define if building universal (internal helper macro) */
 #undef AC_APPLE_UNIVERSAL_BUILD
@@ -347,7 +347,7 @@
 #cmakedefine NEED_MEMORY_H
 
 /* a suitable file/device to read random data from */
-#cmakedefine RANDOM_FILE
+#cmakedefine CARES_RANDOM_FILE "@CARES_RANDOM_FILE@"
 
 /* Define to the type qualifier pointed by arg 5 for recvfrom. */
 #define RECVFROM_QUAL_ARG5 @RECVFROM_QUAL_ARG5@

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -2514,8 +2514,8 @@ static void randomize_key(unsigned char* key,int key_data_len)
         randomized = 1;
     }
 #else /* !WIN32 */
-#ifdef RANDOM_FILE
-  FILE *f = fopen(RANDOM_FILE, "rb");
+#ifdef CARES_RANDOM_FILE
+  FILE *f = fopen(CARES_RANDOM_FILE, "rb");
   if(f) {
     setvbuf(f, NULL, _IONBF, 0);
     counter = aresx_uztosi(fread(key, 1, key_data_len, f));


### PR DESCRIPTION
RANDOM_FILE was never defined by cmake, causing RC4 key generation to use the less secure rand() method. 

Also, due to clashes with chain-building from other projects (e.g. curl) that may define RANDOM_FILE, this was renamed to CARES_RANDOM_FILE.

This is the proposed change for #396