### PR TITLE
Replace uses of sprintf with snprintf

### DIFF
--- a/m4/ax_check_user_namespace.m4
+++ b/m4/ax_check_user_namespace.m4
@@ -34,9 +34,9 @@ int main() {
   pid_t child = clone(userfn, userst + 1024*1024, CLONE_NEWUSER|SIGCHLD, 0);
   if (child < 0) return 1;
 
-  sprintf(buffer, "/proc/%d/uid_map", child);
+  snprintf(buffer, sizeof(buffer), "/proc/%d/uid_map", child);
   fd = open(buffer, O_CREAT|O_WRONLY|O_TRUNC, 0755);
-  sprintf(buffer, "0 %d 1\n", getuid());
+  snprintf(buffer, sizeof(buffer), "0 %d 1\n", getuid());
   write(fd, buffer, strlen(buffer));
   close(fd);
 

--- a/m4/ax_check_uts_namespace.m4
+++ b/m4/ax_check_uts_namespace.m4
@@ -55,9 +55,9 @@ int main() {
   pid_t child = clone(fn, st + 1024*1024, CLONE_NEWUSER|SIGCHLD, 0);
   if (child < 0) return 1;
 
-  sprintf(buffer, "/proc/%d/uid_map", child);
+  snprintf(buffer, sizeof(buffer), "/proc/%d/uid_map", child);
   fd = open(buffer, O_CREAT|O_WRONLY|O_TRUNC, 0755);
-  sprintf(buffer, "0 %d 1\n", getuid());
+  snprintf(buffer, sizeof(buffer), "0 %d 1\n", getuid());
   write(fd, buffer, strlen(buffer));
   close(fd);
 

--- a/src/lib/ares_gethostbyaddr.c
+++ b/src/lib/ares_gethostbyaddr.c
@@ -53,7 +53,7 @@ static void addr_callback(void *arg, int status, int timeouts,
 static void end_aquery(struct addr_query *aquery, int status,
                        struct hostent *host);
 static int file_lookup(struct ares_addr *addr, struct hostent **host);
-static void ptr_rr_name(char *name, const struct ares_addr *addr);
+static void ptr_rr_name(char *name, int name_size, const struct ares_addr *addr);
 
 void ares_gethostbyaddr(ares_channel channel, const void *addr, int addrlen,
                         int family, ares_host_callback callback, void *arg)
@@ -105,7 +105,7 @@ static void next_lookup(struct addr_query *aquery)
       switch (*p)
         {
         case 'b':
-          ptr_rr_name(name, &aquery->addr);
+          ptr_rr_name(name, sizeof(name), &aquery->addr);
           aquery->remaining_lookups = p + 1;
           ares_query(aquery->channel, name, C_IN, T_PTR, addr_callback,
                      aquery);
@@ -255,7 +255,7 @@ static int file_lookup(struct ares_addr *addr, struct hostent **host)
   return status;
 }
 
-static void ptr_rr_name(char *name, const struct ares_addr *addr)
+static void ptr_rr_name(char *name, int name_size, const struct ares_addr *addr)
 {
   if (addr->family == AF_INET)
     {
@@ -264,20 +264,20 @@ static void ptr_rr_name(char *name, const struct ares_addr *addr)
        unsigned long a2 = (laddr >> 16UL) & 0xFFUL;
        unsigned long a3 = (laddr >>  8UL) & 0xFFUL;
        unsigned long a4 = laddr & 0xFFUL;
-       sprintf(name, "%lu.%lu.%lu.%lu.in-addr.arpa", a4, a3, a2, a1);
+       snprintf(name, name_size, "%lu.%lu.%lu.%lu.in-addr.arpa", a4, a3, a2, a1);
     }
   else
     {
        unsigned char *bytes = (unsigned char *)&addr->addrV6;
        /* There are too many arguments to do this in one line using
         * minimally C89-compliant compilers */
-       sprintf(name,
+       snprintf(name, name_size,
                 "%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.",
                 bytes[15]&0xf, bytes[15] >> 4, bytes[14]&0xf, bytes[14] >> 4,
                 bytes[13]&0xf, bytes[13] >> 4, bytes[12]&0xf, bytes[12] >> 4,
                 bytes[11]&0xf, bytes[11] >> 4, bytes[10]&0xf, bytes[10] >> 4,
                 bytes[9]&0xf, bytes[9] >> 4, bytes[8]&0xf, bytes[8] >> 4);
-       sprintf(name+strlen(name),
+       snprintf(name+strlen(name), name_size-strlen(name),
                 "%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.%x.ip6.arpa",
                 bytes[7]&0xf, bytes[7] >> 4, bytes[6]&0xf, bytes[6] >> 4,
                 bytes[5]&0xf, bytes[5] >> 4, bytes[4]&0xf, bytes[4] >> 4,

--- a/src/lib/ares_getnameinfo.c
+++ b/src/lib/ares_getnameinfo.c
@@ -327,7 +327,7 @@ static char *lookup_service(unsigned short port, int flags,
       else
         {
           /* get port as a string */
-          sprintf(tmpbuf, "%u", (unsigned int)ntohs(port));
+          snprintf(tmpbuf, sizeof(tmpbuf), "%u", (unsigned int)ntohs(port));
           name = tmpbuf;
         }
       name_len = strlen(name);
@@ -364,11 +364,11 @@ static void append_scopeid(struct sockaddr_in6 *addr6, unsigned int flags,
     {
       if (is_scope_long)
         {
-          sprintf(&tmpbuf[1], "%lu", (unsigned long)addr6->sin6_scope_id);
+          snprintf(&tmpbuf[1], sizeof(tmpbuf)-1, "%lu", (unsigned long)addr6->sin6_scope_id);
         }
       else
         {
-          sprintf(&tmpbuf[1], "%u", (unsigned int)addr6->sin6_scope_id);
+          snprintf(&tmpbuf[1], sizeof(tmpbuf)-1, "%u", (unsigned int)addr6->sin6_scope_id);
         }
     }
   else
@@ -377,22 +377,22 @@ static void append_scopeid(struct sockaddr_in6 *addr6, unsigned int flags,
         {
           if (is_scope_long)
             {
-              sprintf(&tmpbuf[1], "%lu", (unsigned long)addr6->sin6_scope_id);
+              snprintf(&tmpbuf[1], sizeof(tmpbuf)-1, "%lu", (unsigned long)addr6->sin6_scope_id);
             }
           else
             {
-              sprintf(&tmpbuf[1], "%u", (unsigned int)addr6->sin6_scope_id);
+              snprintf(&tmpbuf[1], sizeof(tmpbuf)-1, "%u", (unsigned int)addr6->sin6_scope_id);
             }
         }
     }
 #else
   if (is_scope_long)
     {
-      sprintf(&tmpbuf[1], "%lu", (unsigned long)addr6->sin6_scope_id);
+      snprintf(&tmpbuf[1], sizeof(tmpbuf)-1, "%lu", (unsigned long)addr6->sin6_scope_id);
     }
   else
     {
-      sprintf(&tmpbuf[1], "%u", (unsigned int)addr6->sin6_scope_id);
+      snprintf(&tmpbuf[1], sizeof(tmpbuf)-1, "%u", (unsigned int)addr6->sin6_scope_id);
     }
   (void) flags;
 #endif

--- a/src/lib/inet_ntop.c
+++ b/src/lib/inet_ntop.c
@@ -84,7 +84,7 @@ inet_ntop4(const unsigned char *src, char *dst, size_t size)
   static const char fmt[] = "%u.%u.%u.%u";
   char tmp[sizeof("255.255.255.255")];
 
-  if ((size_t)sprintf(tmp, fmt, src[0], src[1], src[2], src[3]) >= size) {
+  if ((size_t)snprintf(tmp, sizeof(tmp), fmt, src[0], src[1], src[2], src[3]) >= size) {
     SET_ERRNO(ENOSPC);
     return (NULL);
   }
@@ -171,7 +171,7 @@ inet_ntop6(const unsigned char *src, char *dst, size_t size)
       tp += strlen(tp);
       break;
     }
-    tp += sprintf(tp, "%x", words[i]);
+    tp += snprintf(tp, sizeof(tmp)-(tp-tmp), "%x", words[i]);
   }
   /* Was it a trailing run of 0x00's? */
   if (best.base != -1 && (best.base + best.len) == (NS_IN6ADDRSZ / NS_INT16SZ))

--- a/src/tools/acountry.c
+++ b/src/tools/acountry.c
@@ -172,7 +172,7 @@ int main(int argc, char **argv)
         }
 
       buf = malloc(100);
-      sprintf(buf, nerd_fmt,
+      snprintf(buf, 100, nerd_fmt,
               (unsigned int)(addr.s_addr >> 24),
               (unsigned int)((addr.s_addr >> 16) & 255),
               (unsigned int)((addr.s_addr >> 8) & 255),
@@ -436,7 +436,7 @@ static const struct search_list country_list[] = {
        { 498, "md", "Moldova"                              },
        { 492, "mc", "Monaco"                               },
        { 496, "mn", "Mongolia"                             },
-       { 499, "me", "Montenegro"                           },  
+       { 499, "me", "Montenegro"                           },
        { 500, "ms", "Montserrat"                           },
        { 504, "ma", "Morocco"                              },
        { 508, "mz", "Mozambique"                           },

--- a/test/dns-proto.cc
+++ b/test/dns-proto.cc
@@ -16,7 +16,7 @@ std::string HexDump(std::vector<byte> data) {
   std::stringstream ss;
   for (size_t ii = 0; ii < data.size();  ii++) {
     char buffer[2 + 1];
-    sprintf(buffer, "%02x", data[ii]);
+    snprintf(buffer, sizeof(buffer), "%02x", data[ii]);
     ss << buffer;
   }
   return ss.str();
@@ -159,17 +159,17 @@ std::string AddressToString(const void* vaddr, int len) {
   std::stringstream ss;
   if (len == 4) {
     char buffer[4*4 + 3 + 1];
-    sprintf(buffer, "%u.%u.%u.%u",
-            (unsigned char)addr[0],
-            (unsigned char)addr[1],
-            (unsigned char)addr[2],
-            (unsigned char)addr[3]);
+    snprintf(buffer, sizeof(buffer), "%u.%u.%u.%u",
+             (unsigned char)addr[0],
+             (unsigned char)addr[1],
+             (unsigned char)addr[2],
+             (unsigned char)addr[3]);
     ss << buffer;
   } else if (len == 16) {
     for (int ii = 0; ii < 16;  ii+=2) {
       if (ii > 0) ss << ':';
       char buffer[4 + 1];
-      sprintf(buffer, "%02x%02x", (unsigned char)addr[ii], (unsigned char)addr[ii+1]);
+      snprintf(buffer, sizeof(buffer), "%02x%02x", (unsigned char)addr[ii], (unsigned char)addr[ii+1]);
       ss << buffer;
     }
   } else {


### PR DESCRIPTION
The most recent version of the SDK on macOS recently started complaining about sprintf being deprecated, similar to this:

```
<>/c-ares/src/lib/ares_getnameinfo.c:371:11: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
          sprintf(&tmpbuf[1], "%u", (unsigned int)addr6->sin6_scope_id);
          ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
```

This PR replaces all uses of sprintf with snprintf, with appropriate size values for the buffers used. The only thing I'm concerned about here is this note in `src/lib/config-dos.h`:

```
  /* Because djgpp <= 2.03 doesn't have snprintf() etc. */
  #if (DJGPP_MINOR < 4)
    #define _MPRINTF_REPLACE
  #endif
```

I'm not sure if that's still an issue, and I don't have any way to test that it's good locally. I assume CI covers it.