### PR TITLE
Increase compiler warnings by default

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -23,7 +23,7 @@ Files: m4/ax_pthread.m4
 Copyright: see file
 License: GPL-3.0-or-later WITH Autoconf-exception-3.0
 
-Files: m4/ax_cxx_compile_stdcxx.m4 m4/ax_cxx_compile_stdcxx_11.m4 me/ax_require_defined.m4 m4/ax_check_gnu_make.m4 m4/ax_file_escapes.m4 m4/ax_require_defined.m4 m4/ax_ac_append_to_file.m4 m4/ax_ac_print_to_file.m4 m4/ax_add_am_macro_static.m4 m4/ax_file_escapes.m4 m4/ax_am_macros_static.m4
+Files: m4/ax_cxx_compile_stdcxx.m4 m4/ax_cxx_compile_stdcxx_11.m4 me/ax_require_defined.m4 m4/ax_check_gnu_make.m4 m4/ax_file_escapes.m4 m4/ax_require_defined.m4 m4/ax_ac_append_to_file.m4 m4/ax_ac_print_to_file.m4 m4/ax_add_am_macro_static.m4 m4/ax_file_escapes.m4 m4/ax_am_macros_static.m4 m4/ax_append_flag.m4 m4/ax_append_compile_flags.m4 m4/ax_check_compile_flag.m4
 Copyright: see files
 License: FSFAP
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
-CMAKE_MINIMUM_REQUIRED (VERSION 3.1.0)
+CMAKE_MINIMUM_REQUIRED (VERSION 3.4.3)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 
 INCLUDE (CheckIncludeFiles)
 INCLUDE (CheckTypeSize)
@@ -11,6 +13,8 @@ INCLUDE (CheckStructHasMember)
 INCLUDE (CheckLibraryExists)
 
 PROJECT (c-ares LANGUAGES C VERSION "1.20.1" )
+
+INCLUDE (EnableWarnings)
 
 # Set this version before release
 SET (CARES_VERSION "${PROJECT_VERSION}")

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,12 +32,11 @@ EXTRA_DIST = AUTHORS CHANGES README.cares $(man_MANS) RELEASE-NOTES	\
  CMakeLists.txt Makefile.dj Makefile.m32 Makefile.netware Makefile.msvc \
  Makefile.Watcom AUTHORS CONTRIBUTING.md SECURITY.md TODO
 
-
 CLEANFILES = $(PDFPAGES) $(HTMLPAGES)
 
 DISTCLEANFILES = include/ares_build.h
 
-DIST_SUBDIRS = include src test docs
+DIST_SUBDIRS = include src test docs cmake
 
 SUBDIRS = @BUILD_SUBDIRS@
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -30,13 +30,14 @@ EXTRA_DIST = AUTHORS CHANGES README.cares $(man_MANS) RELEASE-NOTES	\
  c-ares-config.cmake.in libcares.pc.cmake libcares.pc.in buildconf get_ver.awk \
  maketgz TODO README.msvc $(MSVCFILES) INSTALL.md README.md LICENSE.md \
  CMakeLists.txt Makefile.dj Makefile.m32 Makefile.netware Makefile.msvc \
- Makefile.Watcom AUTHORS CONTRIBUTING.md SECURITY.md TODO
+ Makefile.Watcom AUTHORS CONTRIBUTING.md SECURITY.md TODO \
+ cmake/EnableWarnings.cmake
 
 CLEANFILES = $(PDFPAGES) $(HTMLPAGES)
 
 DISTCLEANFILES = include/ares_build.h
 
-DIST_SUBDIRS = include src test docs cmake
+DIST_SUBDIRS = include src test docs
 
 SUBDIRS = @BUILD_SUBDIRS@
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -25,7 +25,7 @@ if [ "$BUILD_TYPE" != "cmake" -a "$BUILD_TYPE" != "valgrind" ]; then
         export LDFLAGS="${LDFLAGS} -isysroot ${SYSROOT}"
     fi
     $SCAN_WRAP ../configure --disable-symbol-hiding --enable-expose-statics --enable-maintainer-mode --enable-debug $CONFIG_OPTS
-    $SCAN_WRAP make V=1
+    $SCAN_WRAP make
 else
     # Use cmake for valgrind to prevent libtool script wrapping of tests that interfere with valgrind
     mkdir cmakebld

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -25,7 +25,7 @@ if [ "$BUILD_TYPE" != "cmake" -a "$BUILD_TYPE" != "valgrind" ]; then
         export LDFLAGS="${LDFLAGS} -isysroot ${SYSROOT}"
     fi
     $SCAN_WRAP ../configure --disable-symbol-hiding --enable-expose-statics --enable-maintainer-mode --enable-debug $CONFIG_OPTS
-    $SCAN_WRAP make
+    $SCAN_WRAP make V=1
 else
     # Use cmake for valgrind to prevent libtool script wrapping of tests that interfere with valgrind
     mkdir cmakebld

