### PR TITLE
Validate hostnames in DNS responses and discard from malicious servers

### DIFF
--- a/src/lib/ares__parse_into_addrinfo.c
+++ b/src/lib/ares__parse_into_addrinfo.c
@@ -70,7 +70,7 @@ int ares__parse_into_addrinfo2(const unsigned char *abuf,
 
   /* Expand the name from the question, and skip past the question. */
   aptr = abuf + HFIXEDSZ;
-  status = ares__expand_name_for_response(aptr, abuf, alen, question_hostname, &len, 1);
+  status = ares__expand_name_for_response(aptr, abuf, alen, question_hostname, &len, 0);
   if (status != ARES_SUCCESS)
     return status;
   if (aptr + len + QFIXEDSZ > abuf + alen)
@@ -86,7 +86,7 @@ int ares__parse_into_addrinfo2(const unsigned char *abuf,
   for (i = 0; i < (int)ancount; i++)
     {
       /* Decode the RR up to the data field. */
-      status = ares__expand_name_for_response(aptr, abuf, alen, &rr_name, &len, 1);
+      status = ares__expand_name_for_response(aptr, abuf, alen, &rr_name, &len, 0);
       if (status != ARES_SUCCESS)
         {
           rr_name = NULL;

--- a/src/lib/ares__parse_into_addrinfo.c
+++ b/src/lib/ares__parse_into_addrinfo.c
@@ -70,7 +70,7 @@ int ares__parse_into_addrinfo2(const unsigned char *abuf,
 
   /* Expand the name from the question, and skip past the question. */
   aptr = abuf + HFIXEDSZ;
-  status = ares__expand_name_for_response(aptr, abuf, alen, question_hostname, &len);
+  status = ares__expand_name_for_response(aptr, abuf, alen, question_hostname, &len, 1);
   if (status != ARES_SUCCESS)
     return status;
   if (aptr + len + QFIXEDSZ > abuf + alen)
@@ -86,7 +86,7 @@ int ares__parse_into_addrinfo2(const unsigned char *abuf,
   for (i = 0; i < (int)ancount; i++)
     {
       /* Decode the RR up to the data field. */
-      status = ares__expand_name_for_response(aptr, abuf, alen, &rr_name, &len);
+      status = ares__expand_name_for_response(aptr, abuf, alen, &rr_name, &len, 1);
       if (status != ARES_SUCCESS)
         {
           rr_name = NULL;
@@ -188,7 +188,7 @@ int ares__parse_into_addrinfo2(const unsigned char *abuf,
         {
           got_cname = 1;
           status = ares__expand_name_for_response(aptr, abuf, alen, &rr_data,
-                                                  &len);
+                                                  &len, 1);
           if (status != ARES_SUCCESS)
             {
               goto failed_stat;

--- a/src/lib/ares_parse_ns_reply.c
+++ b/src/lib/ares_parse_ns_reply.c
@@ -62,7 +62,7 @@ int ares_parse_ns_reply( const unsigned char* abuf, int alen,
 
   /* Expand the name from the question, and skip past the question. */
   aptr = abuf + HFIXEDSZ;
-  status = ares__expand_name_for_response( aptr, abuf, alen, &hostname, &len);
+  status = ares__expand_name_for_response( aptr, abuf, alen, &hostname, &len, 0);
   if ( status != ARES_SUCCESS )
     return status;
   if ( aptr + len + QFIXEDSZ > abuf + alen )
@@ -85,7 +85,7 @@ int ares_parse_ns_reply( const unsigned char* abuf, int alen,
   for ( i = 0; i < ( int ) ancount; i++ )
   {
     /* Decode the RR up to the data field. */
-    status = ares__expand_name_for_response( aptr, abuf, alen, &rr_name, &len );
+    status = ares__expand_name_for_response( aptr, abuf, alen, &rr_name, &len, 0);
     if ( status != ARES_SUCCESS )
       break;
     aptr += len;
@@ -110,7 +110,7 @@ int ares_parse_ns_reply( const unsigned char* abuf, int alen,
     {
       /* Decode the RR data and add it to the nameservers list */
       status = ares__expand_name_for_response( aptr, abuf, alen, &rr_data,
-                                               &len);
+                                               &len, 1);
       if ( status != ARES_SUCCESS )
       {
         ares_free(rr_name);

--- a/src/lib/ares_parse_ptr_reply.c
+++ b/src/lib/ares_parse_ptr_reply.c
@@ -63,7 +63,7 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
 
   /* Expand the name from the question, and skip past the question. */
   aptr = abuf + HFIXEDSZ;
-  status = ares__expand_name_for_response(aptr, abuf, alen, &ptrname, &len);
+  status = ares__expand_name_for_response(aptr, abuf, alen, &ptrname, &len, 0);
   if (status != ARES_SUCCESS)
     return status;
   if (aptr + len + QFIXEDSZ > abuf + alen)
@@ -84,7 +84,7 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
   for (i = 0; i < (int)ancount; i++)
     {
       /* Decode the RR up to the data field. */
-      status = ares__expand_name_for_response(aptr, abuf, alen, &rr_name, &len);
+      status = ares__expand_name_for_response(aptr, abuf, alen, &rr_name, &len, 0);
       if (status != ARES_SUCCESS)
         break;
       aptr += len;
@@ -110,7 +110,7 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
         {
           /* Decode the RR data and set hostname to it. */
           status = ares__expand_name_for_response(aptr, abuf, alen, &rr_data,
-                                                  &len);
+                                                  &len, 1);
           if (status != ARES_SUCCESS)
             {
               ares_free(rr_name);
@@ -146,7 +146,7 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
         {
           /* Decode the RR data and replace ptrname with it. */
           status = ares__expand_name_for_response(aptr, abuf, alen, &rr_data,
-                                                  &len);
+                                                  &len, 1);
           if (status != ARES_SUCCESS)
             {
               ares_free(rr_name);

--- a/src/lib/ares_parse_soa_reply.c
+++ b/src/lib/ares_parse_soa_reply.c
@@ -60,7 +60,7 @@ ares_parse_soa_reply(const unsigned char *abuf, int alen,
   aptr = abuf + HFIXEDSZ;
 
   /* query name */
-  status = ares__expand_name_for_response(aptr, abuf, alen, &qname, &len);
+  status = ares__expand_name_for_response(aptr, abuf, alen, &qname, &len, 0);
   if (status != ARES_SUCCESS)
     goto failed_stat;
 
@@ -83,7 +83,7 @@ ares_parse_soa_reply(const unsigned char *abuf, int alen,
   for (i = 0; i < ancount; i++)
   {
     rr_name = NULL;
-    status  = ares__expand_name_for_response (aptr, abuf, alen, &rr_name, &len);
+    status  = ares__expand_name_for_response (aptr, abuf, alen, &rr_name, &len, 0);
     if (status != ARES_SUCCESS)
      {
       ares_free(rr_name);
@@ -120,7 +120,7 @@ ares_parse_soa_reply(const unsigned char *abuf, int alen,
 
       /* nsname */
       status = ares__expand_name_for_response(aptr, abuf, alen, &soa->nsname,
-                                               &len);
+                                               &len, 0);
       if (status != ARES_SUCCESS)
        {
         ares_free(rr_name);
@@ -130,7 +130,7 @@ ares_parse_soa_reply(const unsigned char *abuf, int alen,
 
       /* hostmaster */
       status = ares__expand_name_for_response(aptr, abuf, alen,
-                                               &soa->hostmaster, &len);
+                                               &soa->hostmaster, &len, 0);
       if (status != ARES_SUCCESS)
        {
         ares_free(rr_name);

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -356,9 +356,13 @@ int ares__read_line(FILE *fp, char **buf, size_t *bufsize);
 void ares__free_query(struct query *query);
 unsigned short ares__generate_new_id(rc4_key* key);
 struct timeval ares__tvnow(void);
+int ares__expand_name_validated(const unsigned char *encoded,
+                                const unsigned char *abuf,
+                                int alen, char **s, long *enclen,
+                                int is_hostname);
 int ares__expand_name_for_response(const unsigned char *encoded,
                                    const unsigned char *abuf, int alen,
-                                   char **s, long *enclen);
+                                   char **s, long *enclen, int is_hostname);
 void ares__init_servers_state(ares_channel channel);
 void ares__destroy_servers_state(ares_channel channel);
 int ares__parse_qtype_reply(const unsigned char* abuf, int alen, int* qtype);

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -606,7 +606,7 @@ static void process_answer(ares_channel channel, unsigned char *abuf,
   /* If we use EDNS and server answers with FORMERR without an OPT RR, the protocol
    * extension is not understood by the responder. We must retry the query
    * without EDNS enabled.
-   */
+  wrap */
   if (channel->flags & ARES_FLAG_EDNS)
   {
       packetsz = channel->ednspsz;

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -605,8 +605,7 @@ static void process_answer(ares_channel channel, unsigned char *abuf,
   packetsz = PACKETSZ;
   /* If we use EDNS and server answers with FORMERR without an OPT RR, the protocol
    * extension is not understood by the responder. We must retry the query
-   * without EDNS enabled.
-  wrap */
+   * without EDNS enabled. */
   if (channel->flags & ARES_FLAG_EDNS)
   {
       packetsz = channel->ednspsz;

--- a/test/ares-test-parse.cc
+++ b/test/ares-test-parse.cc
@@ -60,6 +60,8 @@ TEST_F(LibraryTest, ParseIndirectRootName) {
   ares_free_hostent(host);
 }
 
+
+#if 0 /* We are validating hostnames now, its not clear how this would ever be valid */
 TEST_F(LibraryTest, ParseEscapedName) {
   std::vector<byte> data = {
     0x12, 0x34,  // qid
@@ -105,6 +107,7 @@ TEST_F(LibraryTest, ParseEscapedName) {
   EXPECT_EQ('c', hent.name_[6]);
   ares_free_hostent(host);
 }
+#endif
 
 TEST_F(LibraryTest, ParsePartialCompressedName) {
   std::vector<byte> data = {


### PR DESCRIPTION
DNS servers could intentionally return malformed DNS responses that could cause client-side issues (like XSS).  Attempt to identify such responses and throw them away and return EBADRESP.

It is not clear if there are any legitimate use cases where a DNS response might return a non-validly formatted hostname.

