### PR TITLE
Fix Segment Fault in `ares_process.c`

### DIFF
--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -617,7 +617,7 @@ static void process_answer(ares_channel channel, unsigned char *abuf,
        list_node = list_node->next)
     {
       struct query *q = list_node->data;
-      if ((q->qid == id) && same_questions(q->qbuf, q->qlen, abuf, alen))
+      if (q && (q->qid == id) && same_questions(q->qbuf, q->qlen, abuf, alen))
         {
           query = q;
           break;

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -573,7 +573,7 @@ static void process_timeouts(ares_channel channel, struct timeval *now)
         {
           query = list_node->data;
           list_node = list_node->next;  /* in case the query gets deleted */
-          if (query->timeout.tv_sec && ares__timedout(now, &query->timeout))
+          if (query && query->timeout.tv_sec && ares__timedout(now, &query->timeout))
             {
               query->error_status = ARES_ETIMEOUT;
               ++query->timeouts;


### PR DESCRIPTION
I met 2 segment faults in my project. Crashed in the `if` statement at line 576 and 620:
<https://github.com/c-ares/c-ares/blob/bad62225b7f6b278b92e8e85a255600b629ef517/src/lib/ares_process.c#L572-L583>

At line 576, GDB shows that `query` is NULL, so `query->timeout` will cause a segment fault.

<https://github.com/c-ares/c-ares/blob/bad62225b7f6b278b92e8e85a255600b629ef517/src/lib/ares_process.c#L616-L625>

At line 620, GDB shows that `q` is NULL, so `q->qid` will cause a segment fault.

------
I fixed them intuitively: check whether it is NULL first.

```cpp
// added a `query &&`
if (query && query->timeout.tv_sec && ares__timedout(now, &query->timeout))
// added a `q &&`
if (q && (q->qid == id) && same_questions(q->qbuf, q->qlen, abuf, alen))
```
Then everything works fine in my project.

But I don't know why `query` and `q` are NULL here. Is there a further root bug? I'll appreciate it if anyone could explain to me.