--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -1,0 +1,405 @@
+# EnableWarnings.cmake
+#
+# Checks for and turns on a large number of warning C flags.
+#
+# Adds the following helper functions:
+#
+#	remove_warnings(... list of warnings ...)
+#		Turn off given list of individual warnings for all targets and subdirectories added after this.
+#
+#   remove_all_warnings()
+#		Remove all warning flags, add -w to suppress built-in warnings.
+#
+#   remove_all_warnings_from_targets(... list of targets ...)
+#       Suppress warnings for the given targets only.
+#
+#   push_warnings()
+#		Save current warning flags by pushing them onto an internal stack. Note that modifications to the internal
+#		stack are only visible in the current CMakeLists.txt file and its children.
+#
+#       Note: changing warning flags multiple times in the same directory only affects add_subdirectory() calls.
+#             Targets in the directory will always use the warning flags in effect at the end of the CMakeLists.txt
+#             file - this is due to really weird and annoying legacy behavior of CMAKE_C_FLAGS.
+#
+#   pop_warnings()
+#       Restore the last set of flags that were saved with push_warnings(). Note that modifications to the internal
+#		stack are only visible in the current CMakeLists.txt file and its children.
+#
+
+if (_internal_enable_warnings_already_run)
+	return()
+endif ()
+set(_internal_enable_warnings_already_run TRUE)
+
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
+
+get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+
+# internal helper: _int_enable_warnings_set_flags_ex(langs_var configs_var [warnings flags])
+function(_int_enable_warnings_set_flags_ex langs_var configs_var)
+	if (NOT ARGN)
+		return()
+	endif ()
+
+	if (NOT ${configs_var})
+		set(${configs_var} "NONE")
+	endif ()
+	string(TOUPPER "${${configs_var}}" ${configs_var})
+
+	foreach(_flag ${ARGN})
+		string(MAKE_C_IDENTIFIER "HAVE_${_flag}" varname)
+
+		if ("C" IN_LIST ${langs_var})
+			check_c_compiler_flag(${_flag} ${varname})
+			if (${varname})
+				foreach (config IN LISTS ${configs_var})
+					if (config STREQUAL "NONE")
+						set(config)
+					else ()
+						set(config "_${config}")
+					endif ()
+					string(APPEND CMAKE_C_FLAGS${config} " ${_flag}")
+				endforeach ()
+			endif ()
+		endif ()
+
+		if ("CXX" IN_LIST ${langs_var})
+			string(APPEND varname "_CXX")
+			check_cxx_compiler_flag(${_flag} ${varname})
+			if (${varname})
+				foreach (config IN LISTS ${configs_var})
+					if (config STREQUAL "NONE")
+						set(config)
+					else ()
+						set(config "_${config}")
+					endif ()
+					string(APPEND CMAKE_CXX_FLAGS${config} " ${_flag}")
+				endforeach ()
+			endif ()
+		endif ()
+	endforeach()
+
+	foreach(lang C CXX)
+		foreach (config IN LISTS ${configs_var})
+			string(TOUPPER "${config}" config)
+			if (config STREQUAL "NONE")
+				set(config)
+			else ()
+				set(config "_${config}")
+			endif ()
+			string(STRIP "${CMAKE_${lang}_FLAGS${config}}" CMAKE_${lang}_FLAGS${config})
+			set(CMAKE_${lang}_FLAGS${config} "${CMAKE_${lang}_FLAGS${config}}" PARENT_SCOPE)
+		endforeach ()
+	endforeach()
+endfunction()
+
+# internal helper: _int_enable_warnings_set_flags(langs_var [warnings flags])
+macro(_int_enable_warnings_set_flags langs_var)
+	set(configs "NONE")
+	_int_enable_warnings_set_flags_ex(${langs_var} configs ${ARGN})
+endmacro()
+
+set(_flags_C)
+set(_flags_CXX)
+set(_debug_flags_C)
+set(_debug_flags_CXX)
+
+if (MSVC)
+	# Visual Studio uses a completely different nomenclature for warnings than gcc/mingw/clang, so none of the
+	# "-W[name]" warnings will work.
+
+	# W4 would be better but it produces unnecessary warnings like:
+	# *  warning C4706: assignment within conditional expression
+	#     Triggered when doing "while(1)"
+	# * warning C4115: 'timeval' : named type definition in parentheses
+	# * warning C4201: nonstandard extension used : nameless struct/union
+	#     Triggered by system includes (commctrl.h, shtypes.h, Shlobj.h)
+	set(_flags
+		/W3
+		/we4013 # Treat "function undefined, assuming extern returning int" warning as an error. https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4013
+	)
+
+	# Disable some warnings to reduce noise level on visual studio.
+	if (NOT WIN32_STRICT_WARNINGS)
+		list(APPEND _flags
+			/wd4018 # Disable signed/unsigned mismatch warnings. https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4018
+			/wd4068 # Disable unknown pragma warning. https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4068
+			/wd4244 # Disable integer type conversion warnings. https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244
+			/wd4267 # Disable warnings about converting size_t to a smaller type. https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267
+		)
+	endif ()
+	list(APPEND _flags_C   ${_flags})
+	list(APPEND _flags_CXX ${_flags})
+
+elseif (CMAKE_C_COMPILER_ID MATCHES "Intel")
+	# Intel's compiler warning flags are more like Visual Studio than GCC, though the numbers aren't the same.
+	set(_flags
+		# Use warning level 3, quite wordy.
+		-w3
+		# Disable warnings we don't care about (add more as they are encountered).
+		-wd383    # Spammy warning about initializing from a temporary object in C++ (which is done all the time ...).
+		-wd11074  # Diagnostic related to inlining.
+		-wd11076  # Diagnostic related to inlining.
+	)
+
+	list(APPEND _flags_C   ${_flags})
+	list(APPEND _flags_CXX ${_flags})
+
+elseif (CMAKE_C_COMPILER_ID MATCHES "XL")
+	set (_flags
+		-qwarn64
+		-qformat=all
+		-qflag=i:i
+	)
+	list(APPEND _flags_C   ${_flags})
+	list(APPEND _flags_CXX ${_flags})
+
+else ()
+	# If we're compiling with GCC / Clang / MinGW (or anything else besides Visual Studio or Intel):
+	# C Flags:
+	list(APPEND _flags_C
+		-Wall
+		-Wextra
+
+		# Enable additional warnings not covered by Wall and Wextra.
+		-Wcast-align
+		-Wconversion
+		-Wdeclaration-after-statement
+		-Wdouble-promotion
+		-Wfloat-equal
+		-Wformat-security
+		-Winit-self
+		-Wjump-misses-init
+		-Wlogical-op
+		-Wmissing-braces
+		-Wmissing-declarations
+		-Wmissing-format-attribute
+		-Wmissing-include-dirs
+		-Wmissing-prototypes
+		-Wnested-externs
+		-Wno-coverage-mismatch
+		-Wold-style-definition
+		-Wpacked
+		-Wpointer-arith
+		-Wredundant-decls
+		-Wshadow
+		-Wsign-conversion
+		-Wstrict-overflow
+		-Wstrict-prototypes
+		-Wtrampolines
+		-Wundef
+		-Wunused
+		-Wvariadic-macros
+		-Wvla
+		-Wwrite-strings
+
+		# On Windows MinGW I think implicit fallthrough enabled by -Wextra must not default to 3
+		-Wimplicit-fallthrough=3
+
+		# Treat implicit variable typing and implicit function declarations as errors.
+		-Werror=implicit-int
+		-Werror=implicit-function-declaration
+
+		# Make MacOSX honor -mmacosx-version-min
+		-Werror=partial-availability
+
+		# Some clang versions might warn if an argument like "-I/path/to/headers" is unused,
+		# silence these.
+		-Qunused-arguments
+	)
+
+	# C++ flags:
+	list(APPEND _flags_CXX
+		-Wall
+		-Wextra
+
+		# Enable additional warnings not covered by Wall and Wextra.
+		-Wcast-align
+		-Wformat-security
+		-Wmissing-declarations
+		-Wmissing-format-attribute
+		-Wpacked-bitfield-compat
+		-Wredundant-decls
+		-Wvla
+
+		# Turn off unused parameter warnings with C++ (they happen often in C++ and Qt).
+		-Wno-unused-parameter
+
+		# Some clang versions might warn if an argument like "-I/path/to/headers" is unused,
+		# silence these.
+		-Qunused-arguments
+	)
+
+	# Note: when cross-compiling to Windows from Cygwin, the Qt Mingw packages have a bunch of
+	#       noisy type-conversion warnings in headers. So, only enable those warnings if we're
+	#       not building that configuration.
+	if (NOT (WIN32 AND (CMAKE_HOST_SYSTEM_NAME MATCHES "CYGWIN")))
+		list(APPEND _flags_CXX
+			-Wconversion
+			-Wfloat-equal
+			-Wsign-conversion
+		)
+	endif ()
+
+	# Add flags to force colored output even when output is redirected via pipe.
+	if (CMAKE_GENERATOR MATCHES "Ninja")
+		set(color_default TRUE)
+	else ()
+		set(color_default FALSE)
+	endif ()
+	option(FORCE_COLOR "Force compiler to always colorize, even when output is redirected." ${color_default})
+	mark_as_advanced(FORCE FORCE_COLOR)
+	if (FORCE_COLOR)
+		set(_flags
+			-fdiagnostics-color=always # GCC
+			-fcolor-diagnostics        # Clang
+		)
+		list(APPEND _flags_C   ${_flags})
+		list(APPEND _flags_CXX ${_flags})
+	endif ()
+
+	# Add -fno-omit-frame-pointer (and optionally -fno-inline) to make debugging and stack dumps nicer.
+	set(_flags
+		-fno-omit-frame-pointer
+	)
+	option(M_NO_INLINE "Disable function inlining for RelWithDebInfo and Debug configurations?" FALSE)
+	if (M_NO_INLINE)
+		list(APPEND _flags
+			-fno-inline
+		)
+	endif ()
+	list(APPEND _debug_flags_C   ${_flags})
+	list(APPEND _debug_flags_CXX ${_flags})
+endif ()
+
+# Check and set compiler flags.
+set(_debug_configs
+	RelWithDebInfo
+	Debug
+)
+foreach(_lang ${languages})
+	_int_enable_warnings_set_flags(_lang ${_flags_${_lang}})
+	_int_enable_warnings_set_flags_ex(_lang _debug_configs ${_debug_flags_${_lang}})
+
+	# Ensure pure Debug builds are NOT optimized (not possible on Visual Studio).
+	# Any optimization of a Debug build will prevent debuggers like lldb from
+	# fully displaying backtraces and stepping.
+	if (NOT MSVC)
+		set(_config Debug)
+		_int_enable_warnings_set_flags_ex(_lang _config -O0)
+	endif ()
+endforeach()
+
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Helper functions
+
+
+# This function can be called in subdirectories, to prune out warnings that they don't want.
+#  vararg: warning flags to remove from list of enabled warnings. All "no" flags after EXPLICIT_DISABLE
+#          will be added to C flags.
+#
+# Ex.: remove_warnings(-Wall -Wdouble-promotion -Wcomment) prunes those warnings flags from the compile command.
+function(remove_warnings)
+	get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+	set(langs C)
+	if ("CXX" IN_LIST languages)
+		list(APPEND langs CXX)
+	endif ()
+
+	foreach(lang ${langs})
+		set(toadd)
+		set(in_explicit_disable FALSE)
+		foreach (flag ${ARGN})
+			if (flag STREQUAL "EXPLICIT_DISABLE")
+				set(in_explicit_disable TRUE)
+			elseif (in_explicit_disable)
+				list(APPEND toadd "${flag}")
+			else ()
+				string(REGEX REPLACE "${flag}([ \t]+|$)" "" CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS}")
+			endif ()
+		endforeach ()
+		_int_enable_warnings_set_flags(lang ${toadd})
+		string(STRIP "${CMAKE_${lang}_FLAGS}" CMAKE_${lang}_FLAGS)
+		set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS}" PARENT_SCOPE)
+	endforeach()
+endfunction()
+
+
+# Explicitly suppress all warnings. As long as this flag is the last warning flag, warnings will be
+# suppressed even if earlier flags enabled warnings.
+function(remove_all_warnings)
+	get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+	set(langs C)
+	if ("CXX" IN_LIST languages)
+		list(APPEND langs CXX)
+	endif ()
+
+	foreach(lang ${langs})
+		string(REGEX REPLACE "[-/][Ww][^ \t]*([ \t]+|$)" "" CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS}")
+		if (MSVC)
+			string(APPEND CMAKE_${lang}_FLAGS " /w")
+		else ()
+			string(APPEND CMAKE_${lang}_FLAGS " -w")
+		endif ()
+		string(STRIP "${CMAKE_${lang}_FLAGS}" CMAKE_${lang}_FLAGS)
+		set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS}" PARENT_SCOPE)
+	endforeach()
+endfunction()
+
+
+function(remove_all_warnings_from_targets)
+	foreach (target ${ARGN})
+		if (MSVC)
+			target_compile_options(${target} PRIVATE "/w")
+		else ()
+			target_compile_options(${target} PRIVATE "-w")
+		endif ()
+	endforeach()
+endfunction()
+
+
+# Save the current warning settings to an internal variable.
+function(push_warnings)
+	get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+	set(langs C)
+	if ("CXX" IN_LIST languages)
+		list(APPEND langs CXX)
+	endif ()
+
+	foreach(lang ${langs})
+		if (CMAKE_${lang}_FLAGS MATCHES ";")
+			message(AUTHOR_WARNING "Cannot push warnings for ${lang}, CMAKE_${lang}_FLAGS contains semicolons")
+			continue()
+		endif ()
+		# Add current flags to end of internal list.
+		list(APPEND _enable_warnings_internal_${lang}_flags_stack "${CMAKE_${lang}_FLAGS}")
+		# Propagate results up to caller's scope.
+		set(_enable_warnings_internal_${lang}_flags_stack "${_enable_warnings_internal_${lang}_flags_stack}" PARENT_SCOPE)
+	endforeach()
+endfunction()
+
+
+# Restore the current warning settings from an internal variable.
+function(pop_warnings)
+	get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+	set(langs C)
+	if ("CXX" IN_LIST languages)
+		list(APPEND langs CXX)
+	endif ()
+
+	foreach(lang ${langs})
+		if (NOT _enable_warnings_internal_${lang}_flags_stack)
+			continue()
+		endif ()
+		# Pop flags off of end of list, overwrite current flags with whatever we popped off.
+		list(GET _enable_warnings_internal_${lang}_flags_stack -1 CMAKE_${lang}_FLAGS)
+		list(REMOVE_AT _enable_warnings_internal_${lang}_flags_stack -1)
+		# Propagate results up to caller's scope.
+		set(_enable_warnings_internal_${lang}_flags_stack "${_enable_warnings_internal_${lang}_flags_stack}" PARENT_SCOPE)
+		string(STRIP "${CMAKE_${lang}_FLAGS}" CMAKE_${lang}_FLAGS)
+		set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS}" PARENT_SCOPE)
+	endforeach()
+endfunction()

