### PR TITLE
ares__buf should return standard error codes.  more helpers implemented.

### DIFF
--- a/src/lib/ares__buf.c
+++ b/src/lib/ares__buf.c
@@ -96,22 +96,15 @@ static int ares__buf_is_const(const ares__buf_t *buf)
 }
 
 
-static void ares__buf_reclaim(ares__buf_t *buf, size_t needed_size)
+static void ares__buf_reclaim(ares__buf_t *buf)
 {
   size_t prefix_size;
-  size_t remaining_size;
   size_t data_size;
 
   if (buf == NULL)
     return;
 
   if (ares__buf_is_const(buf))
-    return;
-
-  remaining_size = buf->alloc_buf_len - buf->data_len;
-
-  /* No need to do an expensive move operation, we have enough to just append */
-  if (remaining_size >= needed_size)
     return;
 
   if (buf->tag_offset != SIZE_MAX) {
@@ -143,23 +136,33 @@ static int ares__buf_ensure_space(ares__buf_t *buf, size_t needed_size)
   unsigned char *ptr;
 
   if (buf == NULL)
-    return 0;
+    return ARES_EFORMERR;
 
   if (ares__buf_is_const(buf))
-    return 0;
+    return ARES_EFORMERR;
+
+  /* When calling ares__buf_finish_str() we end up adding a null terminator,
+   * so we want to ensure the size is always sufficient for this as we don't
+   * want an ARES_ENOMEM at that point */
+  needed_size++;
+
+  /* No need to do an expensive move operation, we have enough to just append */
+  remaining_size = buf->alloc_buf_len - buf->data_len;
+  if (remaining_size >= needed_size)
+    return ARES_SUCCESS;
 
   /* See if just moving consumed data frees up enough space */
-  ares__buf_reclaim(buf, needed_size);
+  ares__buf_reclaim(buf);
 
   remaining_size = buf->alloc_buf_len - buf->data_len;
   if (remaining_size >= needed_size)
-    return 1;
+    return ARES_SUCCESS;
 
   alloc_size = buf->alloc_buf_len;
 
   /* Not yet started */
   if (alloc_size == 0)
-    alloc_size = 512;
+    alloc_size = 16; /* Always shifts 1, so ends up being 32 minimum */
 
   /* Increase allocation by powers of 2 */
   do {
@@ -169,38 +172,44 @@ static int ares__buf_ensure_space(ares__buf_t *buf, size_t needed_size)
 
   ptr = ares_realloc(buf->alloc_buf, alloc_size);
   if (ptr == NULL)
-    return 0;
+    return ARES_ENOMEM;
 
   buf->alloc_buf     = ptr;
   buf->alloc_buf_len = alloc_size;
   buf->data          = ptr;
 
-  return 1;
+  return ARES_SUCCESS;
 }
 
 
 int ares__buf_append(ares__buf_t *buf, const unsigned char *data,
                      size_t data_len)
 {
-  if (data == NULL || data_len == 0)
-    return 0;
+  int status;
 
-  if (!ares__buf_ensure_space(buf, data_len))
-    return 0;
+  if (data == NULL || data_len == 0)
+    return ARES_EFORMERR;
+
+  status = ares__buf_ensure_space(buf, data_len);
+  if (status != ARES_SUCCESS)
+    return status;
 
   memcpy(buf->alloc_buf + buf->data_len, data, data_len);
   buf->data_len += data_len;
-  return 1;
+  return ARES_SUCCESS;
 }
 
 
 unsigned char *ares__buf_append_start(ares__buf_t *buf, size_t *len)
 {
-  if (len == NULL || *len == 0)
-    return 0;
+  int status;
 
-  if (!ares__buf_ensure_space(buf, *len))
-    return 0;
+  if (len == NULL || *len == 0)
+    return NULL;
+
+  status = ares__buf_ensure_space(buf, *len);
+  if (status != ARES_SUCCESS)
+    return NULL;
 
   *len = buf->alloc_buf_len - buf->data_len;
   return buf->alloc_buf + buf->data_len;
@@ -216,6 +225,40 @@ void ares__buf_append_finish(ares__buf_t *buf, size_t len)
 }
 
 
+unsigned char *ares__buf_finish_bin(ares__buf_t *buf, size_t *len)
+{
+  unsigned char *ptr = NULL;
+  if (buf == NULL || len == NULL || ares__buf_is_const(buf))
+    return NULL;
+
+  ares__buf_reclaim(buf);
+  ptr  = buf->alloc_buf;
+  *len = buf->data_len;
+  ares_free(buf);
+  return ptr;
+}
+
+
+char *ares__buf_finish_str(ares__buf_t *buf, size_t *len)
+{
+  char  *ptr;
+  size_t mylen;
+
+  ptr = (char *)ares__buf_finish_bin(buf, &mylen);
+  if (ptr == NULL)
+    return NULL;
+
+  if (len != NULL)
+    *len = mylen;
+
+  /* NOTE: ensured via ares__buf_ensure_space() that there is always at least
+   *       1 extra byte available for this specific use-case */
+  ptr[mylen] = 0;
+
+  return ptr;
+}
+
+
 void ares__buf_tag(ares__buf_t *buf)
 {
   if (buf == NULL)
@@ -228,21 +271,21 @@ void ares__buf_tag(ares__buf_t *buf)
 int ares__buf_tag_rollback(ares__buf_t *buf)
 {
   if (buf == NULL || buf->tag_offset == SIZE_MAX)
-    return 0;
+    return ARES_EFORMERR;
 
   buf->offset     = buf->tag_offset;
   buf->tag_offset = SIZE_MAX;
-  return 1;
+  return ARES_SUCCESS;
 }
 
 
 int ares__buf_tag_clear(ares__buf_t *buf)
 {
   if (buf == NULL || buf->tag_offset == SIZE_MAX)
-    return 0;
+    return ARES_EFORMERR;
 
   buf->tag_offset = SIZE_MAX;
-  return 1;
+  return ARES_SUCCESS;
 }
 
 
@@ -276,10 +319,10 @@ int ares__buf_consume(ares__buf_t *buf, size_t len)
   ares__buf_fetch(buf, &remaining_len);
 
   if (remaining_len < len)
-    return 0;
+    return ARES_EBADRESP;
 
   buf->offset += len;
-  return 1;
+  return ARES_SUCCESS;
 }
 
 
@@ -289,7 +332,7 @@ int ares__buf_fetch_be16(ares__buf_t *buf, unsigned short *u16)
   const unsigned char *ptr = ares__buf_fetch(buf, &remaining_len);
 
   if (buf == NULL || u16 == NULL || remaining_len < sizeof(*u16))
-    return 0;
+    return ARES_EBADRESP;
 
   *u16 = (unsigned short)((unsigned short)(ptr[0]) << 8 | (unsigned short)ptr[1]);
 
@@ -304,10 +347,117 @@ int ares__buf_fetch_bytes(ares__buf_t *buf, unsigned char *bytes,
   const unsigned char *ptr = ares__buf_fetch(buf, &remaining_len);
 
   if (buf == NULL || bytes == NULL || len == 0 || remaining_len < len)
-    return 0;
+    return ARES_EBADRESP;
 
   memcpy(bytes, ptr, len);
   return ares__buf_consume(buf, len);
+}
+
+
+size_t ares__buf_consume_whitespace(ares__buf_t *buf, int include_linefeed)
+{
+  size_t               remaining_len = 0;
+  const unsigned char *ptr           = ares__buf_fetch(buf, &remaining_len);
+  size_t               i;
+
+  if (ptr == NULL)
+    return 0;
+
+  for (i=0; i<remaining_len; i++) {
+    switch(ptr[i]) {
+      case '\r':
+      case '\t':
+      case ' ':
+      case '\v':
+      case '\f':
+        break;
+      case '\n':
+        if (!include_linefeed)
+          goto done;
+        break;
+      default:
+        goto done;
+    }
+  }
+
+done:
+  if (i > 0)
+    ares__buf_consume(buf, i);
+  return i;
+}
+
+size_t ares__buf_consume_nonwhitespace(ares__buf_t *buf)
+{
+  size_t               remaining_len = 0;
+  const unsigned char *ptr           = ares__buf_fetch(buf, &remaining_len);
+  size_t               i;
+
+  if (ptr == NULL)
+    return 0;
+
+  for (i=0; i<remaining_len; i++) {
+    switch(ptr[i]) {
+      case '\r':
+      case '\t':
+      case ' ':
+      case '\v':
+      case '\f':
+      case '\n':
+        goto done;
+      default:
+        break;
+    }
+  }
+
+done:
+  if (i > 0)
+    ares__buf_consume(buf, i);
+  return i;
+}
+
+size_t ares__buf_consume_line(ares__buf_t *buf, int include_linefeed)
+{
+  size_t               remaining_len = 0;
+  const unsigned char *ptr           = ares__buf_fetch(buf, &remaining_len);
+  size_t               i;
+
+  if (ptr == NULL)
+    return 0;
+
+  for (i=0; i<remaining_len; i++) {
+    switch(ptr[i]) {
+      case '\n':
+        if (include_linefeed)
+          i++;
+        goto done;
+      default:
+        break;
+    }
+  }
+
+done:
+  if (i > 0)
+    ares__buf_consume(buf, i);
+  return i;
+}
+
+
+int ares__buf_begins_with(ares__buf_t *buf, const unsigned char *data,
+                          size_t data_len)
+{
+  size_t               remaining_len = 0;
+  const unsigned char *ptr           = ares__buf_fetch(buf, &remaining_len);
+
+  if (ptr == NULL || data == NULL || data_len == 0)
+    return ARES_EFORMERR;
+
+  if (data_len > remaining_len)
+    return ARES_EBADRESP;
+
+  if (memcmp(ptr, data, data_len) == 0)
+    return ARES_EBADRESP;
+
+  return ARES_SUCCESS;
 }
 
 
@@ -324,6 +474,3 @@ const unsigned char *ares__buf_peek(const ares__buf_t *buf, size_t *len)
   return ares__buf_fetch(buf, len);
 }
 
-#if 0
-int ares__buf_fetch_dnsheader(ares__buf_t *buf, ares_dns_header_t *header);
-#endif


### PR DESCRIPTION
Some final cleanups before 1.20.0 release to limit the need to make API changes to new code in the next release.