### PR TITLE
its not 1991 anymore, lower default timeout and retry count

### DIFF
--- a/docs/ares_init_options.3
+++ b/docs/ares_init_options.3
@@ -73,7 +73,7 @@ description of possible flag values.
 The number of seconds each name server is given to respond to a query on the
 first try.  (After the first try, the timeout algorithm becomes more
 complicated, but scales linearly with the value of \fItimeout\fP.)  The
-default is five seconds. This option is being deprecated by
+default is two seconds. This option is being deprecated by
 \fIARES_OPT_TIMEOUTMS\fP starting in c-ares 1.5.2.
 .TP 18
 .B ARES_OPT_TIMEOUTMS
@@ -82,7 +82,7 @@ default is five seconds. This option is being deprecated by
 The number of milliseconds each name server is given to respond to a query on
 the first try.  (After the first try, the timeout algorithm becomes more
 complicated, but scales linearly with the value of \fItimeout\fP.)  The
-default is five seconds. Note that this option is specified with the same
+default is two seconds. Note that this option is specified with the same
 struct field as the former \fIARES_OPT_TIMEOUT\fP, it is but the option bits
 that tell c-ares how to interpret the number. This option was added in c-ares
 1.5.2.
@@ -91,7 +91,7 @@ that tell c-ares how to interpret the number. This option was added in c-ares
 .B int \fItries\fP;
 .br
 The number of tries the resolver will try contacting each name server
-before giving up.  The default is four tries.
+before giving up.  The default is three tries.
 .TP 18
 .B ARES_OPT_NDOTS
 .B int \fIndots\fP;

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -39,8 +39,8 @@
 #define HAVE_WRITEV 1
 #endif
 
-#define DEFAULT_TIMEOUT         5000 /* milliseconds */
-#define DEFAULT_TRIES           4
+#define DEFAULT_TIMEOUT         2000 /* milliseconds */
+#define DEFAULT_TRIES           3
 #ifndef INADDR_NONE
 #define INADDR_NONE 0xffffffff
 #endif


### PR DESCRIPTION
A lot of time has passed since the original timeouts and retry counts were chosen.  We have on and off issues reported due to this.  Even on geostationary satellite links, latency is worst case around 1.5s.  This PR changes the per-server timeout to 2s and the retry count lowered from 4 to 3.   