--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -1,3 +1,6 @@
+# Copyright (c) Monetra Technologies LLC
+# SPDX-License-Identifier: MIT
+
 # EnableWarnings.cmake
 #
 # Checks for and turns on a large number of warning C flags.

--- a/configure.ac
+++ b/configure.ac
@@ -200,6 +200,7 @@ CARES_CHECK_COMPILER
 CARES_SET_COMPILER_BASIC_OPTS
 CARES_SET_COMPILER_DEBUG_OPTS
 CARES_SET_COMPILER_OPTIMIZE_OPTS
+CARES_SET_COMPILER_WARNING_OPTS
 
 if test "$want_warnings" = "yes"; then
   AX_APPEND_COMPILE_FLAGS([-Wall \
@@ -239,8 +240,6 @@ if test "$want_warnings" = "yes"; then
     -Werror=partial-availability \
   ], [CFLAGS], [-Werror])
 fi
-
-CARES_SET_COMPILER_WARNING_OPTS
 
 if test "$compiler_id" = "INTEL_UNIX_C"; then
   #

--- a/configure.ac
+++ b/configure.ac
@@ -940,6 +940,49 @@ if test X"$want_werror" = Xyes; then
 fi
 AC_SUBST(CARES_CFLAG_EXTRAS)
 
+
+dnl
+dnl CFLAGS
+dnl
+
+AX_APPEND_COMPILE_FLAGS([\
+  -Wall \
+  -Wextra \
+  -Wcast-align \
+  -Wconversion \
+  -Wdeclaration-after-statement \
+  -Wdouble-promotion \
+  -Wfloat-equal \
+  -Wformat-security \
+  -Winit-self \
+  -Wjump-misses-init \
+  -Wlogical-op \
+  -Wmissing-braces \
+  -Wmissing-declarations \
+  -Wmissing-format-attribute \
+  -Wmissing-include-dirs \
+  -Wmissing-prototypes \
+  -Wnested-externs \
+  -Wno-coverage-mismatch \
+  -Wold-style-definition \
+  -Wpacked \
+  -Wpointer-arith \
+  -Wredundant-decls \
+  -Wshadow \
+  -Wsign-conversion \
+  -Wstrict-overflow \
+  -Wstrict-prototypes \
+  -Wtrampolines \
+  -Wundef \
+  -Wunused \
+  -Wvariadic-macros \
+  -Wvla \
+  -Wwrite-strings \
+  -Werror=implicit-int \
+  -Werror=implicit-function-declaration \
+  -Werror=partial-availability \
+], [CFLAGS], [-Werror])
+
 dnl squeeze whitespace out of some variables
 
 squeeze CFLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -200,6 +200,46 @@ CARES_CHECK_COMPILER
 CARES_SET_COMPILER_BASIC_OPTS
 CARES_SET_COMPILER_DEBUG_OPTS
 CARES_SET_COMPILER_OPTIMIZE_OPTS
