### PR TITLE
Avoid producing an ill-formed result when qualifying a name with the root domain

### DIFF
--- a/src/lib/ares_search.c
+++ b/src/lib/ares_search.c
@@ -223,6 +223,11 @@ int ares__cat_domain(const char *name, const char *domain, char **s)
     return ARES_ENOMEM;
   memcpy(*s, name, nlen);
   (*s)[nlen] = '.';
+  if (strcmp(domain, ".") == 0) {
+    /* Avoid appending the root domain to the separator, which would set *s to
+       an ill-formed value (ending in two consequtive dots). */
+    dlen = 0;
+  }
   memcpy(*s + nlen + 1, domain, dlen);
   (*s)[nlen + 1 + dlen] = 0;
   return ARES_SUCCESS;

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -525,6 +525,22 @@ TEST(Misc, OnionDomain) {
   EXPECT_EQ(1, ares__is_onion_domain("YES.ONION"));
   EXPECT_EQ(1, ares__is_onion_domain("YES.ONION."));
 }
+
+TEST_F(LibraryTest, CatDomain) {
+  char *s;
+
+  ares__cat_domain("foo", "example.net", &s);
+  EXPECT_STREQ("foo.example.net", s);
+  ares_free(s);
+
+  ares__cat_domain("foo", ".", &s);
+  EXPECT_STREQ("foo.", s);
+  ares_free(s);
+
+  ares__cat_domain("foo", "example.net.", &s);
+  EXPECT_STREQ("foo.example.net.", s);
+  ares_free(s);
+}
 #endif
 
 #ifdef CARES_EXPOSE_STATICS


### PR DESCRIPTION
This prevents the result of qualifying "name" with "." being "name.." which is ill-formed.

Fixes: https://github.com/c-ares/c-ares/issues/545