### PR TITLE
use strncasecmp in ares__strsplit

### DIFF
--- a/src/lib/ares_strsplit.c
+++ b/src/lib/ares_strsplit.c
@@ -18,7 +18,6 @@
 #endif
 
 #include "ares_setup.h"
-#include "ares_strsplit.h"
 #include "ares.h"
 #include "ares_private.h"
 
@@ -55,7 +54,7 @@ char **ares__strsplit(const char *in, const char *delms, size_t *num_elm) {
       count++;
       p += i;
     }
-  } while(*p++ != 0);
+  } while (*p++ != 0);
 
   if (count == 0)
     return NULL;
@@ -68,15 +67,9 @@ char **ares__strsplit(const char *in, const char *delms, size_t *num_elm) {
   for (p = in; j < count; p += i + 1) {
     i = strcspn(p, delms);
     if (i != 0) {
-      for (k = 0; k < j; k++) {
-#ifdef WIN32
-        if (strnicmp(table[k], p, i) == 0 && table[k][i] == 0)
-          break;
-#else
+      for (k = 0; k < j; k++)
         if (strncasecmp(table[k], p, i) == 0 && table[k][i] == 0)
           break;
-#endif
-      }
       if (k == j) {
         /* copy unique strings only */
         table[j] = ares_malloc(i + 1);

--- a/src/lib/ares_strsplit.c
+++ b/src/lib/ares_strsplit.c
@@ -67,9 +67,10 @@ char **ares__strsplit(const char *in, const char *delms, size_t *num_elm) {
   for (p = in; j < count; p += i + 1) {
     i = strcspn(p, delms);
     if (i != 0) {
-      for (k = 0; k < j; k++)
+      for (k = 0; k < j; k++) {
         if (strncasecmp(table[k], p, i) == 0 && table[k][i] == 0)
           break;
+      }
       if (k == j) {
         /* copy unique strings only */
         table[j] = ares_malloc(i + 1);


### PR DESCRIPTION
The previous code used a custom solution with #ifdef CPP directives. The logic in strncasecmp is more thorough, and it is preferred.

There are also two more minor fixes:

1) A space is added between a control flow keyword its parenthesis, to
   match the style elsewhere in the file.
2) The included headers are cleaned up; ares_private.h includes all
   the relevant private header functions (such as ares__strsplit and
   strncasecmp)