### PR TITLE
Allow for CMake to use absolute install paths

### DIFF
--- a/libcares.pc.cmake
+++ b/libcares.pc.cmake
@@ -4,10 +4,9 @@
 #              | (_|_____| (_| | | |  __/\__ \
 #               \___|     \__,_|_|  \___||___/
 #
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}/@CMAKE_INSTALL_BINDIR@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+exec_prefix=@CMAKE_INSTALL_FULL_BINDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: c-ares
 URL: https://c-ares.org/


### PR DESCRIPTION
Certain build systems such as Nix will install dev related items separately from library and runtime outputs. The current:
```
# libcares.pc.cmake
prefix=@CMAKE_INSTALL_PREFIX@
includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
```
will create paths such as `includedir=/nix/store/pgvk94m98y2sq5x91mpz2nsm7pd2yqkp-c-ares-1.18.1-dev//nix/store/pgvk94m98y2sq5x91mpz2nsm7pd2yqkp-c-ares-1.18.1-dev/include` which should be `includedir=/nix/store/pgvk94m98y2sq5x91mpz2nsm7pd2yqkp-c-ares-1.18.1-dev/include`

Result of PR:
```
cat ./result-dev/lib/pkgconfig/libcares.pc
#***************************************************************************
# Project        ___       __ _ _ __ ___  ___
#               / __|____ / _` | '__/ _ \/ __|
#              | (_|_____| (_| | | |  __/\__ \
#               \___|     \__,_|_|  \___||___/
#
exec_prefix=/nix/store/shskwbrmq0nl2xvwc53xfby6x7xymils-c-ares-1.18.1/bin
libdir=/nix/store/shskwbrmq0nl2xvwc53xfby6x7xymils-c-ares-1.18.1/lib
includedir=/nix/store/i14bqixhc0gi30ajlgbn31g0p77asj5n-c-ares-1.18.1-dev/include

Name: c-ares
URL: https://c-ares.org/
Description: asynchronous DNS lookup library
Version: 1.18.1
Requires:
Requires.private:
Cflags: -I${includedir}
Libs: -L${libdir} -lcares
Libs.private:
```