### PR TITLE
Watcom Portability Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.dll
 *.exe
 *.obj
+*.map
 .*.swp
 Debug
 Release

--- a/Makefile.Watcom
+++ b/Makefile.Watcom
@@ -75,7 +75,6 @@ LIB_ARG  = $(OBJ_BASE)\stat\wlib.arg
 
 OBJS = $(CSOURCES:.c=.obj)
 OBJS = $OBJ_DIR\$(OBJS: = $OBJ_DIR\)
-SAMPLEOBJS = $(SAMPLESOURCES:.c=.obj)
 
 #
 # Use $(OBJS) as a template to generate $(OBJS_STAT) and $(OBJS_DYN).

--- a/Makefile.Watcom
+++ b/Makefile.Watcom
@@ -1,6 +1,7 @@
 #
 #  Watcom / OpenWatcom / Win32 makefile for cares.
 #  Quick hack by Guenter; comments to: /dev/nul
+#  Updated by Douglas R. Reno, comments to: renodr2002@gmail.com. 2023
 #
 
 !ifndef %watcom
@@ -38,9 +39,9 @@ MD = mkdir
 RD = rmdir /q /s 2>NUL
 CP = copy
 
-CFLAGS = -3r -mf -hc -zff -zgf -zq -zm -zc -s -fr=con -w2 -fpi -oilrtfm &
-         -wcd=201 -bt=nt -d+ -dWIN32 -dCARES_BUILDING_LIBRARY           &
-         -dNTDDI_VERSION=0x05010000 -I. $(SYS_INCL)
+CFLAGS = -3r -mf -hc -zff -zgf -zq -zm -zc -s -fr=con -w2 -fpi -oilrtfm -aa &
+         -wcd=201 -bt=nt -d+ -dWIN32 -dCARES_BUILDING_LIBRARY               &
+         -dNTDDI_VERSION=0x06000000 -I. -I.\include -I.\src\lib $(SYS_INCL)
 
 LFLAGS = option quiet, map, caseexact, eliminate
 
@@ -69,11 +70,12 @@ LIB_ARG  = $(OBJ_BASE)\stat\wlib.arg
 !ifneq __MAKEOPTS__ -u
 !error You MUST call wmake with the -u switch!
 !else
-!include Makefile.inc
+!include src\lib\Makefile.inc
 !endif
 
 OBJS = $(CSOURCES:.c=.obj)
 OBJS = $OBJ_DIR\$(OBJS: = $OBJ_DIR\)
+SAMPLEOBJS = $(SAMPLESOURCES:.c=.obj)
 
 #
 # Use $(OBJS) as a template to generate $(OBJS_STAT) and $(OBJS_DYN).
@@ -82,10 +84,11 @@ OBJ_DIR    = $(OBJ_BASE)\stat
 OBJS_STAT  = $+ $(OBJS) $-
 
 OBJ_DIR    = $(OBJ_BASE)\dyn
-OBJS_DYN   = $+ $(OBJS) $-
+OBJS_DYN   += $(OBJS) $-
 
 ARESBUILDH = ares_build.h
 RESOURCE   = $(OBJ_BASE)\dyn\cares.res
+ARESBUILDH = include\ares_build.h
 
 all: $(ARESBUILDH) $(OBJ_BASE) $(TARGETS) $(DEMOS) .SYMBOLIC
 	@echo Welcome to cares
@@ -94,10 +97,10 @@ $(OBJ_BASE):
 	-$(MD) $^@
 	-$(MD) $^@\stat
 	-$(MD) $^@\dyn
-	-$(MD) $^@\demos
+	-$(MD) $^@\tools
 
 $(ARESBUILDH): .EXISTSONLY
-	$(CP) $^@.dist $^@
+	@echo Make sure to run buildconf.bat!
 
 $(LIBNAME).dll: $(OBJS_DYN) $(RESOURCE) $(LINK_ARG)
 	$(LD) name $^@ @$]@
@@ -105,14 +108,20 @@ $(LIBNAME).dll: $(OBJS_DYN) $(RESOURCE) $(LINK_ARG)
 $(LIBNAME).lib: $(OBJS_STAT) $(LIB_ARG)
 	$(AR) -q -b -c $^@ @$]@
 
-adig.exe: $(OBJ_BASE)\demos\adig.obj $(OBJ_BASE)\demos\ares_getopt.obj $(LIBNAME).lib
-	$(LD) name $^@ system nt $(LFLAGS) file { $(OBJ_BASE)\demos\ares_getopt.obj $[@ } library $]@, ws2_32.lib
+$(OBJ_BASE)\tools\ares_getopt.obj:
+	$(CC) $(CFLAGS) -DCARES_STATICLIB .\src\tools\ares_getopt.c -fo=$^@
 
-ahost.exe: $(OBJ_BASE)\demos\ahost.obj $(OBJ_BASE)\demos\ares_getopt.obj $(LIBNAME).lib
-	$(LD) name $^@ system nt $(LFLAGS) file { $(OBJ_BASE)\demos\ares_getopt.obj $[@ } library $]@, ws2_32.lib
+adig.exe: $(OBJ_BASE)\tools\ares_getopt.obj $(LIBNAME).lib
+	$(CC) $(CFLAGS) src\tools\adig.c -fo=$(OBJ_BASE)\tools\adig.obj
+	$(LD) name $^@ system nt $(LFLAGS) file { $(OBJ_BASE)\tools\adig.obj $[@ } library $]@, ws2_32.lib, iphlpapi.lib
 
