### PR TITLE
Fix stop to use memory in stack

### DIFF
--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -430,16 +430,20 @@ static int file_lookup(struct host_query *hquery)
   FILE *fp;
   int error;
   int status;
-  const char *path_hosts = NULL;
+  char *path_hosts = NULL;
 
   if (hquery->hints.ai_flags & ARES_AI_ENVHOSTS)
     {
-      path_hosts = getenv("CARES_HOSTS");
+      path_hosts = ares_strdup(getenv("CARES_HOSTS"));
+      if (!path_hosts)
+        return ARES_ENOMEM;
     }
 
   if (hquery->channel->hosts_path)
     {
-      path_hosts = hquery->channel->hosts_path;
+      path_hosts = ares_strdup(hquery->channel->hosts_path);
+      if (!path_hosts)
+        return ARES_ENOMEM;
     }
 
   if (!path_hosts)
@@ -473,15 +477,15 @@ static int file_lookup(struct host_query *hquery)
         return ARES_ENOTFOUND;
 
       strcat(PATH_HOSTS, WIN_PATH_HOSTS);
-      path_hosts = PATH_HOSTS;
-
 #elif defined(WATT32)
       const char *PATH_HOSTS = _w32_GetHostsFile();
 
       if (!PATH_HOSTS)
         return ARES_ENOTFOUND;
 #endif
-      path_hosts = PATH_HOSTS;
+      path_hosts = ares_strdup(PATH_HOSTS);
+      if (!path_hosts)
+        return ARES_ENOMEM;
     }
 
   fp = fopen(path_hosts, "r");
@@ -507,6 +511,7 @@ static int file_lookup(struct host_query *hquery)
       status = ares__readaddrinfo(fp, hquery->name, hquery->port, &hquery->hints, hquery->ai);
       fclose(fp);
     }
+  ares_free(path_hosts);
 
   /* RFC6761 section 6.3 #3 states that "Name resolution APIs and libraries
    * SHOULD recognize localhost names as special and SHOULD always return the


### PR DESCRIPTION
char PATH_HOSTS[MAX_PATH] at L448 is memory in stack and becomes invalid outside the scope. It is unsafe to use it.

Found by doing ares_getaddrinfo on resolving "localhost" in Release build (win32).