### PR TITLE
Add include guards to ares_data.h

### DIFF
--- a/src/lib/ares_data.h
+++ b/src/lib/ares_data.h
@@ -1,3 +1,6 @@
+#ifndef __ARES_DATA_H
+#define __ARES_DATA_H
+
 
 /* Copyright (C) 2009-2013 by Daniel Stenberg
  *
@@ -74,3 +77,5 @@ struct ares_data {
 
 void *ares_malloc_data(ares_datatype type);
 
+
+#endif // __ARES_DATA_H


### PR DESCRIPTION
I am getting a compilation error somehow telling me about this problem. All the other header files in the src/lib folder do have an include guard so it look like an overthought.