### PR TITLE
Fix ares_getaddrinfo() numerical address fast path with AF_UNSPEC

### DIFF
--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -326,7 +326,7 @@ static int fake_addrinfo(const char *name,
         }
     }
 
-  if (family == AF_INET6 || family == AF_UNSPEC)
+  if (!result && (family == AF_INET6 || family == AF_UNSPEC))
     {
       struct ares_in6_addr addr6;
       result = ares_inet_pton(AF_INET6, name, &addr6) < 1 ? 0 : 1;


### PR DESCRIPTION
The conversion of numeric IPv4 addresses in fake_addrinfo() is broken when
the family is AF_UNSPEC. The initial call to ares_inet_pton with AF_INET
will succeed, but the subsequent call using AF_INET6 will fail. This results
in the fake_addrinfo() fast path failing, and ares_getaddrinfo() making a
query when none should be required.

Resolve this by only attempting the call to ares_inet_pton with AF_INET6
if the initial call with AF_INET was unsuccessful.