### PR TITLE
remove union type from ares_expand functions

### DIFF
--- a/docs/ares_parse_caa_reply.3
+++ b/docs/ares_parse_caa_reply.3
@@ -92,7 +92,7 @@ static void dns_callback(void *arg,
                          int status,
                          int timeouts,
                          unsigned char *abuf,
-                         int alen)
+                         size_t alen)
   {
     struct ares_caa_reply *caa_out;
     int err;

--- a/include/ares.h
+++ b/include/ares.h
@@ -302,7 +302,7 @@ typedef void (*ares_callback)(void *arg,
                               int status,
                               int timeouts,
                               unsigned char *abuf,
-                              int alen);
+                              size_t alen);
 
 typedef void (*ares_host_callback)(void *arg,
                                    int status,
@@ -423,7 +423,7 @@ CARES_EXTERN void ares_set_socket_functions(ares_channel channel,
 
 CARES_EXTERN void ares_send(ares_channel channel,
                             const unsigned char *qbuf,
-                            int qlen,
+                            size_t qlen,
                             ares_callback callback,
                             void *arg);
 
@@ -492,7 +492,7 @@ CARES_EXTERN int ares_create_query(const char *name,
                                    unsigned short id,
                                    int rd,
                                    unsigned char **buf,
-                                   int *buflen,
+                                   size_t *buflen,
                                    int max_udp_size);
 
 CARES_EXTERN int ares_mkquery(const char *name,
@@ -501,19 +501,19 @@ CARES_EXTERN int ares_mkquery(const char *name,
                               unsigned short id,
                               int rd,
                               unsigned char **buf,
-                              int *buflen);
+                              size_t *buflen);
 
 CARES_EXTERN int ares_expand_name(const unsigned char *encoded,
                                   const unsigned char *abuf,
-                                  int alen,
+                                  size_t alen,
                                   char **s,
-                                  long *enclen);
+                                  size_t *enclen);
 
 CARES_EXTERN int ares_expand_string(const unsigned char *encoded,
                                     const unsigned char *abuf,
-                                    int alen,
+                                    size_t alen,
                                     unsigned char **s,
-                                    long *enclen);
+                                    size_t *enclen);
 
 /*
  * NOTE: before c-ares 1.7.0 we would most often use the system in6_addr
@@ -654,58 +654,58 @@ struct ares_addrinfo_hints {
 */
 
 CARES_EXTERN int ares_parse_a_reply(const unsigned char *abuf,
-                                    int alen,
+                                    size_t alen,
                                     struct hostent **host,
                                     struct ares_addrttl *addrttls,
                                     int *naddrttls);
 
 CARES_EXTERN int ares_parse_aaaa_reply(const unsigned char *abuf,
-                                       int alen,
+                                       size_t alen,
                                        struct hostent **host,
                                        struct ares_addr6ttl *addrttls,
                                        int *naddrttls);
 
 CARES_EXTERN int ares_parse_caa_reply(const unsigned char* abuf,
-				      int alen,
+				      size_t alen,
 				      struct ares_caa_reply** caa_out);
 
 CARES_EXTERN int ares_parse_ptr_reply(const unsigned char *abuf,
-                                      int alen,
+                                      size_t alen,
                                       const void *addr,
                                       int addrlen,
                                       int family,
                                       struct hostent **host);
 
 CARES_EXTERN int ares_parse_ns_reply(const unsigned char *abuf,
-                                     int alen,
+                                     size_t alen,
                                      struct hostent **host);
 
 CARES_EXTERN int ares_parse_srv_reply(const unsigned char* abuf,
-                                      int alen,
+                                      size_t alen,
                                       struct ares_srv_reply** srv_out);
 
 CARES_EXTERN int ares_parse_mx_reply(const unsigned char* abuf,
-                                      int alen,
+                                      size_t alen,
                                       struct ares_mx_reply** mx_out);
 
 CARES_EXTERN int ares_parse_txt_reply(const unsigned char* abuf,
-                                      int alen,
+                                      size_t alen,
                                       struct ares_txt_reply** txt_out);
 
 CARES_EXTERN int ares_parse_txt_reply_ext(const unsigned char* abuf,
-                                          int alen,
+                                          size_t alen,
                                           struct ares_txt_ext** txt_out);
 
 CARES_EXTERN int ares_parse_naptr_reply(const unsigned char* abuf,
-                                        int alen,
+                                        size_t alen,
                                         struct ares_naptr_reply** naptr_out);
 
 CARES_EXTERN int ares_parse_soa_reply(const unsigned char* abuf,
-				      int alen,
+				      size_t alen,
 				      struct ares_soa_reply** soa_out);
 
 CARES_EXTERN int ares_parse_uri_reply(const unsigned char* abuf,
-                                      int alen,
+                                      size_t alen,
                                       struct ares_uri_reply** uri_out);
 
 CARES_EXTERN void ares_free_string(void *str);

