### PR TITLE
ignore aminclude_static.am, as generated by AX_AM_MACROS_STATIC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ c-ares-config.cmake
 c-ares-config-version.cmake
 Makefile.inc.cmake
 cmake_install.cmake
+aminclude_static.am

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -17,3 +17,4 @@ ares-libfuzzer
 ares-libfuzzer-name
 libFuzzer.a
 Fuzzer
+aminclude_static.am


### PR DESCRIPTION
Fix By: Jay Freeman (@saurik)