### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -382,6 +382,20 @@ sure that the var `OSTYPE` contains the string 'linux'; set the var
 `NDKBASE` to point to the base of your Novell NDK; and then type
 `make -f Makefile.netware` from the top source directory;
 
+VCPKG
+=====
+
+You can build and install c-ares using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+```sh or powershell
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install c-ares
+```
+
+The c-ares port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 PORTS
 =====


### PR DESCRIPTION
`c-ares` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `c-ares` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `c-ares`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/c-ares/portfile.cmake). We try to keep the library maintained as close as possible to the original library. 😊