### PR TITLE
Turn off IPV6_V6ONLY on Windows if it is supported

### DIFF
--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -983,14 +983,16 @@ static int setsocknonblock(ares_socket_t sockfd,    /* operate on this */
 /* It makes support for IPv4-mapped IPv6 addresses.
  * Linux kernel, NetBSD, FreeBSD and Darwin: default is off;
  * Windows Vista and later: default is on;
- * DragonFly BSD: off and dummy setting;
- * OpenBSD and previous Windows: unsupported.
+ * DragonFly BSD: acts like off, and dummy setting;
+ * OpenBSD and earlier Windows: unsupported.
  * Linux: controlled by /proc/sys/net/ipv6/bindv6only.
  */
 static void set_ipv6_v6only(ares_socket_t sockfd, int on)
 {
   (void)setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, (void *)&on, sizeof(on));
 }
+#else
+#define set_ipv6_v6only(s,v)
 #endif
 
 static int configure_socket(ares_socket_t s, int family, ares_channel channel)
@@ -1055,9 +1057,7 @@ static int configure_socket(ares_socket_t s, int family, ares_channel channel)
       if (bind(s, &local.sa, sizeof(local.sa6)) < 0)
         return -1;
     }
-#if defined(IPV6_V6ONLY) && defined(WIN32)
     set_ipv6_v6only(s, 0);
-#endif
   }
 
   return 0;

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -979,6 +979,20 @@ static int setsocknonblock(ares_socket_t sockfd,    /* operate on this */
 #endif
 }
 
+#if defined(IPV6_V6ONLY) && defined(WIN32)
+/* It makes support for IPv4-mapped IPv6 addresses.
+ * Linux kernel, NetBSD, FreeBSD and Darwin: default is off;
+ * Windows Vista and later: default is on;
+ * DragonFly BSD: off and dummy setting;
+ * OpenBSD and previous Windows: unsupported.
+ * Linux: controlled by /proc/sys/net/ipv6/bindv6only.
+ */
+static void set_ipv6_v6only(ares_socket_t sockfd, int on)
+{
+  (void)setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, (void *)&on, sizeof(on));
+}
+#endif
+
 static int configure_socket(ares_socket_t s, int family, ares_channel channel)
 {
   union {
@@ -1041,6 +1055,9 @@ static int configure_socket(ares_socket_t s, int family, ares_channel channel)
       if (bind(s, &local.sa, sizeof(local.sa6)) < 0)
         return -1;
     }
+#if defined(IPV6_V6ONLY) && defined(WIN32)
+    set_ipv6_v6only(s, 0);
+#endif
   }
 
   return 0;


### PR DESCRIPTION
It makes support for IPv4-mapped IPv6 addresses.

IPV6_V6ONLY refs:
https://en.wikipedia.org/wiki/IPv6#IPv4-mapped_IPv6_addresses
https://github.com/golang/go/blob/master/src/net/ipsock_posix.go
https://en.wikipedia.org/wiki/Unix-like
off:
https://www.kernel.org/doc/html/latest/networking/ip-sysctl.html#proc-sys-net-ipv6-variables
https://man.netbsd.org/inet6.4
https://man.freebsd.org/cgi/man.cgi?query=inet6
https://github.com/apple-oss-distributions/xnu/blob/main/bsd/man/man4/inet6.4
on:
https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
acts like off, but returns 1 and dummy setting:
https://man.dragonflybsd.org/?command=inet6
https://man.dragonflybsd.org/?command=ip6
unsupported and read-only returns 1:
https://man.openbsd.org/inet6.4

default value refs:
https://datatracker.ietf.org/doc/html/rfc3493#section-5.3
https://www.kernel.org/doc/html/latest/networking/ip-sysctl.html#proc-sys-net-ipv6-variables
