### PR TITLE
Fix typo in fuzzcheck target name

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -37,7 +37,7 @@ CXXFLAGS += -Wall $(PTHREAD_CFLAGS)
 # Makefile.inc provides the various *SOURCES and *HEADERS defines
 include Makefile.inc
 
-TESTS = arestest fuzzcheck.sho
+TESTS = arestest fuzzcheck.sh
 
 noinst_LTLIBRARIES = libgmock.la
 


### PR DESCRIPTION
This seems to be a vim'esque typo introduced with c1b00c41.