--- a/src/lib/ares__parse_into_addrinfo.c
+++ b/src/lib/ares__parse_into_addrinfo.c
@@ -42,14 +42,14 @@
 #include "ares_private.h"
 
 int ares__parse_into_addrinfo(const unsigned char *abuf,
-                              int alen, int cname_only_is_enodata,
+                              size_t alen, int cname_only_is_enodata,
                               unsigned short port,
                               struct ares_addrinfo *ai)
 {
   unsigned int qdcount, ancount;
   int status, i, rr_type, rr_class, rr_len, rr_ttl;
   int got_a = 0, got_aaaa = 0, got_cname = 0;
-  long len;
+  size_t len;
   const unsigned char *aptr;
   char *question_hostname = NULL;
   char *hostname, *rr_name = NULL, *rr_data;

--- a/src/lib/ares_create_query.c
+++ b/src/lib/ares_create_query.c
@@ -79,7 +79,7 @@
 
 int ares_create_query(const char *name, int dnsclass, int type,
                       unsigned short id, int rd, unsigned char **bufp,
-                      int *buflenp, int max_udp_size)
+                      size_t *buflenp, int max_udp_size)
 {
   size_t len;
   unsigned char *q;
@@ -191,8 +191,7 @@ int ares_create_query(const char *name, int dnsclass, int type,
     return ARES_EBADNAME;
   }
 
-  /* we know this fits in an int at this point */
-  *buflenp = (int) buflen;
+  *buflenp = buflen;
   *bufp = buf;
 
   return ARES_SUCCESS;

--- a/src/lib/ares_expand_name.c
+++ b/src/lib/ares_expand_name.c
@@ -31,8 +31,10 @@
 /* Maximum number of indirections allowed for a name */
 #define MAX_INDIRS 50
 
-static int name_length(const unsigned char *encoded, const unsigned char *abuf,
-                       int alen, int is_hostname);
+static int compute_lengths(const unsigned char *encoded,
+                           const unsigned char *abuf,
+                           size_t alen, int is_hostname,
+                           size_t *name_length, size_t *enclen);
 
 /* Reserved characters for names that need to be escaped */
 static int is_reservedch(int ch)
@@ -104,206 +106,181 @@ static int is_hostnamech(int ch)
  *
  * In the more complicated case, a label may be terminated by an
  * indirection pointer, specified by two bytes with the high bits of
- * the first byte (corresponding to INDIR_MASK) set to 11.  With the
- * two high bits of the first byte stripped off, the indirection
- * pointer gives an offset from the beginning of the containing
- * message with more labels to decode.  Indirection can happen an
- * arbitrary number of times, so we have to detect loops.
+ * the first byte set to 11.  With the two high bits of the first byte
+ * stripped off, the indirection pointer gives an offset from the
+ * beginning of the containing message with more labels to decode.
+ * Indirection can happen an arbitrary number of times, so we have to
+ * detect loops.
  *
  * Since the expanded name uses '.' as a label separator, we use
  * backslashes to escape periods or backslashes in the expanded name.
  *
- * If the result is expected to be a hostname, then no escaped data is allowed
- * and will return error.
+ * If the result is expected to be a hostname, then no escaped data is
+ * allowed and will return the error ARES_EBADNAME. If memory
+ * allocation fails, the error ARES_ENOMEM is returned.
  */
-
 int ares__expand_name_validated(const unsigned char *encoded,
                                 const unsigned char *abuf,
-                                int alen, char **s, long *enclen,
-                                int is_hostname)
-{
-  int len, indir = 0;
-  char *q;
-  const unsigned char *p;
-  union {
-    ares_ssize_t sig;
-     size_t uns;
-  } nlen;
-
-  nlen.sig = name_length(encoded, abuf, alen, is_hostname);
-  if (nlen.sig < 0)
+                                size_t alen, char **s, size_t *enclen,
+                                int is_hostname) {
+  char *name = NULL;
+  size_t length, offset, n = 0;
+  int c, type, first_label = 1;
+  char high, low;
+  if(compute_lengths(encoded, abuf, alen, is_hostname, &length, enclen) < 0)
     return ARES_EBADNAME;
-
-  *s = ares_malloc(nlen.uns + 1);
-  if (!*s)
+  if((name = ares_malloc(length + 1)) == NULL)
     return ARES_ENOMEM;
-  q = *s;
-
-  if (nlen.uns == 0) {
-    /* RFC2181 says this should be ".": the root of the DNS tree.
-     * Since this function strips trailing dots though, it becomes ""
-     */
-    q[0] = '\0';
-
-    /* indirect root label (like 0xc0 0x0c) is 2 bytes long (stupid, but
-       valid) */
-    if ((*encoded & INDIR_MASK) == INDIR_MASK)
-      *enclen = 2L;
-    else
-      *enclen = 1L;  /* the caller should move one byte to get past this */
-
-    return ARES_SUCCESS;
-  }
-
-  /* No error-checking necessary; it was all done by name_length(). */
-  p = encoded;
-  while (*p)
-    {
-      if ((*p & INDIR_MASK) == INDIR_MASK)
-        {
-          if (!indir)
-            {
-              *enclen = aresx_uztosl(p + 2U - encoded);
-              indir = 1;
-            }
-          p = abuf + ((*p & ~INDIR_MASK) << 8 | *(p + 1));
-        }
+  while(n < length) {
+    type = encoded[0] >> 6; /* the two highest bits */
+    high = encoded[0] & 63; /* 63 is 00111111 in binary */
+    low = encoded[1];
+    if(type == 0) {
+      /* The case of a label.
+         @high is the length of the label.
+      */
+      encoded++;
+      if(first_label)
+        first_label = 0;
       else
-        {
-          int name_len = *p;
-          len = name_len;
-          p++;
+        name[n++] = '.';
+      while(high--) {
+        c = *encoded;
+        if (!ares__isprint(c)) {
+          /* If we encounter such a character, then we know that
+             is_hostname is false since the previous call to
+             compute_lengths() has not returned in error.
 
-          while (len--)
-            {
-              /* Output as \DDD for consistency with RFC1035 5.1, except
-               * for the special case of a root name response  */
-              if (!ares__isprint(*p) && !(name_len == 1 && *p == 0))
-                {
-                  *q++ = '\\';
-                  *q++ = (char)('0' + *p / 100);
-                  *q++ = (char)('0' + (*p % 100) / 10);
-                  *q++ = (char)('0' + (*p % 10));
-                }
-              else if (is_reservedch(*p))
-                {
-                  *q++ = '\\';
-                  *q++ = *p;
-                }
-              else
-                {
-                  *q++ = *p;
-                }
-              p++;
-            }
-          *q++ = '.';
+             Output as \DDD for consistency with RFC1035 5.1, except
+             for the special case of a root name response.
+          */
+          if(!(length == 1 && c == 0)) {
+            name[n++] = '\\';
+            name[n++] = '0' + c / 100;
+            name[n++] = '0' + (c % 100) / 10;
+            name[n++] = '0' + c % 10;
+          }
         }
-     }
-
-  if (!indir)
-    *enclen = aresx_uztosl(p + 1U - encoded);
-
-  /* Nuke the trailing period if we wrote one. */
-  if (q > *s)
-    *(q - 1) = 0;
-  else
-    *q = 0; /* zero terminate; LCOV_EXCL_LINE: empty names exit above */
-
+        else if (is_reservedch(c)) {
+          name[n++] = '\\';
+          name[n++] = c;
+        } else {
+          name[n++] = c;
+        }
+        encoded++;
+      }
+    } else {
+      /* The case of a pointer.
+         @high and @low must be combined to form the offset.
+       */
+      offset = high << 8 | low;
+      encoded = &abuf[offset];
+    }
+  }
+  name[n] = '\0';
+  *s = name;
   return ARES_SUCCESS;
 }
 
-
 int ares_expand_name(const unsigned char *encoded, const unsigned char *abuf,
-                     int alen, char **s, long *enclen)
+                     size_t alen, char **s, size_t *enclen)
 {
   return ares__expand_name_validated(encoded, abuf, alen, s, enclen, 0);
 }
 
