### PR TITLE
Fix for ares dns timeout fix and Returning the available address

### DIFF
--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -576,6 +576,10 @@ static void host_callback(void *arg, int status, int timeouts,
   if (status == ARES_SUCCESS)
     {
       addinfostatus = ares__parse_into_addrinfo(abuf, alen, 1, hquery->port, hquery->ai);
+      if (hquery->hints.ai_family  == AF_UNSPEC && addinfostatus == ARES_SUCCESS && hquery->ai->nodes)
+        {
+          hquery->channel->ares_succ_resp_flag = 1;
+        }
     }
 
   if (!hquery->remaining)
@@ -748,6 +752,7 @@ void ares_getaddrinfo(ares_channel channel,
   hquery->next_domain = -1;
   hquery->remaining = 0;
   hquery->nodata_cnt = 0;
+  hquery->channel->ares_succ_resp_flag = 0;
 
   /* Start performing lookups according to channel->lookups. */
   next_lookup(hquery, ARES_ECONNREFUSED /* initial error code */);

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -331,6 +331,7 @@ struct ares_channeldata {
 
   /* Path for hosts file, configurable via ares_options */
   char *hosts_path;
+  int ares_succ_resp_flag;
 };
 
 /* Does the domain end in ".onion" or ".onion."? Case-insensitive. */

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -764,7 +764,7 @@ static void next_server(ares_channel channel, struct query *query,
    * servers to try. In total, we need to do channel->nservers * channel->tries
    * attempts. Use query->try to remember how many times we already attempted
    * this query. Use modular arithmetic to find the next server to try. */
-  while (++(query->try_count) < (channel->nservers * channel->tries))
+  while ((++(query->try_count) < (channel->nservers * channel->tries)) && (!channel->ares_succ_resp_flag))
     {
       struct server_state *server;
 


### PR DESCRIPTION
#544 As part of this PR raising this new PR.

C-ares should promptly return the partial query response to curl within the curl timeout. In other words, C-ares should immediately provide either an IPv4 or IPv6 address without waiting for a potentially failed query to complete.

Two scenarios illustrate this behavior:

Single Server Scenario: In the first scenario, when there is only a single server available, and the PF_UNSPEC case is encountered, C-ares will initiate queries for both IPv4 and IPv6 address classes. If the IPv4 query succeeds, it will immediately return the IPv4 address, bypassing the need to complete the IPv6 query.
Multiple Servers Scenario: In the second scenario, suppose there are two servers—S1 and S2. When facing the PF_UNSPEC case, C-ares will initiate queries for both IPv4 and IPv6 address classes. If the IPv4 query is successful but the IPv6 query fails with S1 server, C-ares will not proceed to retry the IPv6 query with S2 server. Instead, it will promptly return the available IPv4 address.
This approach ensures that C-ares does not unnecessarily delay the response to curl, enhancing efficiency and responsiveness.

**Changes:**
In this file [src/lib/ares_private.h](https://github.com/c-ares/c-ares/compare/main...sachusachin622:dev/ares-dns-timeout-fix?expand=1#diff-99be976f40a9f77bf713f4f1f878ba101d3d01fa9b9fbb41cc27a721935a9d53) 
we are declaring one new flag **ares_succ_resp_flag** to set this flag when we get the successful response.

In this file [src/lib/ares_getaddrinfo.c](https://github.com/c-ares/c-ares/compare/main...sachusachin622:dev/ares-dns-timeout-fix?expand=1#diff-8f022ca768aa72d2ef3c6774683fd3591eb1639966829d5157ea5cfdbc61d7b1)
We are setting this ares_succ_resp_flag

In this file [src/lib/ares_process.c](https://github.com/c-ares/c-ares/compare/main...sachusachin622:dev/ares-dns-timeout-fix?expand=1#diff-1cbf06a764b0c1e45d9090473de26423e9d0586021f6295caf4e5a785e700f3a)
We are checking the flag is set or not if it is one it will not send new query

Please help me to review. Is my changes are correct.

Thanks,
Sachin

