### PR TITLE
MINGW fixes for c-ares

### DIFF
--- a/src/lib/ares_setup.h
+++ b/src/lib/ares_setup.h
@@ -28,15 +28,11 @@
  * configuration file for platforms which lack config tool.
  */
 
-#ifdef HAVE_CONFIG_H
-#include "ares_config.h"
-#else
-
 #ifdef WIN32
 #include "config-win32.h"
-#endif
-
-#endif /* HAVE_CONFIG_H */
+#elif defined(HAVE_CONFIG_H)
+#include "ares_config.h"
+#endif /* WIN32 */
 
 /* ================================================================ */
 /* Definition of preprocessor macros/symbols which modify compiler  */


### PR DESCRIPTION
Build tested using yocto's meta-mingw layer to build an SDK.

Issues seen are:

1. HAVE_CONFIG takes precedence of WIN32 definitions.