### PR TITLE
Fix internal datatype usage and warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
-CMAKE_MINIMUM_REQUIRED (VERSION 3.4.3)
+CMAKE_MINIMUM_REQUIRED (VERSION 3.5.0)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 

--- a/src/lib/ares__addrinfo2hostent.c
+++ b/src/lib/ares__addrinfo2hostent.c
@@ -170,13 +170,13 @@ ares_status_t ares__addrinfo2hostent(const struct ares_addrinfo *ai, int family,
                 {
                   memcpy((*host)->h_addr_list[i],
                      &(CARES_INADDR_CAST(struct sockaddr_in6 *, next->ai_addr)->sin6_addr),
-                     (*host)->h_length);
+                     (size_t)(*host)->h_length);
                 }
               else
                 {
                   memcpy((*host)->h_addr_list[i],
                      &(CARES_INADDR_CAST(struct sockaddr_in *, next->ai_addr)->sin_addr),
-                     (*host)->h_length);
+                     (size_t)(*host)->h_length);
                 }
               ++i;
             }

--- a/src/lib/ares__addrinfo2hostent.c
+++ b/src/lib/ares__addrinfo2hostent.c
@@ -61,7 +61,7 @@ ares_status_t ares__addrinfo2hostent(const struct ares_addrinfo *ai, int family,
   struct ares_addrinfo_cname *next_cname;
   char **aliases = NULL;
   char *addrs = NULL;
-  int naliases = 0, naddrs = 0, alias = 0, i;
+  size_t naliases = 0, naddrs = 0, alias = 0, i;
 
   if (ai == NULL || host == NULL)
     return ARES_EBADQUERY;
@@ -153,7 +153,7 @@ ares_status_t ares__addrinfo2hostent(const struct ares_addrinfo *ai, int family,
 
   if (naddrs)
     {
-      addrs = ares_malloc(naddrs * (*host)->h_length);
+      addrs = ares_malloc(naddrs * (size_t)(*host)->h_length);
       if (!addrs)
         {
           goto enomem;
@@ -165,7 +165,7 @@ ares_status_t ares__addrinfo2hostent(const struct ares_addrinfo *ai, int family,
         {
           if(next->ai_family == family)
             {
-              (*host)->h_addr_list[i] = addrs + (i * (*host)->h_length);
+              (*host)->h_addr_list[i] = addrs + (i * (size_t)(*host)->h_length);
               if (family == AF_INET6)
                 {
                   memcpy((*host)->h_addr_list[i],
@@ -206,10 +206,10 @@ enomem:
 
 
 ares_status_t ares__addrinfo2addrttl(const struct ares_addrinfo *ai, int family,
-                                     int req_naddrttls,
+                                     size_t req_naddrttls,
                                      struct ares_addrttl *addrttls,
                                      struct ares_addr6ttl *addr6ttls,
-                                     int *naddrttls)
+                                     size_t *naddrttls)
 {
   struct ares_addrinfo_node *next;
   struct ares_addrinfo_cname *next_cname;

--- a/src/lib/ares__addrinfo_localhost.c
+++ b/src/lib/ares__addrinfo_localhost.c
@@ -49,7 +49,7 @@
 
 ares_status_t ares_append_ai_node(int aftype,
                                   unsigned short port,
-                                  int ttl,
+                                  unsigned short ttl,
                                   const void *adata,
                                   struct ares_addrinfo_node **nodes)
 {

--- a/src/lib/ares__addrinfo_localhost.c
+++ b/src/lib/ares__addrinfo_localhost.c
@@ -49,7 +49,7 @@
 
 ares_status_t ares_append_ai_node(int aftype,
                                   unsigned short port,
-                                  unsigned short ttl,
+                                  unsigned int ttl,
                                   const void *adata,
                                   struct ares_addrinfo_node **nodes)
 {
@@ -80,7 +80,7 @@ ares_status_t ares_append_ai_node(int aftype,
       node->ai_family = AF_INET;
       node->ai_addrlen = sizeof(*sin);
       node->ai_addr = (struct sockaddr *)sin;
-      node->ai_ttl = ttl;
+      node->ai_ttl = (int)ttl;
     }
 
   if (aftype == AF_INET6)
@@ -100,7 +100,7 @@ ares_status_t ares_append_ai_node(int aftype,
       node->ai_family = AF_INET6;
       node->ai_addrlen = sizeof(*sin6);
       node->ai_addr = (struct sockaddr *)sin6;
-      node->ai_ttl = ttl;
+      node->ai_ttl = (int)ttl;
     }
 
   return ARES_SUCCESS;

--- a/src/lib/ares__close_sockets.c
+++ b/src/lib/ares__close_sockets.c
@@ -74,7 +74,7 @@ void ares__check_cleanup_conn(ares_channel channel, ares_socket_t fd)
 {
   ares__llist_node_t       *node;
   struct server_connection *conn;
-  int                       do_cleanup = 0;
+  ares_bool_t               do_cleanup = ARES_FALSE;
 
   node = ares__htable_asvp_get_direct(channel->connnode_by_socket, fd);
   if (node == NULL) {
@@ -89,13 +89,13 @@ void ares__check_cleanup_conn(ares_channel channel, ares_socket_t fd)
 
   /* If we are configured not to stay open, close it out */
   if (!(channel->flags & ARES_FLAG_STAYOPEN)) {
-    do_cleanup = 1;
+    do_cleanup = ARES_TRUE;
   }
 
   /* If the udp connection hit its max queries, always close it */
   if (!conn->is_tcp && channel->udp_max_queries > 0 &&
-      conn->total_queries >= (size_t)channel->udp_max_queries) {
-    do_cleanup = 1;
+      conn->total_queries >= channel->udp_max_queries) {
+    do_cleanup = ARES_TRUE;
   }
 
   if (do_cleanup) {

--- a/src/lib/ares__parse_into_addrinfo.c
+++ b/src/lib/ares__parse_into_addrinfo.c
@@ -58,7 +58,9 @@ ares_status_t ares__parse_into_addrinfo(const unsigned char *abuf,
   size_t qdcount, ancount;
   ares_status_t status;
   size_t i;
-  int rr_type, rr_class, rr_len, rr_ttl;
+  int rr_type, rr_class;
+  size_t rr_len;
+  unsigned int rr_ttl;
   ares_bool_t got_a = ARES_FALSE, got_aaaa = ARES_FALSE, got_cname = ARES_FALSE;
   size_t len;
   const unsigned char *aptr;
@@ -94,7 +96,7 @@ ares_status_t ares__parse_into_addrinfo(const unsigned char *abuf,
   aptr += len + QFIXEDSZ;
 
   /* Examine each answer resource record (RR) in turn. */
-  for (i = 0; i < (int)ancount; i++)
+  for (i = 0; i < ancount; i++)
     {
       /* Decode the RR up to the data field. */
       status = ares__expand_name_for_response(aptr, abuf, alen, &rr_name, &len, 0);
@@ -173,7 +175,7 @@ ares_status_t ares__parse_into_addrinfo(const unsigned char *abuf,
               ares_free(rr_data);
               goto failed_stat;
             }
-          cname->ttl = rr_ttl;
+          cname->ttl = (int)rr_ttl;
           cname->alias = rr_name;
           cname->name = rr_data;
           rr_name = NULL;

--- a/src/lib/ares__parse_into_addrinfo.c
+++ b/src/lib/ares__parse_into_addrinfo.c
@@ -50,16 +50,17 @@
 #include "ares_private.h"
 
 ares_status_t ares__parse_into_addrinfo(const unsigned char *abuf,
-                                        int alen,
+                                        size_t alen,
                                         ares_bool_t cname_only_is_enodata,
                                         unsigned short port,
                                         struct ares_addrinfo *ai)
 {
-  unsigned int qdcount, ancount;
+  size_t qdcount, ancount;
   ares_status_t status;
-  int i, rr_type, rr_class, rr_len, rr_ttl;
+  size_t i;
+  int rr_type, rr_class, rr_len, rr_ttl;
   ares_bool_t got_a = ARES_FALSE, got_aaaa = ARES_FALSE, got_cname = ARES_FALSE;
-  long len;
+  size_t len;
   const unsigned char *aptr;
   char *question_hostname = NULL;
   char *hostname, *rr_name = NULL, *rr_data;

--- a/src/lib/ares__readaddrinfo.c
+++ b/src/lib/ares__readaddrinfo.c
@@ -52,7 +52,7 @@ ares_status_t ares__readaddrinfo(FILE *fp,
   char *line = NULL, *p, *q;
   char *txtaddr, *txthost, *txtalias;
   char *aliases[MAX_ALIASES];
-  unsigned int i, alias_count;
+  size_t i, alias_count;
   ares_status_t status = ARES_SUCCESS;
   size_t linesize;
   struct ares_addrinfo_cname *cname = NULL, *cnames = NULL;

--- a/src/lib/ares__sortaddrinfo.c
+++ b/src/lib/ares__sortaddrinfo.c
@@ -57,9 +57,9 @@
 struct addrinfo_sort_elem
 {
   struct ares_addrinfo_node *ai;
-  int has_src_addr;
+  ares_bool_t has_src_addr;
   ares_sockaddr src_addr;
-  int original_order;
+  size_t original_order;
 };
 
 #define ARES_IPV6_ADDR_MC_SCOPE(a) ((a)->s6_addr[1] & 0x0f)
@@ -299,7 +299,7 @@ static int rfc6724_compare(const void *ptr1, const void *ptr2)
   /* Rule 1: Avoid unusable destinations. */
   if (a1->has_src_addr != a2->has_src_addr)
     {
-      return a2->has_src_addr - a1->has_src_addr;
+      return ((int)a2->has_src_addr) - ((int)a1->has_src_addr);
     }
 
   /* Rule 2: Prefer matching scope. */
@@ -380,7 +380,7 @@ static int rfc6724_compare(const void *ptr1, const void *ptr2)
    * Rule 10: Leave the order unchanged.
    * We need this since qsort() is not necessarily stable.
    */
-  return a1->original_order - a2->original_order;
+  return ((int)a1->original_order) - ((int)a2->original_order);
 }
 
 /*
@@ -454,8 +454,8 @@ ares_status_t ares__sortaddrinfo(ares_channel channel,
                                  struct ares_addrinfo_node *list_sentinel)
 {
   struct ares_addrinfo_node *cur;
-  int nelem = 0, i;
-  int has_src_addr;
+  size_t nelem = 0, i;
+  ares_bool_t has_src_addr;
   struct addrinfo_sort_elem *elems;
 
   cur = list_sentinel->ai_next;

--- a/src/lib/ares__sortaddrinfo.c
+++ b/src/lib/ares__sortaddrinfo.c
@@ -255,15 +255,16 @@ static int get_precedence(const struct sockaddr *addr)
 /*
  * Find number of matching initial bits between the two addresses a1 and a2.
  */
-static int common_prefix_len(const struct in6_addr *a1,
+static size_t common_prefix_len(const struct in6_addr *a1,
                              const struct in6_addr *a2)
 {
-  const char *p1 = (const char *)a1;
-  const char *p2 = (const char *)a2;
-  unsigned i;
+  const unsigned char *p1 = (const unsigned char *)a1;
+  const unsigned char *p2 = (const unsigned char *)a2;
+  size_t i;
   for (i = 0; i < sizeof(*a1); ++i)
     {
-      int x, j;
+      unsigned char x;
+      size_t j;
       if (p1[i] == p2[i])
         {
           continue;
@@ -294,7 +295,7 @@ static int rfc6724_compare(const void *ptr1, const void *ptr2)
   int label_src1, label_dst1, label_match1;
   int label_src2, label_dst2, label_match2;
   int precedence1, precedence2;
-  int prefixlen1, prefixlen2;
+  size_t prefixlen1, prefixlen2;
 
   /* Rule 1: Avoid unusable destinations. */
   if (a1->has_src_addr != a2->has_src_addr)
@@ -372,7 +373,7 @@ static int rfc6724_compare(const void *ptr1, const void *ptr2)
       prefixlen2 = common_prefix_len(&a2_src->sin6_addr, &a2_dst->sin6_addr);
       if (prefixlen1 != prefixlen2)
         {
-          return prefixlen2 - prefixlen1;
+          return (int)prefixlen2 - (int)prefixlen1;
         }
     }
 
@@ -387,7 +388,7 @@ static int rfc6724_compare(const void *ptr1, const void *ptr2)
  * Find the source address that will be used if trying to connect to the given
  * address.
  *
- * Returns 1 if a source address was found, 0 if the address is unreachable,
+ * Returns 1 if a source address was found, 0 if the address is unreachable
  * and -1 if a fatal error occurred. If 0 or 1, the contents of src_addr are
  * undefined.
  */
@@ -455,7 +456,7 @@ ares_status_t ares__sortaddrinfo(ares_channel channel,
 {
   struct ares_addrinfo_node *cur;
   size_t nelem = 0, i;
-  ares_bool_t has_src_addr;
+  int has_src_addr;
   struct addrinfo_sort_elem *elems;
 
   cur = list_sentinel->ai_next;
@@ -490,7 +491,7 @@ ares_status_t ares__sortaddrinfo(ares_channel channel,
           ares_free(elems);
           return ARES_ENOTFOUND;
         }
-      elems[i].has_src_addr = has_src_addr;
+      elems[i].has_src_addr = (has_src_addr == 1)?ARES_TRUE:ARES_FALSE;
     }
 
   /* Sort the addresses, and rearrange the linked list so it matches the sorted

--- a/src/lib/ares__timeval.c
+++ b/src/lib/ares__timeval.c
@@ -59,7 +59,7 @@ struct timeval ares__tvnow(void)
   struct timespec tsnow;
   if(0 == clock_gettime(CLOCK_MONOTONIC, &tsnow)) {
     now.tv_sec = tsnow.tv_sec;
-    now.tv_usec = tsnow.tv_nsec / 1000;
+    now.tv_usec = (int)(tsnow.tv_nsec / 1000);
   }
   /*
   ** Even when the configure process has truly detected monotonic clock

--- a/src/lib/ares_create_query.c
+++ b/src/lib/ares_create_query.c
@@ -163,7 +163,7 @@ int ares_create_query(const char *name, int dnsclass, int type,
         {
           if (*p == '\\' && *(p + 1) != 0)
             p++;
-          *q++ = *p;
+          *q++ = (unsigned char)*p;
         }
 
       /* Go to the next label and repeat, unless we hit the end. */
@@ -188,7 +188,7 @@ int ares_create_query(const char *name, int dnsclass, int type,
       DNS_RR_SET_CLASS(q, max_udp_size);
       q += (EDNSFIXEDSZ-1);
   }
-  buflen = (q - buf);
+  buflen = (size_t)(q - buf);
 
   /* Reject names that are longer than the maximum of 255 bytes that's
    * specified in RFC 1035 ("To simplify implementations, the total length of

--- a/src/lib/ares_destroy.c
+++ b/src/lib/ares_destroy.c
@@ -121,7 +121,7 @@ void ares_destroy(ares_channel channel)
 void ares__destroy_servers_state(ares_channel channel)
 {
   struct server_state *server;
-  int i;
+  size_t i;
 
   if (channel->servers)
     {
@@ -136,5 +136,5 @@ void ares__destroy_servers_state(ares_channel channel)
       ares_free(channel->servers);
       channel->servers = NULL;
     }
-  channel->nservers = -1;
+  channel->nservers = 0;
 }

--- a/src/lib/ares_destroy.c
+++ b/src/lib/ares_destroy.c
@@ -54,7 +54,7 @@ void ares_destroy_options(struct ares_options *options)
 
 void ares_destroy(ares_channel channel)
 {
-  int                 i;
+  size_t              i;
   ares__llist_node_t *node = NULL;
 
   if (!channel)

--- a/src/lib/ares_expand_name.c
+++ b/src/lib/ares_expand_name.c
@@ -173,14 +173,14 @@ ares_status_t ares__expand_name_validated(const unsigned char *encoded,
         {
           if (!indir)
             {
-              *enclen = aresx_uztosl(p + 2U - encoded);
+              *enclen = (size_t)(p + 2U - encoded);
               indir = 1;
             }
           p = abuf + ((*p & ~INDIR_MASK) << 8 | *(p + 1));
         }
       else
         {
-          int name_len = *p;
+          size_t name_len = *p;
           len = name_len;
           p++;
 
@@ -198,11 +198,11 @@ ares_status_t ares__expand_name_validated(const unsigned char *encoded,
               else if (is_reservedch(*p))
                 {
                   *q++ = '\\';
-                  *q++ = *p;
+                  *q++ = (char)*p;
                 }
               else
                 {
-                  *q++ = *p;
+                  *q++ = (char)*p;
                 }
               p++;
             }
@@ -211,7 +211,7 @@ ares_status_t ares__expand_name_validated(const unsigned char *encoded,
      }
 
   if (!indir)
-    *enclen = aresx_uztosl(p + 1U - encoded);
+    *enclen = (size_t)(p + 1U - encoded);
 
   /* Nuke the trailing period if we wrote one. */
   if (q > *s)
@@ -235,8 +235,8 @@ int ares_expand_name(const unsigned char *encoded, const unsigned char *abuf,
 
   status = ares__expand_name_validated(encoded, abuf, (size_t)alen, s,
                                        &enclen_temp, ARES_FALSE);
-  *enclen = enclen_temp;
-  return status;
+  *enclen = (long)enclen_temp;
+  return (int)status;
 }
 
 /* Return the length of the expansion of an encoded domain name, or
@@ -260,7 +260,7 @@ static ares_ssize_t name_length(const unsigned char *encoded,
           /* Check the offset and go there. */
           if (encoded + 1 >= abuf + alen)
             return -1;
-          offset = (*encoded & ~INDIR_MASK) << 8 | *(encoded + 1);
+          offset = (size_t)(*encoded & ~INDIR_MASK) << 8 | *(encoded + 1);
           if (offset >= alen)
             return -1;
           encoded = abuf + offset;
@@ -274,7 +274,7 @@ static ares_ssize_t name_length(const unsigned char *encoded,
         }
       else if (top == 0x00)
         {
-          int name_len = *encoded;
+          size_t name_len = *encoded;
           offset = name_len;
           if (encoded + offset + 1 >= abuf + alen)
             return -1;
@@ -317,7 +317,7 @@ static ares_ssize_t name_length(const unsigned char *encoded,
   /* If there were any labels at all, then the number of dots is one
    * less than the number of labels, so subtract one.
    */
-  return (n) ? n - 1 : n;
+  return (ares_ssize_t)((n) ? n - 1 : n);
 }
 
 /* Like ares_expand_name_validated  but returns EBADRESP in case of invalid

--- a/src/lib/ares_expand_string.c
+++ b/src/lib/ares_expand_string.c
@@ -87,9 +87,9 @@ int ares_expand_string(const unsigned char *encoded,
   if (alen < 0)
     return ARES_EBADRESP;
 
-  status = ares_expand_string_ex(encoded, abuf, alen, s, &temp_enclen);
+  status = ares_expand_string_ex(encoded, abuf, (size_t)alen, s, &temp_enclen);
 
   *enclen = (long)temp_enclen;
-  return status;
+  return (int)status;
 }
 

--- a/src/lib/ares_expand_string.c
+++ b/src/lib/ares_expand_string.c
@@ -36,43 +36,60 @@
 #include "ares.h"
 #include "ares_private.h" /* for the memdebug */
 
+
 /* Simply decodes a length-encoded character string. The first byte of the
  * input is the length of the string to be returned and the bytes thereafter
  * are the characters of the string. The returned result will be NULL
  * terminated.
  */
+ares_status_t ares_expand_string_ex(const unsigned char *encoded,
+                                    const unsigned char *abuf,
+                                    size_t alen,
+                                    unsigned char **s,
+                                    size_t *enclen)
+{
+  unsigned char *q;
+  size_t         len;
+
+  if (encoded == abuf+alen)
+    return ARES_EBADSTR;
+
+  len = *encoded;
+  if (encoded + len + 1 > abuf + alen)
+    return ARES_EBADSTR;
+
+  encoded++;
+
+  *s = ares_malloc(len+1);
+  if (*s == NULL)
+    return ARES_ENOMEM;
+  q = *s;
+  strncpy((char *)q, (char *)encoded, len);
+  q[len] = '\0';
+
+  *s = q;
+
+  *enclen = len+1;
+
+  return ARES_SUCCESS;
+}
+
+
 int ares_expand_string(const unsigned char *encoded,
                        const unsigned char *abuf,
                        int alen,
                        unsigned char **s,
                        long *enclen)
 {
-  unsigned char *q;
-  union {
-    ares_ssize_t sig;
-     size_t uns;
-  } elen;
+  ares_status_t status;
+  size_t        temp_enclen = 0;
 
-  if (encoded == abuf+alen)
-    return ARES_EBADSTR;
+  if (alen < 0)
+    return ARES_EBADRESP;
 
-  elen.uns = *encoded;
-  if (encoded+elen.sig+1 > abuf+alen)
-    return ARES_EBADSTR;
+  status = ares_expand_string_ex(encoded, abuf, alen, s, &temp_enclen);
 
-  encoded++;
-
-  *s = ares_malloc(elen.uns+1);
-  if (*s == NULL)
-    return ARES_ENOMEM;
-  q = *s;
-  strncpy((char *)q, (char *)encoded, elen.uns);
-  q[elen.uns] = '\0';
-
-  *s = q;
-
-  *enclen = (long)(elen.sig+1);
-
-  return ARES_SUCCESS;
+  *enclen = (long)temp_enclen;
+  return status;
 }
 

--- a/src/lib/ares_fds.c
+++ b/src/lib/ares_fds.c
@@ -35,7 +35,7 @@ int ares_fds(ares_channel channel, fd_set *read_fds, fd_set *write_fds)
 {
   struct server_state *server;
   ares_socket_t nfds;
-  int i;
+  size_t i;
 
   /* Are there any active queries? */
   size_t active_queries = ares__llist_len(channel->all_queries);

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -77,16 +77,15 @@ struct host_query
   void *arg;
   struct ares_addrinfo_hints hints;
   int sent_family; /* this family is what was is being used */
-  int timeouts;    /* number of timeouts we saw for this request */
+  size_t timeouts;    /* number of timeouts we saw for this request */
   const char *remaining_lookups; /* types of lookup we need to perform ("fb" by
                                     default, file and dns respectively) */
   struct ares_addrinfo *ai;      /* store results between lookups */
   unsigned short qid_a;    /* qid for A request */
   unsigned short qid_aaaa; /* qid for AAAA request */
-  int remaining;   /* number of DNS answers waiting for */
-  int next_domain; /* next search domain to try */
-  int nodata_cnt; /* Track nodata responses to possibly override final result */
-
+  size_t remaining;   /* number of DNS answers waiting for */
+  ares_ssize_t next_domain; /* next search domain to try */
+  size_t nodata_cnt; /* Track nodata responses to possibly override final result */
 };
 
 static const struct ares_addrinfo_hints default_hints = {
@@ -290,27 +289,28 @@ static unsigned short lookup_service(const char *service, int flags)
  * fake up a host entry, end the query immediately, and return true.
  * Otherwise return false.
  */
-static int fake_addrinfo(const char *name,
-                         unsigned short port,
-                         const struct ares_addrinfo_hints *hints,
-                         struct ares_addrinfo *ai,
-                         ares_addrinfo_callback callback,
-                         void *arg)
+static ares_bool_t fake_addrinfo(const char *name,
+                                 unsigned short port,
+                                 const struct ares_addrinfo_hints *hints,
+                                 struct ares_addrinfo *ai,
+                                 ares_addrinfo_callback callback,
+                                 void *arg)
 {
   struct ares_addrinfo_cname *cname;
   ares_status_t status = ARES_SUCCESS;
-  int result = 0;
+  ares_bool_t result = ARES_FALSE;
   int family = hints->ai_family;
   if (family == AF_INET || family == AF_INET6 || family == AF_UNSPEC)
     {
       /* It only looks like an IP address if it's all numbers and dots. */
-      int numdots = 0, valid = 1;
+      size_t numdots = 0;
+      ares_bool_t valid = ARES_TRUE;
       const char *p;
       for (p = name; *p; p++)
         {
           if (!ISDIGIT(*p) && *p != '.')
             {
-              valid = 0;
+              valid = ARES_FALSE;
               break;
             }
           else if (*p == '.')
@@ -323,18 +323,18 @@ static int fake_addrinfo(const char *name,
        * (although inet_pton doesn't think so).
        */
       if (numdots != 3 || !valid)
-        result = 0;
+        result = ARES_FALSE;
       else
         {
           struct in_addr addr4;
-          result = ares_inet_pton(AF_INET, name, &addr4) < 1 ? 0 : 1;
+          result = ares_inet_pton(AF_INET, name, &addr4) < 1 ? ARES_FALSE : ARES_TRUE;
           if (result)
             {
               status = ares_append_ai_node(AF_INET, port, 0, &addr4, &ai->nodes);
               if (status != ARES_SUCCESS)
                 {
                   callback(arg, status, 0, NULL);
-                  return 1;
+                  return ARES_TRUE;
                 }
             }
         }
@@ -343,20 +343,20 @@ static int fake_addrinfo(const char *name,
   if (!result && (family == AF_INET6 || family == AF_UNSPEC))
     {
       struct ares_in6_addr addr6;
-      result = ares_inet_pton(AF_INET6, name, &addr6) < 1 ? 0 : 1;
+      result = ares_inet_pton(AF_INET6, name, &addr6) < 1 ? ARES_FALSE : ARES_TRUE;
       if (result)
         {
           status = ares_append_ai_node(AF_INET6, port, 0, &addr6, &ai->nodes);
           if (status != ARES_SUCCESS)
             {
               callback(arg, status, 0, NULL);
-              return 1;
+              return ARES_TRUE;
             }
         }
     }
 
   if (!result)
-    return 0;
+    return ARES_FALSE;
 
   if (hints->ai_flags & ARES_AI_CANONNAME)
     {
@@ -365,7 +365,7 @@ static int fake_addrinfo(const char *name,
         {
           ares_freeaddrinfo(ai);
           callback(arg, ARES_ENOMEM, 0, NULL);
-          return 1;
+          return ARES_TRUE;
         }
 
       /* Duplicate the name, to avoid a constness violation. */
@@ -374,7 +374,7 @@ static int fake_addrinfo(const char *name,
         {
           ares_freeaddrinfo(ai);
           callback(arg, ARES_ENOMEM, 0, NULL);
-          return 1;
+          return ARES_TRUE;
         }
     }
 
@@ -382,7 +382,7 @@ static int fake_addrinfo(const char *name,
   ai->nodes->ai_protocol = hints->ai_protocol;
 
   callback(arg, ARES_SUCCESS, 0, ai);
-  return 1;
+  return ARES_TRUE;
 }
 
 static void end_hquery(struct host_query *hquery, ares_status_t status)
@@ -850,7 +850,7 @@ static ares_bool_t next_dns_lookup(struct host_query *hquery)
 static ares_bool_t as_is_first(const struct host_query* hquery)
 {
   char* p;
-  int ndots = 0;
+  size_t ndots = 0;
   size_t nname = hquery->name?strlen(hquery->name):0;
   for (p = hquery->name; p && *p; p++)
     {

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -793,7 +793,7 @@ static ares_bool_t next_dns_lookup(struct host_query *hquery)
     }
 
   /* if as_is_first is false, try hquery->name at last */
-  if (!s && hquery->next_domain == hquery->channel->ndomains) {
+  if (!s && (size_t)hquery->next_domain == hquery->channel->ndomains) {
     if (!as_is_first(hquery))
       {
         s = hquery->name;
@@ -801,7 +801,7 @@ static ares_bool_t next_dns_lookup(struct host_query *hquery)
     hquery->next_domain++;
   }
 
-  if (!s && hquery->next_domain < hquery->channel->ndomains && !as_is_only(hquery))
+  if (!s && (size_t)hquery->next_domain < hquery->channel->ndomains && !as_is_only(hquery))
     {
       status = ares__cat_domain(
           hquery->name,

--- a/src/lib/ares_gethostbyaddr.c
+++ b/src/lib/ares_gethostbyaddr.c
@@ -56,7 +56,7 @@ struct addr_query {
   void *arg;
 
   const char *remaining_lookups;
-  int timeouts;
+  size_t timeouts;
 };
 
 static void next_lookup(struct addr_query *aquery);
@@ -65,7 +65,7 @@ static void addr_callback(void *arg, int status, int timeouts,
 static void end_aquery(struct addr_query *aquery, ares_status_t status,
                        struct hostent *host);
 static ares_status_t file_lookup(struct ares_addr *addr, struct hostent **host);
-static void ptr_rr_name(char *name, int name_size, const struct ares_addr *addr);
+static void ptr_rr_name(char *name, size_t name_size, const struct ares_addr *addr);
 
 void ares_gethostbyaddr(ares_channel channel, const void *addr, int addrlen,
                         int family, ares_host_callback callback, void *arg)
@@ -267,7 +267,7 @@ static ares_status_t file_lookup(struct ares_addr *addr, struct hostent **host)
   return status;
 }
 
-static void ptr_rr_name(char *name, int name_size, const struct ares_addr *addr)
+static void ptr_rr_name(char *name, size_t name_size, const struct ares_addr *addr)
 {
   if (addr->family == AF_INET)
     {

--- a/src/lib/ares_gethostbyaddr.c
+++ b/src/lib/ares_gethostbyaddr.c
@@ -146,7 +146,7 @@ static void addr_callback(void *arg, int status, int timeouts,
   struct hostent *host;
   size_t addrlen;
 
-  aquery->timeouts += timeouts;
+  aquery->timeouts += (size_t)timeouts;
   if (status == ARES_SUCCESS)
     {
       if (aquery->addr.family == AF_INET)
@@ -161,10 +161,10 @@ static void addr_callback(void *arg, int status, int timeouts,
           status = ares_parse_ptr_reply(abuf, alen, &aquery->addr.addrV6,
                                         (int)addrlen, AF_INET6, &host);
         }
-      end_aquery(aquery, status, host);
+      end_aquery(aquery, (ares_status_t)status, host);
     }
   else if (status == ARES_EDESTRUCTION || status == ARES_ECANCELLED)
-    end_aquery(aquery, status, NULL);
+    end_aquery(aquery, (ares_status_t)status, NULL);
   else
     next_lookup(aquery);
 }
@@ -172,7 +172,7 @@ static void addr_callback(void *arg, int status, int timeouts,
 static void end_aquery(struct addr_query *aquery, ares_status_t status,
                        struct hostent *host)
 {
-  aquery->callback(aquery->arg, status, aquery->timeouts, host);
+  aquery->callback(aquery->arg, (int)status, (int)aquery->timeouts, host);
   if (host)
     ares_free_hostent(host);
   ares_free(aquery);

--- a/src/lib/ares_gethostbyname.c
+++ b/src/lib/ares_gethostbyname.c
@@ -73,7 +73,7 @@ static void ares_gethostbyname_callback(void *arg, int status, int timeouts,
 
   if (status == ARES_SUCCESS)
     {
-      status = ares__addrinfo2hostent(result, AF_UNSPEC, &hostent);
+      status = (int)ares__addrinfo2hostent(result, AF_UNSPEC, &hostent);
     }
 
   /* addrinfo2hostent will only return ENODATA if there are no addresses _and_
@@ -239,7 +239,7 @@ static ares_status_t file_lookup(const char *name, int family,
 int ares_gethostbyname_file(ares_channel channel, const char *name,
                             int family, struct hostent **host)
 {
-  ares_status_t result;
+  ares_status_t status;
 
   /* We only take the channel to ensure that ares_init() been called. */
   if(channel == NULL)
@@ -253,13 +253,13 @@ int ares_gethostbyname_file(ares_channel channel, const char *name,
   /* Just chain to the internal implementation we use here; it's exactly
    * what we want.
    */
-  result = file_lookup(name, family, host);
-  if(result != ARES_SUCCESS)
+  status = file_lookup(name, family, host);
+  if(status != ARES_SUCCESS)
     {
       /* We guarantee a NULL hostent on failure. */
       *host = NULL;
     }
-  return result;
+  return (int)status;
 }
 
 static ares_status_t file_lookup(const char *name, int family,

--- a/src/lib/ares_gethostbyname.c
+++ b/src/lib/ares_gethostbyname.c
@@ -51,13 +51,13 @@
 #include "ares_private.h"
 
 static void sort_addresses(struct hostent *host,
-                           const struct apattern *sortlist, int nsort);
+                           const struct apattern *sortlist, size_t nsort);
 static void sort6_addresses(struct hostent *host,
-                            const struct apattern *sortlist, int nsort);
-static int get_address_index(const struct in_addr *addr,
-                             const struct apattern *sortlist, int nsort);
-static int get6_address_index(const struct ares_in6_addr *addr,
-                              const struct apattern *sortlist, int nsort);
+                            const struct apattern *sortlist, size_t nsort);
+static size_t get_address_index(const struct in_addr *addr,
+                                const struct apattern *sortlist, size_t nsort);
+static size_t get6_address_index(const struct ares_in6_addr *addr,
+                                 const struct apattern *sortlist, size_t nsort);
 
 struct host_query {
   ares_host_callback callback;
@@ -128,10 +128,11 @@ void ares_gethostbyname(ares_channel channel, const char *name, int family,
 
 
 static void sort_addresses(struct hostent *host,
-                           const struct apattern *sortlist, int nsort)
+                           const struct apattern *sortlist, size_t nsort)
 {
   struct in_addr a1, a2;
-  int i1, i2, ind1, ind2;
+  int i1, i2;
+  size_t ind1, ind2;
 
   /* This is a simple insertion sort, not optimized at all.  i1 walks
    * through the address list, with the loop invariant that everything
@@ -157,11 +158,11 @@ static void sort_addresses(struct hostent *host,
 /* Find the first entry in sortlist which matches addr.  Return nsort
  * if none of them match.
  */
-static int get_address_index(const struct in_addr *addr,
-                             const struct apattern *sortlist,
-                             int nsort)
+static size_t get_address_index(const struct in_addr *addr,
+                                const struct apattern *sortlist,
+                                size_t nsort)
 {
-  int i;
+  size_t i;
 
   for (i = 0; i < nsort; i++)
     {
@@ -184,10 +185,11 @@ static int get_address_index(const struct in_addr *addr,
 }
 
 static void sort6_addresses(struct hostent *host,
-                            const struct apattern *sortlist, int nsort)
+                            const struct apattern *sortlist, size_t nsort)
 {
   struct ares_in6_addr a1, a2;
-  int i1, i2, ind1, ind2;
+  int i1, i2;
+  size_t ind1, ind2;
 
   /* This is a simple insertion sort, not optimized at all.  i1 walks
    * through the address list, with the loop invariant that everything
@@ -213,11 +215,11 @@ static void sort6_addresses(struct hostent *host,
 /* Find the first entry in sortlist which matches addr.  Return nsort
  * if none of them match.
  */
-static int get6_address_index(const struct ares_in6_addr *addr,
-                              const struct apattern *sortlist,
-                              int nsort)
+static size_t get6_address_index(const struct ares_in6_addr *addr,
+                                 const struct apattern *sortlist,
+                                 size_t nsort)
 {
-  int i;
+  size_t i;
 
   for (i = 0; i < nsort; i++)
     {

--- a/src/lib/ares_getnameinfo.c
+++ b/src/lib/ares_getnameinfo.c
@@ -61,7 +61,7 @@ struct nameinfo_query {
     struct sockaddr_in6 addr6;
   } addr;
   int family;
-  int flags;
+  unsigned int flags;
   size_t timeouts;
 };
 
@@ -75,7 +75,7 @@ struct nameinfo_query {
 
 static void nameinfo_callback(void *arg, int status, int timeouts,
                               struct hostent *host);
-static char *lookup_service(unsigned short port, int flags,
+static char *lookup_service(unsigned short port, unsigned int flags,
                             char *buf, size_t buflen);
 #ifdef HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID
 static void append_scopeid(struct sockaddr_in6 *addr6, unsigned int scopeid,
@@ -85,12 +85,13 @@ STATIC_TESTABLE char *ares_striendstr(const char *s1, const char *s2);
 
 void ares_getnameinfo(ares_channel channel, const struct sockaddr *sa,
                       ares_socklen_t salen,
-                      int flags, ares_nameinfo_callback callback, void *arg)
+                      int flags_int, ares_nameinfo_callback callback, void *arg)
 {
   struct sockaddr_in *addr = NULL;
   struct sockaddr_in6 *addr6 = NULL;
   struct nameinfo_query *niquery;
   unsigned short port = 0;
+  unsigned int flags = (unsigned int)flags_int;
 
   /* Validate socket address family and length */
   if ((sa->sa_family == AF_INET) &&
@@ -204,7 +205,7 @@ static void nameinfo_callback(void *arg, int status, int timeouts,
   char srvbuf[33];
   char *service = NULL;
 
-  niquery->timeouts += timeouts;
+  niquery->timeouts += (size_t)timeouts;
   if (status == ARES_SUCCESS)
     {
       /* They want a service too */
@@ -235,7 +236,7 @@ static void nameinfo_callback(void *arg, int status, int timeouts,
              }
         }
 #endif
-      niquery->callback(niquery->arg, ARES_SUCCESS, niquery->timeouts,
+      niquery->callback(niquery->arg, ARES_SUCCESS, (int)niquery->timeouts,
                         (char *)(host->h_name),
                         service);
       ares_free(niquery);
@@ -267,16 +268,16 @@ static void nameinfo_callback(void *arg, int status, int timeouts,
             service = lookup_service(niquery->addr.addr6.sin6_port,
                                      niquery->flags, srvbuf, sizeof(srvbuf));
         }
-      niquery->callback(niquery->arg, ARES_SUCCESS, niquery->timeouts, ipbuf,
+      niquery->callback(niquery->arg, ARES_SUCCESS, (int)niquery->timeouts, ipbuf,
                         service);
       ares_free(niquery);
       return;
     }
-  niquery->callback(niquery->arg, status, niquery->timeouts, NULL, NULL);
+  niquery->callback(niquery->arg, status, (int)niquery->timeouts, NULL, NULL);
   ares_free(niquery);
 }
 
-static char *lookup_service(unsigned short port, int flags,
+static char *lookup_service(unsigned short port, unsigned int flags,
                             char *buf, size_t buflen)
 {
   const char *proto;

--- a/src/lib/ares_getnameinfo.c
+++ b/src/lib/ares_getnameinfo.c
@@ -62,7 +62,7 @@ struct nameinfo_query {
   } addr;
   int family;
   int flags;
-  int timeouts;
+  size_t timeouts;
 };
 
 #ifdef HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID
@@ -90,7 +90,7 @@ void ares_getnameinfo(ares_channel channel, const struct sockaddr *sa,
   struct sockaddr_in *addr = NULL;
   struct sockaddr_in6 *addr6 = NULL;
   struct nameinfo_query *niquery;
-  unsigned int port = 0;
+  unsigned short port = 0;
 
   /* Validate socket address family and length */
   if ((sa->sa_family == AF_INET) &&

--- a/src/lib/ares_getsock.c
+++ b/src/lib/ares_getsock.c
@@ -42,6 +42,9 @@ int ares_getsock(ares_channel channel,
   /* Are there any active queries? */
   size_t active_queries = ares__llist_len(channel->all_queries);
 
+  if (numsocks <= 0)
+    return 0;
+
   for (i = 0; i < channel->nservers; i++) {
     ares__llist_node_t *node;
     server = &channel->servers[i];
@@ -52,7 +55,7 @@ int ares_getsock(ares_channel channel,
 
       struct server_connection *conn = ares__llist_node_val(node);
 
-      if (sockindex >= numsocks || sockindex >= ARES_GETSOCK_MAXNUM)
+      if (sockindex >= (size_t)numsocks || sockindex >= ARES_GETSOCK_MAXNUM)
         break;
 
       /* We only need to register interest in UDP sockets if we have

--- a/src/lib/ares_getsock.c
+++ b/src/lib/ares_getsock.c
@@ -34,7 +34,7 @@ int ares_getsock(ares_channel channel,
                  int numsocks) /* size of the 'socks' array */
 {
   struct server_state *server;
-  int i;
+  size_t i;
   size_t sockindex=0;
   unsigned int bitmap = 0;
   unsigned int setbits = 0xffffffff;

--- a/src/lib/ares_getsock.c
+++ b/src/lib/ares_getsock.c
@@ -36,7 +36,7 @@ int ares_getsock(ares_channel channel,
   struct server_state *server;
   int i;
   size_t sockindex=0;
-  int bitmap = 0;
+  unsigned int bitmap = 0;
   unsigned int setbits = 0xffffffff;
 
   /* Are there any active queries? */
@@ -78,5 +78,5 @@ int ares_getsock(ares_channel channel,
       sockindex++;
     }
   }
-  return bitmap;
+  return (int)bitmap;
 }

--- a/src/lib/ares_getsock.c
+++ b/src/lib/ares_getsock.c
@@ -35,7 +35,7 @@ int ares_getsock(ares_channel channel,
 {
   struct server_state *server;
   int i;
-  int sockindex=0;
+  size_t sockindex=0;
   int bitmap = 0;
   unsigned int setbits = 0xffffffff;
 

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -589,8 +589,6 @@ static ares_status_t init_by_options(ares_channel channel,
   if (optmask & ARES_OPT_UDP_MAX_QUERIES)
     channel->udp_max_queries = (size_t)options->udp_max_queries;
 
-  channel->optmask = optmask;
-
   return ARES_SUCCESS;
 }
 

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -152,8 +152,6 @@ int ares_init_options(ares_channel *channelptr, struct ares_options *options,
    * been set yet.
    */
   channel->rotate = -1;
-  channel->socket_send_buffer_size = -1;
-  channel->socket_receive_buffer_size = -1;
 
   /* Generate random key */
 
@@ -500,12 +498,10 @@ static ares_status_t init_by_options(ares_channel channel,
       channel->sock_state_cb_data = options->sock_state_cb_data;
     }
 
-  if ((optmask & ARES_OPT_SOCK_SNDBUF)
-      && channel->socket_send_buffer_size == -1)
+  if (optmask & ARES_OPT_SOCK_SNDBUF && options->socket_send_buffer_size > 0)
     channel->socket_send_buffer_size = options->socket_send_buffer_size;
 
-  if ((optmask & ARES_OPT_SOCK_RCVBUF)
-      && channel->socket_receive_buffer_size == -1)
+  if (optmask & ARES_OPT_SOCK_RCVBUF && channel->socket_receive_buffer_size > 0)
     channel->socket_receive_buffer_size = options->socket_receive_buffer_size;
 
   if (optmask & ARES_OPT_EDNSPSZ)

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -152,7 +152,6 @@ int ares_init_options(ares_channel *channelptr, struct ares_options *options,
    * been set yet.
    */
   channel->rotate = -1;
-  channel->ednspsz = -1;
   channel->socket_send_buffer_size = -1;
   channel->socket_receive_buffer_size = -1;
 
@@ -509,8 +508,8 @@ static ares_status_t init_by_options(ares_channel channel,
       && channel->socket_receive_buffer_size == -1)
     channel->socket_receive_buffer_size = options->socket_receive_buffer_size;
 
-  if ((optmask & ARES_OPT_EDNSPSZ) && channel->ednspsz == -1)
-    channel->ednspsz = options->ednspsz;
+  if (optmask & ARES_OPT_EDNSPSZ)
+    channel->ednspsz = (size_t)options->ednspsz;
 
   /* Copy the IPv4 servers, if given. */
   if (optmask & ARES_OPT_SERVERS)
@@ -1635,7 +1634,7 @@ static ares_status_t init_by_defaults(ares_channel channel)
   if (channel->tcp_port == 0)
     channel->tcp_port = htons(NAMESERVER_PORT);
 
-  if (channel->ednspsz == -1)
+  if (channel->ednspsz == 0)
     channel->ednspsz = EDNSPACKETSZ;
 
   if (channel->nservers == 0) {

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -416,8 +416,10 @@ int ares_save_options(ares_channel channel, struct ares_options *options,
     for (i = 0; i < channel->ndomains; i++)
     {
       options->domains[i] = ares_strdup(channel->domains[i]);
-      if (!options->domains[i])
+      if (!options->domains[i]) {
+        options->ndomains = (int)i;
         return ARES_ENOMEM;
+      }
     }
   }
   options->ndomains = (int)channel->ndomains;

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -2074,7 +2074,7 @@ static ares_status_t config_sortlist(struct apattern **sortlist, int *nsort,
         q++;
       if (q-str >= 16)
         return ARES_EBADSTR;
-      memcpy(ipbuf, str, q-str);
+      memcpy(ipbuf, str, (size_t)(q-str));
       ipbuf[q-str] = '\0';
       /* Find the prefix */
       if (*q == '/')
@@ -2084,7 +2084,7 @@ static ares_status_t config_sortlist(struct apattern **sortlist, int *nsort,
             q++;
           if (q-str >= 32)
             return ARES_EBADSTR;
-          memcpy(ipbufpfx, str, q-str);
+          memcpy(ipbufpfx, str, (size_t)(q-str));
           ipbufpfx[q-str] = '\0';
           str = str2;
         }
@@ -2123,7 +2123,7 @@ static ares_status_t config_sortlist(struct apattern **sortlist, int *nsort,
         {
           if (ipbufpfx[0])
             {
-              memcpy(ipbuf, str, q-str);
+              memcpy(ipbuf, str, (size_t)(q-str));
               ipbuf[q-str] = '\0';
               if (ip_addr(ipbuf, q-str, &pat.mask.addr4) != 0)
                 natural_mask(&pat);

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -589,6 +589,8 @@ static ares_status_t init_by_options(ares_channel channel,
   if (optmask & ARES_OPT_UDP_MAX_QUERIES)
     channel->udp_max_queries = (size_t)options->udp_max_queries;
 
+  channel->optmask = optmask;
+
   return ARES_SUCCESS;
 }
 
@@ -1454,7 +1456,8 @@ static ares_status_t init_by_resolv_conf(ares_channel channel)
         else if ((p = try_config(line, "nameserver", ';')) &&
                 channel->nservers == 0)
           status = config_nameserver(&servers, &nservers, p);
-        else if ((p = try_config(line, "sortlist", ';')) && channel->nsort == 0)
+        else if ((p = try_config(line, "sortlist", ';')) &&
+          !(channel->optmask & ARES_OPT_SORTLIST))
           status = config_sortlist(&sortlist, &nsort, p);
         else if ((p = try_config(line, "options", ';')))
           status = set_options(channel, p);

--- a/src/lib/ares_options.c
+++ b/src/lib/ares_options.c
@@ -89,7 +89,7 @@ int ares_get_servers(ares_channel channel,
 
   *servers = srvr_head;
 
-  return status;
+  return (int)status;
 }
 
 int ares_get_servers_ports(ares_channel channel,
@@ -146,15 +146,15 @@ int ares_get_servers_ports(ares_channel channel,
 
   *servers = srvr_head;
 
-  return status;
+  return (int)status;
 }
 
 int ares_set_servers(ares_channel channel,
                      struct ares_addr_node *servers)
 {
   struct ares_addr_node *srvr;
-  int num_srvrs = 0;
-  int i;
+  size_t num_srvrs = 0;
+  size_t i;
 
   if (ares_library_initialized() != ARES_SUCCESS)
     return ARES_ENOTINITIALIZED;  /* LCOV_EXCL_LINE: n/a on non-WinSock */
@@ -181,7 +181,7 @@ int ares_set_servers(ares_channel channel,
           return ARES_ENOMEM;
         }
       memset(channel->servers, 0, num_srvrs * sizeof(*channel->servers));
-      channel->nservers = num_srvrs;
+      channel->nservers = (int)num_srvrs;
       /* Fill servers state address data */
       for (i = 0, srvr = servers; srvr; i++, srvr = srvr->next)
         {
@@ -206,8 +206,8 @@ int ares_set_servers_ports(ares_channel channel,
                            struct ares_addr_port_node *servers)
 {
   struct ares_addr_port_node *srvr;
-  int num_srvrs = 0;
-  int i;
+  size_t num_srvrs = 0;
+  size_t i;
 
   if (ares_library_initialized() != ARES_SUCCESS)
     return ARES_ENOTINITIALIZED;  /* LCOV_EXCL_LINE: n/a on non-WinSock */
@@ -234,7 +234,7 @@ int ares_set_servers_ports(ares_channel channel,
           return ARES_ENOMEM;
         }
       memset(channel->servers, 0, num_srvrs * sizeof(*channel->servers));
-      channel->nservers = num_srvrs;
+      channel->nservers = (int)num_srvrs;
       /* Fill servers state address data */
       for (i = 0, srvr = servers; srvr; i++, srvr = srvr->next)
         {
@@ -265,7 +265,7 @@ static ares_status_t set_servers_csv(ares_channel channel,
   char* ptr;
   char* start_host;
   int cc = 0;
-  ares_status_t rv = ARES_SUCCESS;
+  ares_status_t status = ARES_SUCCESS;
   struct ares_addr_port_node *servers = NULL;
   struct ares_addr_port_node *last = NULL;
 
@@ -341,18 +341,16 @@ static ares_status_t set_servers_csv(ares_channel channel,
         }
       }
       /* resolve host, try ipv4 first, rslt is in network byte order */
-      rv = ares_inet_pton(AF_INET, start_host, &in4);
-      if (!rv) {
+      if (!ares_inet_pton(AF_INET, start_host, &in4)) {
         /* Ok, try IPv6 then */
-        rv = ares_inet_pton(AF_INET6, start_host, &in6);
-        if (!rv) {
-          rv = ARES_EBADSTR;
+        if (!ares_inet_pton(AF_INET6, start_host, &in6)) {
+          status = ARES_EBADSTR;
           goto out;
         }
         /* was ipv6, add new server */
         s = ares_malloc(sizeof(*s));
         if (!s) {
-          rv = ARES_ENOMEM;
+          status = ARES_ENOMEM;
           goto out;
         }
         s->family = AF_INET6;
@@ -362,7 +360,7 @@ static ares_status_t set_servers_csv(ares_channel channel,
         /* was ipv4, add new server */
         s = ares_malloc(sizeof(*s));
         if (!s) {
-          rv = ARES_ENOMEM;
+          status = ARES_ENOMEM;
           goto out;
         }
         s->family = AF_INET;
@@ -389,7 +387,7 @@ static ares_status_t set_servers_csv(ares_channel channel,
     }
   }
 
-  rv = ares_set_servers_ports(channel, servers);
+  status = (ares_status_t)ares_set_servers_ports(channel, servers);
 
   out:
   if (csv)
@@ -400,18 +398,18 @@ static ares_status_t set_servers_csv(ares_channel channel,
     ares_free(s);
   }
 
-  return rv;
+  return status;
 }
 
 int ares_set_servers_csv(ares_channel channel,
                          const char* _csv)
 {
-  return set_servers_csv(channel, _csv, FALSE);
+  return (int)set_servers_csv(channel, _csv, FALSE);
 }
 
 int ares_set_servers_ports_csv(ares_channel channel,
                                const char* _csv)
 {
-  return set_servers_csv(channel, _csv, TRUE);
+  return (int)set_servers_csv(channel, _csv, TRUE);
 }
 

--- a/src/lib/ares_options.c
+++ b/src/lib/ares_options.c
@@ -44,7 +44,7 @@ int ares_get_servers(ares_channel channel,
   struct ares_addr_node *srvr_last = NULL;
   struct ares_addr_node *srvr_curr;
   ares_status_t status = ARES_SUCCESS;
-  int i;
+  size_t i;
 
   if (!channel)
     return ARES_ENODATA;
@@ -99,7 +99,7 @@ int ares_get_servers_ports(ares_channel channel,
   struct ares_addr_port_node *srvr_last = NULL;
   struct ares_addr_port_node *srvr_curr;
   ares_status_t status = ARES_SUCCESS;
-  int i;
+  size_t i;
 
   if (!channel)
     return ARES_ENODATA;
@@ -181,7 +181,7 @@ int ares_set_servers(ares_channel channel,
           return ARES_ENOMEM;
         }
       memset(channel->servers, 0, num_srvrs * sizeof(*channel->servers));
-      channel->nservers = (int)num_srvrs;
+      channel->nservers = num_srvrs;
       /* Fill servers state address data */
       for (i = 0, srvr = servers; srvr; i++, srvr = srvr->next)
         {
@@ -234,7 +234,7 @@ int ares_set_servers_ports(ares_channel channel,
           return ARES_ENOMEM;
         }
       memset(channel->servers, 0, num_srvrs * sizeof(*channel->servers));
-      channel->nservers = (int)num_srvrs;
+      channel->nservers = num_srvrs;
       /* Fill servers state address data */
       for (i = 0, srvr = servers; srvr; i++, srvr = srvr->next)
         {

--- a/src/lib/ares_parse_a_reply.c
+++ b/src/lib/ares_parse_a_reply.c
@@ -96,5 +96,5 @@ fail:
   ares_free(ai.name);
   ares_free(question_hostname);
 
-  return status;
+  return (int)status;
 }

--- a/src/lib/ares_parse_a_reply.c
+++ b/src/lib/ares_parse_a_reply.c
@@ -58,36 +58,36 @@ int ares_parse_a_reply(const unsigned char *abuf, int alen,
   struct ares_addrinfo ai;
   char *question_hostname = NULL;
   ares_status_t status;
-  int req_naddrttls = 0;
+  size_t req_naddrttls = 0;
 
-  if (naddrttls)
-    {
-      req_naddrttls = *naddrttls;
-      *naddrttls = 0;
-    }
+  if (alen < 0)
+    return ARES_EBADRESP;
+
+  if (naddrttls) {
+    req_naddrttls = (size_t)*naddrttls;
+    *naddrttls = 0;
+  }
 
   memset(&ai, 0, sizeof(ai));
 
-  status = ares__parse_into_addrinfo(abuf, alen, 0, 0, &ai);
-  if (status != ARES_SUCCESS && status != ARES_ENODATA)
-    {
+  status = ares__parse_into_addrinfo(abuf, (size_t)alen, 0, 0, &ai);
+  if (status != ARES_SUCCESS && status != ARES_ENODATA) {
+    goto fail;
+  }
+
+  if (host != NULL) {
+    status = ares__addrinfo2hostent(&ai, AF_INET, host);
+    if (status != ARES_SUCCESS && status != ARES_ENODATA) {
       goto fail;
     }
+  }
 
-  if (host != NULL)
-    {
-      status = ares__addrinfo2hostent(&ai, AF_INET, host);
-      if (status != ARES_SUCCESS && status != ARES_ENODATA)
-        {
-          goto fail;
-        }
-    }
-
-  if (addrttls != NULL && req_naddrttls)
-   {
-     ares__addrinfo2addrttl(&ai, AF_INET, req_naddrttls, addrttls,
-                            NULL, naddrttls);
-   }
+  if (addrttls != NULL && req_naddrttls) {
+    size_t temp_naddrttls = 0;
+    ares__addrinfo2addrttl(&ai, AF_INET, req_naddrttls, addrttls,
+                           NULL, &temp_naddrttls);
+    *naddrttls = (int)temp_naddrttls;
+  }
 
 
 fail:

--- a/src/lib/ares_parse_aaaa_reply.c
+++ b/src/lib/ares_parse_aaaa_reply.c
@@ -66,7 +66,7 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
     return ARES_EBADRESP;
 
   if (naddrttls) {
-    req_naddrttls = *naddrttls;
+    req_naddrttls = (size_t)*naddrttls;
     *naddrttls = 0;
   }
 
@@ -97,6 +97,6 @@ fail:
   ares_free(question_hostname);
   ares_free(ai.name);
 
-  return status;
+  return (int)status;
 }
 

--- a/src/lib/ares_parse_aaaa_reply.c
+++ b/src/lib/ares_parse_aaaa_reply.c
@@ -60,35 +60,35 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
   struct ares_addrinfo ai;
   char *question_hostname = NULL;
   ares_status_t status;
-  int req_naddrttls = 0;
+  size_t req_naddrttls = 0;
 
-  if (naddrttls)
-    {
-      req_naddrttls = *naddrttls;
-      *naddrttls = 0;
-    }
+  if (alen < 0)
+    return ARES_EBADRESP;
+
+  if (naddrttls) {
+    req_naddrttls = *naddrttls;
+    *naddrttls = 0;
+  }
 
   memset(&ai, 0, sizeof(ai));
 
-  status = ares__parse_into_addrinfo(abuf, alen, 0, 0, &ai);
-  if (status != ARES_SUCCESS && status != ARES_ENODATA)
-    {
+  status = ares__parse_into_addrinfo(abuf, (size_t)alen, 0, 0, &ai);
+  if (status != ARES_SUCCESS && status != ARES_ENODATA) {
+    goto fail;
+  }
+
+  if (host != NULL) {
+    status = ares__addrinfo2hostent(&ai, AF_INET6, host);
+    if (status != ARES_SUCCESS && status != ARES_ENODATA) {
       goto fail;
     }
+  }
 
-  if (host != NULL)
-    {
-      status = ares__addrinfo2hostent(&ai, AF_INET6, host);
-      if (status != ARES_SUCCESS && status != ARES_ENODATA)
-        {
-          goto fail;
-        }
-    }
-
-  if (addrttls != NULL && req_naddrttls)
-   {
-     ares__addrinfo2addrttl(&ai, AF_INET6, req_naddrttls, NULL,
-                            addrttls, naddrttls);
+  if (addrttls != NULL && req_naddrttls) {
+    size_t temp_naddrttls = 0;
+    ares__addrinfo2addrttl(&ai, AF_INET6, req_naddrttls, NULL,
+                          addrttls, &temp_naddrttls);
+    *naddrttls = (int)temp_naddrttls;
    }
 
 fail:

--- a/src/lib/ares_parse_caa_reply.c
+++ b/src/lib/ares_parse_caa_reply.c
@@ -72,15 +72,17 @@
 #include "ares_private.h"
 
 int
-ares_parse_caa_reply (const unsigned char *abuf, int alen,
+ares_parse_caa_reply (const unsigned char *abuf, int alen_int,
                       struct ares_caa_reply **caa_out)
 {
-  unsigned int qdcount, ancount, i;
+  size_t qdcount, ancount, i;
   const unsigned char *aptr;
   const unsigned char *strptr;
   ares_status_t status;
-  int rr_type, rr_class, rr_len;
-  long len;
+  int rr_type, rr_class;
+  size_t rr_len;
+  size_t len;
+  size_t alen;
   char *hostname = NULL, *rr_name = NULL;
   struct ares_caa_reply *caa_head = NULL;
   struct ares_caa_reply *caa_last = NULL;
@@ -88,6 +90,11 @@ ares_parse_caa_reply (const unsigned char *abuf, int alen,
 
   /* Set *caa_out to NULL for all failure cases. */
   *caa_out = NULL;
+
+  if (alen_int < 0)
+    return ARES_EBADRESP;
+
+  alen = (size_t)alen_int;
 
   /* Give up if abuf doesn't have room for a header. */
   if (alen < HFIXEDSZ)
@@ -103,7 +110,7 @@ ares_parse_caa_reply (const unsigned char *abuf, int alen,
 
   /* Expand the name from the question, and skip past the question. */
   aptr = abuf + HFIXEDSZ;
-  status = ares_expand_name (aptr, abuf, alen, &hostname, &len);
+  status = ares__expand_name_for_response(aptr, abuf, alen, &hostname, &len, ARES_TRUE);
   if (status != ARES_SUCCESS)
     return status;
 
@@ -118,7 +125,7 @@ ares_parse_caa_reply (const unsigned char *abuf, int alen,
   for (i = 0; i < ancount; i++)
     {
       /* Decode the RR up to the data field. */
-      status = ares_expand_name (aptr, abuf, alen, &rr_name, &len);
+      status = ares__expand_name_for_response(aptr, abuf, alen, &rr_name, &len, ARES_FALSE);
       if (status != ARES_SUCCESS)
         {
           break;

--- a/src/lib/ares_parse_caa_reply.c
+++ b/src/lib/ares_parse_caa_reply.c
@@ -112,7 +112,7 @@ ares_parse_caa_reply (const unsigned char *abuf, int alen_int,
   aptr = abuf + HFIXEDSZ;
   status = ares__expand_name_for_response(aptr, abuf, alen, &hostname, &len, ARES_TRUE);
   if (status != ARES_SUCCESS)
-    return status;
+    return (int)status;
 
   if (aptr + len + QFIXEDSZ > abuf + alen)
     {
@@ -173,8 +173,8 @@ ares_parse_caa_reply (const unsigned char *abuf, int alen_int,
               break;
             }
           caa_curr->critical = (int)*strptr++;
-          caa_curr->plength = (int)*strptr++;
-          if (caa_curr->plength <= 0 || (int)caa_curr->plength >= rr_len - 2)
+          caa_curr->plength = *strptr++;
+          if (caa_curr->plength <= 0 || caa_curr->plength >= rr_len - 2)
             {
               status = ARES_EBADRESP;
               break;
@@ -231,7 +231,7 @@ ares_parse_caa_reply (const unsigned char *abuf, int alen_int,
     {
       if (caa_head)
         ares_free_data (caa_head);
-      return status;
+      return (int)status;
     }
 
   /* everything looks fine, return the data */

--- a/src/lib/ares_parse_mx_reply.c
+++ b/src/lib/ares_parse_mx_reply.c
@@ -84,7 +84,7 @@ ares_parse_mx_reply (const unsigned char *abuf, int alen_int,
   aptr = abuf + HFIXEDSZ;
   status = ares__expand_name_for_response(aptr, abuf, alen, &hostname, &len, ARES_TRUE);
   if (status != ARES_SUCCESS)
-    return status;
+    return (int)status;
 
   if (aptr + len + QFIXEDSZ > abuf + alen)
     {
@@ -172,7 +172,7 @@ ares_parse_mx_reply (const unsigned char *abuf, int alen_int,
     {
       if (mx_head)
         ares_free_data (mx_head);
-      return status;
+      return (int)status;
     }
 
   /* everything looks fine, return the data */

--- a/src/lib/ares_parse_mx_reply.c
+++ b/src/lib/ares_parse_mx_reply.c
@@ -45,14 +45,16 @@
 #include "ares_private.h"
 
 int
-ares_parse_mx_reply (const unsigned char *abuf, int alen,
+ares_parse_mx_reply (const unsigned char *abuf, int alen_int,
                      struct ares_mx_reply **mx_out)
 {
-  unsigned int qdcount, ancount, i;
+  size_t qdcount, ancount, i;
   const unsigned char *aptr, *vptr;
   ares_status_t status;
-  int rr_type, rr_class, rr_len;
-  long len;
+  int rr_type, rr_class;
+  size_t rr_len;
+  size_t alen;
+  size_t len;
   char *hostname = NULL, *rr_name = NULL;
   struct ares_mx_reply *mx_head = NULL;
   struct ares_mx_reply *mx_last = NULL;
@@ -60,6 +62,11 @@ ares_parse_mx_reply (const unsigned char *abuf, int alen,
 
   /* Set *mx_out to NULL for all failure cases. */
   *mx_out = NULL;
+
+  if (alen_int < 0)
+    return ARES_EBADRESP;
+
+  alen = (size_t)alen_int;
 
   /* Give up if abuf doesn't have room for a header. */
   if (alen < HFIXEDSZ)
@@ -75,7 +82,7 @@ ares_parse_mx_reply (const unsigned char *abuf, int alen,
 
   /* Expand the name from the question, and skip past the question. */
   aptr = abuf + HFIXEDSZ;
-  status = ares_expand_name (aptr, abuf, alen, &hostname, &len);
+  status = ares__expand_name_for_response(aptr, abuf, alen, &hostname, &len, ARES_TRUE);
   if (status != ARES_SUCCESS)
     return status;
 
@@ -90,7 +97,7 @@ ares_parse_mx_reply (const unsigned char *abuf, int alen,
   for (i = 0; i < ancount; i++)
     {
       /* Decode the RR up to the data field. */
-      status = ares_expand_name (aptr, abuf, alen, &rr_name, &len);
+      status = ares__expand_name_for_response(aptr, abuf, alen, &rr_name, &len, ARES_FALSE);
       if (status != ARES_SUCCESS)
         {
           break;
@@ -142,7 +149,7 @@ ares_parse_mx_reply (const unsigned char *abuf, int alen,
           mx_curr->priority = DNS__16BIT(vptr);
           vptr += sizeof(unsigned short);
 
-          status = ares_expand_name (vptr, abuf, alen, &mx_curr->host, &len);
+          status = ares__expand_name_for_response(vptr, abuf, alen, &mx_curr->host, &len, ARES_FALSE);
           if (status != ARES_SUCCESS)
             break;
         }

--- a/src/lib/ares_parse_naptr_reply.c
+++ b/src/lib/ares_parse_naptr_reply.c
@@ -83,7 +83,7 @@ ares_parse_naptr_reply (const unsigned char *abuf, int alen_int,
   aptr = abuf + HFIXEDSZ;
   status = ares__expand_name_for_response(aptr, abuf, alen, &hostname, &len, ARES_TRUE);
   if (status != ARES_SUCCESS)
-    return status;
+    return (int)status;
 
   if (aptr + len + QFIXEDSZ > abuf + alen)
     {
@@ -190,7 +190,7 @@ ares_parse_naptr_reply (const unsigned char *abuf, int alen_int,
     {
       if (naptr_head)
         ares_free_data (naptr_head);
-      return status;
+      return (int)status;
     }
 
   /* everything looks fine, return the data */

--- a/src/lib/ares_parse_ns_reply.c
+++ b/src/lib/ares_parse_ns_reply.c
@@ -48,20 +48,28 @@
 #include "ares_dns.h"
 #include "ares_private.h"
 
-int ares_parse_ns_reply( const unsigned char* abuf, int alen,
+int ares_parse_ns_reply( const unsigned char* abuf, int alen_int,
                          struct hostent** host )
 {
-  unsigned int qdcount, ancount;
+  size_t qdcount, ancount;
   ares_status_t status;
-  int i, rr_type, rr_class, rr_len;
-  int nameservers_num;
-  long len;
+  size_t i;
+  int rr_type, rr_class;
+  size_t rr_len;
+  size_t nameservers_num;
+  size_t alen;
+  size_t len;
   const unsigned char *aptr;
   char* hostname, *rr_name, *rr_data, **nameservers;
   struct hostent *hostent;
 
   /* Set *host to NULL for all failure cases. */
   *host = NULL;
+
+  if (alen_int < 0)
+    return ARES_EBADRESP;
+
+  alen = (size_t)alen_int;
 
   /* Give up if abuf doesn't have room for a header. */
   if ( alen < HFIXEDSZ )
@@ -75,7 +83,7 @@ int ares_parse_ns_reply( const unsigned char* abuf, int alen,
 
   /* Expand the name from the question, and skip past the question. */
   aptr = abuf + HFIXEDSZ;
-  status = ares__expand_name_for_response( aptr, abuf, alen, &hostname, &len, 0);
+  status = ares__expand_name_for_response( aptr, abuf, alen, &hostname, &len, ARES_FALSE);
   if ( status != ARES_SUCCESS )
     return status;
   if ( aptr + len + QFIXEDSZ > abuf + alen )
@@ -95,10 +103,10 @@ int ares_parse_ns_reply( const unsigned char* abuf, int alen,
   nameservers_num = 0;
 
   /* Examine each answer resource record (RR) in turn. */
-  for ( i = 0; i < ( int ) ancount; i++ )
+  for ( i = 0; i < ancount; i++ )
   {
     /* Decode the RR up to the data field. */
-    status = ares__expand_name_for_response( aptr, abuf, alen, &rr_name, &len, 0);
+    status = ares__expand_name_for_response( aptr, abuf, alen, &rr_name, &len, ARES_FALSE);
     if ( status != ARES_SUCCESS )
       break;
     aptr += len;
@@ -123,7 +131,7 @@ int ares_parse_ns_reply( const unsigned char* abuf, int alen,
     {
       /* Decode the RR data and add it to the nameservers list */
       status = ares__expand_name_for_response( aptr, abuf, alen, &rr_data,
-                                               &len, 1);
+                                               &len, ARES_TRUE);
       if ( status != ARES_SUCCESS )
       {
         ares_free(rr_name);

--- a/src/lib/ares_parse_ns_reply.c
+++ b/src/lib/ares_parse_ns_reply.c
@@ -85,7 +85,7 @@ int ares_parse_ns_reply( const unsigned char* abuf, int alen_int,
   aptr = abuf + HFIXEDSZ;
   status = ares__expand_name_for_response( aptr, abuf, alen, &hostname, &len, ARES_FALSE);
   if ( status != ARES_SUCCESS )
-    return status;
+    return (int)status;
   if ( aptr + len + QFIXEDSZ > abuf + alen )
   {
     ares_free( hostname );
@@ -194,5 +194,5 @@ int ares_parse_ns_reply( const unsigned char* abuf, int alen_int,
     ares_free( nameservers[i] );
   ares_free( nameservers );
   ares_free( hostname );
-  return status;
+  return (int)status;
 }

--- a/src/lib/ares_parse_ptr_reply.c
+++ b/src/lib/ares_parse_ptr_reply.c
@@ -225,7 +225,7 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen_int, const void *ad
       hostent->h_addrtype = aresx_sitoss(family);
       hostent->h_length = aresx_sitoss(addrlen);
       if (addr && addrlen)
-        memcpy(hostent->h_addr_list[0], addr, addrlen);
+        memcpy(hostent->h_addr_list[0], addr, (size_t)addrlen);
       hostent->h_addr_list[1] = NULL;
       *host = hostent;
       ares_free(aliases);

--- a/src/lib/ares_parse_ptr_reply.c
+++ b/src/lib/ares_parse_ptr_reply.c
@@ -85,7 +85,7 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen_int, const void *ad
   aptr = abuf + HFIXEDSZ;
   status = ares__expand_name_for_response(aptr, abuf, alen, &ptrname, &len, 0);
   if (status != ARES_SUCCESS)
-    return status;
+    return (int)status;
   if (aptr + len + QFIXEDSZ > abuf + alen)
     {
       ares_free(ptrname);
@@ -101,7 +101,7 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen_int, const void *ad
       ares_free(ptrname);
       return ARES_ENOMEM;
     }
-  for (i = 0; i < (int)ancount; i++)
+  for (i = 0; i < ancount; i++)
     {
       /* Decode the RR up to the data field. */
       status = ares__expand_name_for_response(aptr, abuf, alen, &rr_name, &len, ARES_FALSE);
@@ -206,7 +206,7 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen_int, const void *ad
 
 
       if (addr && addrlen) {
-        hostent->h_addr_list[0] = ares_malloc(addrlen);
+        hostent->h_addr_list[0] = ares_malloc((size_t)addrlen);
         if (!hostent->h_addr_list[0])
           goto fail;
       } else {
@@ -244,5 +244,5 @@ fail:
   if (hostname)
     ares_free(hostname);
   ares_free(ptrname);
-  return status;
+  return (int)status;
 }

--- a/src/lib/ares_parse_soa_reply.c
+++ b/src/lib/ares_parse_soa_reply.c
@@ -195,5 +195,5 @@ failed_stat:
     ares_free_data(soa);
   if (qname)
     ares_free(qname);
-  return status;
+  return (int)status;
 }

--- a/src/lib/ares_parse_soa_reply.c
+++ b/src/lib/ares_parse_soa_reply.c
@@ -45,16 +45,25 @@
 #include "ares_private.h"
 
 int
-ares_parse_soa_reply(const unsigned char *abuf, int alen,
+ares_parse_soa_reply(const unsigned char *abuf, int alen_int,
 		     struct ares_soa_reply **soa_out)
 {
   const unsigned char *aptr;
-  long len;
+  size_t len;
+  size_t alen;
   char *qname = NULL, *rr_name = NULL;
   struct ares_soa_reply *soa = NULL;
-  int qdcount, ancount, qclass;
+  size_t qdcount, ancount;
+  int qclass;
   ares_status_t status;
-  int i, rr_type, rr_class, rr_len;
+  size_t i;
+  int rr_type, rr_class;
+  size_t rr_len;
+
+  if (alen_int < 0)
+    return ARES_EBADRESP;
+
+  alen = (size_t)alen_int;
 
   if (alen < HFIXEDSZ)
     return ARES_EBADRESP;
@@ -71,7 +80,7 @@ ares_parse_soa_reply(const unsigned char *abuf, int alen,
   aptr = abuf + HFIXEDSZ;
 
   /* query name */
-  status = ares__expand_name_for_response(aptr, abuf, alen, &qname, &len, 0);
+  status = ares__expand_name_for_response(aptr, abuf, alen, &qname, &len, ARES_FALSE);
   if (status != ARES_SUCCESS)
     goto failed_stat;
 
@@ -94,7 +103,7 @@ ares_parse_soa_reply(const unsigned char *abuf, int alen,
   for (i = 0; i < ancount; i++)
   {
     rr_name = NULL;
-    status  = ares__expand_name_for_response (aptr, abuf, alen, &rr_name, &len, 0);
+    status  = ares__expand_name_for_response (aptr, abuf, alen, &rr_name, &len, ARES_FALSE);
     if (status != ARES_SUCCESS)
      {
       ares_free(rr_name);
@@ -131,7 +140,7 @@ ares_parse_soa_reply(const unsigned char *abuf, int alen,
 
       /* nsname */
       status = ares__expand_name_for_response(aptr, abuf, alen, &soa->nsname,
-                                               &len, 0);
+                                               &len, ARES_FALSE);
       if (status != ARES_SUCCESS)
        {
         ares_free(rr_name);
@@ -141,7 +150,7 @@ ares_parse_soa_reply(const unsigned char *abuf, int alen,
 
       /* hostmaster */
       status = ares__expand_name_for_response(aptr, abuf, alen,
-                                               &soa->hostmaster, &len, 0);
+                                               &soa->hostmaster, &len, ARES_FALSE);
       if (status != ARES_SUCCESS)
        {
         ares_free(rr_name);

--- a/src/lib/ares_parse_srv_reply.c
+++ b/src/lib/ares_parse_srv_reply.c
@@ -84,7 +84,7 @@ ares_parse_srv_reply (const unsigned char *abuf, int alen_int,
   aptr = abuf + HFIXEDSZ;
   status = ares__expand_name_for_response(aptr, abuf, alen, &hostname, &len, ARES_TRUE);
   if (status != ARES_SUCCESS)
-    return status;
+    return (int)status;
 
   if (aptr + len + QFIXEDSZ > abuf + alen)
     {
@@ -176,7 +176,7 @@ ares_parse_srv_reply (const unsigned char *abuf, int alen_int,
     {
       if (srv_head)
         ares_free_data (srv_head);
-      return status;
+      return (int)status;
     }
 
   /* everything looks fine, return the data */

--- a/src/lib/ares_parse_srv_reply.c
+++ b/src/lib/ares_parse_srv_reply.c
@@ -45,14 +45,16 @@
 #include "ares_private.h"
 
 int
-ares_parse_srv_reply (const unsigned char *abuf, int alen,
+ares_parse_srv_reply (const unsigned char *abuf, int alen_int,
                       struct ares_srv_reply **srv_out)
 {
-  unsigned int qdcount, ancount, i;
+  size_t qdcount, ancount, i;
   const unsigned char *aptr, *vptr;
   ares_status_t status;
-  int rr_type, rr_class, rr_len;
-  long len;
+  int rr_type, rr_class;
+  size_t rr_len;
+  size_t len;
+  size_t alen;
   char *hostname = NULL, *rr_name = NULL;
   struct ares_srv_reply *srv_head = NULL;
   struct ares_srv_reply *srv_last = NULL;
@@ -60,6 +62,11 @@ ares_parse_srv_reply (const unsigned char *abuf, int alen,
 
   /* Set *srv_out to NULL for all failure cases. */
   *srv_out = NULL;
+
+  if (alen_int < 0)
+    return ARES_EBADRESP;
+
+  alen = (size_t)alen_int;
 
   /* Give up if abuf doesn't have room for a header. */
   if (alen < HFIXEDSZ)
@@ -75,7 +82,7 @@ ares_parse_srv_reply (const unsigned char *abuf, int alen,
 
   /* Expand the name from the question, and skip past the question. */
   aptr = abuf + HFIXEDSZ;
-  status = ares_expand_name (aptr, abuf, alen, &hostname, &len);
+  status = ares__expand_name_for_response(aptr, abuf, alen, &hostname, &len, ARES_TRUE);
   if (status != ARES_SUCCESS)
     return status;
 
@@ -90,7 +97,7 @@ ares_parse_srv_reply (const unsigned char *abuf, int alen,
   for (i = 0; i < ancount; i++)
     {
       /* Decode the RR up to the data field. */
-      status = ares_expand_name (aptr, abuf, alen, &rr_name, &len);
+      status = ares__expand_name_for_response(aptr, abuf, alen, &rr_name, &len, ARES_FALSE);
       if (status != ARES_SUCCESS)
         {
           break;
@@ -146,7 +153,7 @@ ares_parse_srv_reply (const unsigned char *abuf, int alen,
           srv_curr->port = DNS__16BIT(vptr);
           vptr += sizeof(unsigned short);
 
-          status = ares_expand_name (vptr, abuf, alen, &srv_curr->host, &len);
+          status = ares__expand_name_for_response(vptr, abuf, alen, &srv_curr->host, &len, ARES_FALSE);
           if (status != ARES_SUCCESS)
             break;
         }

--- a/src/lib/ares_parse_txt_reply.c
+++ b/src/lib/ares_parse_txt_reply.c
@@ -84,7 +84,7 @@ ares__parse_txt_reply (const unsigned char *abuf, size_t alen,
   aptr = abuf + HFIXEDSZ;
   status = ares__expand_name_for_response(aptr, abuf, alen, &hostname, &len, ARES_TRUE);
   if (status != ARES_SUCCESS)
-    return status;
+    return (int)status;
 
   if (aptr + len + QFIXEDSZ > abuf + alen)
     {
@@ -201,7 +201,7 @@ ares__parse_txt_reply (const unsigned char *abuf, size_t alen,
     {
       if (txt_head)
         ares_free_data (txt_head);
-      return status;
+      return (int)status;
     }
 
   /* everything looks fine, return the data */

--- a/src/lib/ares_parse_uri_reply.c
+++ b/src/lib/ares_parse_uri_reply.c
@@ -58,7 +58,7 @@ ares_parse_uri_reply (const unsigned char *abuf, int alen_int,
   ares_status_t status;
   int rr_type, rr_class;
   size_t rr_len;
-  unsigned short rr_ttl;
+  unsigned int rr_ttl;
   size_t len;
   size_t alen;
   char *uri_str = NULL, *rr_name = NULL;
@@ -76,7 +76,7 @@ ares_parse_uri_reply (const unsigned char *abuf, int alen_int,
 
   /* Give up if abuf doesn't have room for a header. */
   if (alen < HFIXEDSZ){
-	  return ARES_EBADRESP;
+    return ARES_EBADRESP;
   }
 
   /* Fetch the question and answer count from the header. */
@@ -86,14 +86,14 @@ ares_parse_uri_reply (const unsigned char *abuf, int alen_int,
       return ARES_EBADRESP;
   }
   if (ancount == 0) {
-	  return ARES_ENODATA;
+    return ARES_ENODATA;
   }
   /* Expand the name from the question, and skip past the question. */
   aptr = abuf + HFIXEDSZ;
 
   status = ares__expand_name_for_response(aptr, abuf, alen, &uri_str, &len, ARES_TRUE);
-  if (status != ARES_SUCCESS){
-	  return status;
+  if (status != ARES_SUCCESS) {
+    return (int)status;
   }
   if (aptr + len + QFIXEDSZ > abuf + alen)
     {
@@ -162,14 +162,13 @@ ares_parse_uri_reply (const unsigned char *abuf, int alen_int,
           uri_curr->weight = DNS__16BIT(vptr);
           vptr += sizeof(unsigned short);
           uri_curr->uri = (char *)ares_malloc(rr_len-3);
-	  	  if (!uri_curr->uri)
-	      	{
-	      	  status = ARES_ENOMEM;
-			  break;
-		    }
+          if (!uri_curr->uri) {
+            status = ARES_ENOMEM;
+            break;
+          }
           uri_curr->uri = strncpy(uri_curr->uri, (const char *)vptr, rr_len-4);
           uri_curr->uri[rr_len-4]='\0';
-          uri_curr->ttl = rr_ttl;
+          uri_curr->ttl = (int)rr_ttl;
         }
 
       /* Don't lose memory in the next iteration */
@@ -190,7 +189,7 @@ ares_parse_uri_reply (const unsigned char *abuf, int alen_int,
     {
       if (uri_head)
         ares_free_data (uri_head);
-      return status;
+      return (int)status;
     }
 
   /* everything looks fine, return the data */

--- a/src/lib/ares_platform.c
+++ b/src/lib/ares_platform.c
@@ -11003,7 +11003,8 @@ struct servent *getservbyport(int port, const char *proto)
 {
   unsigned short u_port;
   const char *protocol = NULL;
-  int i, error = 0;
+  int error = 0;
+  size_t i;
 
   u_port = ntohs((unsigned short)port);
 

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -265,13 +265,13 @@ struct ares_channeldata {
   size_t timeout; /* in milliseconds */
   size_t tries;
   size_t ndots;
-  int rotate; /* if true, all servers specified are used */
+  int rotate; /* -1 unset, 0 = no rotate, 1 = rotate */
   unsigned short udp_port; /* stored in network order */
   unsigned short tcp_port; /* stored in network order */
   int socket_send_buffer_size;
   int socket_receive_buffer_size;
   char **domains;
-  int ndomains;
+  size_t ndomains;
   struct apattern *sortlist;
   int nsort;
   char *lookups;

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -411,7 +411,7 @@ void ares__freeaddrinfo_cnames(struct ares_addrinfo_cname *ai_cname);
 struct ares_addrinfo_cname *ares__append_addrinfo_cname(struct ares_addrinfo_cname **ai_cname);
 
 ares_status_t ares_append_ai_node(int aftype, unsigned short port,
-                                  unsigned short ttl,
+                                  unsigned int ttl,
                                   const void *adata,
                                   struct ares_addrinfo_node **nodes);
 

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -273,7 +273,7 @@ struct ares_channeldata {
   char **domains;
   size_t ndomains;
   struct apattern *sortlist;
-  int nsort;
+  size_t nsort;
   char *lookups;
   int ednspsz;
 

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -275,7 +275,7 @@ struct ares_channeldata {
   struct apattern *sortlist;
   size_t nsort;
   char *lookups;
-  int ednspsz;
+  size_t ednspsz;
 
   /* For binding to local devices and/or IP addresses.  Leave
    * them null/zero for no binding.

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -265,7 +265,7 @@ struct ares_channeldata {
   size_t timeout; /* in milliseconds */
   size_t tries;
   size_t ndots;
-  int rotate; /* -1 unset, 0 = no rotate, 1 = rotate */
+  ares_bool_t rotate;
   unsigned short udp_port; /* stored in network order */
   unsigned short tcp_port; /* stored in network order */
   int socket_send_buffer_size; /* setsockopt takes int */
@@ -276,7 +276,7 @@ struct ares_channeldata {
   size_t nsort;
   char *lookups;
   size_t ednspsz;
-  int optmask;
+  unsigned int optmask;
 
   /* For binding to local devices and/or IP addresses.  Leave
    * them null/zero for no binding.

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -276,6 +276,7 @@ struct ares_channeldata {
   size_t nsort;
   char *lookups;
   size_t ednspsz;
+  int optmask;
 
   /* For binding to local devices and/or IP addresses.  Leave
    * them null/zero for no binding.

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -268,8 +268,8 @@ struct ares_channeldata {
   int rotate; /* -1 unset, 0 = no rotate, 1 = rotate */
   unsigned short udp_port; /* stored in network order */
   unsigned short tcp_port; /* stored in network order */
-  int socket_send_buffer_size;
-  int socket_receive_buffer_size;
+  int socket_send_buffer_size; /* setsockopt takes int */
+  int socket_receive_buffer_size; /* setsockopt takes int */
   char **domains;
   size_t ndomains;
   struct apattern *sortlist;

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -284,8 +284,6 @@ struct ares_channeldata {
   unsigned int local_ip4;
   unsigned char local_ip6[16];
 
-  int optmask; /* the option bitfield passed in at init time */
-
   /* Server addresses and communications state */
   struct server_state *servers;
   size_t nservers;

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -261,10 +261,10 @@ struct apattern {
 
 struct ares_channeldata {
   /* Configuration data */
-  int flags;
-  int timeout; /* in milliseconds */
-  int tries;
-  int ndots;
+  unsigned int flags;
+  size_t timeout; /* in milliseconds */
+  size_t tries;
+  size_t ndots;
   int rotate; /* if true, all servers specified are used */
   unsigned short udp_port; /* stored in network order */
   unsigned short tcp_port; /* stored in network order */
@@ -288,7 +288,7 @@ struct ares_channeldata {
 
   /* Server addresses and communications state */
   struct server_state *servers;
-  int nservers;
+  size_t nservers;
 
   /* random state to use when generating new ids */
   ares_rand_state *rand_state;

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -107,9 +107,9 @@ ares_bool_t ares__timedout(struct timeval *now, struct timeval *check)
 }
 
 /* add the specific number of milliseconds to the time in the first argument */
-static void timeadd(struct timeval *now, int millisecs)
+static void timeadd(struct timeval *now, size_t millisecs)
 {
-  now->tv_sec += millisecs/1000;
+  now->tv_sec += (time_t)millisecs/1000;
   now->tv_usec += (millisecs%1000)*1000;
 
   if(now->tv_usec >= 1000000) {
@@ -188,7 +188,7 @@ static void write_tcp_data(ares_channel channel,
                            struct timeval *now)
 {
   struct server_state *server;
-  int i;
+  size_t i;
 
   if(!write_fds && (write_fd == ARES_SOCKET_BAD))
     /* no possible action */
@@ -371,7 +371,7 @@ static int socket_list_append(ares_socket_t **socketlist, ares_socket_t fd,
 static ares_socket_t *channel_socket_list(ares_channel channel, size_t *num)
 {
   size_t         alloc_cnt = 1 << 4;
-  int            i;
+  size_t         i;
   ares_socket_t *out       = ares_malloc(alloc_cnt * sizeof(*out));
 
   *num = 0;
@@ -738,7 +738,7 @@ static ares_status_t next_server(ares_channel channel, struct query *query,
    * this query. Use modular arithmetic to find the next server to try.
    * A query can be requested be terminated at the next interval by setting
    * query->no_retries */
-  while (++(query->try_count) < (size_t)(channel->nservers * channel->tries) &&
+  while (++(query->try_count) < ((size_t)channel->nservers * channel->tries) &&
          !query->no_retries) {
     struct server_state *server;
 
@@ -776,7 +776,7 @@ ares_status_t ares__send_query(ares_channel channel, struct query *query,
 {
   struct server_state *server;
   struct server_connection *conn;
-  int timeplus;
+  size_t timeplus;
   ares_status_t status;
 
   server = &channel->servers[query->server];

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -72,7 +72,8 @@ static void read_packets(ares_channel channel, fd_set *read_fds,
                          ares_socket_t read_fd, struct timeval *now);
 static void process_timeouts(ares_channel channel, struct timeval *now);
 static void process_answer(ares_channel channel, const unsigned char *abuf,
-                           int alen, struct server_connection *conn, int tcp,
+                           size_t alen, struct server_connection *conn,
+                           ares_bool_t tcp,
                            struct timeval *now);
 static void handle_error(struct server_connection *conn, struct timeval *now);
 static void skip_server(ares_channel channel, struct query *query,
@@ -82,19 +83,19 @@ static ares_status_t next_server(ares_channel channel, struct query *query,
 static ares_status_t open_socket(ares_channel channel,
                                  struct server_state *server,
                                  ares_bool_t is_tcp);
-static ares_bool_t same_questions(const unsigned char *qbuf, int qlen,
-                                  const unsigned char *abuf, int alen);
+static ares_bool_t same_questions(const unsigned char *qbuf, size_t qlen,
+                                  const unsigned char *abuf, size_t alen);
 static ares_bool_t same_address(struct sockaddr *sa, struct ares_addr *aa);
-static int has_opt_rr(const unsigned char *abuf, int alen);
+static ares_bool_t has_opt_rr(const unsigned char *abuf, size_t alen);
 static void end_query(ares_channel channel, struct query *query,
-                      ares_status_t status, const unsigned char *abuf, int alen);
+                      ares_status_t status, const unsigned char *abuf, size_t alen);
 static ares_ssize_t ares__socket_write(ares_channel channel, ares_socket_t s,
                                        const void * data, size_t len);
 
 /* return true if now is exactly check time or later */
 ares_bool_t ares__timedout(struct timeval *now, struct timeval *check)
 {
-  long secs = (now->tv_sec - check->tv_sec);
+  time_t secs = (now->tv_sec - check->tv_sec);
 
   if(secs > 0)
     return ARES_TRUE; /* yes, timed out */
@@ -231,7 +232,7 @@ static void write_tcp_data(ares_channel channel,
     }
 
     /* Strip data written from the buffer */
-    ares__buf_consume(server->tcp_send, count);
+    ares__buf_consume(server->tcp_send, (size_t)count);
 
     /* Notify state callback all data is written */
     if (ares__buf_len(server->tcp_send) == 0) {
@@ -305,7 +306,7 @@ static void read_tcp_data(ares_channel channel, struct server_connection *conn,
   }
 
   /* Record amount of data read */
-  ares__buf_append_finish(server->tcp_parser, count);
+  ares__buf_append_finish(server->tcp_parser, (size_t)count);
 
   /* Process all queued answers */
   while (1) {
@@ -340,7 +341,7 @@ static void read_tcp_data(ares_channel channel, struct server_connection *conn,
     data_len -= 2;
 
     /* We finished reading this answer; process it */
-    process_answer(channel, data, (int)data_len, conn, 1, now);
+    process_answer(channel, data, data_len, conn, ARES_TRUE, now);
 
     /* Since we processed the answer, clear the tag so space can be reclaimed */
     ares__buf_tag_clear(server->tcp_parser);
@@ -454,7 +455,7 @@ static void read_udp_packets_fd(ares_channel channel,
 #endif
 
     } else {
-      process_answer(channel, buf, (int)read_len, conn, 0, now);
+      process_answer(channel, buf, (size_t)read_len, conn, ARES_FALSE, now);
     }
   /* process_answer may invalidate "conn" and close the file descriptor, so
    * check to see if file descriptor is still valid before looping! */
@@ -559,10 +560,12 @@ static void process_timeouts(ares_channel channel, struct timeval *now)
 
 /* Handle an answer from a server. */
 static void process_answer(ares_channel channel, const unsigned char *abuf,
-                           int alen, struct server_connection *conn, int tcp,
+                           size_t alen, struct server_connection *conn,
+                           ares_bool_t tcp,
                            struct timeval *now)
 {
-  int tc, rcode, packetsz;
+  int tc, rcode;
+  size_t packetsz;
   unsigned short id;
   struct query *query;
   /* Cache these as once ares__send_query() gets called, it may end up
@@ -608,10 +611,10 @@ static void process_answer(ares_channel channel, const unsigned char *abuf,
    * without EDNS enabled. */
   if (channel->flags & ARES_FLAG_EDNS)
   {
-      packetsz = channel->ednspsz;
-      if (rcode == FORMERR && has_opt_rr(abuf, alen) != 1)
+      packetsz = (size_t)channel->ednspsz;
+      if (rcode == FORMERR && !has_opt_rr(abuf, alen))
       {
-          int qlen = (query->tcplen - 2) - EDNSFIXEDSZ;
+          size_t qlen = (query->tcplen - 2) - EDNSFIXEDSZ;
           channel->flags ^= ARES_FLAG_EDNS;
           query->tcplen -= EDNSFIXEDSZ;
           query->qlen -= EDNSFIXEDSZ;
@@ -666,7 +669,7 @@ static void process_answer(ares_channel channel, const unsigned char *abuf,
               break;
           }
           skip_server(channel, query, server);
-          if (query->server == (int)server->idx) /* Is this ever not true? */
+          if (query->server == server->idx) /* Is this ever not true? */
             next_server(channel, query, now);
           ares__check_cleanup_conn(channel, fd);
           return;
@@ -698,7 +701,7 @@ static void handle_error(struct server_connection *conn,
   while ((node = ares__llist_node_first(list_copy)) != NULL) {
     struct query       *query = ares__llist_node_val(node);
 
-    assert(query->server == (int)server->idx);
+    assert(query->server == server->idx);
     skip_server(channel, query, server);
     /* next_server will remove the current node from the list */
     next_server(channel, query, now);
@@ -735,12 +738,12 @@ static ares_status_t next_server(ares_channel channel, struct query *query,
    * this query. Use modular arithmetic to find the next server to try.
    * A query can be requested be terminated at the next interval by setting
    * query->no_retries */
-  while (++(query->try_count) < (channel->nservers * channel->tries) &&
+  while (++(query->try_count) < (size_t)(channel->nservers * channel->tries) &&
          !query->no_retries) {
     struct server_state *server;
 
     /* Move on to the next server. */
-    query->server = (query->server + 1) % channel->nservers;
+    query->server = (query->server + 1) % (size_t)channel->nservers;
     server = &channel->servers[query->server];
 
     /* We don't want to use this server if (1) we've decided to skip this
@@ -872,7 +875,7 @@ ares_status_t ares__send_query(ares_channel channel, struct query *query,
   timeplus = channel->timeout;
   {
     /* How many times do we want to double it?  Presume sane values here. */
-    const int shift = query->try_count / channel->nservers;
+    const size_t shift = query->try_count / (size_t)channel->nservers;
 
     /* Is there enough room to shift timeplus left that many times?
      *
@@ -883,7 +886,7 @@ ares_status_t ares__send_query(ares_channel channel, struct query *query,
      *
      * This has the side benefit of leaving negative numbers unchanged.
      */
-    if(shift <= (int)(sizeof(int) * CHAR_BIT - 1)
+    if(shift <= (sizeof(int) * CHAR_BIT - 1)
        && (timeplus >> (sizeof(int) * CHAR_BIT - 1 - shift)) == 0)
     {
       timeplus <<= shift;
@@ -1207,18 +1210,18 @@ static ares_status_t open_socket(ares_channel channel,
 }
 
 
-static ares_bool_t same_questions(const unsigned char *qbuf, int qlen,
-                                  const unsigned char *abuf, int alen)
+static ares_bool_t same_questions(const unsigned char *qbuf, size_t qlen,
+                                  const unsigned char *abuf, size_t alen)
 {
   struct {
     const unsigned char *p;
-    int qdcount;
+    size_t qdcount;
     char *name;
-    long namelen;
+    size_t namelen;
     int type;
     int dnsclass;
   } q, a;
-  int i, j;
+  size_t i, j;
 
   if (qlen < HFIXEDSZ || alen < HFIXEDSZ)
     return ARES_FALSE;
@@ -1234,7 +1237,7 @@ static ares_bool_t same_questions(const unsigned char *qbuf, int qlen,
   for (i = 0; i < q.qdcount; i++)
     {
       /* Decode the question in the query. */
-      if (ares_expand_name(q.p, qbuf, qlen, &q.name, &q.namelen)
+      if (ares__expand_name_for_response(q.p, qbuf, qlen, &q.name, &q.namelen, ARES_FALSE)
           != ARES_SUCCESS)
         return ARES_FALSE;
       q.p += q.namelen;
@@ -1252,7 +1255,7 @@ static ares_bool_t same_questions(const unsigned char *qbuf, int qlen,
       for (j = 0; j < a.qdcount; j++)
         {
           /* Decode the question in the answer. */
-          if (ares_expand_name(a.p, abuf, alen, &a.name, &a.namelen)
+          if (ares__expand_name_for_response(a.p, abuf, alen, &a.name, &a.namelen, ARES_FALSE)
               != ARES_SUCCESS)
             {
               ares_free(q.name);
@@ -1315,14 +1318,14 @@ static ares_bool_t same_address(struct sockaddr *sa, struct ares_addr *aa)
 }
 
 /* search for an OPT RR in the response */
-static int has_opt_rr(const unsigned char *abuf, int alen)
+static ares_bool_t has_opt_rr(const unsigned char *abuf, size_t alen)
 {
-  unsigned int qdcount, ancount, nscount, arcount, i;
+  size_t qdcount, ancount, nscount, arcount, i;
   const unsigned char *aptr;
-  int status;
+  ares_status_t status;
 
   if (alen < HFIXEDSZ)
-    return -1;
+    return ARES_FALSE;
 
   /* Parse the answer header. */
   qdcount = DNS_HEADER_QDCOUNT(abuf);
@@ -1336,13 +1339,13 @@ static int has_opt_rr(const unsigned char *abuf, int alen)
   for (i = 0; i < qdcount; i++)
     {
       char* name;
-      long len;
-      status = ares_expand_name(aptr, abuf, alen, &name, &len);
+      size_t len;
+      status = ares__expand_name_for_response(aptr, abuf, alen, &name, &len, ARES_FALSE);
       if (status != ARES_SUCCESS)
-        return -1;
+        return ARES_FALSE;
       ares_free_string(name);
       if (aptr + len + QFIXEDSZ > abuf + alen)
-        return -1;
+        return ARES_FALSE;
       aptr += len + QFIXEDSZ;
     }
 
@@ -1350,19 +1353,19 @@ static int has_opt_rr(const unsigned char *abuf, int alen)
   for (i = 0; i < ancount + nscount; i++)
     {
       char* name;
-      long len;
-      int dlen;
-      status = ares_expand_name(aptr, abuf, alen, &name, &len);
+      size_t len;
+      size_t dlen;
+      status = ares__expand_name_for_response(aptr, abuf, alen, &name, &len, ARES_FALSE);
       if (status != ARES_SUCCESS)
-        return -1;
+        return ARES_FALSE;
       ares_free_string(name);
       if (aptr + len + RRFIXEDSZ > abuf + alen)
-        return -1;
+        return ARES_FALSE;
       aptr += len;
       dlen = DNS_RR_LEN(aptr);
       aptr += RRFIXEDSZ;
       if (aptr + dlen > abuf + alen)
-        return -1;
+        return ARES_FALSE;
       aptr += dlen;
     }
 
@@ -1370,14 +1373,14 @@ static int has_opt_rr(const unsigned char *abuf, int alen)
   for (i = 0; i < arcount; i++)
     {
       char* name;
-      long len;
-      int dlen;
-      status = ares_expand_name(aptr, abuf, alen, &name, &len);
+      size_t len;
+      size_t dlen;
+      status = ares__expand_name_for_response(aptr, abuf, alen, &name, &len, ARES_FALSE);
       if (status != ARES_SUCCESS)
-        return -1;
+        return ARES_FALSE;
       ares_free_string(name);
       if (aptr + len + RRFIXEDSZ > abuf + alen)
-        return -1;
+        return ARES_FALSE;
       aptr += len;
 
       if (DNS_RR_TYPE(aptr) == T_OPT)
@@ -1386,11 +1389,11 @@ static int has_opt_rr(const unsigned char *abuf, int alen)
       dlen = DNS_RR_LEN(aptr);
       aptr += RRFIXEDSZ;
       if (aptr + dlen > abuf + alen)
-        return -1;
+        return ARES_FALSE;
       aptr += dlen;
     }
 
-  return 0;
+  return ARES_TRUE;
 }
 
 static void ares_detach_query(struct query *query)
@@ -1406,18 +1409,18 @@ static void ares_detach_query(struct query *query)
 }
 
 static void end_query(ares_channel channel, struct query *query,
-                      ares_status_t status, const unsigned char *abuf, int alen)
+                      ares_status_t status, const unsigned char *abuf, size_t alen)
 {
   (void)channel;
 
   ares_detach_query(query);
 
   /* Invoke the callback. */
-  query->callback(query->arg, status, query->timeouts,
+  query->callback(query->arg, (int)status, (int)query->timeouts,
                   /* due to prior design flaws, abuf isn't meant to be modified,
                    * but bad prototypes, ugh.  Lets cast off constfor compat. */
                   (unsigned char *)((void *)((size_t)abuf)),
-                  alen);
+                  (int)alen);
   ares__free_query(query);
 }
 

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -1384,7 +1384,7 @@ static ares_bool_t has_opt_rr(const unsigned char *abuf, size_t alen)
       aptr += len;
 
       if (DNS_RR_TYPE(aptr) == T_OPT)
-        return 1;
+        return ARES_TRUE;
 
       dlen = DNS_RR_LEN(aptr);
       aptr += RRFIXEDSZ;
@@ -1393,7 +1393,7 @@ static ares_bool_t has_opt_rr(const unsigned char *abuf, size_t alen)
       aptr += dlen;
     }
 
-  return ARES_TRUE;
+  return ARES_FALSE;
 }
 
 static void ares_detach_query(struct query *query)

--- a/src/lib/ares_query.c
+++ b/src/lib/ares_query.c
@@ -73,12 +73,12 @@ ares_status_t ares_query_qid(ares_channel channel, const char *name,
 
   /* Compose the query. */
   rd = !(channel->flags & ARES_FLAG_NORECURSE);
-  status = ares_create_query(name, dnsclass, type, id, rd, &qbuf,
+  status = (ares_status_t)ares_create_query(name, dnsclass, type, id, rd, &qbuf,
               &qlen, (channel->flags & ARES_FLAG_EDNS) ? channel->ednspsz : 0);
   if (status != ARES_SUCCESS)
     {
       if (qbuf != NULL) ares_free(qbuf);
-      callback(arg, status, 0, NULL, 0);
+      callback(arg, (int)status, 0, NULL, 0);
       return status;
     }
 

--- a/src/lib/ares_query.c
+++ b/src/lib/ares_query.c
@@ -94,7 +94,7 @@ ares_status_t ares_query_qid(ares_channel channel, const char *name,
   qquery->arg = arg;
 
   /* Send it off.  qcallback will be called when we get an answer. */
-  status = ares_send_ex(channel, qbuf, qlen, qcallback, qquery);
+  status = ares_send_ex(channel, qbuf, (size_t)qlen, qcallback, qquery);
   ares_free_string(qbuf);
 
   if (status == ARES_SUCCESS && qid)
@@ -113,7 +113,7 @@ void ares_query(ares_channel channel, const char *name, int dnsclass,
 static void qcallback(void *arg, int status, int timeouts, unsigned char *abuf, int alen)
 {
   struct qquery *qquery = (struct qquery *) arg;
-  unsigned int ancount;
+  size_t ancount;
   int rcode;
 
   if (status != ARES_SUCCESS)

--- a/src/lib/ares_query.c
+++ b/src/lib/ares_query.c
@@ -74,7 +74,7 @@ ares_status_t ares_query_qid(ares_channel channel, const char *name,
   /* Compose the query. */
   rd = !(channel->flags & ARES_FLAG_NORECURSE);
   status = (ares_status_t)ares_create_query(name, dnsclass, type, id, rd, &qbuf,
-              &qlen, (channel->flags & ARES_FLAG_EDNS) ? channel->ednspsz : 0);
+              &qlen, (channel->flags & ARES_FLAG_EDNS) ? (int)channel->ednspsz : 0);
   if (status != ARES_SUCCESS)
     {
       if (qbuf != NULL) ares_free(qbuf);

--- a/src/lib/ares_rand.c
+++ b/src/lib/ares_rand.c
@@ -291,7 +291,7 @@ static void ares__rand_bytes_fetch(ares_rand_state *state, unsigned char *buf,
           if (rv <= 0)
             continue; /* Just retry. */
 
-          bytes_read += rv;
+          bytes_read += (size_t)rv;
           if (bytes_read == len)
             return;
         }

--- a/src/lib/ares_search.c
+++ b/src/lib/ares_search.c
@@ -295,7 +295,7 @@ ares_status_t ares__single_domain(ares_channel channel, const char *name,
                       *s = ares_malloc((size_t)(q - p + 1));
                       if (*s)
                         {
-                          memcpy(*s, p, q - p);
+                          memcpy(*s, p, (size_t)(q - p));
                           (*s)[q - p] = 0;
                         }
                       ares_free(line);

--- a/src/lib/ares_send.c
+++ b/src/lib/ares_send.c
@@ -115,7 +115,7 @@ ares_status_t ares_send_ex(ares_channel channel, const unsigned char *qbuf,
       query->server_info[i].tcp_connection_generation = 0;
     }
 
-  packetsz = (channel->flags & ARES_FLAG_EDNS) ? (size_t)channel->ednspsz : PACKETSZ;
+  packetsz = (channel->flags & ARES_FLAG_EDNS) ? channel->ednspsz : PACKETSZ;
   query->using_tcp = (channel->flags & ARES_FLAG_USEVC) || qlen > packetsz;
 
   query->error_status = ARES_ECONNREFUSED;

--- a/src/lib/ares_send.c
+++ b/src/lib/ares_send.c
@@ -38,10 +38,10 @@
 #include "ares_private.h"
 
 ares_status_t ares_send_ex(ares_channel channel, const unsigned char *qbuf,
-                           int qlen, ares_callback callback, void *arg)
+                           size_t qlen, ares_callback callback, void *arg)
 {
   struct query *query;
-  int i, packetsz;
+  size_t i, packetsz;
   struct timeval now;
 
   /* Verify that the query is at least long enough to hold the header. */
@@ -150,5 +150,5 @@ ares_status_t ares_send_ex(ares_channel channel, const unsigned char *qbuf,
 void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
                ares_callback callback, void *arg)
 {
-  ares_send_ex(channel, qbuf, qlen, callback, arg);
+  ares_send_ex(channel, qbuf, (size_t)qlen, callback, arg);
 }

--- a/src/lib/ares_send.c
+++ b/src/lib/ares_send.c
@@ -71,7 +71,7 @@ ares_status_t ares_send_ex(ares_channel channel, const unsigned char *qbuf,
       callback(arg, ARES_ENOMEM, 0, NULL, 0);
       return ARES_ENOMEM;
     }
-  query->server_info = ares_malloc(channel->nservers *
+  query->server_info = ares_malloc((size_t)channel->nservers *
                                    sizeof(query->server_info[0]));
   if (!query->server_info)
     {
@@ -107,15 +107,15 @@ ares_status_t ares_send_ex(ares_channel channel, const unsigned char *qbuf,
    * of the next server we want to use. */
   query->server = channel->last_server;
   if (channel->rotate == 1)
-    channel->last_server = (channel->last_server + 1) % channel->nservers;
+    channel->last_server = (channel->last_server + 1) % (size_t)channel->nservers;
 
-  for (i = 0; i < channel->nservers; i++)
+  for (i = 0; i < (size_t)channel->nservers; i++)
     {
       query->server_info[i].skip_server = ARES_FALSE;
       query->server_info[i].tcp_connection_generation = 0;
     }
 
-  packetsz = (channel->flags & ARES_FLAG_EDNS) ? channel->ednspsz : PACKETSZ;
+  packetsz = (channel->flags & ARES_FLAG_EDNS) ? (size_t)channel->ednspsz : PACKETSZ;
   query->using_tcp = (channel->flags & ARES_FLAG_USEVC) || qlen > packetsz;
 
   query->error_status = ARES_ECONNREFUSED;

--- a/src/lib/ares_strerror.c
+++ b/src/lib/ares_strerror.c
@@ -31,7 +31,7 @@
 
 const char *ares_strerror(int code)
 {
-  ares_status_t status = code;
+  ares_status_t status = (ares_status_t)code;
   switch (status) {
     case ARES_SUCCESS:
       return "Successful completion";

--- a/src/lib/bitncmp.c
+++ b/src/lib/bitncmp.c
@@ -34,15 +34,16 @@
  * author:
  *	Paul Vixie (ISC), June 1996
  */
-int ares__bitncmp(const void *l, const void *r, int n)
+int ares__bitncmp(const void *l, const void *r, size_t n)
 {
-  unsigned int lb, rb;
-  int x, b;
+  size_t lb, rb;
+  ares_ssize_t x;
+  size_t b;
 
   b = n / 8;
   x = memcmp(l, r, b);
   if (x || (n % 8) == 0)
-    return (x);
+    return (int)x;
 
   lb = ((const unsigned char *)l)[b];
   rb = ((const unsigned char *)r)[b];

--- a/src/lib/bitncmp.h
+++ b/src/lib/bitncmp.h
@@ -27,7 +27,7 @@
 #define __ARES_BITNCMP_H
 
 #ifndef HAVE_BITNCMP
-int ares__bitncmp(const void *l, const void *r, int n);
+int ares__bitncmp(const void *l, const void *r, size_t n);
 #else
 #define ares__bitncmp(x,y,z) bitncmp(x,y,z)
 #endif

--- a/src/lib/inet_net_pton.c
+++ b/src/lib/inet_net_pton.c
@@ -185,11 +185,11 @@ ares_inet_net_pton_ipv4(const char *src, unsigned char *dst, size_t size)
 }
 
 static int
-getbits(const char *src, int *bitsp)
+getbits(const char *src, size_t *bitsp)
 {
   static const char digits[] = "0123456789";
-  int n;
-  int val;
+  size_t n;
+  size_t val;
   char ch;
 
   val = 0;
@@ -202,7 +202,7 @@ getbits(const char *src, int *bitsp)
       if (n++ != 0 && val == 0)       /* no leading zeros */
         return (0);
       val *= 10;
-      val += aresx_sztosi(pch - digits);
+      val += (size_t)(pch - digits);
       if (val > 128)                  /* range */
         return (0);
       continue;
@@ -317,7 +317,7 @@ ares_inet_net_pton_ipv6(const char *src, unsigned char *dst, size_t size)
 {
   struct ares_in6_addr in6;
   int                  ret;
-  int                  bits;
+  size_t               bits;
   size_t               bytes;
   char                 buf[INET6_ADDRSTRLEN + sizeof("/128")];
   char                *sep;
@@ -351,7 +351,7 @@ ares_inet_net_pton_ipv6(const char *src, unsigned char *dst, size_t size)
     return (-1);
   }
   memcpy(dst, &in6, bytes);
-  return (bits);
+  return (int)bits;
 }
 
 /*

--- a/src/tools/adig.c
+++ b/src/tools/adig.c
@@ -531,7 +531,9 @@ static const unsigned char *display_rr(const unsigned char *aptr,
                                        const unsigned char *abuf, int alen)
 {
   const unsigned char *p;
-  int type, dnsclass, ttl, dlen, status, i;
+  int type, dnsclass;
+  unsigned int ttl;
+  int dlen, status, i;
   long len;
   int vlen;
   char addr[46];

--- a/src/tools/ahost.c
+++ b/src/tools/ahost.c
@@ -101,7 +101,7 @@ int main(int argc, char **argv)
           optmask |= ARES_OPT_DOMAINS;
           options.ndomains++;
           options.domains = (char **)realloc(options.domains,
-                                             options.ndomains * sizeof(char *));
+                                             (size_t)options.ndomains * sizeof(char *));
           options.domains[options.ndomains - 1] = strdup(optarg);
           break;
         case 't':

--- a/test/ares-fuzz.c
+++ b/test/ares-fuzz.c
@@ -46,15 +46,17 @@ static unsigned char afl_buffer[kMaxAflInputSize];
 int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size);
 
 static void ProcessFile(int fd) {
-  int count = read(fd, afl_buffer, kMaxAflInputSize);
+  ssize_t count = read(fd, afl_buffer, kMaxAflInputSize);
   /*
    * Make a copy of the data so that it's not part of a larger
    * buffer (where buffer overflows would go unnoticed).
    */
-  unsigned char *copied_data = (unsigned char *)malloc(count);
-  memcpy(copied_data, afl_buffer, count);
-  LLVMFuzzerTestOneInput(copied_data, count);
-  free(copied_data);
+  if (count > 0) {
+    unsigned char *copied_data = (unsigned char *)malloc((size_t)count);
+    memcpy(copied_data, afl_buffer, (size_t)count);
+    LLVMFuzzerTestOneInput(copied_data, (size_t)count);
+    free(copied_data);
+  }
 }
 
 int main(int argc, char *argv[]) {

--- a/test/ares-fuzz.c
+++ b/test/ares-fuzz.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Brad House
+ * Copyright (C) The c-ares project
  *
  * Permission to use, copy, modify, and distribute this
  * software and its documentation for any purpose and without
@@ -31,6 +31,8 @@
 #include <unistd.h>
 #endif
 
+#include "ares.h"
+
 #define kMaxAflInputSize (1 << 20)
 static unsigned char afl_buffer[kMaxAflInputSize];
 
@@ -46,7 +48,7 @@ static unsigned char afl_buffer[kMaxAflInputSize];
 int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size);
 
 static void ProcessFile(int fd) {
-  ssize_t count = read(fd, afl_buffer, kMaxAflInputSize);
+  ares_ssize_t count = read(fd, afl_buffer, kMaxAflInputSize);
   /*
    * Make a copy of the data so that it's not part of a larger
    * buffer (where buffer overflows would go unnoticed).

--- a/test/ares-test-fuzz-name.c
+++ b/test/ares-test-fuzz-name.c
@@ -23,16 +23,18 @@
 // Include ares internal file for DNS protocol constants
 #include "ares_nameser.h"
 
+int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size);
+
 // Entrypoint for Clang's libfuzzer, exercising query creation.
 int LLVMFuzzerTestOneInput(const unsigned char *data,
                            unsigned long size) {
   // Null terminate the data.
   char *name = malloc(size + 1);
+  unsigned char *buf = NULL;
+  int buflen = 0;
   name[size] = '\0';
   memcpy(name, data, size);
 
-  unsigned char *buf = NULL;
-  int buflen = 0;
   ares_create_query(name, C_IN, T_AAAA, 1234, 0, &buf, &buflen, 1024);
   free(buf);
   free(name);

--- a/test/ares-test-fuzz.c
+++ b/test/ares-test-fuzz.c
@@ -19,57 +19,60 @@
 
 #include "ares.h"
 
+int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size);
+
+
 // Entrypoint for Clang's libfuzzer
-int LLVMFuzzerTestOneInput(const unsigned char *data,
-                           unsigned long size) {
+int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
+{
   // Feed the data into each of the ares_parse_*_reply functions.
   struct hostent *host = NULL;
   struct ares_addrttl info[5];
-  int count = 5;
-  ares_parse_a_reply(data, size, &host, info, &count);
-  if (host) ares_free_hostent(host);
-
-  host = NULL;
   struct ares_addr6ttl info6[5];
-  count = 5;
-  ares_parse_aaaa_reply(data, size, &host, info6, &count);
-  if (host) ares_free_hostent(host);
-
-  host = NULL;
   unsigned char addrv4[4] = {0x10, 0x20, 0x30, 0x40};
-  ares_parse_ptr_reply(data, size, addrv4, sizeof(addrv4), AF_INET, &host);
+  struct ares_srv_reply* srv = NULL;
+  struct ares_mx_reply* mx = NULL;
+  struct ares_txt_reply* txt = NULL;
+  struct ares_soa_reply* soa = NULL;
+  struct ares_naptr_reply* naptr = NULL;
+  struct ares_caa_reply* caa = NULL;
+  struct ares_uri_reply* uri = NULL;
+  int count = 5;
+  ares_parse_a_reply(data, (int)size, &host, info, &count);
   if (host) ares_free_hostent(host);
 
   host = NULL;
-  ares_parse_ns_reply(data, size, &host);
+  count = 5;
+  ares_parse_aaaa_reply(data, (int)size, &host, info6, &count);
   if (host) ares_free_hostent(host);
 
-  struct ares_srv_reply* srv = NULL;
-  ares_parse_srv_reply(data, size, &srv);
+  host = NULL;
+  ares_parse_ptr_reply(data, (int)size, addrv4, sizeof(addrv4), AF_INET, &host);
+  if (host) ares_free_hostent(host);
+
+  host = NULL;
+  ares_parse_ns_reply(data, (int)size, &host);
+  if (host) ares_free_hostent(host);
+
+  ares_parse_srv_reply(data, (int)size, &srv);
   if (srv) ares_free_data(srv);
 
-  struct ares_mx_reply* mx = NULL;
-  ares_parse_mx_reply(data, size, &mx);
+  ares_parse_mx_reply(data, (int)size, &mx);
   if (mx) ares_free_data(mx);
 
-  struct ares_txt_reply* txt = NULL;
-  ares_parse_txt_reply(data, size, &txt);
+  ares_parse_txt_reply(data, (int)size, &txt);
   if (txt) ares_free_data(txt);
 
-  struct ares_soa_reply* soa = NULL;
-  ares_parse_soa_reply(data, size, &soa);
+  ares_parse_soa_reply(data, (int)size, &soa);
   if (soa) ares_free_data(soa);
 
-  struct ares_naptr_reply* naptr = NULL;
-  ares_parse_naptr_reply(data, size, &naptr);
+  ares_parse_naptr_reply(data, (int)size, &naptr);
   if (naptr) ares_free_data(naptr);
 
-  struct ares_caa_reply* caa = NULL;
-  ares_parse_caa_reply(data, size, &caa);
+  ares_parse_caa_reply(data, (int)size, &caa);
   if (caa) ares_free_data(caa);
 
-  struct ares_uri_reply* uri = NULL;
-  ares_parse_uri_reply(data, size, &uri);
+  ares_parse_uri_reply(data, (int)size, &uri);
   if (uri) ares_free_data(uri);
 
   return 0;

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -581,7 +581,7 @@ TEST_F(DefaultChannelTest, SingleDomain) {
 
 TEST_F(DefaultChannelTest, SaveInvalidChannel) {
   int saved = channel_->nservers;
-  channel_->nservers = -1;
+  channel_->nservers = 0;
   struct ares_options opts;
   int optmask = 0;
   EXPECT_EQ(ARES_ENODATA, ares_save_options(channel_, &opts, &optmask));


### PR DESCRIPTION
PR #568 increased the warning levels and c-ares code emitted a bunch of warnings.  This PR fixes those warnings and starts transitioning internal data types into more proper forms (e.g. data lengths should be size_t not int).  It does, however, have to manually cast back to what the public API needs due to API and ABI compliance (we aren't looking to break integrations, just clean up internals).

Fix By: Brad House (@bradh352)