### PR TITLE
ares_strsplit: add an underscore for internal name

### DIFF
--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -233,7 +233,7 @@ done:
       if (channel->servers)
         ares_free(channel->servers);
       if (channel->ndomains != -1)
-        ares_strsplit_free(channel->domains, channel->ndomains);
+        ares__strsplit_free(channel->domains, channel->ndomains);
       if (channel->sortlist)
         ares_free(channel->sortlist);
       if(channel->lookups)
@@ -1995,12 +1995,12 @@ static int set_search(ares_channel channel, const char *str)
   if(channel->ndomains != -1) {
     /* LCOV_EXCL_START: all callers check ndomains == -1 */
     /* if we already have some domains present, free them first */
-    ares_strsplit_free(channel->domains, channel->ndomains);
+    ares__strsplit_free(channel->domains, channel->ndomains);
     channel->domains = NULL;
     channel->ndomains = -1;
   } /* LCOV_EXCL_STOP */
 
-  channel->domains  = ares_strsplit(str, ", ", 1, &cnt);
+  channel->domains  = ares__strsplit(str, ", ", 1, &cnt);
   channel->ndomains = (int)cnt;
   if (channel->domains == NULL || channel->ndomains == 0) {
     channel->domains  = NULL;

--- a/src/lib/ares_strsplit.c
+++ b/src/lib/ares_strsplit.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018 by John Schember <john@nachtimwald.com>
+/* Copyright (C) 2018 - 2022 by John Schember <john@nachtimwald.com>
  *
  * Permission to use, copy, modify, and distribute this
  * software and its documentation for any purpose and without
@@ -62,7 +62,7 @@ static int is_delim(char c, const char *delims, size_t num_delims)
 }
 
 
-void ares_strsplit_free(char **elms, size_t num_elm)
+void ares__strsplit_free(char **elms, size_t num_elm)
 {
   size_t i;
 
@@ -75,7 +75,7 @@ void ares_strsplit_free(char **elms, size_t num_elm)
 }
 
 
-char **ares_strsplit(const char *in, const char *delms, int make_set, size_t *num_elm)
+char **ares__strsplit(const char *in, const char *delms, int make_set, size_t *num_elm)
 {
   char *parsestr;
   char **temp;
@@ -152,7 +152,7 @@ char **ares_strsplit(const char *in, const char *delms, int make_set, size_t *nu
     out[nelms] = ares_strdup(temp[i]);
     if (out[nelms] == NULL)
     {
-      ares_strsplit_free(out, nelms);
+      ares__strsplit_free(out, nelms);
       ares_free(parsestr);
       ares_free(temp);
       return NULL;
@@ -165,7 +165,7 @@ char **ares_strsplit(const char *in, const char *delms, int make_set, size_t *nu
    * array. */
   if (nelms == 0)
   {
-    ares_strsplit_free(out, nelms);
+    ares__strsplit_free(out, nelms);
     out = NULL;
   }
 

--- a/src/lib/ares_strsplit.h
+++ b/src/lib/ares_strsplit.h
@@ -1,7 +1,8 @@
+
 #ifndef HEADER_CARES_STRSPLIT_H
 #define HEADER_CARES_STRSPLIT_H
 
-/* Copyright (C) 2018 by John Schember <john@nachtimwald.com>
+/* Copyright (C) 2018 - 2022 by John Schember <john@nachtimwald.com>
  *
  * Permission to use, copy, modify, and distribute this
  * software and its documentation for any purpose and without
@@ -33,10 +34,10 @@
  * returns an allocated array of allocated string elements.
  *
  */
-char **ares_strsplit(const char *in, const char *delms, int make_set, size_t *num_elm);
+char **ares__strsplit(const char *in, const char *delms, int make_set, size_t *num_elm);
 
-/* Frees the result returned from ares_strsplit(). */
-void ares_strsplit_free(char **elms, size_t num_elm);
+/* Frees the result returned from ares__strsplit(). */
+void ares__strsplit_free(char **elms, size_t num_elm);
 
 
 #endif /* HEADER_CARES_STRSPLIT_H */


### PR DESCRIPTION
We use the `ares__` prefix for internal functions. One underscore for public functions. This is an internal function.