### PR TITLE
docs: reformat/cleanup man pages SYNOPSIS sections

### DIFF
--- a/docs/ares_destroy_options.3
+++ b/docs/ares_destroy_options.3
@@ -18,9 +18,9 @@
 ares_destroy_options \- Destroy options initialized with ares_save_options
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B void ares_destroy_options(struct ares_options *\fIoptions\fP)
+#include <ares.h>
+
+void ares_destroy_options(struct ares_options *\fIoptions\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_destroy_options(3)\fP function destroys the options struct

--- a/docs/ares_dup.3
+++ b/docs/ares_dup.3
@@ -18,9 +18,9 @@
 ares_dup \- Duplicate a resolver channel
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_dup(ares_channel *\fIdest\fP, ares_channel \fIsource\fP)
+#include <ares.h>
+
+int ares_dup(ares_channel *\fIdest\fP, ares_channel \fIsource\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_dup(3)\fP function duplicates an existing communications channel

--- a/docs/ares_expand_name.3
+++ b/docs/ares_expand_name.3
@@ -18,11 +18,11 @@
 ares_expand_name \- Expand a DNS-encoded domain name
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_expand_name(const unsigned char *\fIencoded\fP,
-.B      const unsigned char *\fIabuf\fP, int \fIalen\fP, char **\fIs\fP,
-.B 	long *\fIenclen\fP)
+#include <ares.h>
+
+int ares_expand_name(const unsigned char *\fIencoded\fP,
+                     const unsigned char *\fIabuf\fP, int \fIalen\fP,
+                     char **\fIs\fP, long *\fIenclen\fP)
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_expand_string.3
+++ b/docs/ares_expand_string.3
@@ -18,11 +18,11 @@
 ares_expand_string \- Expand a length encoded string
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_expand_string(const unsigned char *\fIencoded\fP,
-.B      const unsigned char *\fIabuf\fP, int \fIalen\fP, unsigned char **\fIs\fP,
-.B 	long *\fIenclen\fP)
+#include <ares.h>
+
+int ares_expand_string(const unsigned char *\fIencoded\fP,
+                       const unsigned char *\fIabuf\fP, int \fIalen\fP,
+                       unsigned char **\fIs\fP, long *\fIenclen\fP)
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_free_data.3
+++ b/docs/ares_free_data.3
@@ -19,11 +19,9 @@
 ares_free_data \- Free data allocated by several c-ares functions
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B void ares_free_data(void *\fIdataptr\fP)
-.PP
-.B cc file.c -lcares
+#include <ares.h>
+
+void ares_free_data(void *\fIdataptr\fP)
 .fi
 .SH DESCRIPTION
 .PP

--- a/docs/ares_free_hostent.3
+++ b/docs/ares_free_hostent.3
@@ -18,9 +18,9 @@
 ares_free_hostent \- Free host structure allocated by ares functions
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B void ares_free_hostent(struct hostent *\fIhost\fP)
+#include <ares.h>
+
+void ares_free_hostent(struct hostent *\fIhost\fP)
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_free_string.3
+++ b/docs/ares_free_string.3
@@ -18,9 +18,9 @@
 ares_free_string \- Free strings allocated by ares functions
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B void ares_free_string(void *\fIstr\fP)
+#include <ares.h>
+
+void ares_free_string(void *\fIstr\fP)
 .fi
 .SH DESCRIPTION
 The \fIares_free_string(3)\fP function frees a string allocated by an ares

--- a/docs/ares_get_servers.3
+++ b/docs/ares_get_servers.3
@@ -19,10 +19,13 @@
 ares_get_servers, ares_get_servers_ports \- Retrieve name servers from an initialized ares_channel
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_get_servers(ares_channel \fIchannel\fP, struct ares_addr_node **\fIservers\fP)
-.B int ares_get_servers_ports(ares_channel \fIchannel\fP, struct ares_addr_port_node **\fIservers\fP)
+#include <ares.h>
+
+int ares_get_servers(ares_channel \fIchannel\fP,
+                     struct ares_addr_node **\fIservers\fP)
+
+int ares_get_servers_ports(ares_channel \fIchannel\fP,
+                           struct ares_addr_port_node **\fIservers\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_get_servers(3)\fP function retrieves name servers configuration

--- a/docs/ares_getaddrinfo.3
+++ b/docs/ares_getaddrinfo.3
@@ -18,14 +18,16 @@
 ares_getaddrinfo \- Initiate a host query by name and service
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B typedef void (*ares_addrinfo_callback)(void *\fIarg\fP, int \fIstatus\fP,
-.B 	int \fItimeouts\fP, struct ares_addrinfo *\fIresult\fP)
-.PP
-.B void ares_getaddrinfo(ares_channel \fIchannel\fP, const char *\fIname\fP,
-.B 	const char* \fIservice\fP, const struct ares_addrinfo_hints *\fIhints\fP,
-.B 	ares_addrinfo_callback \fIcallback\fP, void *\fIarg\fP)
+#include <ares.h>
+
+typedef void (*ares_addrinfo_callback)(void *\fIarg\fP, int \fIstatus\fP,
+                                       int \fItimeouts\fP,
+                                       struct ares_addrinfo *\fIresult\fP)
+
+void ares_getaddrinfo(ares_channel \fIchannel\fP, const char *\fIname\fP,
+                      const char* \fIservice\fP,
+                      const struct ares_addrinfo_hints *\fIhints\fP,
+                      ares_addrinfo_callback \fIcallback\fP, void *\fIarg\fP)
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_gethostbyaddr.3
+++ b/docs/ares_gethostbyaddr.3
@@ -18,14 +18,15 @@
 ares_gethostbyaddr \- Initiate a host query by address
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B typedef void (*ares_host_callback)(void *\fIarg\fP, int \fIstatus\fP,
-.B	int \fItimeouts\fP, struct hostent *\fIhostent\fP)
-.PP
-.B void ares_gethostbyaddr(ares_channel \fIchannel\fP, const void *\fIaddr\fP,
-.B 	int \fIaddrlen\fP, int \fIfamily\fP, ares_host_callback \fIcallback\fP,
-.B 	void *\fIarg\fP)
+#include <ares.h>
+
+typedef void (*ares_host_callback)(void *\fIarg\fP, int \fIstatus\fP,
+                                   int \fItimeouts\fP,
+                                   struct hostent *\fIhostent\fP)
+
+void ares_gethostbyaddr(ares_channel \fIchannel\fP, const void *\fIaddr\fP,
+                        int \fIaddrlen\fP, int \fIfamily\fP,
+                        ares_host_callback \fIcallback\fP, void *\fIarg\fP)
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_gethostbyname.3
+++ b/docs/ares_gethostbyname.3
@@ -18,13 +18,15 @@
 ares_gethostbyname \- Initiate a host query by name
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B typedef void (*ares_host_callback)(void *\fIarg\fP, int \fIstatus\fP,
-.B	int \fItimeouts\fP, struct hostent *\fIhostent\fP)
-.PP
-.B void ares_gethostbyname(ares_channel \fIchannel\fP, const char *\fIname\fP,
-.B 	int \fIfamily\fP, ares_host_callback \fIcallback\fP, void *\fIarg\fP)
+#include <ares.h>
+
+typedef void (*ares_host_callback)(void *\fIarg\fP, int \fIstatus\fP,
+                                   int \fItimeouts\fP,
+                                   struct hostent *\fIhostent\fP)
+
+void ares_gethostbyname(ares_channel \fIchannel\fP, const char *\fIname\fP,
+                        int \fIfamily\fP, ares_host_callback \fIcallback\fP,
+                        void *\fIarg\fP)
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_gethostbyname_file.3
+++ b/docs/ares_gethostbyname_file.3
@@ -18,10 +18,10 @@
 ares_gethostbyname_file \- Lookup a name in the system's hosts file
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_gethostbyname_file(ares_channel \fIchannel\fP, const char *\fIname\fP,
-.B 	int \fIfamily\fP, struct hostent **host)
+#include <ares.h>
+
+int ares_gethostbyname_file(ares_channel \fIchannel\fP, const char *\fIname\fP,
+                            int \fIfamily\fP, struct hostent **host)
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_getnameinfo.3
+++ b/docs/ares_getnameinfo.3
@@ -18,14 +18,15 @@
 ares_getnameinfo \- Address-to-nodename translation in protocol-independent manner
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B typedef void (*ares_nameinfo_callback)(void *\fIarg\fP, int \fIstatus\fP,
-.B	int \fItimeouts\fP, char *\fInode\fP, char *\fIservice\fP)
-.PP
-.B void ares_getnameinfo(ares_channel \fIchannel\fP, const struct sockaddr *\fIsa\fP,
-.B 	ares_socklen_t \fIsalen\fP, int \fIflags\fP, ares_nameinfo_callback \fIcallback\fP,
-.B 	void *\fIarg\fP)
+#include <ares.h>
+
+typedef void (*ares_nameinfo_callback)(void *\fIarg\fP, int \fIstatus\fP,
+                                       int \fItimeouts\fP, char *\fInode\fP,
+                                       char *\fIservice\fP)
+
+void ares_getnameinfo(ares_channel \fIchannel\fP, const struct sockaddr *\fIsa\fP,
+                      ares_socklen_t \fIsalen\fP, int \fIflags\fP,
+                      ares_nameinfo_callback \fIcallback\fP, void *\fIarg\fP)
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_getsock.3
+++ b/docs/ares_getsock.3
@@ -18,10 +18,10 @@
 ares_getsock \- get socket descriptors to wait on
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_getsock(ares_channel \fIchannel\fP, ares_socket_t *\fIsocks\fP,
-.B int \fInumsocks\fP);
+#include <ares.h>
+
+int ares_getsock(ares_channel \fIchannel\fP, ares_socket_t *\fIsocks\fP,
+                 int \fInumsocks\fP);
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_inet_ntop.3
+++ b/docs/ares_inet_ntop.3
@@ -18,10 +18,10 @@
 ares_inet_ntop \- convert a network format address to presentation format
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B const char *
-.B ares_inet_ntop(int af, const void *src, char *dst, ares_socklen_t size);
+#include <ares.h>
+
+const char *ares_inet_ntop(int \fIaf\fP, const void *\fIsrc\fP, char *\fIdst\fP,
+                           ares_socklen_t \fIsize\fP);
 .fi
 .SH DESCRIPTION
 This is a portable version with the identical functionality of the commonly

--- a/docs/ares_inet_pton.3
+++ b/docs/ares_inet_pton.3
@@ -18,9 +18,9 @@
 ares_inet_pton \- convert an IPv4 or IPv6 address from text to binary form
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B const char *ares_inet_pton(int af, const char *src, void *dst);
+#include <ares.h>
+
+const char *ares_inet_pton(int \fIaf\fP, const char *\fIsrc\fP, void *\fIdst\fP);
 .fi
 .SH DESCRIPTION
 This is a portable version with the identical functionality of the commonly

--- a/docs/ares_mkquery.3
+++ b/docs/ares_mkquery.3
@@ -18,11 +18,11 @@
 ares_mkquery \- Compose a single-question DNS query buffer
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_mkquery(const char *\fIname\fP, int \fIdnsclass\fP, int \fItype\fP,
-.B	unsigned short \fIid\fP, int \fIrd\fP, unsigned char **\fIbuf\fP,
-.B	int *\fIbuflen\fP)
+#include <ares.h>
+
+int ares_mkquery(const char *\fIname\fP, int \fIdnsclass\fP, int \fItype\fP,
+                 unsigned short \fIid\fP, int \fIrd\fP, unsigned char **\fIbuf\fP,
+                 int *\fIbuflen\fP)
 .fi
 .SH DESCRIPTION
 Deprecated function. See \fIares_create_query(3)\fP instead!

--- a/docs/ares_parse_a_reply.3
+++ b/docs/ares_parse_a_reply.3
@@ -18,11 +18,11 @@
 ares_parse_a_reply \- Parse a reply to a DNS query of type A
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_parse_a_reply(const unsigned char *\fIabuf\fP, int \fIalen\fP,
-.B 	struct hostent **\fIhost\fP,
-.B      struct ares_addrttl *\fIaddrttls\fP, int *\fInaddrttls\fP);
+#include <ares.h>
+
+int ares_parse_a_reply(const unsigned char *\fIabuf\fP, int \fIalen\fP,
+                       struct hostent **\fIhost\fP,
+                       struct ares_addrttl *\fIaddrttls\fP, int *\fInaddrttls\fP);
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_parse_aaaa_reply.3
+++ b/docs/ares_parse_aaaa_reply.3
@@ -18,11 +18,11 @@
 ares_parse_aaaa_reply \- Parse a reply to a DNS query of type AAAA
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_parse_aaaa_reply(const unsigned char *\fIabuf\fP, int \fIalen\fP,
-.B 	struct hostent **\fIhost\fP,         
-.B      struct ares_addr6ttl *\fIaddrttls\fP, int *\fInaddrttls\fP);
+#include <ares.h>
+
+int ares_parse_aaaa_reply(const unsigned char *\fIabuf\fP, int \fIalen\fP,
+                          struct hostent **\fIhost\fP,         
+                          struct ares_addr6ttl *\fIaddrttls\fP, int *\fInaddrttls\fP);
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_parse_mx_reply.3
+++ b/docs/ares_parse_mx_reply.3
@@ -17,11 +17,10 @@
 .SH NAME
 ares_parse_mx_reply \- Parse a reply to a DNS query of type MX
 .SH SYNOPSIS
-.nf
-.B #include <ares.h>
-.PP
-.B int ares_parse_mx_reply(const unsigned char* \fIabuf\fP, int \fIalen\fP,
-.B                          struct ares_mx_reply** \fImx_out\fP);
+#include <ares.h>
+
+int ares_parse_mx_reply(const unsigned char* \fIabuf\fP, int \fIalen\fP,
+                        struct ares_mx_reply** \fImx_out\fP);
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_parse_naptr_reply.3
+++ b/docs/ares_parse_naptr_reply.3
@@ -18,10 +18,10 @@
 ares_parse_naptr_reply \- Parse a reply to a DNS query of type NAPTR
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_parse_naptr_reply(const unsigned char* \fIabuf\fP, int \fIalen\fP,
-.B                          struct ares_naptr_reply** \fInaptr_out\fP);
+#include <ares.h>
+
+int ares_parse_naptr_reply(const unsigned char* \fIabuf\fP, int \fIalen\fP,
+                           struct ares_naptr_reply** \fInaptr_out\fP);
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_parse_ns_reply.3
+++ b/docs/ares_parse_ns_reply.3
@@ -18,10 +18,10 @@
 ares_parse_ns_reply \- Parse a reply to a DNS query of type NS into a hostent
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_parse_ns_reply(const unsigned char *\fIabuf\fP, int \fIalen\fP,
-.B 	struct hostent **\fIhost\fP);
+#include <ares.h>
+
+int ares_parse_ns_reply(const unsigned char *\fIabuf\fP, int \fIalen\fP,
+                        struct hostent **\fIhost\fP);
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_parse_ptr_reply.3
+++ b/docs/ares_parse_ptr_reply.3
@@ -18,11 +18,11 @@
 ares_parse_ptr_reply \- Parse a reply to a DNS query of type PTR into a hostent
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_parse_ptr_reply(const unsigned char *\fIabuf\fP, int \fIalen\fP,
-.B 	const void *\fIaddr\fP, int \fIaddrlen\fP, int \fIfamily\fP,
-.B	struct hostent **\fIhost\fP);
+#include <ares.h>
+
+int ares_parse_ptr_reply(const unsigned char *\fIabuf\fP, int \fIalen\fP,
+                         const void *\fIaddr\fP, int \fIaddrlen\fP,
+                         int \fIfamily\fP, struct hostent **\fIhost\fP);
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_parse_soa_reply.3
+++ b/docs/ares_parse_soa_reply.3
@@ -18,10 +18,10 @@
 ares_parse_soa_reply \- Parse a reply to a DNS query of type SOA
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_parse_soa_reply(const unsigned char* \fIabuf\fP, int \fIalen\fP,
-.B				struct ares_soa_reply** \fIsoa_out\fP);
+#include <ares.h>
+
+int ares_parse_soa_reply(const unsigned char* \fIabuf\fP, int \fIalen\fP,
+                         struct ares_soa_reply** \fIsoa_out\fP);
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_parse_srv_reply.3
+++ b/docs/ares_parse_srv_reply.3
@@ -18,10 +18,10 @@
 ares_parse_srv_reply \- Parse a reply to a DNS query of type SRV
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_parse_srv_reply(const unsigned char* \fIabuf\fP, int \fIalen\fP,
-.B                          struct ares_srv_reply** \fIsrv_out\fP);
+#include <ares.h>
+
+int ares_parse_srv_reply(const unsigned char* \fIabuf\fP, int \fIalen\fP,
+                         struct ares_srv_reply** \fIsrv_out\fP);
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_parse_txt_reply.3
+++ b/docs/ares_parse_txt_reply.3
@@ -18,13 +18,13 @@
 ares_parse_txt_reply \- Parse a reply to a DNS query of type TXT
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_parse_txt_reply(const unsigned char* \fIabuf\fP, int \fIalen\fP,
-.B                         struct ares_txt_reply **\fItxt_out\fP);
-.PP
-.B int ares_parse_txt_reply_ext(const unsigned char* \fIabuf\fP, int \fIalen\fP,
-.B                              struct ares_txt_ext **\fItxt_out\fP);
+#include <ares.h>
+
+int ares_parse_txt_reply(const unsigned char* \fIabuf\fP, int \fIalen\fP,
+                         struct ares_txt_reply **\fItxt_out\fP);
+
+int ares_parse_txt_reply_ext(const unsigned char* \fIabuf\fP, int \fIalen\fP,
+                             struct ares_txt_ext **\fItxt_out\fP);
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_parse_uri_reply.3
+++ b/docs/ares_parse_uri_reply.3
@@ -18,10 +18,10 @@
 ares_parse_uri_reply \- Parse a reply to a DNS query of type URI
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_parse_uri_reply(const unsigned char* \fIabuf\fP, int \fIalen\fP,
-.B                          struct ares_uri_reply** \fIuri_out\fP);
+#include <ares.h>
+
+int ares_parse_uri_reply(const unsigned char* \fIabuf\fP, int \fIalen\fP,
+                         struct ares_uri_reply** \fIuri_out\fP);
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_query.3
+++ b/docs/ares_query.3
@@ -18,14 +18,15 @@
 ares_query \- Initiate a single-question DNS query
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B typedef void (*ares_callback)(void *\fIarg\fP, int \fIstatus\fP,
-.B	int \fItimeouts\fP, unsigned char *\fIabuf\fP, int \fIalen\fP)
-.PP
-.B void ares_query(ares_channel \fIchannel\fP, const char *\fIname\fP,
-.B 	int \fIdnsclass\fP, int \fItype\fP, ares_callback \fIcallback\fP,
-.B	void *\fIarg\fP)
+#include <ares.h>
+
+typedef void (*ares_callback)(void *\fIarg\fP, int \fIstatus\fP,
+                              int \fItimeouts\fP, unsigned char *\fIabuf\fP,
+                              int \fIalen\fP)
+
+void ares_query(ares_channel \fIchannel\fP, const char *\fIname\fP,
+                int \fIdnsclass\fP, int \fItype\fP,
+                ares_callback \fIcallback\fP, void *\fIarg\fP)
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_save_options.3
+++ b/docs/ares_save_options.3
@@ -18,9 +18,10 @@
 ares_save_options \- Save configuration values obtained from initialized ares_channel
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_save_options(ares_channel \fIchannel\fP, struct ares_options *\fIoptions\fP, int *\fIoptmask\fP)
+#include <ares.h>
+
+int ares_save_options(ares_channel \fIchannel\fP,
+                      struct ares_options *\fIoptions\fP, int *\fIoptmask\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_save_options(3)\fP function saves the channel data identified by

--- a/docs/ares_search.3
+++ b/docs/ares_search.3
@@ -18,14 +18,15 @@
 ares_search \- Initiate a DNS query with domain search
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B typedef void (*ares_callback)(void *\fIarg\fP, int \fIstatus\fP,
-.B	int \fItimeouts\fP, unsigned char *\fIabuf\fP, int \fIalen\fP)
-.PP
-.B void ares_search(ares_channel \fIchannel\fP, const char *\fIname\fP,
-.B 	int \fIdnsclass\fP, int \fItype\fP, ares_callback \fIcallback\fP,
-.B	void *\fIarg\fP)
+#include <ares.h>
+
+typedef void (*ares_callback)(void *\fIarg\fP, int \fIstatus\fP,
+                              int \fItimeouts\fP, unsigned char *\fIabuf\fP,
+                              int \fIalen\fP)
+
+void ares_search(ares_channel \fIchannel\fP, const char *\fIname\fP,
+                 int \fIdnsclass\fP, int \fItype\fP,
+                 ares_callback \fIcallback\fP, void *\fIarg\fP)
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_send.3
+++ b/docs/ares_send.3
@@ -18,13 +18,14 @@
 ares_send \- Initiate a DNS query
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B typedef void (*ares_callback)(void *\fIarg\fP, int \fIstatus\fP,
-.B	int \fItimeouts\fP, unsigned char *\fIabuf\fP, int \fIalen\fP)
-.PP
-.B void ares_send(ares_channel \fIchannel\fP, const unsigned char *\fIqbuf\fP,
-.B 	int \fIqlen\fP, ares_callback \fIcallback\fP, void *\fIarg\fP)
+#include <ares.h>
+
+typedef void (*ares_callback)(void *\fIarg\fP, int \fIstatus\fP,
+                              int \fItimeouts\fP, unsigned char *\fIabuf\fP,
+                              int \fIalen\fP)
+
+void ares_send(ares_channel \fIchannel\fP, const unsigned char *\fIqbuf\fP,
+               int \fIqlen\fP, ares_callback \fIcallback\fP, void *\fIarg\fP)
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_set_local_dev.3
+++ b/docs/ares_set_local_dev.3
@@ -18,9 +18,9 @@
 ares_set_local_dev \- Bind to a specific network device when creating sockets.
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B void ares_set_local_dev(ares_channel \fIchannel\fP, const char* \fIlocal_dev_name\fP)
+#include <ares.h>
+
+void ares_set_local_dev(ares_channel \fIchannel\fP, const char* \fIlocal_dev_name\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_set_local_dev\fP function causes all future sockets

--- a/docs/ares_set_local_ip4.3
+++ b/docs/ares_set_local_ip4.3
@@ -18,9 +18,9 @@
 ares_set_local_ip4 \- Set local IPv4 address outgoing requests.
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B void ares_set_local_ip4(ares_channel \fIchannel\fP, unsigned int \fIlocal_ip\fP)
+#include <ares.h>
+
+void ares_set_local_ip4(ares_channel \fIchannel\fP, unsigned int \fIlocal_ip\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_set_local_ip4\fP function sets the IP address for outbound

--- a/docs/ares_set_local_ip6.3
+++ b/docs/ares_set_local_ip6.3
@@ -18,15 +18,15 @@
 ares_set_local_ip6 \- Set local IPv6 address outgoing requests.
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B void ares_set_local_ip6(ares_channel \fIchannel\fP, const unsigned char* \fIlocal_ip6\fP)
+#include <ares.h>
+
+void ares_set_local_ip6(ares_channel \fIchannel\fP, const unsigned char* \fIlocal_ip6\fP)
 .fi
 .SH DESCRIPTION
-The \fBares_set_local_ip6\fP function sets the IPv6 address for outbound
-IPv6 requests.  The parameter \fIlocal_ip6\fP is specified in network byte
-order.  This allows users to specify outbound interfaces when used on
-multi-homed systems.  The local_ip6 argument must be 16 bytes in length.
+The \fBares_set_local_ip6\fP function sets the IPv6 address for outbound IPv6
+requests.  The parameter \fIlocal_ip6\fP is specified in network byte order.
+This allows users to specify outbound interfaces when used on multi-homed
+systems.  The \fIlocal_ip6\fP argument must be 16 bytes in length.
 .SH SEE ALSO
 .BR ares_set_local_ip4 (3)
 .SH NOTES

--- a/docs/ares_set_servers.3
+++ b/docs/ares_set_servers.3
@@ -18,10 +18,13 @@
 ares_set_servers, ares_set_servers_ports \- Initialize an ares_channel name servers configuration
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_set_servers(ares_channel \fIchannel\fP, struct ares_addr_node *\fIservers\fP)
-.B int ares_set_servers_ports(ares_channel \fIchannel\fP, struct ares_addr_port_node *\fIservers\fP)
+#include <ares.h>
+
+int ares_set_servers(ares_channel \fIchannel\fP,
+                     struct ares_addr_node *\fIservers\fP)
+
+int ares_set_servers_ports(ares_channel \fIchannel\fP,
+                           struct ares_addr_port_node *\fIservers\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_set_servers(3)\fP function initializes name servers configuration

--- a/docs/ares_set_servers_csv.3
+++ b/docs/ares_set_servers_csv.3
@@ -18,10 +18,11 @@
 ares_set_servers_csv, ares_set_servers_ports_csv \- Set list of DNS servers to be used.
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_set_servers_csv(ares_channel \fIchannel\fP, const char* \fIservers\fP)
-.B int ares_set_servers_ports_csv(ares_channel \fIchannel\fP, const char* \fIservers\fP)
+#include <ares.h>
+
+int ares_set_servers_csv(ares_channel \fIchannel\fP, const char* \fIservers\fP)
+
+int ares_set_servers_ports_csv(ares_channel \fIchannel\fP, const char* \fIservers\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_set_servers_csv\fP and \fBares_set_servers_ports_csv\fPfunctions set

--- a/docs/ares_set_socket_callback.3
+++ b/docs/ares_set_socket_callback.3
@@ -4,15 +4,15 @@
 ares_set_socket_callback \- Set a socket creation callback
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B typedef int (*ares_sock_create_callback)(ares_socket_t \fIsocket_fd\fP,
+#include <ares.h>
+
+typedef int (*ares_sock_create_callback)(ares_socket_t \fIsocket_fd\fP,
                                          int \fItype\fP,
                                          void *\fIuserdata\fP)
-.PP
-.B void ares_set_socket_callback(ares_channel \fIchannel\fP,
-                             ares_sock_create_callback \fIcallback\fP,
-                             void *\fIuserdata\fP)
+
+void ares_set_socket_callback(ares_channel \fIchannel\fP,
+                              ares_sock_create_callback \fIcallback\fP,
+                              void *\fIuserdata\fP)
 .PP
 .B cc file.c -lcares
 .fi

--- a/docs/ares_set_socket_configure_callback.3
+++ b/docs/ares_set_socket_configure_callback.3
@@ -4,17 +4,15 @@
 ares_set_socket_configure_callback \- Set a socket configuration callback
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B typedef int (*ares_sock_config_callback)(ares_socket_t \fIsocket_fd\fP,
+#include <ares.h>
+
+typedef int (*ares_sock_config_callback)(ares_socket_t \fIsocket_fd\fP,
                                          int \fItype\fP,
                                          void *\fIuserdata\fP)
-.PP
-.B void ares_set_socket_configure_callback(ares_channel \fIchannel\fP,
-                             ares_sock_config_callback \fIcallback\fP,
-                             void *\fIuserdata\fP)
-.PP
-.B cc file.c -lcares
+
+void ares_set_socket_configure_callback(ares_channel \fIchannel\fP,
+                                        ares_sock_config_callback \fIcallback\fP,
+                                        void *\fIuserdata\fP)
 .fi
 .SH DESCRIPTION
 .PP

--- a/docs/ares_set_socket_functions.3
+++ b/docs/ares_set_socket_functions.3
@@ -4,21 +4,20 @@
 ares_set_socket_functions \- Set socket io callbacks
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B struct ares_socket_functions {
-	ares_socket_t(*\fIasocket\fP)(int, int, int, void *);
-	int(*\fIaclose\fP)(ares_socket_t, void *);
-	int(*\fIaconnect\fP)(ares_socket_t, const struct sockaddr *, ares_socklen_t, void *);
-	ares_ssize_t(*\fIarecvfrom\fP)(ares_socket_t, void *, size_t, int, struct sockaddr *, ares_socklen_t *, void *);
-	ares_ssize_t(*\fIasendv\fP)(ares_socket_t, const struct iovec *, int, void *);
-   };
+#include <ares.h>
 
-.PP
-.B void ares_set_socket_functions(ares_channel \fIchannel\fP,
-				  const struct ares_socket_functions * \fIfunctions\fP,
-				  void *\fIuser_data\fP);
+struct ares_socket_functions {
+    ares_socket_t (*\fIasocket\fP)(int, int, int, void *);
+    int (*\fIaclose\fP)(ares_socket_t, void *);
+    int (*\fIaconnect\fP)(ares_socket_t, const struct sockaddr *, ares_socklen_t, void *);
+    ares_ssize_t (*\fIarecvfrom\fP)(ares_socket_t, void *, size_t, int,
+                              struct sockaddr *, ares_socklen_t *, void *);
+    ares_ssize_t (*\fIasendv\fP)(ares_socket_t, const struct iovec *, int, void *);
+};
 
+void ares_set_socket_functions(ares_channel \fIchannel\fP,
+                               const struct ares_socket_functions * \fIfunctions\fP,
+                               void *\fIuser_data\fP);
 .fi
 .SH DESCRIPTION
 .PP

--- a/docs/ares_set_sortlist.3
+++ b/docs/ares_set_sortlist.3
@@ -16,9 +16,9 @@
 ares_set_sortlist \- Initialize an ares_channel sortlist configuration
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B int ares_set_sortlist(ares_channel \fIchannel\fP, const char *\fIsortstr\fP)
+#include <ares.h>
+
+int ares_set_sortlist(ares_channel \fIchannel\fP, const char *\fIsortstr\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_set_sortlist(3)\fP function initializes an address sortlist configuration

--- a/docs/ares_strerror.3
+++ b/docs/ares_strerror.3
@@ -18,9 +18,9 @@
 ares_strerror \- Get the description of an ares library error code
 .SH SYNOPSIS
 .nf
-.B #include <ares.h>
-.PP
-.B const char *ares_strerror(int \fIcode\fP)
+#include <ares.h>
+
+const char *ares_strerror(int \fIcode\fP)
 .fi
 .SH DESCRIPTION
 The


### PR DESCRIPTION
To make them render "nicer" in both terminals and on the website.

- Removes the bold
- Removes .PP lines
- Indents them more like proper code style