### PR TITLE
configure.ac: fix STDC_HEADERS typo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -493,7 +493,7 @@ dnl Back to "normal" configuring
 dnl **********************************************************************
 
 dnl Checks for header files.
-STDC_HEADERS
+AC_HEADER_STDC
 
 AC_PROG_EGREP
 


### PR DESCRIPTION
There is no autoconf macro called STDC_HEADERS. AC_HEADER_STDC however does
exist and it defines the STDC_HEADERS macro for use.

Not clear that STDC_HEADERS from its use in the repo is needed but
would rather not meddle with it for now.

Fixes an annoying warning on `./configure`:
```
/var/tmp/portage/net-dns/c-ares-1.18.1/work/c-ares-1.18.1/configure: 24546: STDC_HEADERS: not found
```

Signed-off-by: Sam James <sam@gentoo.org>