### PR TITLE
CMake: Fix build in cygwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,11 +195,14 @@ ELSE ()
 ENDIF ()
 
 # Include order matters for these windows files.
+# As cygwin environment has both socket.h and winsock2.h
+# headers check WIN32 not to include the later one here
+IF (WIN32)
 CHECK_INCLUDE_FILES ("winsock2.h;windows.h"            HAVE_WINSOCK2_H)
 CHECK_INCLUDE_FILES ("winsock2.h;ws2tcpip.h;windows.h" HAVE_WS2TCPIP_H)
 CHECK_INCLUDE_FILES ("winsock.h;windows.h"             HAVE_WINSOCK_H)
 CHECK_INCLUDE_FILES (windows.h                         HAVE_WINDOWS_H)
-
+ENDIF ()
 
 # Set system-specific compiler flags
 IF (CMAKE_SYSTEM_NAME STREQUAL "Darwin")


### PR DESCRIPTION
 As cygwin environment has both socket.h and winsock2.h
 headers check WIN32 not to include the later one here