### PR TITLE
ares_getaddrinfo(): Fail faster on AF_UNSPEC if we've already received one address class 

### DIFF
--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -51,6 +51,7 @@
 #include "ares.h"
 #include "bitncmp.h"
 #include "ares_private.h"
+#include "ares_dns.h"
 
 #ifdef WATT32
 #undef WIN32
@@ -75,6 +76,8 @@ struct host_query
   int remaining;   /* number of DNS answers waiting for */
   int next_domain; /* next search domain to try */
   int nodata_cnt; /* Track nodata responses to possibly override final result */
+  unsigned short qid_a;    /* qid for A request */
+  unsigned short qid_aaaa; /* qid for AAAA request */
 };
 
 static const struct ares_addrinfo_hints default_hints = {
@@ -565,17 +568,42 @@ static void next_lookup(struct host_query *hquery, int status)
     }
 }
 
+
+static void terminate_retries(struct host_query *hquery, unsigned short qid)
+{
+  unsigned short term_qid = (qid == hquery->qid_a)?hquery->qid_aaaa:hquery->qid_a;
+  ares_channel   channel  = hquery->channel;
+  struct query  *query    = NULL;
+
+  /* No other outstanding queries, nothing to do */
+  if (!hquery->remaining)
+    return;
+
+  query = ares__htable_stvp_get_direct(channel->queries_by_qid, term_qid);
+  if (query == NULL)
+    return;
+
+  query->no_retries = 1;
+}
+
+
 static void host_callback(void *arg, int status, int timeouts,
                           unsigned char *abuf, int alen)
 {
   struct host_query *hquery = (struct host_query*)arg;
   int addinfostatus = ARES_SUCCESS;
+  unsigned short qid = 0;
   hquery->timeouts += timeouts;
   hquery->remaining--;
 
   if (status == ARES_SUCCESS)
     {
       addinfostatus = ares__parse_into_addrinfo(abuf, alen, 1, hquery->port, hquery->ai);
+      if (addinfostatus == ARES_SUCCESS && alen >= HFIXEDSZ)
+        {
+          qid = DNS_HEADER_QID(abuf); /* Converts to host byte order */
+          terminate_retries(hquery, qid);
+        }
     }
 
   if (!hquery->remaining)
@@ -796,16 +824,20 @@ static int next_dns_lookup(struct host_query *hquery)
         {
           case AF_INET:
             hquery->remaining += 1;
-            ares_query(hquery->channel, s, C_IN, T_A, host_callback, hquery);
+            hquery->qid_a = ares_query_qid(hquery->channel, s, C_IN, T_A,
+                                           host_callback, hquery);
             break;
           case AF_INET6:
             hquery->remaining += 1;
-            ares_query(hquery->channel, s, C_IN, T_AAAA, host_callback, hquery);
+            hquery->qid_aaaa = ares_query_qid(hquery->channel, s, C_IN, T_AAAA,
+                                              host_callback, hquery);
             break;
           case AF_UNSPEC:
             hquery->remaining += 2;
-            ares_query(hquery->channel, s, C_IN, T_A, host_callback, hquery);
-            ares_query(hquery->channel, s, C_IN, T_AAAA, host_callback, hquery);
+            hquery->qid_a = ares_query_qid(hquery->channel, s, C_IN, T_A,
+                                           host_callback, hquery);
+            hquery->qid_aaaa = ares_query_qid(hquery->channel, s, C_IN, T_AAAA,
+                                              host_callback, hquery);
             break;
           default: break;
         }

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -753,7 +753,7 @@ void ares_getaddrinfo(ares_channel channel,
       callback(arg, ARES_ENOMEM, 0, NULL);
       return;
     }
-
+  memset(hquery, 0, sizeof(*hquery));
   hquery->name = ares_strdup(name);
   ares_free(alias_name);
   if (!hquery->name)

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -366,12 +366,20 @@ extern void (*ares_free)(void *ptr);
 int ares__timedout(struct timeval *now,
                    struct timeval *check);
 
-void ares__send_query(ares_channel channel, struct query *query,
-                      struct timeval *now);
-/* Identical to ares_query, but returns the query id */
-unsigned short ares_query_qid(ares_channel channel, const char *name,
+/* Returns one of the normal ares status codes like ARES_SUCCESS */
+int ares__send_query(ares_channel channel, struct query *query,
+                     struct timeval *now);
+
+/* Identical to ares_query, but returns a normal ares return code like
+ * ARES_SUCCESS, and can be passed the qid by reference which will be
+ * filled in on ARES_SUCCESS */
+int ares_query_qid(ares_channel channel, const char *name,
                               int dnsclass, int type, ares_callback callback,
-                              void *arg);
+                              void *arg, unsigned short *qid);
+/* Identical to ares_send() except returns normal ares return codes like
+ * ARES_SUCCESS */
+int ares_send_ex(ares_channel channel, const unsigned char *qbuf, int qlen,
+                 ares_callback callback, void *arg);
 void ares__close_connection(struct server_connection *conn);
 void ares__close_sockets(struct server_state *server);
 void ares__check_cleanup_conn(ares_channel channel, ares_socket_t fd);

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -248,6 +248,8 @@ struct query {
   int using_tcp;
   int error_status;
   int timeouts; /* number of timeouts we saw for this request */
+  int no_retries; /* do not perform any additional retries, this is set when
+                   * a query is to be canceled */
 };
 
 /* Per-server state for a query */
@@ -366,6 +368,10 @@ int ares__timedout(struct timeval *now,
 
 void ares__send_query(ares_channel channel, struct query *query,
                       struct timeval *now);
+/* Identical to ares_query, but returns the query id */
+unsigned short ares_query_qid(ares_channel channel, const char *name,
+                              int dnsclass, int type, ares_callback callback,
+                              void *arg);
 void ares__close_connection(struct server_connection *conn);
 void ares__close_sockets(struct server_state *server);
 void ares__check_cleanup_conn(ares_channel channel, ares_socket_t fd);

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -806,8 +806,11 @@ static void next_server(ares_channel channel, struct query *query,
   /* We need to try each server channel->tries times. We have channel->nservers
    * servers to try. In total, we need to do channel->nservers * channel->tries
    * attempts. Use query->try to remember how many times we already attempted
-   * this query. Use modular arithmetic to find the next server to try. */
-  while (++(query->try_count) < (channel->nservers * channel->tries)) {
+   * this query. Use modular arithmetic to find the next server to try.
+   * A query can be requested be terminated at the next interval by setting
+   * query->no_retries */
+  while (++(query->try_count) < (channel->nservers * channel->tries) &&
+         !query->no_retries) {
     struct server_state *server;
 
     /* Move on to the next server. */

--- a/src/lib/ares_query.c
+++ b/src/lib/ares_query.c
@@ -52,8 +52,9 @@ static unsigned short generate_unique_id(ares_channel channel)
   return (unsigned short)id;
 }
 
-void ares_query(ares_channel channel, const char *name, int dnsclass,
-                int type, ares_callback callback, void *arg)
+unsigned short ares_query_qid(ares_channel channel, const char *name,
+                              int dnsclass, int type, ares_callback callback,
+                              void *arg)
 {
   struct qquery *qquery;
   unsigned char *qbuf;
@@ -68,7 +69,7 @@ void ares_query(ares_channel channel, const char *name, int dnsclass,
     {
       if (qbuf != NULL) ares_free(qbuf);
       callback(arg, status, 0, NULL, 0);
-      return;
+      return 0;
     }
 
   /* Allocate and fill in the query structure. */
@@ -77,7 +78,7 @@ void ares_query(ares_channel channel, const char *name, int dnsclass,
     {
       ares_free_string(qbuf);
       callback(arg, ARES_ENOMEM, 0, NULL, 0);
-      return;
+      return 0;
     }
   qquery->callback = callback;
   qquery->arg = arg;
@@ -85,7 +86,15 @@ void ares_query(ares_channel channel, const char *name, int dnsclass,
   /* Send it off.  qcallback will be called when we get an answer. */
   ares_send(channel, qbuf, qlen, qcallback, qquery);
   ares_free_string(qbuf);
+  return id;
 }
+
+void ares_query(ares_channel channel, const char *name, int dnsclass,
+                int type, ares_callback callback, void *arg)
+{
+  ares_query_qid(channel, name, dnsclass, type, callback, arg);
+}
+
 
 static void qcallback(void *arg, int status, int timeouts, unsigned char *abuf, int alen)
 {

--- a/src/lib/ares_query.c
+++ b/src/lib/ares_query.c
@@ -52,9 +52,9 @@ static unsigned short generate_unique_id(ares_channel channel)
   return (unsigned short)id;
 }
 
-unsigned short ares_query_qid(ares_channel channel, const char *name,
-                              int dnsclass, int type, ares_callback callback,
-                              void *arg)
+int ares_query_qid(ares_channel channel, const char *name,
+                   int dnsclass, int type, ares_callback callback,
+                   void *arg, unsigned short *qid)
 {
   struct qquery *qquery;
   unsigned char *qbuf;
@@ -69,7 +69,7 @@ unsigned short ares_query_qid(ares_channel channel, const char *name,
     {
       if (qbuf != NULL) ares_free(qbuf);
       callback(arg, status, 0, NULL, 0);
-      return 0;
+      return status;
     }
 
   /* Allocate and fill in the query structure. */
@@ -78,21 +78,25 @@ unsigned short ares_query_qid(ares_channel channel, const char *name,
     {
       ares_free_string(qbuf);
       callback(arg, ARES_ENOMEM, 0, NULL, 0);
-      return 0;
+      return ARES_ENOMEM;
     }
   qquery->callback = callback;
   qquery->arg = arg;
 
   /* Send it off.  qcallback will be called when we get an answer. */
-  ares_send(channel, qbuf, qlen, qcallback, qquery);
+  status = ares_send_ex(channel, qbuf, qlen, qcallback, qquery);
   ares_free_string(qbuf);
-  return id;
+
+  if (status == ARES_SUCCESS && qid)
+    *qid = id;
+
+  return status;
 }
 
 void ares_query(ares_channel channel, const char *name, int dnsclass,
                 int type, ares_callback callback, void *arg)
 {
-  ares_query_qid(channel, name, dnsclass, type, callback, arg);
+  ares_query_qid(channel, name, dnsclass, type, callback, arg, NULL);
 }
 
 

--- a/src/lib/ares_send.c
+++ b/src/lib/ares_send.c
@@ -28,8 +28,8 @@
 #include "ares_dns.h"
 #include "ares_private.h"
 
-void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
-               ares_callback callback, void *arg)
+int ares_send_ex(ares_channel channel, const unsigned char *qbuf, int qlen,
+                 ares_callback callback, void *arg)
 {
   struct query *query;
   int i, packetsz;
@@ -39,19 +39,19 @@ void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
   if (qlen < HFIXEDSZ || qlen >= (1 << 16))
     {
       callback(arg, ARES_EBADQUERY, 0, NULL, 0);
-      return;
+      return ARES_EBADQUERY;
     }
   if (channel->nservers < 1)
     {
       callback(arg, ARES_ESERVFAIL, 0, NULL, 0);
-      return;
+      return ARES_ESERVFAIL;
     }
   /* Allocate space for query and allocated fields. */
   query = ares_malloc(sizeof(struct query));
   if (!query)
     {
       callback(arg, ARES_ENOMEM, 0, NULL, 0);
-      return;
+      return ARES_ENOMEM;
     }
   memset(query, 0, sizeof(*query));
   query->channel = channel;
@@ -60,7 +60,7 @@ void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
     {
       ares_free(query);
       callback(arg, ARES_ENOMEM, 0, NULL, 0);
-      return;
+      return ARES_ENOMEM;
     }
   query->server_info = ares_malloc(channel->nservers *
                                    sizeof(query->server_info[0]));
@@ -69,7 +69,7 @@ void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
       ares_free(query->tcpbuf);
       ares_free(query);
       callback(arg, ARES_ENOMEM, 0, NULL, 0);
-      return;
+      return ARES_ENOMEM;
     }
 
   /* Compute the query ID.  Start with no timeout. */
@@ -121,7 +121,7 @@ void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
   if (query->node_all_queries == NULL) {
     callback(arg, ARES_ENOMEM, 0, NULL, 0);
     ares__free_query(query);
-    return;
+    return ARES_ENOMEM;
   }
 
   /* Keep track of queries bucketed by qid, so we can process DNS
@@ -130,10 +130,16 @@ void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
   if (!ares__htable_stvp_insert(channel->queries_by_qid, query->qid, query)) {
     callback(arg, ARES_ENOMEM, 0, NULL, 0);
     ares__free_query(query);
-    return;
+    return ARES_ENOMEM;
   }
 
   /* Perform the first query action. */
   now = ares__tvnow();
-  ares__send_query(channel, query, &now);
+  return ares__send_query(channel, query, &now);
+}
+
+void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
+               ares_callback callback, void *arg)
+{
+  ares_send_ex(channel, qbuf, qlen, callback, arg);
 }

--- a/src/lib/ares_send.c
+++ b/src/lib/ares_send.c
@@ -53,6 +53,7 @@ void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
       callback(arg, ARES_ENOMEM, 0, NULL, 0);
       return;
     }
+  memset(query, 0, sizeof(*query));
   query->channel = channel;
   query->tcpbuf = ares_malloc(qlen + 2);
   if (!query->tcpbuf)


### PR DESCRIPTION
As per #541, when using AF_UNSPEC with ares_getaddrinfo() (and in turn with ares_gethostbynam()) if we receive a successful response for one address class, we should not allow the other address class to continue on with retries, just return the address class we have.

This will limit the overall query time to whatever timeout remains for the pending query for the other address class, it will not, however, terminate the other query as it may still prove to be successful (possibly coming in less than a millisecond later) and we'd want that result still.  It just turns off additional error processing to get the result back quicker.