### PR TITLE
Add str len check in config_sortlist to avoid stack overflow

### DIFF
--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -1913,6 +1913,8 @@ static int config_sortlist(struct apattern **sortlist, int *nsort,
       q = str;
       while (*q && *q != '/' && *q != ';' && !ISSPACE(*q))
         q++;
+      if (q-str >= 16)
+        return ARES_EBADSTR;
       memcpy(ipbuf, str, q-str);
       ipbuf[q-str] = '\0';
       /* Find the prefix */
@@ -1921,6 +1923,8 @@ static int config_sortlist(struct apattern **sortlist, int *nsort,
           const char *str2 = q+1;
           while (*q && *q != ';' && !ISSPACE(*q))
             q++;
+          if (q-str >= 32)
+            return ARES_EBADSTR;
           memcpy(ipbufpfx, str, q-str);
           ipbufpfx[q-str] = '\0';
           str = str2;

--- a/test/ares-test-init.cc
+++ b/test/ares-test-init.cc
@@ -275,6 +275,8 @@ TEST_F(DefaultChannelTest, SetAddresses) {
 
 TEST_F(DefaultChannelTest, SetSortlistFailures) {
   EXPECT_EQ(ARES_ENODATA, ares_set_sortlist(nullptr, "1.2.3.4"));
+  EXPECT_EQ(ARES_EBADSTR, ares_set_sortlist(channel_, "111.111.111.111*/16"));
+  EXPECT_EQ(ARES_EBADSTR, ares_set_sortlist(channel_, "111.111.111.111/255.255.255.240*"));
   EXPECT_EQ(ARES_SUCCESS, ares_set_sortlist(channel_, "xyzzy ; lwk"));
   EXPECT_EQ(ARES_SUCCESS, ares_set_sortlist(channel_, "xyzzy ; 0x123"));
 }


### PR DESCRIPTION
In `ares_set_sortlist`, it calls `config_sortlist(..., sortstr)` to parse the input str and initialize a sortlist configuration.

However, `ares_set_sortlist` has not any checks about the validity of the input str. It is very easy to create an arbitrary length stack overflow with the unchecked `memcpy(ipbuf, str, q-str);` and `memcpy(ipbufpfx, str, q-str);` statements in the config_sortlist call, which could potentially cause severe security impact in practical programs.

This commit add necessary check for `ipbuf` and `ipbufpfx` which avoid the potential stack overflows.

fixes #496

Signed-off-by: hopper-vul <hopper.vul@gmail.com>