### PR TITLE
change comment style to old-style

### DIFF
--- a/src/lib/ares_data.h
+++ b/src/lib/ares_data.h
@@ -78,4 +78,4 @@ struct ares_data {
 void *ares_malloc_data(ares_datatype type);
 
 
-#endif // __ARES_DATA_H
+#endif /* __ARES_DATA_H */


### PR DESCRIPTION
Following the README.md guidelines,

    "Comments must be written in the old-style"

the comment is changed to the old style.