### PR TITLE
Test Harness: use ares_timeout() instead of 100ms hard coded

### DIFF
--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -101,9 +101,11 @@ void ProcessWork(ares_channel channel,
       }
     }
 
-    // Wait for activity or timeout.
-    tv.tv_sec = 0;
-    tv.tv_usec = 100000;  // 100ms
+    /* If ares_timeout returns NULL, it means there are no requests in queue,
+     * so we can break out */
+    if (ares_timeout(channel, NULL, &tv) == NULL)
+      return;
+
     count = select(nfds, &readers, &writers, nullptr, &tv);
     if (count < 0) {
       fprintf(stderr, "select() failed, errno %d\n", errno);


### PR DESCRIPTION
The test framework was using 100ms timeout passed to select(), and not using ares_timeout() to calculate the actual recommended value based on the queries in queue.  Using ares_timeout() tests the functionality of ares_timeout() itself and will provide more responsive results.