### PR TITLE
fix: -Wunreachable-code warning in ares__init_rand_engine()

### DIFF
--- a/src/lib/ares_rand.c
+++ b/src/lib/ares_rand.c
@@ -58,6 +58,8 @@ BOOLEAN WINAPI SystemFunction036(PVOID RandomBuffer, ULONG RandomBufferLength);
 #endif
 
 
+#if defined(CARES_RANDOM_FILE) && !defined(HAVE_ARC4RANDOM_BUF) && !defined(HAVE_GETRANDOM) && !defined(_WIN32)
+
 #define ARES_RC4_KEY_LEN 32 /* 256 bits */
 
 #ifdef _MSC_VER
@@ -73,8 +75,6 @@ static unsigned int ares_u32_from_ptr(void *addr)
     }
     return (unsigned int)((size_t)addr & 0xFFFFFFFF);
 }
-
-#if defined(CARES_RANDOM_FILE) && !defined(HAVE_ARC4RANDOM_BUF) && !defined(HAVE_GETRANDOM) && !defined(_WIN32)
 
 /* initialize an rc4 key as the last possible fallback. */
 static void ares_rc4_generate_key(ares_rand_rc4 *rc4_state, unsigned char *key, size_t key_len)

--- a/src/lib/ares_rand.c
+++ b/src/lib/ares_rand.c
@@ -168,13 +168,13 @@ static int ares__init_rand_engine(ares_rand_state *state)
     return 1;
   }
   /* Fall-Thru on failure to RC4 */
-#endif
 
   state->type = ARES_RAND_RC4;
   ares_rc4_init(&state->state.rc4);
 
   /* Currently cannot fail */
   return 1;
+#endif
 }
 
 

--- a/src/lib/ares_rand.c
+++ b/src/lib/ares_rand.c
@@ -58,8 +58,6 @@ BOOLEAN WINAPI SystemFunction036(PVOID RandomBuffer, ULONG RandomBufferLength);
 #endif
 
 
-#if defined(CARES_RANDOM_FILE) && !defined(HAVE_ARC4RANDOM_BUF) && !defined(HAVE_GETRANDOM) && !defined(_WIN32)
-
 #define ARES_RC4_KEY_LEN 32 /* 256 bits */
 
 #ifdef _MSC_VER
@@ -75,6 +73,7 @@ static unsigned int ares_u32_from_ptr(void *addr)
     }
     return (unsigned int)((size_t)addr & 0xFFFFFFFF);
 }
+
 
 /* initialize an rc4 key as the last possible fallback. */
 static void ares_rc4_generate_key(ares_rand_rc4 *rc4_state, unsigned char *key, size_t key_len)
@@ -111,6 +110,7 @@ static void ares_rc4_generate_key(ares_rand_rc4 *rc4_state, unsigned char *key, 
   }
 }
 
+
 static void ares_rc4_init(ares_rand_rc4 *rc4_state)
 {
   unsigned char key[ARES_RC4_KEY_LEN];
@@ -131,7 +131,6 @@ static void ares_rc4_init(ares_rand_rc4 *rc4_state)
   rc4_state->i = 0;
   rc4_state->j = 0;
 }
-#endif
 
 /* Just outputs the key schedule, no need to XOR with any data since we have none */
 static void ares_rc4_prng(ares_rand_rc4 *rc4_state, unsigned char *buf, size_t len)
@@ -169,13 +168,13 @@ static int ares__init_rand_engine(ares_rand_state *state)
     return 1;
   }
   /* Fall-Thru on failure to RC4 */
+#endif
 
   state->type = ARES_RAND_RC4;
   ares_rc4_init(&state->state.rc4);
 
   /* Currently cannot fail */
   return 1;
-#endif
 }
 
 

--- a/src/lib/ares_rand.c
+++ b/src/lib/ares_rand.c
@@ -110,7 +110,7 @@ static void ares_rc4_generate_key(ares_rand_rc4 *rc4_state, unsigned char *key, 
   }
 }
 
-
+#if defined(CARES_RANDOM_FILE) && !defined(HAVE_ARC4RANDOM_BUF) && !defined(HAVE_GETRANDOM) && !defined(_WIN32)
 static void ares_rc4_init(ares_rand_rc4 *rc4_state)
 {
   unsigned char key[ARES_RC4_KEY_LEN];
@@ -131,6 +131,7 @@ static void ares_rc4_init(ares_rand_rc4 *rc4_state)
   rc4_state->i = 0;
   rc4_state->j = 0;
 }
+#endif
 
 /* Just outputs the key schedule, no need to XOR with any data since we have none */
 static void ares_rc4_prng(ares_rand_rc4 *rc4_state, unsigned char *buf, size_t len)

--- a/src/lib/ares_rand.c
+++ b/src/lib/ares_rand.c
@@ -74,6 +74,7 @@ static unsigned int ares_u32_from_ptr(void *addr)
     return (unsigned int)((size_t)addr & 0xFFFFFFFF);
 }
 
+#if defined(CARES_RANDOM_FILE) && !defined(HAVE_ARC4RANDOM_BUF) && !defined(HAVE_GETRANDOM) && !defined(_WIN32)
 
 /* initialize an rc4 key as the last possible fallback. */
 static void ares_rc4_generate_key(ares_rand_rc4 *rc4_state, unsigned char *key, size_t key_len)
@@ -110,7 +111,6 @@ static void ares_rc4_generate_key(ares_rand_rc4 *rc4_state, unsigned char *key, 
   }
 }
 
-#if defined(CARES_RANDOM_FILE) && !defined(HAVE_ARC4RANDOM_BUF) && !defined(HAVE_GETRANDOM) && !defined(_WIN32)
 static void ares_rc4_init(ares_rand_rc4 *rc4_state)
 {
   unsigned char key[ARES_RC4_KEY_LEN];


### PR DESCRIPTION
I'm one of the Electron maintainers and came across this issue when updating our Node.js snapshot, which uses c-ares. Since Electron builds Node.js with `-Werror` and `-Wunreachable-code`, this caused a FTBFS on Win32 until we patched it.

This doesn't show up under the default build flags; but since it does show up for anyone using those flags, I thought I'd upstream the patch.