+
+if test "$want_warnings" = "yes"; then
+  AX_APPEND_COMPILE_FLAGS([-Wall \
+    -Wextra \
+    -Wcast-align \
+    -Wconversion \
+    -Wdeclaration-after-statement \
+    -Wdouble-promotion \
+    -Wfloat-equal \
+    -Wformat-security \
+    -Winit-self \
+    -Wjump-misses-init \
+    -Wlogical-op \
+    -Wmissing-braces \
+    -Wmissing-declarations \
+    -Wmissing-format-attribute \
+    -Wmissing-include-dirs \
+    -Wmissing-prototypes \
+    -Wnested-externs \
+    -Wno-coverage-mismatch \
+    -Wold-style-definition \
+    -Wpacked \
+    -Wpointer-arith \
+    -Wredundant-decls \
+    -Wshadow \
+    -Wsign-conversion \
+    -Wstrict-overflow \
+    -Wstrict-prototypes \
+    -Wtrampolines \
+    -Wundef \
+    -Wunused \
+    -Wvariadic-macros \
+    -Wvla \
+    -Wwrite-strings \
+    -Werror=implicit-int \
+    -Werror=implicit-function-declaration \
+    -Werror=partial-availability \
+  ], [CFLAGS], [-Werror])
+fi
+
 CARES_SET_COMPILER_WARNING_OPTS
 
 if test "$compiler_id" = "INTEL_UNIX_C"; then
