### PR TITLE
Avoid warnings from ranlib on macOS

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -82,6 +82,19 @@ IF (CARES_STATIC)
 		SET_TARGET_PROPERTIES (${LIBNAME} PROPERTIES POSITION_INDEPENDENT_CODE True)
 	ENDIF ()
 
+	IF (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+		# This defaults to "qc" but since macOS always runs ranlib right after, we can pass "Sqc" and avoid
+		# the step of generating a symbol table. ranlib will do it for us.
+		set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Sqc <TARGET> <LINK_FLAGS> <OBJECTS>")
+		set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Sqc <TARGET> <LINK_FLAGS> <OBJECTS>")
+
+		# -no_warning_for_no_symbols is a special flag in the macOS version of ranlib that stops it from
+		# printing a warning about object files that don't contain any symbols. This warning is printed for
+		# android/windows/etc files when building on macOS.
+		set(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+		set(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+	endif()
+
 	TARGET_INCLUDE_DIRECTORIES (${LIBNAME}
 		PUBLIC "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>"
 		       "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
@@ -114,7 +127,3 @@ IF (CARES_STATIC)
 		ADD_LIBRARY (${PROJECT_NAME}::cares ALIAS ${LIBNAME})
 	ENDIF ()
 ENDIF ()
-
-
-
-


### PR DESCRIPTION
This fixes these warnings emitted when building a static library on macOS as reported in https://github.com/c-ares/c-ares/issues/446:

```
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: auxil/c-ares/lib/libcares.a(ares_android.c.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: auxil/c-ares/lib/libcares.a(ares_getenv.c.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: auxil/c-ares/lib/libcares.a(ares_platform.c.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: auxil/c-ares/lib/libcares.a(ares_strcasecmp.c.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: auxil/c-ares/lib/libcares.a(ares_writev.c.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: auxil/c-ares/lib/libcares.a(windows_port.c.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: auxil/c-ares/lib/libcares.a(ares_android.c.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: auxil/c-ares/lib/libcares.a(ares_getenv.c.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: auxil/c-ares/lib/libcares.a(ares_platform.c.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: auxil/c-ares/lib/libcares.a(ares_strcasecmp.c.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: auxil/c-ares/lib/libcares.a(ares_writev.c.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: auxil/c-ares/lib/libcares.a(windows_port.c.o) has no symbols
```