### PR TITLE
src: z/OS minor update, add missing semicolon in ares_init.c

### DIFF
--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -1470,7 +1470,7 @@ static int init_by_resolv_conf(ares_channel channel)
   struct __res_state *res = 0;
   int count4, count6;
   __STATEEXTIPV6 *v6;
-  struct server_state *pserver
+  struct server_state *pserver;
   if (0 == res) {
     int rc = res_init();
     while (rc == -1 && h_errno == TRY_AGAIN) {


### PR DESCRIPTION
This is a minor update, code is missing a semicolon.