@@ -939,49 +979,6 @@ if test X"$want_werror" = Xyes; then
   CARES_CFLAG_EXTRAS="-Werror"
 fi
 AC_SUBST(CARES_CFLAG_EXTRAS)
-
-
-dnl
-dnl CFLAGS
-dnl
-
-AX_APPEND_COMPILE_FLAGS([\
-  -Wall \
-  -Wextra \
-  -Wcast-align \
-  -Wconversion \
-  -Wdeclaration-after-statement \
-  -Wdouble-promotion \
-  -Wfloat-equal \
-  -Wformat-security \
-  -Winit-self \
-  -Wjump-misses-init \
-  -Wlogical-op \
-  -Wmissing-braces \
-  -Wmissing-declarations \
-  -Wmissing-format-attribute \
-  -Wmissing-include-dirs \
-  -Wmissing-prototypes \
-  -Wnested-externs \
-  -Wno-coverage-mismatch \
-  -Wold-style-definition \
-  -Wpacked \
-  -Wpointer-arith \
-  -Wredundant-decls \
-  -Wshadow \
-  -Wsign-conversion \
-  -Wstrict-overflow \
-  -Wstrict-prototypes \
-  -Wtrampolines \
-  -Wundef \
-  -Wunused \
-  -Wvariadic-macros \
-  -Wvla \
-  -Wwrite-strings \
-  -Werror=implicit-int \
-  -Werror=implicit-function-declaration \
-  -Werror=partial-availability \
-], [CFLAGS], [-Werror])
 
 dnl squeeze whitespace out of some variables
 