-acountry.exe: $(OBJ_BASE)\demos\acountry.obj $(OBJ_BASE)\demos\ares_getopt.obj $(LIBNAME).lib
-	$(LD) name $^@ system nt $(LFLAGS) file { $(OBJ_BASE)\demos\ares_getopt.obj $[@ } library $]@, ws2_32.lib
+ahost.exe: $(OBJ_BASE)\tools\ares_getopt.obj $(LIBNAME).lib
+	$(CC) $(CFLAGS) src\tools\ahost.c -fo=$(OBJ_BASE)\tools\ahost.obj
+	$(LD) name $^@ system nt $(LFLAGS) file { $(OBJ_BASE)\tools\ahost.obj $[@ } library $]@, ws2_32.lib, iphlpapi.lib
+
+acountry.exe: $(OBJ_BASE)\tools\ares_getopt.obj $(LIBNAME).lib
+	$(CC) $(CFLAGS) src\tools\acountry.c -fo=$(OBJ_BASE)\tools\acountry.obj
+	$(LD) name $^@ system nt $(LFLAGS) file { $(OBJ_BASE)\tools\acountry.obj $[@ } library $]@, ws2_32.lib, iphlpapi.lib
 
 clean: .SYMBOLIC
 	-$(RM) $(OBJS_STAT)
@@ -124,24 +133,23 @@ vclean realclean: clean .SYMBOLIC
 	-$(RM) $(DEMOS) $(DEMOS:.exe=.map)
 	-$(RD) $(OBJ_BASE)\stat
 	-$(RD) $(OBJ_BASE)\dyn
-	-$(RD) $(OBJ_BASE)\demos
+	-$(RD) $(OBJ_BASE)\tools
 	-$(RD) $(OBJ_BASE)
 
 .ERASE
-$(RESOURCE): cares.rc .AUTODEPEND
+.c: .\src\lib
+
+.ERASE
+$(RESOURCE): src\lib\cares.rc .AUTODEPEND
 	$(RC) $(DEBUG) -q -r -zm -I..\include $(SYS_INCL) $[@ -fo=$^@
 
 .ERASE
 .c{$(OBJ_BASE)\dyn}.obj:
-	$(CC) $(CFLAGS) -bd $[@ -fo=$^@
+	$(CC) $(CFLAGS) -bd .\src\lib\$^& -fo=$^@
 
 .ERASE
 .c{$(OBJ_BASE)\stat}.obj:
-	$(CC) $(CFLAGS) -DCARES_STATICLIB $[@ -fo=$^@
-
-.ERASE
-.c{$(OBJ_BASE)\demos}.obj:
-	$(CC) $(CFLAGS) -DCARES_STATICLIB $[@ -fo=$^@
+	$(CC) $(CFLAGS) -DCARES_STATICLIB .\src\lib\$^& -fo=$^@
 
 $(LINK_ARG): $(__MAKEFILES__)
 	%create $^@
@@ -155,6 +163,7 @@ $(LINK_ARG): $(__MAKEFILES__)
 	@%append $^@ library $(%watt_root)\lib\wattcpw_imp.lib
 !else
 	@%append $^@ library ws2_32.lib
+	@%append $^@ library iphlpapi.lib
 !endif
 
 $(LIB_ARG): $(__MAKEFILES__)

--- a/src/lib/ares__addrinfo_localhost.c
+++ b/src/lib/ares__addrinfo_localhost.c
@@ -131,7 +131,7 @@ static int ares__system_loopback_addrs(int aftype,
                                        unsigned short port,
                                        struct ares_addrinfo_node **nodes)
 {
-#if defined(_WIN32) && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600
+#if defined(_WIN32) && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600 && !defined(__WATCOMC__)
   PMIB_UNICASTIPADDRESS_TABLE table;
   unsigned int i;
   int status;

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -746,6 +746,17 @@ static ULONG getBestRouteMetric(IF_LUID * const luid, /* Can't be const :( */
                                 const ULONG interfaceMetric)
 {
   /* On this interface, get the best route to that destination. */
+#if defined(__WATCOMC__)
+  /* OpenWatcom's builtin Windows SDK does not have a definition for
+   * MIB_IPFORWARD_ROW2, and also does not allow the usage of SOCKADDR_INET
+   * as a variable. Let's work around this by returning the worst possible
+   * metric, but only when using the OpenWatcom compiler.
+   * It may be worth investigating using a different version of the Windows
+   * SDK with OpenWatcom in the future, though this may be fixed in OpenWatcom
+   * 2.0.
+   */
+  return (ULONG)-1;
+#else
   MIB_IPFORWARD_ROW2 row;
   SOCKADDR_INET ignored;
   if(GetBestRoute2(/* The interface to use.  The index is ignored since we are
@@ -778,6 +789,7 @@ static ULONG getBestRouteMetric(IF_LUID * const luid, /* Can't be const :( */
    * which describes the combination as a "sum".
    */
   return row.Metric + interfaceMetric;
+#endif /* __WATCOMC__ */
 }
 
 /*


### PR DESCRIPTION
- Modify the Watcom Makefile for the source code reorganization (#352)
- Add *.map files into .gitignore
- Fix build errors with Watcom's builtin Windows SDK (which is rather outdated). It's smart enough to understand Windows Vista, but doesn't have PMIB_UNICASTIPADDRESS_TABLE or MIB_IPFORWARD_ROW2.

It may be possible to use a different Windows SDK with the Watcom compiler, such as the most recent Windows 10 SDK. Alternatively the SDK in OpenWatcom 2.0 (which is in development) should fix this.

I have no problems testing this Makefile prior to releases, just give me a ping.

Tested with Windows Vista, Windows 7, and Windows 10 using 'adig', 'acountry', and 'ahost'. This also seems to work on Windows XP, though this is likely due to the compiler in use.