### PR TITLE
add build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ CHANGES.dist
 c-ares-*.tar.gz.asc
 ares_parse_mx_reply.pdf
 /[0-9]*.patch
+build


### PR DESCRIPTION
This commit adds the build directory to be ignored by git.

The motivation for adding this to .gitignore as opposed to
.git/info/exclude is that the CMake example in INSTALL.md uses build
as the name of the directory to be used by CMake. This will cause
git to report build as an untracked file.