--- a/m4/ax_append_compile_flags.m4
+++ b/m4/ax_append_compile_flags.m4
@@ -1,0 +1,65 @@
+# ===========================================================================
+#  http://www.gnu.org/software/autoconf-archive/ax_append_compile_flags.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_COMPILE_FLAGS([FLAG1 FLAG2 ...], [FLAGS-VARIABLE], [EXTRA-FLAGS])
+#
+# DESCRIPTION
+#
+#   For every FLAG1, FLAG2 it is checked whether the compiler works with the
+#   flag.  If it does, the flag is added FLAGS-VARIABLE
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  During the check the flag is always added to the
+#   current language's flags.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   NOTE: This macro depends on the AX_APPEND_FLAG and
+#   AX_CHECK_COMPILE_FLAG. Please keep this macro in sync with
+#   AX_APPEND_LINK_FLAGS.
+#
+# LICENSE
+#
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 3
+
+AC_DEFUN([AX_APPEND_COMPILE_FLAGS],
+[AC_REQUIRE([AX_CHECK_COMPILE_FLAG])
+AC_REQUIRE([AX_APPEND_FLAG])
+for flag in $1; do
+  AX_CHECK_COMPILE_FLAG([$flag], [AX_APPEND_FLAG([$flag], [$2])], [], [$3])
+done
+])dnl AX_APPEND_COMPILE_FLAGS

