### PR TITLE
Tool: STAYOPEN flag could make tools not terminate

### DIFF
--- a/src/tools/acountry.c
+++ b/src/tools/acountry.c
@@ -229,6 +229,8 @@ static void wait_ares(ares_channel channel)
       if (nfds == 0)
         break;
       tvp = ares_timeout(channel, NULL, &tv);
+      if (tvp == NULL)
+        break;
       nfds = select(nfds, &read_fds, &write_fds, NULL, tvp);
       if (nfds < 0)
         continue;

--- a/src/tools/adig.c
+++ b/src/tools/adig.c
@@ -375,6 +375,8 @@ int main(int argc, char **argv)
       if (nfds == 0)
         break;
       tvp = ares_timeout(channel, NULL, &tv);
+      if (tvp == NULL)
+        break;
       count = select(nfds, &read_fds, &write_fds, NULL, tvp);
       if (count < 0 && (status = SOCKERRNO) != EINVAL)
         {

--- a/src/tools/ahost.c
+++ b/src/tools/ahost.c
@@ -167,6 +167,8 @@ int main(int argc, char **argv)
       if (nfds == 0)
         break;
       tvp = ares_timeout(channel, NULL, &tv);
+      if (tvp == NULL)
+        break;
       res = select(nfds, &read_fds, &write_fds, NULL, tvp);
       if (-1 == res)
         break;


### PR DESCRIPTION
If a flag is set to keep the connections to the DNS servers open even if there are no queries, the tools would not exit until the remote server closed the connection due to the user of ares_fds() to determine if there are any active queries.  Instead, rely on ares_timeout() returning NULL if there are no active queries (technically this returns the value passed to max_tv in ares_timeout(), but in our use case, that is always NULL).

Fixes Issue: #452
Fix By: Brad House (@bradh352)