-/* Return the length of the expansion of an encoded domain name, or
- * -1 if the encoding is invalid.
+/* Store the decoded length in @name_length and the number of bytes
+ * that must be skipped by the callee to continue processing in
+ * @enclen.
+ *
+ * If the encoding is invalid, the values pointed to by @name_length
+ * and @enclen are indeterminate, and -1 is returned. If successful,
+ * returns 0.
  */
-static int name_length(const unsigned char *encoded, const unsigned char *abuf,
-                       int alen, int is_hostname)
-{
-  int n = 0, offset, indir = 0, top;
-
-  /* Allow the caller to pass us abuf + alen and have us check for it. */
-  if (encoded >= abuf + alen)
+static int compute_lengths(const unsigned char *encoded,
+                           const unsigned char *abuf,
+                           size_t alen, int is_hostname,
+                           size_t *name_length, size_t *enclen) {
+  size_t offset, n = 0, bytes_processed = 0;
+  int c, type, first_label = 1, indirections = 0;
+  char high, low;
+  if(encoded >= abuf + alen)
     return -1;
-
-  while (*encoded)
-    {
-      top = (*encoded & INDIR_MASK);
-      if (top == INDIR_MASK)
-        {
-          /* Check the offset and go there. */
-          if (encoded + 1 >= abuf + alen)
-            return -1;
-          offset = (*encoded & ~INDIR_MASK) << 8 | *(encoded + 1);
-          if (offset >= alen)
-            return -1;
-          encoded = abuf + offset;
-
-          /* If we've seen more indirects than the message length,
-           * then there's a loop.
-           */
-          ++indir;
-          if (indir > alen || indir > MAX_INDIRS)
-            return -1;
-        }
-      else if (top == 0x00)
-        {
-          int name_len = *encoded;
-          offset = name_len;
-          if (encoded + offset + 1 >= abuf + alen)
-            return -1;
-          encoded++;
-
-          while (offset--)
-            {
-              if (!ares__isprint(*encoded) && !(name_len == 1 && *encoded == 0))
-                {
-                  if (is_hostname)
-                    return -1;
-                  n += 4;
-                }
-              else if (is_reservedch(*encoded))
-                {
-                  if (is_hostname)
-                    return -1;
-                  n += 2;
-                }
-              else
-                {
-                  if (is_hostname && !is_hostnamech(*encoded))
-                    return -1;
-                  n += 1;
-                }
-              encoded++;
-            }
-
-          n++;
-        }
+  while(*encoded != '\0') {
+    type = encoded[0] >> 6; /* the two highest bits */
+    high = encoded[0] & 63; /* 63 is 00111111 in binary */
+    switch(type) {
+    case 0:
+      /* The case of a label.
+         @high is the length of the label.
+      */
+      if(encoded + high + 1 >= abuf + alen)
+        return -1;
+      bytes_processed += high + 1;
+      encoded++;
+      if(first_label)
+        first_label = 0;
       else
-        {
-          /* RFC 1035 4.1.4 says other options (01, 10) for top 2
-           * bits are reserved.
-           */
-          return -1;
+        n++; /* accounting for the dot '.' */
+      while(high--) {
+        c = *encoded;
+        if (!ares__isprint(c)) {
+          if (is_hostname)
+            return -1;
+          else if (n == 0 && high == 0 && c == 0) {
+            /* root name of empty string */
+            *enclen = 3;
+            *name_length = 0;
+            return 0;
+          }
+          n += 4;
         }
+        else if (is_reservedch(c)) {
+          if (is_hostname)
+            return -1;
+          n += 2;
+        }
+        else {
+          if (is_hostname && !is_hostnamech(c))
+            return -1;
+          n += 1;
+        }
+        encoded++;
+      }
+      break;
+    case 3:
+      /* The case of a pointer.
+         @high and @low must be combined to form the offset.
+       */
+      if(encoded + 1 >= abuf + alen)
+        return -1;
+      low = encoded[1];
+      offset = high << 8 | low;
+      if(offset >= alen)
+        return -1;
+      encoded = &abuf[offset];
+      /* we have processed the pointer */
+      bytes_processed += 2;
+      if(indirections++ == 0)
+        *enclen = bytes_processed;
+      if(indirections >= MAX_INDIRS)
+        return -1;
+      break;
+    default:
+      /* RFU */
+      return -1;
     }
-
-  /* If there were any labels at all, then the number of dots is one
-   * less than the number of labels, so subtract one.
-   */
-  return (n) ? n - 1 : n;
+  }
+  *name_length = n;
+  if(indirections == 0)
+    *enclen = bytes_processed + 1; /* we end in a zero byte */
+  return 0;
 }
 
 /* Like ares_expand_name_validated  but returns EBADRESP in case of invalid
  * input. */
 int ares__expand_name_for_response(const unsigned char *encoded,
-                                   const unsigned char *abuf, int alen,
-                                   char **s, long *enclen, int is_hostname)
+                                   const unsigned char *abuf, size_t alen,
+                                   char **s, size_t *enclen, int is_hostname)
 {
   int status = ares__expand_name_validated(encoded, abuf, alen, s, enclen,
     is_hostname);

--- a/src/lib/ares_expand_string.c
+++ b/src/lib/ares_expand_string.c
@@ -34,35 +34,32 @@
  */
 int ares_expand_string(const unsigned char *encoded,
                        const unsigned char *abuf,
-                       int alen,
+                       size_t alen,
                        unsigned char **s,
-                       long *enclen)
+                       size_t *enclen)
 {
   unsigned char *q;
-  union {
-    ares_ssize_t sig;
-     size_t uns;
-  } elen;
+  size_t elen;
 
   if (encoded == abuf+alen)
     return ARES_EBADSTR;
 
-  elen.uns = *encoded;
-  if (encoded+elen.sig+1 > abuf+alen)
+  elen = *encoded;
+  if (encoded+elen+1 > abuf+alen)
     return ARES_EBADSTR;
 
   encoded++;
 
-  *s = ares_malloc(elen.uns+1);
+  *s = ares_malloc(elen+1);
   if (*s == NULL)
     return ARES_ENOMEM;
   q = *s;
-  strncpy((char *)q, (char *)encoded, elen.uns);
-  q[elen.uns] = '\0';
+  strncpy((char *)q, (char *)encoded, elen);
+  q[elen] = '\0';
 
   *s = q;
 
-  *enclen = (long)(elen.sig+1);
+  *enclen = elen+1;
 
   return ARES_SUCCESS;
 }

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -110,7 +110,7 @@ static const struct ares_addrinfo empty_addrinfo = {
 
 /* forward declarations */
 static void host_callback(void *arg, int status, int timeouts,
-                          unsigned char *abuf, int alen);
+                          unsigned char *abuf, size_t alen);
 static int as_is_first(const struct host_query *hquery);
 static int as_is_only(const struct host_query* hquery);
 static int next_dns_lookup(struct host_query *hquery);
@@ -566,7 +566,7 @@ static void next_lookup(struct host_query *hquery, int status)
 }
 
 static void host_callback(void *arg, int status, int timeouts,
-                          unsigned char *abuf, int alen)
+                          unsigned char *abuf, size_t alen)
 {
   struct host_query *hquery = (struct host_query*)arg;
   int addinfostatus = ARES_SUCCESS;

--- a/src/lib/ares_gethostbyaddr.c
+++ b/src/lib/ares_gethostbyaddr.c
@@ -51,7 +51,7 @@ struct addr_query {
 
 static void next_lookup(struct addr_query *aquery);
 static void addr_callback(void *arg, int status, int timeouts,
-                          unsigned char *abuf, int alen);
+                          unsigned char *abuf, size_t alen);
 static void end_aquery(struct addr_query *aquery, int status,
                        struct hostent *host);
 static int file_lookup(struct ares_addr *addr, struct hostent **host);
@@ -130,7 +130,7 @@ static void next_lookup(struct addr_query *aquery)
 }
 
 static void addr_callback(void *arg, int status, int timeouts,
-                          unsigned char *abuf, int alen)
+                          unsigned char *abuf, size_t alen)
 {
   struct addr_query *aquery = (struct addr_query *) arg;
   struct hostent *host;

--- a/src/lib/ares_mkquery.c
+++ b/src/lib/ares_mkquery.c
@@ -20,7 +20,7 @@
 #include "ares.h"
 
 int ares_mkquery(const char *name, int dnsclass, int type, unsigned short id,
-                 int rd, unsigned char **buf, int *buflen)
+                 int rd, unsigned char **buf, size_t *buflen)
 {
   return ares_create_query(name, dnsclass, type, id, rd, buf, buflen, 0);
 }

