### PR TITLE
Convert total timeout to per-query for Apple

### DIFF
--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -1347,8 +1347,12 @@ static int init_by_resolv_conf(ares_channel channel)
       channel->tries = res.retry;
     if (channel->rotate == -1)
       channel->rotate = res.options & RES_ROTATE;
-    if (channel->timeout == -1)
+    if (channel->timeout == -1) {
       channel->timeout = res.retrans * 1000;
+#ifdef __APPLE__
+      channel->timeout /= (res.retry + 1) * (res.nscount > 0 ? res.nscount : 1);
+#endif
+    }
 
     res_ndestroy(&res);
   }


### PR DESCRIPTION
On Apple platforms, [libresolv reports the total timeout in `retrans`, not the per-query time](https://github.com/apple-oss-distributions/libresolv/blob/rel/libresolv-68/res_init.c#L1018-L1021).  This patch undoes that math to get the per-query time, which is what c-ares expects.  This is not perfect because libresolv is inconsistent on whether the timeout is multiplied by [`retry` ](https://github.com/apple-oss-distributions/libresolv/blob/rel/libresolv-68/res_init.c#L1336) or [`retry+1`](https://github.com/apple-oss-distributions/libresolv/blob/rel/libresolv-68/res_init.c#L1023), but I don't see any way to distinguish these cases.