### PR TITLE
introduce ares_bool_t datatype

### DIFF
--- a/include/ares.h
+++ b/include/ares.h
@@ -158,6 +158,11 @@ typedef enum {
 } ares_status_t;
 
 
+typedef enum {
+  ARES_FALSE = 0,
+  ARES_TRUE  = 1
+} ares_bool_t;
+
 /* Flag values */
 #define ARES_FLAG_USEVC         (1 << 0)
 #define ARES_FLAG_PRIMARY       (1 << 1)

--- a/src/lib/ares__buf.c
+++ b/src/lib/ares__buf.c
@@ -84,15 +84,15 @@ void ares__buf_destroy(ares__buf_t *buf)
 }
 
 
-static int ares__buf_is_const(const ares__buf_t *buf)
+static ares_bool_t ares__buf_is_const(const ares__buf_t *buf)
 {
   if (buf == NULL)
-    return 0;
+    return ARES_FALSE;
 
   if (buf->data != NULL && buf->alloc_buf == NULL)
-    return 1;
+    return ARES_TRUE;
 
-  return 0;
+  return ARES_FALSE;
 }
 
 

--- a/src/lib/ares__htable.h
+++ b/src/lib/ares__htable.h
@@ -78,10 +78,10 @@ typedef const void *(*ares__htable_bucket_key_t)(const void *bucket);
  * 
  *  \param[in] key1  first key
  *  \param[in] key2  second key
- *  \return 1 if equal, 0 if not
+ *  \return ARES_TRUE if equal, ARES_FALSE if not
  */
-typedef unsigned int (*ares__htable_key_eq_t)(const void *key1,
-                                              const void *key2);
+typedef ares_bool_t (*ares__htable_key_eq_t)(const void *key1,
+                                             const void *key2);
 
 
 /*! Destroy the initialized hashtable 
@@ -115,9 +115,9 @@ size_t ares__htable_num_keys(ares__htable_t *htable);
  *  \param[in] htable  Initialized hashtable.
  *  \param[in] bucket  User-provided bucket to insert. Takes "ownership". Not
  *                     allowed to be NULL.
- *  \return 1 on success, 0 if out of memory
+ *  \return ARES_TRUE on success, ARES_FALSE if out of memory
  */
-unsigned int ares__htable_insert(ares__htable_t *htable, void *bucket);
+ares_bool_t ares__htable_insert(ares__htable_t *htable, void *bucket);
 
 /*! Retrieve bucket from hashtable based on key.
  * 
@@ -131,9 +131,9 @@ void *ares__htable_get(ares__htable_t *htable, const void *key);
  * 
  *  \param[in] htable  Initialized hashtable
  *  \param[in] key     Pointer to key to use for comparison
- *  \return 1 if found, 0 if not found
+ *  \return ARES_TRUE if found, ARES_FALSE if not found
  */
-unsigned int ares__htable_remove(ares__htable_t *htable, const void *key);
+ares_bool_t ares__htable_remove(ares__htable_t *htable, const void *key);
 
 /*! FNV1a hash algorithm.  Can be used as underlying primitive for building
  *  a wrapper hashtable.

--- a/src/lib/ares__htable_asvp.c
+++ b/src/lib/ares__htable_asvp.c
@@ -79,15 +79,15 @@ static void bucket_free(void *bucket)
 }
 
 
-static unsigned int key_eq(const void *key1, const void *key2)
+static ares_bool_t key_eq(const void *key1, const void *key2)
 {
   const ares_socket_t *k1 = key1;
   const ares_socket_t *k2 = key2;
 
   if (*k1 == *k2)
-    return 1;
+    return ARES_TRUE;
 
-  return 0;
+  return ARES_FALSE;
 }
 
 
@@ -118,8 +118,8 @@ fail:
 }
 
 
-unsigned int ares__htable_asvp_insert(ares__htable_asvp_t *htable,
-                                      ares_socket_t key, void *val)
+ares_bool_t ares__htable_asvp_insert(ares__htable_asvp_t *htable,
+                                     ares_socket_t key, void *val)
 {
   ares__htable_asvp_bucket_t *bucket = NULL;
 
@@ -137,17 +137,17 @@ unsigned int ares__htable_asvp_insert(ares__htable_asvp_t *htable,
   if (!ares__htable_insert(htable->hash, bucket))
     goto fail;
 
-  return 1;
+  return ARES_TRUE;
 
 fail:
   if (bucket) {
     ares_free(bucket);
   }
-  return 0;
+  return ARES_FALSE;
 }
 
 
-unsigned int ares__htable_asvp_get(ares__htable_asvp_t *htable,
+ares_bool_t ares__htable_asvp_get(ares__htable_asvp_t *htable,
                                    ares_socket_t key, void **val)
 {
   ares__htable_asvp_bucket_t *bucket = NULL;
@@ -156,15 +156,15 @@ unsigned int ares__htable_asvp_get(ares__htable_asvp_t *htable,
     *val = NULL;
 
   if (htable == NULL)
-    return 0;
+    return ARES_FALSE;
 
   bucket = ares__htable_get(htable->hash, &key);
   if (bucket == NULL)
-    return 0;
+    return ARES_FALSE;
 
   if (val)
     *val = bucket->val;
-  return 1;
+  return ARES_TRUE;
 }
 
 
@@ -177,11 +177,11 @@ void *ares__htable_asvp_get_direct(ares__htable_asvp_t *htable,
 }
 
 
-unsigned int ares__htable_asvp_remove(ares__htable_asvp_t *htable,
+ares_bool_t ares__htable_asvp_remove(ares__htable_asvp_t *htable,
                                       ares_socket_t key)
 {
   if (htable == NULL)
-    return 0;
+    return ARES_FALSE;
 
   return ares__htable_remove(htable->hash, &key);
 }

--- a/src/lib/ares__htable_asvp.h
+++ b/src/lib/ares__htable_asvp.h
@@ -73,9 +73,9 @@ ares__htable_asvp_t *ares__htable_asvp_create(
  *  \param[in] htable Initialized hash table
  *  \param[in] key    key to associate with value
  *  \param[in] val    value to store (takes ownership). May be NULL.
- *  \return 1 on success, 0 on out of memory or misuse
+ *  \return ARES_TRUE on success, ARES_FALSE on out of memory or misuse
  */