--- a/m4/ax_append_flag.m4
+++ b/m4/ax_append_flag.m4
@@ -1,0 +1,69 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_append_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_FLAG(FLAG, [FLAGS-VARIABLE])
+#
+# DESCRIPTION
+#
+#   FLAG is appended to the FLAGS-VARIABLE shell variable, with a space
+#   added in between.
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  FLAGS-VARIABLE is not changed if it already contains
+#   FLAG.  If FLAGS-VARIABLE is unset in the shell, it is set to exactly
+#   FLAG.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 2
+
+AC_DEFUN([AX_APPEND_FLAG],
+[AC_PREREQ(2.59)dnl for _AC_LANG_PREFIX
+AS_VAR_PUSHDEF([FLAGS], [m4_default($2,_AC_LANG_PREFIX[FLAGS])])dnl
+AS_VAR_SET_IF(FLAGS,
+  [case " AS_VAR_GET(FLAGS) " in
+    *" $1 "*)
+      AC_RUN_LOG([: FLAGS already contains $1])
+      ;;
+    *)
+      AC_RUN_LOG([: FLAGS="$FLAGS $1"])
+      AS_VAR_SET(FLAGS, ["AS_VAR_GET(FLAGS) $1"])
+      ;;
+   esac],
+  [AS_VAR_SET(FLAGS,["$1"])])
+AS_VAR_POPDEF([FLAGS])dnl
+])dnl AX_APPEND_FLAG

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -1,0 +1,72 @@
+# ===========================================================================
+#   http://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 2
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.59)dnl for _AC_LANG_PREFIX
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM()],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_IF([test x"AS_VAR_GET(CACHEVAR)" = xyes],
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS

--- a/m4/cares-compilers.m4
+++ b/m4/cares-compilers.m4
@@ -852,27 +852,13 @@ AC_DEFUN([CARES_SET_COMPILER_WARNING_OPTS], [
         #
         if test "$want_warnings" = "yes"; then
           tmp_CFLAGS="$tmp_CFLAGS -pedantic"
-          tmp_CFLAGS="$tmp_CFLAGS -Wall -Wextra"
-          tmp_CFLAGS="$tmp_CFLAGS -Wpointer-arith -Wwrite-strings"
-          tmp_CFLAGS="$tmp_CFLAGS -Wshadow"
-          tmp_CFLAGS="$tmp_CFLAGS -Winline -Wnested-externs"
-          tmp_CFLAGS="$tmp_CFLAGS -Wmissing-declarations"
-          tmp_CFLAGS="$tmp_CFLAGS -Wmissing-prototypes"
+          tmp_CFLAGS="$tmp_CFLAGS -Winline"
           tmp_CFLAGS="$tmp_CFLAGS -Wno-long-long"
-          tmp_CFLAGS="$tmp_CFLAGS -Wfloat-equal"
           tmp_CFLAGS="$tmp_CFLAGS -Wno-multichar -Wsign-compare"
-          tmp_CFLAGS="$tmp_CFLAGS -Wundef"
           tmp_CFLAGS="$tmp_CFLAGS -Wno-format-nonliteral"
-          tmp_CFLAGS="$tmp_CFLAGS -Wendif-labels -Wstrict-prototypes"
-          tmp_CFLAGS="$tmp_CFLAGS -Wdeclaration-after-statement"
-          tmp_CFLAGS="$tmp_CFLAGS -Wcast-align"
+          tmp_CFLAGS="$tmp_CFLAGS -Wendif-labels"
           tmp_CFLAGS="$tmp_CFLAGS -Wno-system-headers"
           tmp_CFLAGS="$tmp_CFLAGS -Wshorten-64-to-32"
-          #
-          dnl Only clang 1.1 or later
-          if test "$compiler_num" -ge "101"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wunused"
-          fi
         fi
         ;;
         #
@@ -896,25 +882,14 @@ AC_DEFUN([CARES_SET_COMPILER_WARNING_OPTS], [
           fi
           #
           dnl Set of options we believe *ALL* gcc versions support:
-          tmp_CFLAGS="$tmp_CFLAGS -Wall -W"
-          #
-          dnl Only gcc 1.4 or later
-          if test "$compiler_num" -ge "104"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wpointer-arith -Wwrite-strings"
-            dnl If not cross-compiling with a gcc older than 3.0
-            if test "x$cross_compiling" != "xyes" ||
-              test "$compiler_num" -ge "300"; then
-              tmp_CFLAGS="$tmp_CFLAGS -Wunused -Wshadow"
-            fi
-          fi
+          tmp_CFLAGS="$tmp_CFLAGS -W"
           #
           dnl Only gcc 2.7 or later
           if test "$compiler_num" -ge "207"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Winline -Wnested-externs"
+            tmp_CFLAGS="$tmp_CFLAGS -Winline"
             dnl If not cross-compiling with a gcc older than 3.0
             if test "x$cross_compiling" != "xyes" ||
               test "$compiler_num" -ge "300"; then
-              tmp_CFLAGS="$tmp_CFLAGS -Wmissing-declarations"
               tmp_CFLAGS="$tmp_CFLAGS -Wmissing-prototypes"
             fi
           fi
@@ -926,12 +901,7 @@ AC_DEFUN([CARES_SET_COMPILER_WARNING_OPTS], [
           #
           dnl Only gcc 2.96 or later
           if test "$compiler_num" -ge "296"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wfloat-equal"
             tmp_CFLAGS="$tmp_CFLAGS -Wno-multichar -Wsign-compare"
-            dnl -Wundef used only if gcc is 2.96 or later since we get
-            dnl lots of "`_POSIX_C_SOURCE' is not defined" in system
-            dnl headers with gcc 2.95.4 on FreeBSD 4.9
-            tmp_CFLAGS="$tmp_CFLAGS -Wundef"
           fi
           #
           dnl Only gcc 2.97 or later
@@ -950,12 +920,7 @@ AC_DEFUN([CARES_SET_COMPILER_WARNING_OPTS], [
           #
           dnl Only gcc 3.3 or later
           if test "$compiler_num" -ge "303"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wendif-labels -Wstrict-prototypes"
-          fi
-          #
-          dnl Only gcc 3.4 or later
-          if test "$compiler_num" -ge "304"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wdeclaration-after-statement"
+            tmp_CFLAGS="$tmp_CFLAGS -Wendif-labels"
           fi
           #
           dnl Only gcc 4.0 or later
@@ -963,17 +928,12 @@ AC_DEFUN([CARES_SET_COMPILER_WARNING_OPTS], [
             tmp_CFLAGS="$tmp_CFLAGS -Wstrict-aliasing=3"
           fi
           #
-          dnl Only gcc 4.2 or later
-          if test "$compiler_num" -ge "402"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wcast-align"
-          fi
-          #
           dnl Only gcc 4.3 or later
           if test "$compiler_num" -ge "403"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wtype-limits -Wold-style-declaration"
             tmp_CFLAGS="$tmp_CFLAGS -Wmissing-parameter-type -Wempty-body"
             tmp_CFLAGS="$tmp_CFLAGS -Wclobbered -Wignored-qualifiers"
-            tmp_CFLAGS="$tmp_CFLAGS -Wconversion -Wno-sign-conversion -Wvla"
+            tmp_CFLAGS="$tmp_CFLAGS -Wno-sign-conversion"
           fi
           #
           dnl Only gcc 4.5 or later
@@ -1025,7 +985,7 @@ AC_DEFUN([CARES_SET_COMPILER_WARNING_OPTS], [
         if test "$want_warnings" = "yes"; then
           if test "$compiler_num" -gt "600"; then
             dnl Show errors, warnings, and remarks
-            tmp_CPPFLAGS="$tmp_CPPFLAGS -Wall -w2"
+            tmp_CPPFLAGS="$tmp_CPPFLAGS -w2"
             dnl Perform extra compile-time code checking
             tmp_CPPFLAGS="$tmp_CPPFLAGS -Wcheck"
             dnl Warn on nested comments
@@ -1036,12 +996,8 @@ AC_DEFUN([CARES_SET_COMPILER_WARNING_OPTS], [
             tmp_CPPFLAGS="$tmp_CPPFLAGS -Wmissing-prototypes"
             dnl Enable warnings for 64-bit portability issues
             tmp_CPPFLAGS="$tmp_CPPFLAGS -Wp64"
-            dnl Enable warnings for questionable pointer arithmetic
-            tmp_CPPFLAGS="$tmp_CPPFLAGS -Wpointer-arith"
             dnl Check for function return typw issues
             tmp_CPPFLAGS="$tmp_CPPFLAGS -Wreturn-type"
-            dnl Warn on variable declarations hiding a previous one
-            tmp_CPPFLAGS="$tmp_CPPFLAGS -Wshadow"
             dnl Warn when a variable is used before initialized
             tmp_CPPFLAGS="$tmp_CPPFLAGS -Wuninitialized"
             dnl Warn if a declared function is not used
@@ -1109,9 +1065,7 @@ AC_DEFUN([CARES_SET_COMPILER_WARNING_OPTS], [
         #
         if test "$want_warnings" = "yes"; then
           dnl Activate all warnings
-          tmp_CFLAGS="$tmp_CFLAGS -Wall"
-          dnl Make string constants be of type const char *
-          tmp_CFLAGS="$tmp_CFLAGS -Wwrite-strings"
+          tmp_CFLAGS="$tmp_CFLAGS"
           dnl Warn use of unsupported GCC features ignored by TCC
           tmp_CFLAGS="$tmp_CFLAGS -Wunsupported"
         fi
@@ -1121,7 +1075,7 @@ AC_DEFUN([CARES_SET_COMPILER_WARNING_OPTS], [
         #
         if test "$want_warnings" = "yes"; then
           dnl Issue all warnings
-          tmp_CFLAGS="$tmp_CFLAGS -Wall -Wextra"
+          tmp_CFLAGS="$tmp_CFLAGS"
         fi
         ;;
         #

--- a/m4/cares-confopts.m4
+++ b/m4/cares-confopts.m4
@@ -229,20 +229,15 @@ AC_DEFUN([CARES_CHECK_OPTION_WARNINGS], [
   AC_BEFORE([$0],[CARES_CHECK_OPTION_WERROR])dnl
   AC_BEFORE([$0],[XC_CHECK_PROG_CC])dnl
   AC_MSG_CHECKING([whether to enable strict compiler warnings])
-  OPT_COMPILER_WARNINGS="default"
+  OPT_COMPILER_WARNINGS="yes"
   AC_ARG_ENABLE(warnings,
 AS_HELP_STRING([--enable-warnings],[Enable strict compiler warnings])
 AS_HELP_STRING([--disable-warnings],[Disable strict compiler warnings]),
-  OPT_COMPILER_WARNINGS=$enableval)
+  OPT_COMPILER_WARNINGS=yes)
   case "$OPT_COMPILER_WARNINGS" in
     no)
       dnl --disable-warnings option used
       want_warnings="no"
-      ;;
-    default)
-      dnl configure option not specified, so
-      dnl use same setting as --enable-debug
-      want_warnings="$want_debug"
       ;;
     *)
       dnl --enable-warnings option used


### PR DESCRIPTION
c-ares was missing a couple of common compiler warnings during building that are widely recognized as a best practice.  This PR makes no code changes, only build system changes to increase warning levels.

This PR does cause some new warnings to be emitted, a follow-up PR will address those.

Fix By: Brad House (@bradh352)