--- a/src/lib/ares_parse_a_reply.c
+++ b/src/lib/ares_parse_a_reply.c
@@ -43,7 +43,7 @@
 #include "ares_dns.h"
 #include "ares_private.h"
 
-int ares_parse_a_reply(const unsigned char *abuf, int alen,
+int ares_parse_a_reply(const unsigned char *abuf, size_t alen,
                        struct hostent **host, struct ares_addrttl *addrttls,
                        int *naddrttls)
 {

--- a/src/lib/ares_parse_aaaa_reply.c
+++ b/src/lib/ares_parse_aaaa_reply.c
@@ -45,7 +45,7 @@
 #include "ares_inet_net_pton.h"
 #include "ares_private.h"
 
-int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
+int ares_parse_aaaa_reply(const unsigned char *abuf, size_t alen,
                           struct hostent **host, struct ares_addr6ttl *addrttls,
                           int *naddrttls)
 {

--- a/src/lib/ares_parse_caa_reply.c
+++ b/src/lib/ares_parse_caa_reply.c
@@ -40,7 +40,7 @@
 #include "ares_private.h"
 
 int
-ares_parse_caa_reply (const unsigned char *abuf, int alen,
+ares_parse_caa_reply (const unsigned char *abuf, size_t alen,
                       struct ares_caa_reply **caa_out)
 {
   unsigned int qdcount, ancount, i;

--- a/src/lib/ares_parse_mx_reply.c
+++ b/src/lib/ares_parse_mx_reply.c
@@ -37,7 +37,7 @@
 #include "ares_private.h"
 
 int
-ares_parse_mx_reply (const unsigned char *abuf, int alen,
+ares_parse_mx_reply (const unsigned char *abuf, size_t alen,
                      struct ares_mx_reply **mx_out)
 {
   unsigned int qdcount, ancount, i;

--- a/src/lib/ares_parse_naptr_reply.c
+++ b/src/lib/ares_parse_naptr_reply.c
@@ -37,13 +37,13 @@
 #include "ares_private.h"
 
 int
-ares_parse_naptr_reply (const unsigned char *abuf, int alen,
+ares_parse_naptr_reply (const unsigned char *abuf, size_t alen,
                         struct ares_naptr_reply **naptr_out)
 {
   unsigned int qdcount, ancount, i;
   const unsigned char *aptr, *vptr;
   int status, rr_type, rr_class, rr_len;
-  long len;
+  size_t len;
   char *hostname = NULL, *rr_name = NULL;
   struct ares_naptr_reply *naptr_head = NULL;
   struct ares_naptr_reply *naptr_last = NULL;

--- a/src/lib/ares_parse_ns_reply.c
+++ b/src/lib/ares_parse_ns_reply.c
@@ -38,13 +38,13 @@
 #include "ares_dns.h"
 #include "ares_private.h"
 
-int ares_parse_ns_reply( const unsigned char* abuf, int alen,
+int ares_parse_ns_reply( const unsigned char* abuf, size_t alen,
                          struct hostent** host )
 {
   unsigned int qdcount, ancount;
   int status, i, rr_type, rr_class, rr_len;
   int nameservers_num;
-  long len;
+  size_t len;
   const unsigned char *aptr;
   char* hostname, *rr_name, *rr_data, **nameservers;
   struct hostent *hostent;

--- a/src/lib/ares_parse_ptr_reply.c
+++ b/src/lib/ares_parse_ptr_reply.c
@@ -36,12 +36,12 @@
 #include "ares_nowarn.h"
 #include "ares_private.h"
 
-int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
+int ares_parse_ptr_reply(const unsigned char *abuf, size_t alen, const void *addr,
                          int addrlen, int family, struct hostent **host)
 {
   unsigned int qdcount, ancount;
   int status, i, rr_type, rr_class, rr_len;
-  long len;
+  size_t len;
   const unsigned char *aptr;
   char *ptrname, *hostname, *rr_name, *rr_data;
   struct hostent *hostent = NULL;

--- a/src/lib/ares_parse_soa_reply.c
+++ b/src/lib/ares_parse_soa_reply.c
@@ -37,11 +37,11 @@
 #include "ares_private.h"
 
 int
-ares_parse_soa_reply(const unsigned char *abuf, int alen,
+ares_parse_soa_reply(const unsigned char *abuf, size_t alen,
 		     struct ares_soa_reply **soa_out)
 {
   const unsigned char *aptr;
-  long len;
+  size_t len;
   char *qname = NULL, *rr_name = NULL;
   struct ares_soa_reply *soa = NULL;
   int qdcount, ancount, qclass;

--- a/src/lib/ares_parse_srv_reply.c
+++ b/src/lib/ares_parse_srv_reply.c
@@ -37,7 +37,7 @@
 #include "ares_private.h"
 
 int
-ares_parse_srv_reply (const unsigned char *abuf, int alen,
+ares_parse_srv_reply (const unsigned char *abuf, size_t alen,
                       struct ares_srv_reply **srv_out)
 {
   unsigned int qdcount, ancount, i;

--- a/src/lib/ares_parse_txt_reply.c
+++ b/src/lib/ares_parse_txt_reply.c
@@ -41,7 +41,7 @@
 #include "ares_private.h"
 
 static int
-ares__parse_txt_reply (const unsigned char *abuf, int alen,
+ares__parse_txt_reply (const unsigned char *abuf, size_t alen,
                        int ex, void **txt_out)
 {
   size_t substr_len;
@@ -201,7 +201,7 @@ ares__parse_txt_reply (const unsigned char *abuf, int alen,
 }
 
 int
-ares_parse_txt_reply (const unsigned char *abuf, int alen,
+ares_parse_txt_reply (const unsigned char *abuf, size_t alen,
                       struct ares_txt_reply **txt_out)
 {
   return ares__parse_txt_reply(abuf, alen, 0, (void **) txt_out);
@@ -209,7 +209,7 @@ ares_parse_txt_reply (const unsigned char *abuf, int alen,
 
 
 int
-ares_parse_txt_reply_ext (const unsigned char *abuf, int alen,
+ares_parse_txt_reply_ext (const unsigned char *abuf, size_t alen,
                           struct ares_txt_ext **txt_out)
 {
   return ares__parse_txt_reply(abuf, alen, 1, (void **) txt_out);

--- a/src/lib/ares_parse_uri_reply.c
+++ b/src/lib/ares_parse_uri_reply.c
@@ -42,7 +42,7 @@
 #endif
 
 int
-ares_parse_uri_reply (const unsigned char *abuf, int alen,
+ares_parse_uri_reply (const unsigned char *abuf, size_t alen,
                       struct ares_uri_reply **uri_out)
 {
   unsigned int qdcount, ancount, i;

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -227,7 +227,7 @@ struct query {
 
   /* Arguments passed to ares_send() (qbuf points into tcpbuf) */
   const unsigned char *qbuf;
-  int qlen;
+  size_t qlen;
   ares_callback callback;
   void *arg;
 
@@ -360,14 +360,14 @@ unsigned short ares__generate_new_id(ares_rand_state *state);
 struct timeval ares__tvnow(void);
 int ares__expand_name_validated(const unsigned char *encoded,
                                 const unsigned char *abuf,
-                                int alen, char **s, long *enclen,
+                                size_t alen, char **s, size_t *enclen,
                                 int is_hostname);
 int ares__expand_name_for_response(const unsigned char *encoded,
-                                   const unsigned char *abuf, int alen,
-                                   char **s, long *enclen, int is_hostname);
+                                   const unsigned char *abuf, size_t alen,
+                                   char **s, size_t *enclen, int is_hostname);
 int ares__init_servers_state(ares_channel channel);
 void ares__destroy_servers_state(ares_channel channel);
-int ares__parse_qtype_reply(const unsigned char* abuf, int alen, int* qtype);
+int ares__parse_qtype_reply(const unsigned char* abuf, size_t alen, int* qtype);
 int ares__single_domain(ares_channel channel, const char *name, char **s);
 int ares__cat_domain(const char *name, const char *domain, char **s);
 int ares__sortaddrinfo(ares_channel channel, struct ares_addrinfo_node *ai_node);
@@ -393,7 +393,7 @@ void ares__addrinfo_cat_cnames(struct ares_addrinfo_cname **head,
                                struct ares_addrinfo_cname *tail);
 
 int ares__parse_into_addrinfo(const unsigned char *abuf,
-                              int alen, int cname_only_is_enodata,
+                              size_t alen, int cname_only_is_enodata,
                               unsigned short port,
                               struct ares_addrinfo *ai);
 

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -70,7 +70,7 @@ static void process_timeouts(ares_channel channel, struct timeval *now);
 static void process_broken_connections(ares_channel channel,
                                        struct timeval *now);
 static void process_answer(ares_channel channel, unsigned char *abuf,
-                           int alen, int whichserver, int tcp,
+                           size_t alen, int whichserver, int tcp,
                            struct timeval *now);
 static void handle_error(ares_channel channel, int whichserver,
                          struct timeval *now);
@@ -80,12 +80,12 @@ static void next_server(ares_channel channel, struct query *query,
                         struct timeval *now);
 static int open_tcp_socket(ares_channel channel, struct server_state *server);
 static int open_udp_socket(ares_channel channel, struct server_state *server);
-static int same_questions(const unsigned char *qbuf, int qlen,
-                          const unsigned char *abuf, int alen);
+static int same_questions(const unsigned char *qbuf, size_t qlen,
+                          const unsigned char *abuf, size_t alen);
 static int same_address(struct sockaddr *sa, struct ares_addr *aa);
-static int has_opt_rr(const unsigned char *abuf, int alen);
+static int has_opt_rr(const unsigned char *abuf, size_t alen);
 static void end_query(ares_channel channel, struct query *query, int status,
-                      unsigned char *abuf, int alen);
+                      unsigned char *abuf, size_t alen);
 
 /* return true if now is exactly check time or later */
 int ares__timedout(struct timeval *now,
@@ -578,7 +578,7 @@ static void process_timeouts(ares_channel channel, struct timeval *now)
 
 /* Handle an answer from a server. */
 static void process_answer(ares_channel channel, unsigned char *abuf,
-                           int alen, int whichserver, int tcp,
+                           size_t alen, int whichserver, int tcp,
                            struct timeval *now)
 {
   int tc, rcode, packetsz;
@@ -616,7 +616,7 @@ static void process_answer(ares_channel channel, unsigned char *abuf,
       packetsz = channel->ednspsz;
       if (rcode == FORMERR && has_opt_rr(abuf, alen) != 1)
       {
-          int qlen = (query->tcplen - 2) - EDNSFIXEDSZ;
+          size_t qlen = (query->tcplen - 2) - EDNSFIXEDSZ;
           channel->flags ^= ARES_FLAG_EDNS;
           query->tcplen -= EDNSFIXEDSZ;
           query->qlen -= EDNSFIXEDSZ;
@@ -1263,8 +1263,8 @@ static int open_udp_socket(ares_channel channel, struct server_state *server)
   return 0;
 }
 
-static int same_questions(const unsigned char *qbuf, int qlen,
-                          const unsigned char *abuf, int alen)
+static int same_questions(const unsigned char *qbuf, size_t qlen,
+                          const unsigned char *abuf, size_t alen)
 {
   struct {
     const unsigned char *p;
@@ -1371,7 +1371,7 @@ static int same_address(struct sockaddr *sa, struct ares_addr *aa)
 }
 
 /* search for an OPT RR in the response */
-static int has_opt_rr(const unsigned char *abuf, int alen)
+static int has_opt_rr(const unsigned char *abuf, size_t alen)
 {
   unsigned int qdcount, ancount, nscount, arcount, i;
   const unsigned char *aptr;
@@ -1450,7 +1450,7 @@ static int has_opt_rr(const unsigned char *abuf, int alen)
 }
 
 static void end_query (ares_channel channel, struct query *query, int status,
-                       unsigned char *abuf, int alen)
+                       unsigned char *abuf, size_t alen)
 {
   int i;
 

--- a/src/lib/ares_query.c
+++ b/src/lib/ares_query.c
@@ -33,7 +33,7 @@ struct qquery {
   void *arg;
 };
 
-static void qcallback(void *arg, int status, int timeouts, unsigned char *abuf, int alen);
+static void qcallback(void *arg, int status, int timeouts, unsigned char *abuf, size_t alen);
 
 
 /* a unique query id is generated using an rc4 key. Since the id may already
@@ -57,7 +57,8 @@ void ares_query(ares_channel channel, const char *name, int dnsclass,
 {
   struct qquery *qquery;
   unsigned char *qbuf;
-  int qlen, rd, status;
+  int rd, status;
+  size_t qlen;
   unsigned short id = generate_unique_id(channel);
 
   /* Compose the query. */
@@ -87,7 +88,7 @@ void ares_query(ares_channel channel, const char *name, int dnsclass,
   ares_free_string(qbuf);
 }
 
-static void qcallback(void *arg, int status, int timeouts, unsigned char *abuf, int alen)
+static void qcallback(void *arg, int status, int timeouts, unsigned char *abuf, size_t alen)
 {
   struct qquery *qquery = (struct qquery *) arg;
   unsigned int ancount;

--- a/src/lib/ares_search.c
+++ b/src/lib/ares_search.c
@@ -42,9 +42,9 @@ struct search_query {
 };
 
 static void search_callback(void *arg, int status, int timeouts,
-                            unsigned char *abuf, int alen);
+                            unsigned char *abuf, size_t alen);
 static void end_squery(struct search_query *squery, int status,
-                       unsigned char *abuf, int alen);
+                       unsigned char *abuf, size_t alen);
 
 void ares_search(ares_channel channel, const char *name, int dnsclass,
                  int type, ares_callback callback, void *arg)
@@ -143,7 +143,7 @@ void ares_search(ares_channel channel, const char *name, int dnsclass,
 }
 
 static void search_callback(void *arg, int status, int timeouts,
-                            unsigned char *abuf, int alen)
+                            unsigned char *abuf, size_t alen)
 {
   struct search_query *squery = (struct search_query *) arg;
   ares_channel channel = squery->channel;
@@ -205,7 +205,7 @@ static void search_callback(void *arg, int status, int timeouts,
 }
 
 static void end_squery(struct search_query *squery, int status,
-                       unsigned char *abuf, int alen)
+                       unsigned char *abuf, size_t alen)
 {
   squery->callback(squery->arg, status, squery->timeouts, abuf, alen);
   ares_free(squery->name);

--- a/src/lib/ares_send.c
+++ b/src/lib/ares_send.c
@@ -28,7 +28,7 @@
 #include "ares_dns.h"
 #include "ares_private.h"
 
-void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
+void ares_send(ares_channel channel, const unsigned char *qbuf, size_t qlen,
                ares_callback callback, void *arg)
 {
   struct query *query;

--- a/src/tools/adig.c
+++ b/src/tools/adig.c
@@ -142,12 +142,12 @@ static const char *rcodes[] = {
 };
 
 static void callback(void *arg, int status, int timeouts,
-                     unsigned char *abuf, int alen);
+                     unsigned char *abuf, size_t alen);
 static const unsigned char *display_question(const unsigned char *aptr,
                                              const unsigned char *abuf,
-                                             int alen);
+                                             size_t alen);
 static const unsigned char *display_rr(const unsigned char *aptr,
-                                       const unsigned char *abuf, int alen);
+                                       const unsigned char *abuf, size_t alen);
 static int convert_query (char **name, int use_bitstring);
 static const char *type_name(int type);
 static const char *class_name(int dnsclass);
@@ -387,7 +387,7 @@ int main(int argc, char **argv)
 }
 
 static void callback(void *arg, int status, int timeouts,
-                     unsigned char *abuf, int alen)
+                     unsigned char *abuf, size_t alen)
 {
   char *name = (char *) arg;
   int id, qr, opcode, aa, tc, rd, ra, rcode;
@@ -479,11 +479,11 @@ static void callback(void *arg, int status, int timeouts,
 
 static const unsigned char *display_question(const unsigned char *aptr,
                                              const unsigned char *abuf,
-                                             int alen)
+                                             size_t alen)
 {
   char *name;
   int type, dnsclass, status;
-  long len;
+  size_t len;
 
   /* Parse the question name. */
   status = ares_expand_name(aptr, abuf, alen, &name, &len);
@@ -517,11 +517,11 @@ static const unsigned char *display_question(const unsigned char *aptr,
 }
 
 static const unsigned char *display_rr(const unsigned char *aptr,
-                                       const unsigned char *abuf, int alen)
+                                       const unsigned char *abuf, size_t alen)
 {
   const unsigned char *p;
   int type, dnsclass, ttl, dlen, status, i;
-  long len;
+  size_t len;
   int vlen;
   char addr[46];
   union {

--- a/test/ares-test-fuzz-name.c
+++ b/test/ares-test-fuzz-name.c
@@ -32,7 +32,7 @@ int LLVMFuzzerTestOneInput(const unsigned char *data,
   memcpy(name, data, size);
 
   unsigned char *buf = NULL;
-  int buflen = 0;
+  size_t buflen = 0;
   ares_create_query(name, C_IN, T_AAAA, 1234, 0, &buf, &buflen, 1024);
   free(buf);
   free(name);

--- a/test/ares-test-misc.cc
+++ b/test/ares-test-misc.cc
@@ -182,7 +182,7 @@ TEST_F(LibraryTest, InetNtoP) {
 
 TEST_F(LibraryTest, Mkquery) {
   byte* p;
-  int len;
+  size_t len;
   ares_mkquery("example.com", C_IN, T_A, 0x1234, 0, &p, &len);
   std::vector<byte> data(p, p + len);
   ares_free_string(p);
@@ -196,7 +196,7 @@ TEST_F(LibraryTest, Mkquery) {
 
 TEST_F(LibraryTest, CreateQuery) {
   byte* p;
-  int len;
+  size_t len;
   EXPECT_EQ(ARES_SUCCESS,
             ares_create_query("exam\\@le.com", C_IN, T_A, 0x1234, 0,
                               &p, &len, 0));
@@ -212,7 +212,7 @@ TEST_F(LibraryTest, CreateQuery) {
 
 TEST_F(LibraryTest, CreateQueryTrailingEscapedDot) {
   byte* p;
-  int len;
+  size_t len;
   EXPECT_EQ(ARES_SUCCESS,
             ares_create_query("example.com\\.", C_IN, T_A, 0x1234, 0,
                               &p, &len, 0));
@@ -225,7 +225,7 @@ TEST_F(LibraryTest, CreateQueryTrailingEscapedDot) {
 
 TEST_F(LibraryTest, CreateQueryNameTooLong) {
   byte* p;
-  int len;
+  size_t len;
   EXPECT_EQ(ARES_EBADNAME,
             ares_create_query(
               "a1234567890123456789.b1234567890123456789.c1234567890123456789.d1234567890123456789."
@@ -237,7 +237,7 @@ TEST_F(LibraryTest, CreateQueryNameTooLong) {
 
 TEST_F(LibraryTest, CreateQueryFailures) {
   byte* p;
-  int len;
+  size_t len;
   // RC1035 has a 255 byte limit on names.
   std::string longname;
   for (int ii = 0; ii < 17; ii++) {
@@ -275,7 +275,7 @@ TEST_F(LibraryTest, CreateQueryFailures) {
 
 TEST_F(LibraryTest, CreateQueryOnionDomain) {
   byte* p;
-  int len;
+  size_t len;
   EXPECT_EQ(ARES_ENOTFOUND,
             ares_create_query("dontleak.onion", C_IN, T_A, 0x1234, 0,
                               &p, &len, 0));
@@ -323,7 +323,7 @@ TEST_F(DefaultChannelTest, SendFailure) {
 }
 
 std::string ExpandName(const std::vector<byte>& data, int offset,
-                       long *enclen) {
+                       size_t *enclen) {
   char *name = nullptr;
   int rc = ares_expand_name(data.data() + offset, data.data(), data.size(),
                             &name, enclen);
@@ -339,7 +339,7 @@ std::string ExpandName(const std::vector<byte>& data, int offset,
 }
 
 TEST_F(LibraryTest, ExpandName) {
-  long enclen;
+  size_t enclen;
   std::vector<byte> data1 = {1, 'a', 2, 'b', 'c', 3, 'd', 'e', 'f', 0};
   EXPECT_EQ("a.bc.def", ExpandName(data1, 0, &enclen));
   EXPECT_EQ(data1.size(), enclen);
@@ -388,7 +388,7 @@ TEST_F(LibraryTest, ExpandName) {
 TEST_F(LibraryTest, ExpandNameFailure) {
   std::vector<byte> data1 = {0x03, 'c', 'o', 'm', 0x00};
   char *name = nullptr;
-  long enclen;
+  size_t enclen;
   SetAllocFail(1);
   EXPECT_EQ(ARES_ENOMEM,
             ares_expand_name(data1.data(), data1.data(), data1.size(),
@@ -469,7 +469,7 @@ TEST_F(LibraryTest, ExpandNameFailure) {
 
 TEST_F(LibraryTest, CreateEDNSQuery) {
   byte* p;
-  int len;
+  size_t len;
   EXPECT_EQ(ARES_SUCCESS,
             ares_create_query("example.com", C_IN, T_A, 0x1234, 0,
                               &p, &len, 1280));
@@ -486,7 +486,7 @@ TEST_F(LibraryTest, CreateEDNSQuery) {
 
 TEST_F(LibraryTest, CreateRootQuery) {
   byte* p;
-  int len;
+  size_t len;
   ares_create_query(".", C_IN, T_A, 0x1234, 0, &p, &len, 0);
   std::vector<byte> data(p, p + len);
   ares_free_string(p);
@@ -519,7 +519,7 @@ TEST_F(LibraryTest, Strerror) {
 TEST_F(LibraryTest, ExpandString) {
   std::vector<byte> s1 = { 3, 'a', 'b', 'c'};
   char* result = nullptr;
-  long len;
+  size_t len;
   EXPECT_EQ(ARES_SUCCESS,
             ares_expand_string(s1.data(), s1.data(), s1.size(),
                                (unsigned char**)&result, &len));

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -304,10 +304,10 @@ void MockServer::ProcessPacket(int fd, struct sockaddr_storage *addr, socklen_t 
     return;
   }
   byte* question = data + 12;
-  int qlen = len - 12;
+  size_t qlen = len - 12;
 
   char *name = nullptr;
-  long enclen;
+  size_t enclen;
   ares_expand_name(question, data, len, &name, &enclen);
   if (!name) {
     std::cerr << "Failed to retrieve name" << std::endl;
@@ -734,7 +734,7 @@ std::ostream& operator<<(std::ostream& os, const SearchResult& result) {
 }
 
 void SearchCallback(void *data, int status, int timeouts,
-                    unsigned char *abuf, int alen) {
+                    unsigned char *abuf, size_t alen) {
   EXPECT_NE(nullptr, data);
   SearchResult* result = reinterpret_cast<SearchResult*>(data);
   result->done_ = true;

--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -327,7 +327,7 @@ std::ostream& operator<<(std::ostream& os, const AddrInfoResult& result);
 void HostCallback(void *data, int status, int timeouts,
                   struct hostent *hostent);
 void SearchCallback(void *data, int status, int timeouts,
-                    unsigned char *abuf, int alen);
+                    unsigned char *abuf, size_t alen);
 void NameInfoCallback(void *data, int status, int timeouts,
                       char *node, char *service);
 void AddrInfoCallback(void *data, int status, int timeouts,

--- a/test/dns-proto.cc
+++ b/test/dns-proto.cc
@@ -197,7 +197,7 @@ std::string AddressToString(const void* vaddr, int len) {
 
 std::string PacketToString(const std::vector<byte>& packet) {
   const byte* data = packet.data();
-  int len = packet.size();
+  size_t len = packet.size();
   std::stringstream ss;
   if (len < NS_HFIXEDSZ) {
     ss << "(too short, len " << len << ")";
@@ -243,7 +243,7 @@ std::string PacketToString(const std::vector<byte>& packet) {
 }
 
 std::string QuestionToString(const std::vector<byte>& packet,
-                             const byte** data, int* len) {
+                             const byte** data, size_t* len) {
   std::stringstream ss;
   ss << "{";
   if (*len < NS_QFIXEDSZ) {
@@ -252,7 +252,7 @@ std::string QuestionToString(const std::vector<byte>& packet,
   }
 
   char *name = nullptr;
-  long enclen;
+  size_t enclen;
   int rc = ares_expand_name(*data, packet.data(), packet.size(), &name, &enclen);
   if (rc != ARES_SUCCESS) {
     ss << "(error from ares_expand_name)";
@@ -279,7 +279,7 @@ std::string QuestionToString(const std::vector<byte>& packet,
 }
 
 std::string RRToString(const std::vector<byte>& packet,
-                       const byte** data, int* len) {
+                       const byte** data, size_t* len) {
   std::stringstream ss;
   ss << "{";
   if (*len < NS_RRFIXEDSZ) {
@@ -288,7 +288,7 @@ std::string RRToString(const std::vector<byte>& packet,
   }
 
   char *name = nullptr;
-  long enclen;
+  size_t enclen;
   int rc = ares_expand_name(*data, packet.data(), packet.size(), &name, &enclen);
   if (rc != ARES_SUCCESS) {
     ss << "(error from ares_expand_name)";
@@ -318,7 +318,7 @@ std::string RRToString(const std::vector<byte>& packet,
     ss << RRTypeToString(rrtype) << " ";
     ss << "TTL=" << DNS_RR_TTL(*data);
   }
-  int rdatalen = DNS_RR_LEN(*data);
+  size_t rdatalen = DNS_RR_LEN(*data);
 
   *data += NS_RRFIXEDSZ;
   *len -= NS_RRFIXEDSZ;

--- a/test/dns-proto.h
+++ b/test/dns-proto.h
@@ -49,9 +49,9 @@ std::string AddressToString(const void* addr, int len);
 // externally-determined inputs.
 std::string PacketToString(const std::vector<byte>& packet);
 std::string QuestionToString(const std::vector<byte>& packet,
-                             const byte** data, int* len);
+                             const byte** data, size_t* len);
 std::string RRToString(const std::vector<byte>& packet,
-                       const byte** data, int* len);
+                       const byte** data, size_t* len);
 
 
 // Manipulate DNS protocol data.


### PR DESCRIPTION
The union type in this context is used for the purpose of type punning. However, there is no need for it, and it is also not used correctly: Union members must have equivalent types, and there is no named signed integer type equivalent to size_t (not in ISO C nor POSIX.)

Theoretically, one can run into trouble if ares_ssize_t is not equivalent to size_t, as some bytes in size_t would be indeterminate, possibly affecting its value.

The union code is replaced with bounds-checked integer conversion code.