-unsigned int ares__htable_asvp_insert(ares__htable_asvp_t *htable,
+ares_bool_t ares__htable_asvp_insert(ares__htable_asvp_t *htable,
                                       ares_socket_t key, void *val);
 
 /*! Retrieve value from hashtable based on key
@@ -83,9 +83,9 @@ unsigned int ares__htable_asvp_insert(ares__htable_asvp_t *htable,
  *  \param[in]  htable  Initialized hash table
  *  \param[in]  key     key to use to search
  *  \param[out] val     Optional.  Pointer to store value.
- *  \return 1 on success, 0 on failure
+ *  \return ARES_TRUE on success, ARES_FALSE on failure
  */
-unsigned int ares__htable_asvp_get(ares__htable_asvp_t *htable,
+ares_bool_t ares__htable_asvp_get(ares__htable_asvp_t *htable,
                                    ares_socket_t key, void **val);
 
 /*! Retrieve value from hashtable directly as return value.  Caveat to this
@@ -103,9 +103,9 @@ void *ares__htable_asvp_get_direct(ares__htable_asvp_t *htable,
  * 
  *  \param[in] htable  Initialized hash table
  *  \param[in] key     key to use to search
- *  \return 1 if found, 0 if not
+ *  \return ARES_TRUE if found, ARES_FALSE if not found
  */
-unsigned int ares__htable_asvp_remove(ares__htable_asvp_t *htable,
+ares_bool_t ares__htable_asvp_remove(ares__htable_asvp_t *htable,
                                       ares_socket_t key);
 
 /*! Retrieve the number of keys stored in the hash table

--- a/src/lib/ares__htable_stvp.c
+++ b/src/lib/ares__htable_stvp.c
@@ -79,15 +79,15 @@ static void bucket_free(void *bucket)
 }
 
 
-static unsigned int key_eq(const void *key1, const void *key2)
+static ares_bool_t key_eq(const void *key1, const void *key2)
 {
   const size_t *k1 = key1;
   const size_t *k2 = key2;
 
   if (*k1 == *k2)
-    return 1;
+    return ARES_TRUE;
 
-  return 0;
+  return ARES_FALSE;
 }
 
 
@@ -118,7 +118,7 @@ fail:
 }
 
 
-unsigned int ares__htable_stvp_insert(ares__htable_stvp_t *htable, size_t key,
+ares_bool_t ares__htable_stvp_insert(ares__htable_stvp_t *htable, size_t key,
                                       void *val)
 {
   ares__htable_stvp_bucket_t *bucket = NULL;
@@ -137,17 +137,17 @@ unsigned int ares__htable_stvp_insert(ares__htable_stvp_t *htable, size_t key,
   if (!ares__htable_insert(htable->hash, bucket))
     goto fail;
 
-  return 1;
+  return ARES_TRUE;
 
 fail:
   if (bucket) {
     ares_free(bucket);
   }
-  return 0;
+  return ARES_FALSE;
 }
 
 
-unsigned int ares__htable_stvp_get(ares__htable_stvp_t *htable, size_t key,
+ares_bool_t ares__htable_stvp_get(ares__htable_stvp_t *htable, size_t key,
                                    void **val)
 {
   ares__htable_stvp_bucket_t *bucket = NULL;
@@ -156,15 +156,15 @@ unsigned int ares__htable_stvp_get(ares__htable_stvp_t *htable, size_t key,
     *val = NULL;
 
   if (htable == NULL)
-    return 0;
+    return ARES_FALSE;
 
   bucket = ares__htable_get(htable->hash, &key);
   if (bucket == NULL)
-    return 0;
+    return ARES_FALSE;
 
   if (val)
     *val = bucket->val;
-  return 1;
+  return ARES_TRUE;
 }
 
 
@@ -176,10 +176,10 @@ void *ares__htable_stvp_get_direct(ares__htable_stvp_t *htable, size_t key)
 }
 
 
-unsigned int ares__htable_stvp_remove(ares__htable_stvp_t *htable, size_t key)
+ares_bool_t ares__htable_stvp_remove(ares__htable_stvp_t *htable, size_t key)
 {
   if (htable == NULL)
-    return 0;
+    return ARES_FALSE;
 
   return ares__htable_remove(htable->hash, &key);
 }

--- a/src/lib/ares__htable_stvp.h
+++ b/src/lib/ares__htable_stvp.h
@@ -70,20 +70,20 @@ ares__htable_stvp_t *ares__htable_stvp_create(
  *  \param[in] htable Initialized hash table
  *  \param[in] key    key to associate with value
  *  \param[in] val    value to store (takes ownership). May be NULL.
- *  \return 1 on success, 0 on out of memory or misuse
+ *  \return ARES_TRUE on success, ARES_FALSE on failure or out of memory
  */
-unsigned int ares__htable_stvp_insert(ares__htable_stvp_t *htable, size_t key,
-                                      void *val);
+ares_bool_t ares__htable_stvp_insert(ares__htable_stvp_t *htable, size_t key,
+                                     void *val);
 
 /*! Retrieve value from hashtable based on key
  * 
  *  \param[in]  htable  Initialized hash table
  *  \param[in]  key     key to use to search
  *  \param[out] val     Optional.  Pointer to store value.
- *  \return 1 on success, 0 on failure
+ *  \return ARES_TRUE on success, ARES_FALSE on failure
  */
-unsigned int ares__htable_stvp_get(ares__htable_stvp_t *htable, size_t key,
-                                   void **val);
+ares_bool_t ares__htable_stvp_get(ares__htable_stvp_t *htable, size_t key,
+                                  void **val);
 
 /*! Retrieve value from hashtable directly as return value.  Caveat to this
  *  function over ares__htable_stvp_get() is that if a NULL value is stored
@@ -99,9 +99,9 @@ void *ares__htable_stvp_get_direct(ares__htable_stvp_t *htable, size_t key);
  * 
  *  \param[in] htable  Initialized hash table
  *  \param[in] key     key to use to search
- *  \return 1 if found, 0 if not
+ *  \return ARES_TRUE if found, ARES_FALSE if not
  */
-unsigned int ares__htable_stvp_remove(ares__htable_stvp_t *htable, size_t key);
+ares_bool_t ares__htable_stvp_remove(ares__htable_stvp_t *htable, size_t key);
 
 /*! Retrieve the number of keys stored in the hash table
  * 

--- a/src/lib/ares__parse_into_addrinfo.c
+++ b/src/lib/ares__parse_into_addrinfo.c
@@ -50,14 +50,15 @@
 #include "ares_private.h"
 
 ares_status_t ares__parse_into_addrinfo(const unsigned char *abuf,
-                                        int alen, int cname_only_is_enodata,
+                                        int alen,
+                                        ares_bool_t cname_only_is_enodata,
                                         unsigned short port,
                                         struct ares_addrinfo *ai)
 {
   unsigned int qdcount, ancount;
   ares_status_t status;
   int i, rr_type, rr_class, rr_len, rr_ttl;
-  int got_a = 0, got_aaaa = 0, got_cname = 0;
+  ares_bool_t got_a = ARES_FALSE, got_aaaa = ARES_FALSE, got_cname = ARES_FALSE;
   long len;
   const unsigned char *aptr;
   char *question_hostname = NULL;
@@ -123,7 +124,7 @@ ares_status_t ares__parse_into_addrinfo(const unsigned char *abuf,
           && rr_len == sizeof(struct in_addr)
           && strcasecmp(rr_name, hostname) == 0)
         {
-          got_a = 1;
+          got_a = ARES_TRUE;
           if (aptr + sizeof(struct in_addr) > abuf + alen)
           {  /* LCOV_EXCL_START: already checked above */
             status = ARES_EBADRESP;
@@ -138,7 +139,7 @@ ares_status_t ares__parse_into_addrinfo(const unsigned char *abuf,
           && rr_len == sizeof(struct ares_in6_addr)
           && strcasecmp(rr_name, hostname) == 0)
         {
-          got_aaaa = 1;
+          got_aaaa = ARES_TRUE;
           if (aptr + sizeof(struct ares_in6_addr) > abuf + alen)
           {  /* LCOV_EXCL_START: already checked above */
             status = ARES_EBADRESP;
@@ -152,7 +153,7 @@ ares_status_t ares__parse_into_addrinfo(const unsigned char *abuf,
 
       if (rr_class == C_IN && rr_type == T_CNAME)
         {
-          got_cname = 1;
+          got_cname = ARES_TRUE;
           status = ares__expand_name_for_response(aptr, abuf, alen, &rr_data,
                                                   &len, 1);
           if (status != ARES_SUCCESS)

--- a/src/lib/ares__readaddrinfo.c
+++ b/src/lib/ares__readaddrinfo.c
@@ -57,8 +57,8 @@ ares_status_t ares__readaddrinfo(FILE *fp,
   size_t linesize;
   struct ares_addrinfo_cname *cname = NULL, *cnames = NULL;
   struct ares_addrinfo_node *nodes = NULL;
-  int match_with_alias, match_with_canonical;
-  int want_cname = hints->ai_flags & ARES_AI_CANONNAME;
+  ares_bool_t match_with_alias, match_with_canonical;
+  ares_bool_t want_cname = (hints->ai_flags & ARES_AI_CANONNAME)?ARES_TRUE:ARES_FALSE;
 
   /* Validate family */
   switch (hints->ai_family) {
@@ -79,8 +79,8 @@ ares_status_t ares__readaddrinfo(FILE *fp,
 
   while ((status = ares__read_line(fp, &line, &linesize)) == ARES_SUCCESS)
     {
-      match_with_alias = 0;
-      match_with_canonical = 0;
+      match_with_alias = ARES_FALSE;
+      match_with_canonical = ARES_FALSE;
       alias_count = 0;
       /* Trim line comment. */
       p = line;
@@ -147,7 +147,7 @@ ares_status_t ares__readaddrinfo(FILE *fp,
       /* Find out if host name matches with canonical host name. */
       if (strcasecmp(txthost, name) == 0)
         {
-          match_with_canonical = 1;
+          match_with_canonical = ARES_TRUE;
         }
 
       /* Find out if host name matches with one of the aliases. */
@@ -162,7 +162,7 @@ ares_status_t ares__readaddrinfo(FILE *fp,
           *p = '\0';
           if (strcasecmp(txtalias, name) == 0)
             {
-              match_with_alias = 1;
+              match_with_alias = ARES_TRUE;
               if (!want_cname)
                 break;
             }

--- a/src/lib/ares__slist.c
+++ b/src/lib/ares__slist.c
@@ -90,7 +90,7 @@ ares__slist_t *ares__slist_create(ares_rand_state *rand_state,
 }
 
 
-static unsigned int ares__slist_coin_flip(ares__slist_t *list)
+static ares_bool_t ares__slist_coin_flip(ares__slist_t *list)
 {
   size_t total_bits = sizeof(list->rand_data) * 8;
   size_t bit;
@@ -108,7 +108,7 @@ static unsigned int ares__slist_coin_flip(ares__slist_t *list)
   bit = total_bits - list->rand_bits;
   list->rand_bits--;
 
-  return (list->rand_data[bit / 8] & (1 << (bit % 8)))?1:0;
+  return (list->rand_data[bit / 8] & (1 << (bit % 8)))?ARES_TRUE:ARES_FALSE;
 }
 
 

--- a/src/lib/ares__timeval.c
+++ b/src/lib/ares__timeval.c
@@ -106,18 +106,3 @@ struct timeval ares__tvnow(void)
 }
 
 #endif
-
-#if 0 /* Not used */
-/*
- * Make sure that the first argument is the more recent time, as otherwise
- * we'll get a weird negative time-diff back...
- *
- * Returns: the time difference in number of milliseconds.
- */
-long ares__tvdiff(struct timeval newer, struct timeval older)
-{
-  return (newer.tv_sec-older.tv_sec)*1000+
-    (newer.tv_usec-older.tv_usec)/1000;
-}
-#endif
-

--- a/src/lib/ares_android.c
+++ b/src/lib/ares_android.c
@@ -96,7 +96,7 @@ int ares_library_init_android(jobject connectivity_manager)
   JNIEnv *env = NULL;
   int need_detatch = 0;
   int res;
-  int ret = ARES_ENOTINITIALIZED;
+  ares_status_t ret = ARES_ENOTINITIALIZED;
   jclass obj_cls = NULL;
 
   if (android_jvm == NULL)

--- a/src/lib/ares_expand_name.c
+++ b/src/lib/ares_expand_name.c
@@ -41,10 +41,10 @@
 #define MAX_INDIRS 50
 
 static int name_length(const unsigned char *encoded, const unsigned char *abuf,
-                       int alen, int is_hostname);
+                       int alen, ares_bool_t is_hostname);
 
 /* Reserved characters for names that need to be escaped */
-static int is_reservedch(int ch)
+static ares_bool_t is_reservedch(int ch)
 {
   switch (ch) {
     case '"':
@@ -55,19 +55,19 @@ static int is_reservedch(int ch)
     case ')':
     case '@':
     case '$':
-      return 1;
+      return ARES_TRUE;
     default:
       break;
   }
 
-  return 0;
+  return ARES_FALSE;
 }
 
-static int ares__isprint(int ch)
+static ares_bool_t ares__isprint(int ch)
 {
   if (ch >= 0x20 && ch <= 0x7E)
-    return 1;
-  return 0;
+    return ARES_TRUE;
+  return ARES_FALSE;
 }
 
 /* Character set allowed by hostnames.  This is to include the normal
@@ -82,21 +82,21 @@ static int ares__isprint(int ch)
  * reported when this validation is not performed.  Security is more
  * important than edge-case compatibility (which is probably invalid
  * anyhow). */
-static int is_hostnamech(int ch)
+static ares_bool_t is_hostnamech(int ch)
 {
   /* [A-Za-z0-9-*._/]
    * Don't use isalnum() as it is locale-specific
    */
   if (ch >= 'A' && ch <= 'Z')
-    return 1;
+    return ARES_TRUE;
   if (ch >= 'a' && ch <= 'z')
-    return 1;
+    return ARES_TRUE;
   if (ch >= '0' && ch <= '9')
-    return 1;
+    return ARES_TRUE;
   if (ch == '-' || ch == '.' || ch == '_' || ch == '/' || ch == '*')
-    return 1;
+    return ARES_TRUE;
 
-  return 0;
+  return ARES_FALSE;
 }
 
 /* Expand an RFC1035-encoded domain name given by encoded.  The
@@ -129,14 +129,14 @@ static int is_hostnamech(int ch)
 ares_status_t ares__expand_name_validated(const unsigned char *encoded,
                                           const unsigned char *abuf,
                                           int alen, char **s, long *enclen,
-                                          int is_hostname)
+                                          ares_bool_t is_hostname)
 {
   int len, indir = 0;
   char *q;
   const unsigned char *p;
   union {
     ares_ssize_t sig;
-     size_t uns;
+    size_t uns;
   } nlen;
 
   nlen.sig = name_length(encoded, abuf, alen, is_hostname);
@@ -225,14 +225,14 @@ ares_status_t ares__expand_name_validated(const unsigned char *encoded,
 int ares_expand_name(const unsigned char *encoded, const unsigned char *abuf,
                      int alen, char **s, long *enclen)
 {
-  return ares__expand_name_validated(encoded, abuf, alen, s, enclen, 0);
+  return ares__expand_name_validated(encoded, abuf, alen, s, enclen, ARES_FALSE);
 }
 
 /* Return the length of the expansion of an encoded domain name, or
  * -1 if the encoding is invalid.
  */
 static int name_length(const unsigned char *encoded, const unsigned char *abuf,
-                       int alen, int is_hostname)
+                       int alen, ares_bool_t is_hostname)
 {
   int n = 0, offset, indir = 0, top;
 
@@ -313,7 +313,7 @@ static int name_length(const unsigned char *encoded, const unsigned char *abuf,
 ares_status_t ares__expand_name_for_response(const unsigned char *encoded,
                                              const unsigned char *abuf,
                                              int alen, char **s, long *enclen,
-                                             int is_hostname)
+                                             ares_bool_t is_hostname)
 {
   ares_status_t status = ares__expand_name_validated(encoded, abuf, alen, s,
                                                      enclen, is_hostname);

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -593,7 +593,7 @@ static void terminate_retries(struct host_query *hquery, unsigned short qid)
   if (query == NULL)
     return;
 
-  query->no_retries = 1;
+  query->no_retries = ARES_TRUE;
 }
 
 

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -123,9 +123,9 @@ static const struct ares_addrinfo empty_addrinfo = {
 /* forward declarations */
 static void host_callback(void *arg, int status, int timeouts,
                           unsigned char *abuf, int alen);
-static int as_is_first(const struct host_query *hquery);
-static int as_is_only(const struct host_query* hquery);
-static int next_dns_lookup(struct host_query *hquery);
+static ares_bool_t as_is_first(const struct host_query *hquery);
+static ares_bool_t as_is_only(const struct host_query* hquery);
+static ares_bool_t next_dns_lookup(struct host_query *hquery);
 
 static struct ares_addrinfo_cname *ares__malloc_addrinfo_cname(void)
 {
@@ -419,25 +419,25 @@ static void end_hquery(struct host_query *hquery, ares_status_t status)
   ares_free(hquery);
 }
 
-static int is_localhost(const char *name)
+static ares_bool_t is_localhost(const char *name)
 {
   /* RFC6761 6.3 says : The domain "localhost." and any names falling within ".localhost." */
   size_t len;
 
   if (name == NULL)
-    return 0;
+    return ARES_FALSE;
 
   if (strcmp(name, "localhost") == 0)
-    return 1;
+    return ARES_TRUE;
 
   len = strlen(name);
   if (len < 10 /* strlen(".localhost") */)
-    return 0;
+    return ARES_FALSE;
 
   if (strcmp(name + (len - 10 /* strlen(".localhost") */), ".localhost") == 0)
-    return 1;
+    return ARES_TRUE;
 
-  return 0;
+  return ARES_FALSE;
 }
 
 static ares_status_t file_lookup(struct host_query *hquery)
@@ -772,10 +772,10 @@ void ares_getaddrinfo(ares_channel channel,
   next_lookup(hquery, ARES_ECONNREFUSED /* initial error code */);
 }
 
-static int next_dns_lookup(struct host_query *hquery)
+static ares_bool_t next_dns_lookup(struct host_query *hquery)
 {
   char *s = NULL;
-  int is_s_allocated = 0;
+  ares_bool_t is_s_allocated = ARES_FALSE;
   ares_status_t status;
 
   /* if next_domain == -1 and as_is_first is true, try hquery->name */
@@ -805,7 +805,7 @@ static int next_dns_lookup(struct host_query *hquery)
           &s);
       if (status == ARES_SUCCESS)
         {
-          is_s_allocated = 1;
+          is_s_allocated = ARES_TRUE;
         }
     }
 
@@ -838,16 +838,16 @@ static int next_dns_lookup(struct host_query *hquery)
         {
           ares_free(s);
         }
-      return 1;
+      return ARES_TRUE;
     }
   else
     {
       assert(!hquery->ai->nodes);
-      return 0;
+      return ARES_FALSE;
     }
 }
 
-static int as_is_first(const struct host_query* hquery)
+static ares_bool_t as_is_first(const struct host_query* hquery)
 {
   char* p;
   int ndots = 0;
@@ -862,16 +862,16 @@ static int as_is_first(const struct host_query* hquery)
   if (nname && hquery->name[nname-1] == '.')
     {
       /* prevent ARES_EBADNAME for valid FQDN, where ndots < channel->ndots  */
-      return 1;
+      return ARES_TRUE;
     }
-  return ndots >= hquery->channel->ndots;
+  return ndots >= hquery->channel->ndots?ARES_TRUE:ARES_FALSE;
 }
 
-static int as_is_only(const struct host_query* hquery)
+static ares_bool_t as_is_only(const struct host_query* hquery)
 {
   size_t nname = hquery->name?strlen(hquery->name):0;
   if (nname && hquery->name[nname-1] == '.')
-    return 1;
-  return 0;
+    return ARES_TRUE;
+  return ARES_FALSE;
 }
 

--- a/src/lib/ares_getnameinfo.c
+++ b/src/lib/ares_getnameinfo.c
@@ -445,13 +445,13 @@ STATIC_TESTABLE char *ares_striendstr(const char *s1, const char *s2)
   return (char *)c1_begin;
 }
 
-int ares__is_onion_domain(const char *name)
+ares_bool_t ares__is_onion_domain(const char *name)
 {
   if (ares_striendstr(name, ".onion"))
-    return 1;
+    return ARES_TRUE;
 
   if (ares_striendstr(name, ".onion."))
-    return 1;
+    return ARES_TRUE;
 
-  return 0;
+  return ARES_FALSE;
 }

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -163,7 +163,7 @@ struct server_state;
 struct server_connection {
   struct server_state *server;
   ares_socket_t        fd;
-  int                  is_tcp;
+  ares_bool_t          is_tcp;
   /* total number of queries run on this connection since it was established */
   size_t               total_queries;
   /* list of outstanding queries to this connection */
@@ -226,16 +226,16 @@ struct query {
   int try_count; /* Number of times we tried this query already. */
   int server; /* Server this query has last been sent to. */
   struct query_server_info *server_info;   /* per-server state */
-  int using_tcp;
+  ares_bool_t using_tcp;
   ares_status_t error_status;
   int timeouts; /* number of timeouts we saw for this request */
-  int no_retries; /* do not perform any additional retries, this is set when
-                   * a query is to be canceled */
+  ares_bool_t no_retries; /* do not perform any additional retries, this is set when
+                           * a query is to be canceled */
 };
 
 /* Per-server state for a query */
 struct query_server_info {
-  int skip_server;  /* should we skip server, due to errors, etc? */
+  ares_bool_t skip_server;  /* should we skip server, due to errors, etc? */
   int tcp_connection_generation;  /* into which TCP connection did we send? */
 };
 
@@ -336,7 +336,7 @@ struct ares_channeldata {
 };
 
 /* Does the domain end in ".onion" or ".onion."? Case-insensitive. */
-int ares__is_onion_domain(const char *name);
+ares_bool_t ares__is_onion_domain(const char *name);
 
 /* Memory management functions */
 extern void *(*ares_malloc)(size_t size);
@@ -344,8 +344,8 @@ extern void *(*ares_realloc)(void *ptr, size_t size);
 extern void (*ares_free)(void *ptr);
 
 /* return true if now is exactly check time or later */
-int ares__timedout(struct timeval *now,
-                   struct timeval *check);
+ares_bool_t ares__timedout(struct timeval *now,
+                           struct timeval *check);
 
 /* Returns one of the normal ares status codes like ARES_SUCCESS */
 ares_status_t ares__send_query(ares_channel channel, struct query *query,
@@ -377,11 +377,11 @@ struct timeval ares__tvnow(void);
 ares_status_t ares__expand_name_validated(const unsigned char *encoded,
                                           const unsigned char *abuf,
                                           int alen, char **s, long *enclen,
-                                          int is_hostname);
+                                          ares_bool_t is_hostname);
 ares_status_t ares__expand_name_for_response(const unsigned char *encoded,
                                              const unsigned char *abuf,
                                              int alen, char **s, long *enclen,
-                                             int is_hostname);
+                                             ares_bool_t is_hostname);
 ares_status_t ares__init_servers_state(ares_channel channel);
 void ares__destroy_servers_state(ares_channel channel);
 ares_status_t ares__single_domain(ares_channel channel, const char *name,
@@ -412,7 +412,8 @@ void ares__addrinfo_cat_cnames(struct ares_addrinfo_cname **head,
                                struct ares_addrinfo_cname *tail);
 
 ares_status_t ares__parse_into_addrinfo(const unsigned char *abuf,
-                                        int alen, int cname_only_is_enodata,
+                                        int alen,
+                                        ares_bool_t cname_only_is_enodata,
                                         unsigned short port,
                                         struct ares_addrinfo *ai);
 
@@ -426,10 +427,6 @@ ares_status_t ares__addrinfo2addrttl(const struct ares_addrinfo *ai, int family,
 ares_status_t ares__addrinfo_localhost(const char *name, unsigned short port,
                                        const struct ares_addrinfo_hints *hints,
                                        struct ares_addrinfo *ai);
-
-#if 0 /* Not used */
-long ares__tvdiff(struct timeval t1, struct timeval t2);
-#endif
 
 ares_socket_t ares__open_socket(ares_channel channel,
                                 int af, int type, int protocol);

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -80,7 +80,8 @@ static void skip_server(ares_channel channel, struct query *query,
 static ares_status_t next_server(ares_channel channel, struct query *query,
                                  struct timeval *now);
 static ares_status_t open_socket(ares_channel channel,
-                                 struct server_state *server, int is_tcp);
+                                 struct server_state *server,
+                                 ares_bool_t is_tcp);
 static ares_bool_t same_questions(const unsigned char *qbuf, int qlen,
                                   const unsigned char *abuf, int alen);
 static ares_bool_t same_address(struct sockaddr *sa, struct ares_addr *aa);
@@ -634,7 +635,7 @@ static void process_answer(ares_channel channel, const unsigned char *abuf,
     {
       if (!query->using_tcp)
         {
-          query->using_tcp = 1;
+          query->using_tcp = ARES_TRUE;
           ares__send_query(channel, query, now);
         }
       ares__check_cleanup_conn(channel, fd);
@@ -721,7 +722,7 @@ static void skip_server(ares_channel channel, struct query *query,
    */
   if (channel->nservers > 1)
     {
-      query->server_info[server->idx].skip_server = 1;
+      query->server_info[server->idx].skip_server = ARES_TRUE;
     }
 }
 
@@ -1052,7 +1053,8 @@ static int configure_socket(ares_socket_t s, int family, ares_channel channel)
 }
 
 static ares_status_t open_socket(ares_channel channel,
-                                 struct server_state *server, int is_tcp)
+                                 struct server_state *server,
+                                 ares_bool_t is_tcp)
 {
   ares_socket_t s;
   int opt;

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -86,14 +86,13 @@ static ares_bool_t same_questions(const unsigned char *qbuf, int qlen,
                                   const unsigned char *abuf, int alen);
 static ares_bool_t same_address(struct sockaddr *sa, struct ares_addr *aa);
 static int has_opt_rr(const unsigned char *abuf, int alen);
-static void end_query(ares_channel channel, struct query *query, int status,
-                      const unsigned char *abuf, int alen);
+static void end_query(ares_channel channel, struct query *query,
+                      ares_status_t status, const unsigned char *abuf, int alen);
 static ares_ssize_t ares__socket_write(ares_channel channel, ares_socket_t s,
                                        const void * data, size_t len);
 
 /* return true if now is exactly check time or later */
-ares_bool_t ares__timedout(struct timeval *now,
-                   struct timeval *check)
+ares_bool_t ares__timedout(struct timeval *now, struct timeval *check)
 {
   long secs = (now->tv_sec - check->tv_sec);
 
@@ -1408,8 +1407,8 @@ static void ares_detach_query(struct query *query)
   query->node_all_queries        = NULL;
 }
 
-static void end_query(ares_channel channel, struct query *query, int status,
-                      const unsigned char *abuf, int alen)
+static void end_query(ares_channel channel, struct query *query,
+                      ares_status_t status, const unsigned char *abuf, int alen)
 {
   (void)channel;
 

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -65,7 +65,7 @@
 #include "ares_private.h"
 
 
-static int try_again(int errnum);
+static ares_bool_t try_again(int errnum);
 static void write_tcp_data(ares_channel channel, fd_set *write_fds,
                            ares_socket_t write_fd, struct timeval *now);
 static void read_packets(ares_channel channel, fd_set *read_fds,
@@ -81,9 +81,9 @@ static ares_status_t next_server(ares_channel channel, struct query *query,
                                  struct timeval *now);
 static ares_status_t open_socket(ares_channel channel,
                                  struct server_state *server, int is_tcp);
-static int same_questions(const unsigned char *qbuf, int qlen,
-                          const unsigned char *abuf, int alen);
-static int same_address(struct sockaddr *sa, struct ares_addr *aa);
+static ares_bool_t same_questions(const unsigned char *qbuf, int qlen,
+                                  const unsigned char *abuf, int alen);
+static ares_bool_t same_address(struct sockaddr *sa, struct ares_addr *aa);
 static int has_opt_rr(const unsigned char *abuf, int alen);
 static void end_query(ares_channel channel, struct query *query, int status,
                       const unsigned char *abuf, int alen);
@@ -91,18 +91,18 @@ static ares_ssize_t ares__socket_write(ares_channel channel, ares_socket_t s,
                                        const void * data, size_t len);
 
 /* return true if now is exactly check time or later */
-int ares__timedout(struct timeval *now,
+ares_bool_t ares__timedout(struct timeval *now,
                    struct timeval *check)
 {
   long secs = (now->tv_sec - check->tv_sec);
 
   if(secs > 0)
-    return 1; /* yes, timed out */
+    return ARES_TRUE; /* yes, timed out */
   if(secs < 0)
-    return 0; /* nope, not timed out */
+    return ARES_FALSE; /* nope, not timed out */
 
   /* if the full seconds were identical, check the sub second parts */
-  return (now->tv_usec - check->tv_usec >= 0);
+  return (now->tv_usec - check->tv_usec) >= 0?ARES_TRUE:ARES_FALSE;
 }
 
 /* add the specific number of milliseconds to the time in the first argument */
@@ -158,7 +158,7 @@ void ares_process_fd(ares_channel channel,
  * http://devrsrc1.external.hp.com/STKS/cgi-bin/man2html?
  *     manpage=/usr/share/man/man2.Z/send.2
  */
-static int try_again(int errnum)
+static ares_bool_t try_again(int errnum)
 {
 #if !defined EWOULDBLOCK && !defined EAGAIN
 #error "Neither EWOULDBLOCK nor EAGAIN defined"
@@ -167,14 +167,14 @@ static int try_again(int errnum)
     {
 #ifdef EWOULDBLOCK
     case EWOULDBLOCK:
-      return 1;
+      return ARES_TRUE;
 #endif
 #if defined EAGAIN && EAGAIN != EWOULDBLOCK
     case EAGAIN:
-      return 1;
+      return ARES_TRUE;
 #endif
     }
-  return 0;
+  return ARES_FALSE;
 }
 
 
@@ -1208,8 +1208,8 @@ static ares_status_t open_socket(ares_channel channel,
 }
 
 
-static int same_questions(const unsigned char *qbuf, int qlen,
-                          const unsigned char *abuf, int alen)
+static ares_bool_t same_questions(const unsigned char *qbuf, int qlen,
+                                  const unsigned char *abuf, int alen)
 {
   struct {
     const unsigned char *p;
@@ -1222,13 +1222,13 @@ static int same_questions(const unsigned char *qbuf, int qlen,
   int i, j;
 
   if (qlen < HFIXEDSZ || alen < HFIXEDSZ)
-    return 0;
+    return ARES_FALSE;
 
   /* Extract qdcount from the request and reply buffers and compare them. */
   q.qdcount = DNS_HEADER_QDCOUNT(qbuf);
   a.qdcount = DNS_HEADER_QDCOUNT(abuf);
   if (q.qdcount != a.qdcount)
-    return 0;
+    return ARES_FALSE;
 
   /* For each question in qbuf, find it in abuf. */
   q.p = qbuf + HFIXEDSZ;
@@ -1237,12 +1237,12 @@ static int same_questions(const unsigned char *qbuf, int qlen,
       /* Decode the question in the query. */
       if (ares_expand_name(q.p, qbuf, qlen, &q.name, &q.namelen)
           != ARES_SUCCESS)
-        return 0;
+        return ARES_FALSE;
       q.p += q.namelen;
       if (q.p + QFIXEDSZ > qbuf + qlen)
         {
           ares_free(q.name);
-          return 0;
+          return ARES_FALSE;
         }
       q.type = DNS_QUESTION_TYPE(q.p);
       q.dnsclass = DNS_QUESTION_CLASS(q.p);
@@ -1257,14 +1257,14 @@ static int same_questions(const unsigned char *qbuf, int qlen,
               != ARES_SUCCESS)
             {
               ares_free(q.name);
-              return 0;
+              return ARES_FALSE;
             }
           a.p += a.namelen;
           if (a.p + QFIXEDSZ > abuf + alen)
             {
               ares_free(q.name);
               ares_free(a.name);
-              return 0;
+              return ARES_FALSE;
             }
           a.type = DNS_QUESTION_TYPE(a.p);
           a.dnsclass = DNS_QUESTION_CLASS(a.p);
@@ -1282,12 +1282,12 @@ static int same_questions(const unsigned char *qbuf, int qlen,
 
       ares_free(q.name);
       if (j == a.qdcount)
-        return 0;
+        return ARES_FALSE;
     }
-  return 1;
+  return ARES_TRUE;
 }
 
-static int same_address(struct sockaddr *sa, struct ares_addr *aa)
+static ares_bool_t same_address(struct sockaddr *sa, struct ares_addr *aa)
 {
   void *addr1;
   void *addr2;
@@ -1300,19 +1300,19 @@ static int same_address(struct sockaddr *sa, struct ares_addr *aa)
             addr1 = &aa->addrV4;
             addr2 = &(CARES_INADDR_CAST(struct sockaddr_in *, sa))->sin_addr;
             if (memcmp(addr1, addr2, sizeof(aa->addrV4)) == 0)
-              return 1; /* match */
+              return ARES_TRUE; /* match */
             break;
           case AF_INET6:
             addr1 = &aa->addrV6;
             addr2 = &(CARES_INADDR_CAST(struct sockaddr_in6 *, sa))->sin6_addr;
             if (memcmp(addr1, addr2, sizeof(aa->addrV6)) == 0)
-              return 1; /* match */
+              return ARES_TRUE; /* match */
             break;
           default:
             break;  /* LCOV_EXCL_LINE */
         }
     }
-  return 0; /* different */
+  return ARES_FALSE; /* different */
 }
 
 /* search for an OPT RR in the response */

--- a/src/lib/ares_rand.c
+++ b/src/lib/ares_rand.c
@@ -186,19 +186,19 @@ BOOLEAN WINAPI SystemFunction036(PVOID RandomBuffer, ULONG RandomBufferLength);
 #endif
 
 
-static int ares__init_rand_engine(ares_rand_state *state)
+static ares_bool_t ares__init_rand_engine(ares_rand_state *state)
 {
   memset(state, 0, sizeof(*state));
 
 #if defined(HAVE_ARC4RANDOM_BUF) || defined(HAVE_GETRANDOM) || defined(_WIN32)
   state->type = ARES_RAND_OS;
-  return 1;
+  return ARES_TRUE;
 #elif defined(CARES_RANDOM_FILE)
   state->type            = ARES_RAND_FILE;
   state->state.rand_file = fopen(CARES_RANDOM_FILE, "rb");
   if (state->state.rand_file) {
     setvbuf(state->state.rand_file, NULL, _IONBF, 0);
-    return 1;
+    return ARES_TRUE;
   }
   /* Fall-Thru on failure to RC4 */
 #endif
@@ -208,7 +208,7 @@ static int ares__init_rand_engine(ares_rand_state *state)
   ares_rc4_init(&state->state.rc4);
 
   /* Currently cannot fail */
-  return 1;
+  return ARES_TRUE;
 #endif
 }
 

--- a/src/lib/ares_send.c
+++ b/src/lib/ares_send.c
@@ -111,7 +111,7 @@ ares_status_t ares_send_ex(ares_channel channel, const unsigned char *qbuf,
 
   for (i = 0; i < channel->nservers; i++)
     {
-      query->server_info[i].skip_server = 0;
+      query->server_info[i].skip_server = ARES_FALSE;
       query->server_info[i].tcp_connection_generation = 0;
     }
 


### PR DESCRIPTION
c-ares currently uses `int` for boolean, which can be confusing as there are some functions which return `int` but use '0' as the success condition.  Some internal variable usage is similar.  Lets try to identify the boolean use cases and split them out into their own data type of ares_bool_t.  Since we're trying to keep C89 compatibility, we can't rely on `stdbool.h` or the `_Bool` C99 data type, so we'll define our own.

Also, chose using an `enum` rather than say `unsigned char` or `int` because of the type safety benefits it provides.  Compilers _should_ warn if you try to pass, ARES_TRUE on to a `ares_status_t` enum (or similar) since they are different enums.

Fix By: Brad House (@bradh352)