### PR TITLE
Configurable hosts path for file_lookup

### DIFF
--- a/docs/ares_init_options.3
+++ b/docs/ares_init_options.3
@@ -41,6 +41,7 @@ struct ares_options {
   int nsort;
   int ednspsz;
   char *resolvconf_path;
+  char *hosts_path;
 };
 
 int ares_init_options(ares_channel *\fIchannelptr\fP,
@@ -194,6 +195,16 @@ The path to use for reading the resolv.conf file. The
 should be set to a path string, and will be honoured on *nix like systems. The
 default is
 .B /etc/resolv.conf
+.br
+.TP 18
+.B ARES_OPT_HOSTS_FILE
+.B char *\fIhosts_path\fP;
+.br
+The path to use for reading the hosts file. The
+.I hosts_path
+should be set to a path string, and will be honoured on *nix like systems. The
+default is
+.B /etc/hosts
 .br
 .PP
 The \fIoptmask\fP parameter also includes options without a corresponding

--- a/include/ares.h
+++ b/include/ares.h
@@ -175,6 +175,7 @@ extern "C" {
 #define ARES_OPT_EDNSPSZ        (1 << 15)
 #define ARES_OPT_NOROTATE       (1 << 16)
 #define ARES_OPT_RESOLVCONF     (1 << 17)
+#define ARES_OPT_HOSTS_FILE     (1 << 18)
 
 /* Nameinfo flag values */
 #define ARES_NI_NOFQDN                  (1 << 0)
@@ -284,6 +285,7 @@ struct ares_options {
   int nsort;
   int ednspsz;
   char *resolvconf_path;
+  char *hosts_path;
 };
 
 struct hostent;

--- a/src/lib/ares_destroy.c
+++ b/src/lib/ares_destroy.c
@@ -38,6 +38,8 @@ void ares_destroy_options(struct ares_options *options)
     ares_free(options->lookups);
   if(options->resolvconf_path)
     ares_free(options->resolvconf_path);
+  if(options->hosts_path)
+    ares_free(options->hosts_path);
 }
 
 void ares_destroy(ares_channel channel)
@@ -89,6 +91,9 @@ void ares_destroy(ares_channel channel)
 
   if (channel->resolvconf_path)
     ares_free(channel->resolvconf_path);
+
+  if (channel->hosts_path)
+    ares_free(channel->hosts_path);
 
   ares_free(channel);
 }

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -416,6 +416,11 @@ static int file_lookup(struct host_query *hquery)
       path_hosts = getenv("CARES_HOSTS");
     }
 
+  if (hquery->channel->hosts_path)
+    {
+      path_hosts = hquery->channel->hosts_path;
+    }
+
   if (!path_hosts)
     {
 #ifdef WIN32

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -339,6 +339,9 @@ struct ares_channeldata {
 
   /* Path for resolv.conf file, configurable via ares_options */
   char *resolvconf_path;
+
+  /* Path for hosts file, configurable via ares_options */
+  char *hosts_path;
 };
 
 /* Does the domain end in ".onion" or ".onion."? Case-insensitive. */


### PR DESCRIPTION
This changeset adds support for configurable hosts file
ARES_OPT_HOSTS_FILE (similar to ARES_OPT_RESOLVCONF).

c-ares does support configurable hosts file via an environment
varibale (ARES_AI_ENVHOSTS). However, if application wants to
support multiple VRF/VPN/namespaces, this environment variable
does not help much