### PR TITLE
`ares_channel` -> `ares_channel_t *`: don't bury the pointer

### DIFF
--- a/docs/ares_cancel.3
+++ b/docs/ares_cancel.3
@@ -22,7 +22,7 @@ ares_cancel \- Cancel a resolve
 .nf
 #include <ares.h>
 
-void ares_cancel(ares_channel \fIchannel\fP)
+void ares_cancel(ares_channel_t *\fIchannel\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_cancel(3)\fP function cancels all lookups/requests made on the the

--- a/docs/ares_destroy.3
+++ b/docs/ares_destroy.3
@@ -22,7 +22,7 @@ ares_destroy \- Destroy a resolver channel
 .nf
 #include <ares.h>
 
-void ares_destroy(ares_channel \fIchannel\fP)
+void ares_destroy(ares_channel_t *\fIchannel\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_destroy(3)\fP function destroys the name service channel

--- a/docs/ares_dup.3
+++ b/docs/ares_dup.3
@@ -22,7 +22,7 @@ ares_dup \- Duplicate a resolver channel
 .nf
 #include <ares.h>
 
-int ares_dup(ares_channel *\fIdest\fP, ares_channel \fIsource\fP)
+int ares_dup(ares_channel_t **\fIdest\fP, ares_channel_t *\fIsource\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_dup(3)\fP function duplicates an existing communications channel

--- a/docs/ares_fds.3
+++ b/docs/ares_fds.3
@@ -22,7 +22,7 @@ ares_fds \- return file descriptors to select on
 .nf
 #include <ares.h>
 
-int ares_fds(ares_channel \fIchannel\fP,
+int ares_fds(ares_channel_t *\fIchannel\fP,
              fd_set *\fIread_fds\fP,
 	     fd_set *\fIwrite_fds\fP)
 .fi

--- a/docs/ares_get_servers.3
+++ b/docs/ares_get_servers.3
@@ -23,10 +23,10 @@ ares_get_servers, ares_get_servers_ports \- Retrieve name servers from an initia
 .nf
 #include <ares.h>
 
-int ares_get_servers(ares_channel \fIchannel\fP,
+int ares_get_servers(ares_channel_t *\fIchannel\fP,
                      struct ares_addr_node **\fIservers\fP)
 
-int ares_get_servers_ports(ares_channel \fIchannel\fP,
+int ares_get_servers_ports(ares_channel_t *\fIchannel\fP,
                            struct ares_addr_port_node **\fIservers\fP)
 .fi
 .SH DESCRIPTION

--- a/docs/ares_getaddrinfo.3
+++ b/docs/ares_getaddrinfo.3
@@ -26,7 +26,7 @@ typedef void (*ares_addrinfo_callback)(void *\fIarg\fP, int \fIstatus\fP,
                                        int \fItimeouts\fP,
                                        struct ares_addrinfo *\fIresult\fP)
 
-void ares_getaddrinfo(ares_channel \fIchannel\fP, const char *\fIname\fP,
+void ares_getaddrinfo(ares_channel_t *\fIchannel\fP, const char *\fIname\fP,
                       const char* \fIservice\fP,
                       const struct ares_addrinfo_hints *\fIhints\fP,
                       ares_addrinfo_callback \fIcallback\fP, void *\fIarg\fP)

--- a/docs/ares_gethostbyaddr.3
+++ b/docs/ares_gethostbyaddr.3
@@ -26,7 +26,7 @@ typedef void (*ares_host_callback)(void *\fIarg\fP, int \fIstatus\fP,
                                    int \fItimeouts\fP,
                                    struct hostent *\fIhostent\fP)
 
-void ares_gethostbyaddr(ares_channel \fIchannel\fP, const void *\fIaddr\fP,
+void ares_gethostbyaddr(ares_channel_t *\fIchannel\fP, const void *\fIaddr\fP,
                         int \fIaddrlen\fP, int \fIfamily\fP,
                         ares_host_callback \fIcallback\fP, void *\fIarg\fP)
 .fi

--- a/docs/ares_gethostbyname.3
+++ b/docs/ares_gethostbyname.3
@@ -26,7 +26,7 @@ typedef void (*ares_host_callback)(void *\fIarg\fP, int \fIstatus\fP,
                                    int \fItimeouts\fP,
                                    struct hostent *\fIhostent\fP)
 
-void ares_gethostbyname(ares_channel \fIchannel\fP, const char *\fIname\fP,
+void ares_gethostbyname(ares_channel_t *\fIchannel\fP, const char *\fIname\fP,
                         int \fIfamily\fP, ares_host_callback \fIcallback\fP,
                         void *\fIarg\fP)
 .fi

--- a/docs/ares_gethostbyname_file.3
+++ b/docs/ares_gethostbyname_file.3
@@ -22,7 +22,7 @@ ares_gethostbyname_file \- Lookup a name in the system's hosts file
 .nf
 #include <ares.h>
 
-int ares_gethostbyname_file(ares_channel \fIchannel\fP, const char *\fIname\fP,
+int ares_gethostbyname_file(ares_channel_t *\fIchannel\fP, const char *\fIname\fP,
                             int \fIfamily\fP, struct hostent **host)
 .fi
 .SH DESCRIPTION

--- a/docs/ares_getnameinfo.3
+++ b/docs/ares_getnameinfo.3
@@ -26,7 +26,7 @@ typedef void (*ares_nameinfo_callback)(void *\fIarg\fP, int \fIstatus\fP,
                                        int \fItimeouts\fP, char *\fInode\fP,
                                        char *\fIservice\fP)
 
-void ares_getnameinfo(ares_channel \fIchannel\fP, const struct sockaddr *\fIsa\fP,
+void ares_getnameinfo(ares_channel_t *\fIchannel\fP, const struct sockaddr *\fIsa\fP,
                       ares_socklen_t \fIsalen\fP, int \fIflags\fP,
                       ares_nameinfo_callback \fIcallback\fP, void *\fIarg\fP)
 .fi

--- a/docs/ares_getsock.3
+++ b/docs/ares_getsock.3
@@ -22,7 +22,7 @@ ares_getsock \- get socket descriptors to wait on
 .nf
 #include <ares.h>
 
-int ares_getsock(ares_channel \fIchannel\fP, ares_socket_t *\fIsocks\fP,
+int ares_getsock(ares_channel_t *\fIchannel\fP, ares_socket_t *\fIsocks\fP,
                  int \fInumsocks\fP);
 .fi
 .SH DESCRIPTION

--- a/docs/ares_init.3
+++ b/docs/ares_init.3
@@ -23,7 +23,7 @@ ares_init \- Initialize a resolver channel
 .nf
 #include <ares.h>
 
-int ares_init(ares_channel *\fIchannelptr\fP)
+int ares_init(ares_channel_t **\fIchannelptr\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_init(3)\fP function initializes a communications channel for name

--- a/docs/ares_init_options.3
+++ b/docs/ares_init_options.3
@@ -47,7 +47,7 @@ struct ares_options {
   int udp_max_queries;
 };
 
-int ares_init_options(ares_channel *\fIchannelptr\fP,
+int ares_init_options(ares_channel_t **\fIchannelptr\fP,
                       struct ares_options *\fIoptions\fP,
                       int \fIoptmask\fP)
 .fi

--- a/docs/ares_parse_caa_reply.3
+++ b/docs/ares_parse_caa_reply.3
@@ -114,7 +114,7 @@ static void dns_callback(void *arg,
     ares_free_data (caa_out);
   }
 
-static void main_loop(ares_channel *channel)
+static void main_loop(ares_channel_t **channel)
   {
     int nfds, count;
     fd_set readers, writers;
@@ -145,7 +145,7 @@ int main(int argc, char **argv)
     if (argc > 1)
       domain = argv[1];
 
-    ares_channel channel;
+    ares_channel_t *channel;
     if ((err = ares_init (&channel)) != ARES_SUCCESS)
       {
         printf ("ares_init() failed (%i)\\n", err);

--- a/docs/ares_process.3
+++ b/docs/ares_process.3
@@ -22,11 +22,11 @@ ares_process \- Process events for name resolution
 .nf
 #include <ares.h>
 
-void ares_process(ares_channel \fIchannel\fP,
+void ares_process(ares_channel_t *\fIchannel\fP,
                   fd_set *\fIread_fds\fP,
                   fd_set *\fIwrite_fds\fP)
 
-void ares_process_fd(ares_channel \fIchannel\fP,
+void ares_process_fd(ares_channel_t *\fIchannel\fP,
                      ares_socket_t \fIread_fd\fP,
                      ares_socket_t \fIwrite_fd\fP)
 .fi

--- a/docs/ares_query.3
+++ b/docs/ares_query.3
@@ -26,7 +26,7 @@ typedef void (*ares_callback)(void *\fIarg\fP, int \fIstatus\fP,
                               int \fItimeouts\fP, unsigned char *\fIabuf\fP,
                               int \fIalen\fP)
 
-void ares_query(ares_channel \fIchannel\fP, const char *\fIname\fP,
+void ares_query(ares_channel_t *\fIchannel\fP, const char *\fIname\fP,
                 int \fIdnsclass\fP, int \fItype\fP,
                 ares_callback \fIcallback\fP, void *\fIarg\fP)
 .fi

--- a/docs/ares_save_options.3
+++ b/docs/ares_save_options.3
@@ -22,7 +22,7 @@ ares_save_options \- Save configuration values obtained from initialized ares_ch
 .nf
 #include <ares.h>
 
-int ares_save_options(ares_channel \fIchannel\fP,
+int ares_save_options(ares_channel_t *\fIchannel\fP,
                       struct ares_options *\fIoptions\fP, int *\fIoptmask\fP)
 .fi
 .SH DESCRIPTION
@@ -60,9 +60,9 @@ this config struct, which may no longer be the complete set of config
 options. \fBares_dup(3)\fP will not have that restriction.
 
 The ares_options struct can not handle potential IPv6 name servers the
-ares_channel might be configured to use. The \fBares_save_options(3)\fP function
+ares_channel_t *might be configured to use. The \fBares_save_options(3)\fP function
 will only return IPv4 servers, if any. In order to retrieve all name servers
-an ares_channel might be using, the \fBares_get_servers(3)\fP function must be
+an ares_channel_t *might be using, the \fBares_get_servers(3)\fP function must be
 used instead.
 .SH SEE ALSO
 .BR ares_destroy_options (3),

--- a/docs/ares_save_options.3
+++ b/docs/ares_save_options.3
@@ -60,9 +60,9 @@ this config struct, which may no longer be the complete set of config
 options. \fBares_dup(3)\fP will not have that restriction.
 
 The ares_options struct can not handle potential IPv6 name servers the
-ares_channel_t *might be configured to use. The \fBares_save_options(3)\fP function
+ares channel might be configured to use. The \fBares_save_options(3)\fP function
 will only return IPv4 servers, if any. In order to retrieve all name servers
-an ares_channel_t *might be using, the \fBares_get_servers(3)\fP function must be
+an ares channel might be using, the \fBares_get_servers(3)\fP function must be
 used instead.
 .SH SEE ALSO
 .BR ares_destroy_options (3),

--- a/docs/ares_search.3
+++ b/docs/ares_search.3
@@ -26,7 +26,7 @@ typedef void (*ares_callback)(void *\fIarg\fP, int \fIstatus\fP,
                               int \fItimeouts\fP, unsigned char *\fIabuf\fP,
                               int \fIalen\fP)
 
-void ares_search(ares_channel \fIchannel\fP, const char *\fIname\fP,
+void ares_search(ares_channel_t *\fIchannel\fP, const char *\fIname\fP,
                  int \fIdnsclass\fP, int \fItype\fP,
                  ares_callback \fIcallback\fP, void *\fIarg\fP)
 .fi

--- a/docs/ares_send.3
+++ b/docs/ares_send.3
@@ -26,7 +26,7 @@ typedef void (*ares_callback)(void *\fIarg\fP, int \fIstatus\fP,
                               int \fItimeouts\fP, unsigned char *\fIabuf\fP,
                               int \fIalen\fP)
 
-void ares_send(ares_channel \fIchannel\fP, const unsigned char *\fIqbuf\fP,
+void ares_send(ares_channel_t *\fIchannel\fP, const unsigned char *\fIqbuf\fP,
                int \fIqlen\fP, ares_callback \fIcallback\fP, void *\fIarg\fP)
 .fi
 .SH DESCRIPTION

--- a/docs/ares_set_local_dev.3
+++ b/docs/ares_set_local_dev.3
@@ -22,7 +22,7 @@ ares_set_local_dev \- Bind to a specific network device when creating sockets.
 .nf
 #include <ares.h>
 
-void ares_set_local_dev(ares_channel \fIchannel\fP, const char* \fIlocal_dev_name\fP)
+void ares_set_local_dev(ares_channel_t *\fIchannel\fP, const char* \fIlocal_dev_name\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_set_local_dev\fP function causes all future sockets

--- a/docs/ares_set_local_ip4.3
+++ b/docs/ares_set_local_ip4.3
@@ -22,7 +22,7 @@ ares_set_local_ip4 \- Set local IPv4 address outgoing requests.
 .nf
 #include <ares.h>
 
-void ares_set_local_ip4(ares_channel \fIchannel\fP, unsigned int \fIlocal_ip\fP)
+void ares_set_local_ip4(ares_channel_t *\fIchannel\fP, unsigned int \fIlocal_ip\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_set_local_ip4\fP function sets the IP address for outbound

--- a/docs/ares_set_local_ip6.3
+++ b/docs/ares_set_local_ip6.3
@@ -22,7 +22,7 @@ ares_set_local_ip6 \- Set local IPv6 address outgoing requests.
 .nf
 #include <ares.h>
 
-void ares_set_local_ip6(ares_channel \fIchannel\fP, const unsigned char* \fIlocal_ip6\fP)
+void ares_set_local_ip6(ares_channel_t *\fIchannel\fP, const unsigned char* \fIlocal_ip6\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_set_local_ip6\fP function sets the IPv6 address for outbound IPv6

--- a/docs/ares_set_servers.3
+++ b/docs/ares_set_servers.3
@@ -17,15 +17,15 @@
 .\"
 .TH ARES_SET_SERVERS 3 "5 March 2010"
 .SH NAME
-ares_set_servers, ares_set_servers_ports \- Initialize an ares_channel name servers configuration
+ares_set_servers, ares_set_servers_ports \- Initialize an ares_channel_t *name servers configuration
 .SH SYNOPSIS
 .nf
 #include <ares.h>
 
-int ares_set_servers(ares_channel \fIchannel\fP,
+int ares_set_servers(ares_channel_t *\fIchannel\fP,
                      struct ares_addr_node *\fIservers\fP)
 
-int ares_set_servers_ports(ares_channel \fIchannel\fP,
+int ares_set_servers_ports(ares_channel_t *\fIchannel\fP,
                            struct ares_addr_port_node *\fIservers\fP)
 .fi
 .SH DESCRIPTION

--- a/docs/ares_set_servers.3
+++ b/docs/ares_set_servers.3
@@ -17,7 +17,8 @@
 .\"
 .TH ARES_SET_SERVERS 3 "5 March 2010"
 .SH NAME
-ares_set_servers, ares_set_servers_ports \- Initialize an ares_channel_t *name servers configuration
+ares_set_servers, ares_set_servers_ports \- Initialize name server configuration
+for an ares channel.
 .SH SYNOPSIS
 .nf
 #include <ares.h>

--- a/docs/ares_set_servers_csv.3
+++ b/docs/ares_set_servers_csv.3
@@ -22,9 +22,9 @@ ares_set_servers_csv, ares_set_servers_ports_csv \- Set list of DNS servers to b
 .nf
 #include <ares.h>
 
-int ares_set_servers_csv(ares_channel \fIchannel\fP, const char* \fIservers\fP)
+int ares_set_servers_csv(ares_channel_t *\fIchannel\fP, const char* \fIservers\fP)
 
-int ares_set_servers_ports_csv(ares_channel \fIchannel\fP, const char* \fIservers\fP)
+int ares_set_servers_ports_csv(ares_channel_t *\fIchannel\fP, const char* \fIservers\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_set_servers_csv\fP and \fBares_set_servers_ports_csv\fPfunctions set

--- a/docs/ares_set_socket_callback.3
+++ b/docs/ares_set_socket_callback.3
@@ -13,7 +13,7 @@ typedef int (*ares_sock_create_callback)(ares_socket_t \fIsocket_fd\fP,
                                          int \fItype\fP,
                                          void *\fIuserdata\fP)
 
-void ares_set_socket_callback(ares_channel \fIchannel\fP,
+void ares_set_socket_callback(ares_channel_t *\fIchannel\fP,
                               ares_sock_create_callback \fIcallback\fP,
                               void *\fIuserdata\fP)
 .PP

--- a/docs/ares_set_socket_configure_callback.3
+++ b/docs/ares_set_socket_configure_callback.3
@@ -12,7 +12,7 @@ typedef int (*ares_sock_config_callback)(ares_socket_t \fIsocket_fd\fP,
                                          int \fItype\fP,
                                          void *\fIuserdata\fP)
 
-void ares_set_socket_configure_callback(ares_channel \fIchannel\fP,
+void ares_set_socket_configure_callback(ares_channel_t *\fIchannel\fP,
                                         ares_sock_config_callback \fIcallback\fP,
                                         void *\fIuserdata\fP)
 .fi

--- a/docs/ares_set_socket_functions.3
+++ b/docs/ares_set_socket_functions.3
@@ -16,7 +16,7 @@ struct ares_socket_functions {
     ares_ssize_t (*\fIasendv\fP)(ares_socket_t, const struct iovec *, int, void *);
 };
 
-void ares_set_socket_functions(ares_channel \fIchannel\fP,
+void ares_set_socket_functions(ares_channel_t *\fIchannel\fP,
                                const struct ares_socket_functions * \fIfunctions\fP,
                                void *\fIuser_data\fP);
 .fi

--- a/docs/ares_set_sortlist.3
+++ b/docs/ares_set_sortlist.3
@@ -16,12 +16,12 @@
 .\"
 .TH ARES_SET_SORTLIST 3 "23 November 2015"
 .SH NAME
-ares_set_sortlist \- Initialize an ares_channel sortlist configuration
+ares_set_sortlist \- Initialize an ares_channel_t *sortlist configuration
 .SH SYNOPSIS
 .nf
 #include <ares.h>
 
-int ares_set_sortlist(ares_channel \fIchannel\fP, const char *\fIsortstr\fP)
+int ares_set_sortlist(ares_channel_t *\fIchannel\fP, const char *\fIsortstr\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_set_sortlist(3)\fP function initializes an address sortlist configuration

--- a/docs/ares_timeout.3
+++ b/docs/ares_timeout.3
@@ -22,7 +22,7 @@ ares_timeout \- return maximum time to wait
 .nf
 #include <ares.h>
 
-struct timeval *ares_timeout(ares_channel \fIchannel\fP,
+struct timeval *ares_timeout(ares_channel_t *\fIchannel\fP,
                              struct timeval *\fImaxtv\fP,
                              struct timeval *\fItv\fP)
 .fi

--- a/include/ares.h
+++ b/include/ares.h
@@ -313,7 +313,12 @@ struct ares_channeldata;
 struct ares_addrinfo;
 struct ares_addrinfo_hints;
 
+/* Legacy typedef, don't use, you can't specify "const" */
 typedef struct ares_channeldata *ares_channel;
+
+/* Current main channel typedef */
+typedef struct ares_channeldata ares_channel_t;
+
 
 typedef void     (*ares_callback)(void *arg, int status, int timeouts,
                               unsigned char *abuf, int alen);
@@ -352,47 +357,48 @@ CARES_EXTERN void        ares_library_cleanup(void);
 
 CARES_EXTERN const char *ares_version(int *version);
 
-CARES_EXTERN int         ares_init(ares_channel *channelptr);
+CARES_EXTERN int         ares_init(ares_channel_t **channelptr);
 
-CARES_EXTERN int         ares_init_options(ares_channel        *channelptr,
+CARES_EXTERN int         ares_init_options(ares_channel_t     **channelptr,
                                            struct ares_options *options, int optmask);
 
-CARES_EXTERN int         ares_save_options(ares_channel         channel,
+CARES_EXTERN int         ares_save_options(ares_channel_t      *channel,
                                            struct ares_options *options, int *optmask);
 
 CARES_EXTERN void        ares_destroy_options(struct ares_options *options);
 
-CARES_EXTERN int         ares_dup(ares_channel *dest, ares_channel src);
+CARES_EXTERN int         ares_dup(ares_channel_t **dest, ares_channel_t *src);
 
-CARES_EXTERN void        ares_destroy(ares_channel channel);
+CARES_EXTERN void        ares_destroy(ares_channel_t *channel);
 
-CARES_EXTERN void        ares_cancel(ares_channel channel);
+CARES_EXTERN void        ares_cancel(ares_channel_t *channel);
 
 /* These next 3 configure local binding for the out-going socket
  * connection.  Use these to specify source IP and/or network device
  * on multi-homed systems.
  */
-CARES_EXTERN void        ares_set_local_ip4(ares_channel channel,
-                                            unsigned int local_ip);
+CARES_EXTERN void        ares_set_local_ip4(ares_channel_t *channel,
+                                            unsigned int    local_ip);
 
 /* local_ip6 should be 16 bytes in length */
-CARES_EXTERN void        ares_set_local_ip6(ares_channel         channel,
+CARES_EXTERN void        ares_set_local_ip6(ares_channel_t      *channel,
                                             const unsigned char *local_ip6);
 
 /* local_dev_name should be null terminated. */
-CARES_EXTERN void        ares_set_local_dev(ares_channel channel,
-                                            const char  *local_dev_name);
+CARES_EXTERN void        ares_set_local_dev(ares_channel_t *channel,
+                                            const char     *local_dev_name);
 
-CARES_EXTERN void        ares_set_socket_callback(ares_channel              channel,
+CARES_EXTERN void        ares_set_socket_callback(ares_channel_t           *channel,
                                                   ares_sock_create_callback callback,
                                                   void                     *user_data);
 
 CARES_EXTERN void        ares_set_socket_configure_callback(
-         ares_channel channel, ares_sock_config_callback callback, void *user_data);
+         ares_channel_t *channel, ares_sock_config_callback callback, void *user_data);
 
-CARES_EXTERN int  ares_set_sortlist(ares_channel channel, const char *sortstr);
+CARES_EXTERN int  ares_set_sortlist(ares_channel_t *channel,
+                                    const char     *sortstr);
 
-CARES_EXTERN void ares_getaddrinfo(ares_channel channel, const char *node,
+CARES_EXTERN void ares_getaddrinfo(ares_channel_t *channel, const char *node,
                                    const char                       *service,
                                    const struct ares_addrinfo_hints *hints,
                                    ares_addrinfo_callback callback, void *arg);
@@ -420,51 +426,54 @@ struct ares_socket_functions {
 };
 
 CARES_EXTERN void
-                  ares_set_socket_functions(ares_channel                        channel,
+                  ares_set_socket_functions(ares_channel_t                     *channel,
                                             const struct ares_socket_functions *funcs,
                                             void                               *user_data);
 
-CARES_EXTERN void ares_send(ares_channel channel, const unsigned char *qbuf,
+CARES_EXTERN void ares_send(ares_channel_t *channel, const unsigned char *qbuf,
                             int qlen, ares_callback callback, void *arg);
 
-CARES_EXTERN void ares_query(ares_channel channel, const char *name,
+CARES_EXTERN void ares_query(ares_channel_t *channel, const char *name,
                              int dnsclass, int type, ares_callback callback,
                              void *arg);
 
-CARES_EXTERN void ares_search(ares_channel channel, const char *name,
+CARES_EXTERN void ares_search(ares_channel_t *channel, const char *name,
                               int dnsclass, int type, ares_callback callback,
                               void *arg);
 
-CARES_EXTERN void ares_gethostbyname(ares_channel channel, const char *name,
+CARES_EXTERN void ares_gethostbyname(ares_channel_t *channel, const char *name,
                                      int family, ares_host_callback callback,
                                      void *arg);
 
-CARES_EXTERN int ares_gethostbyname_file(ares_channel channel, const char *name,
-                                         int family, struct hostent **host);
+CARES_EXTERN int  ares_gethostbyname_file(ares_channel_t *channel,
+                                          const char *name, int family,
+                                          struct hostent **host);
 
-CARES_EXTERN void ares_gethostbyaddr(ares_channel channel, const void *addr,
+CARES_EXTERN void ares_gethostbyaddr(ares_channel_t *channel, const void *addr,
                                      int addrlen, int family,
                                      ares_host_callback callback, void *arg);
 
-CARES_EXTERN void ares_getnameinfo(ares_channel           channel,
+CARES_EXTERN void ares_getnameinfo(ares_channel_t        *channel,
                                    const struct sockaddr *sa,
                                    ares_socklen_t salen, int flags,
                                    ares_nameinfo_callback callback, void *arg);
 
-CARES_EXTERN int  ares_fds(ares_channel channel, fd_set *read_fds,
+CARES_EXTERN int  ares_fds(ares_channel_t *channel, fd_set *read_fds,
                            fd_set *write_fds);
 
-CARES_EXTERN int  ares_getsock(ares_channel channel, ares_socket_t *socks,
+CARES_EXTERN int  ares_getsock(ares_channel_t *channel, ares_socket_t *socks,
                                int numsocks);
 
-CARES_EXTERN struct timeval *
-  ares_timeout(ares_channel channel, struct timeval *maxtv, struct timeval *tv);
+CARES_EXTERN struct timeval *ares_timeout(ares_channel_t *channel,
+                                          struct timeval *maxtv,
+                                          struct timeval *tv);
 
-CARES_EXTERN void ares_process(ares_channel channel, fd_set *read_fds,
+CARES_EXTERN void ares_process(ares_channel_t *channel, fd_set *read_fds,
                                fd_set *write_fds);
 
-CARES_EXTERN void ares_process_fd(ares_channel channel, ares_socket_t read_fd,
-                                  ares_socket_t write_fd);
+CARES_EXTERN void ares_process_fd(ares_channel_t *channel,
+                                  ares_socket_t   read_fd,
+                                  ares_socket_t   write_fd);
 
 CARES_EXTERN int  ares_create_query(const char *name, int dnsclass, int type,
                                     unsigned short id, int rd,
@@ -693,20 +702,20 @@ struct ares_addr_port_node {
   int tcp_port;
 };
 
-CARES_EXTERN int         ares_set_servers(ares_channel           channel,
+CARES_EXTERN int         ares_set_servers(ares_channel_t        *channel,
                                           struct ares_addr_node *servers);
-CARES_EXTERN int         ares_set_servers_ports(ares_channel                channel,
+CARES_EXTERN int         ares_set_servers_ports(ares_channel_t             *channel,
                                                 struct ares_addr_port_node *servers);
 
 /* Incomming string format: host[:port][,host[:port]]... */
-CARES_EXTERN int         ares_set_servers_csv(ares_channel channel,
-                                              const char  *servers);
-CARES_EXTERN int         ares_set_servers_ports_csv(ares_channel channel,
-                                                    const char  *servers);
+CARES_EXTERN int         ares_set_servers_csv(ares_channel_t *channel,
+                                              const char     *servers);
+CARES_EXTERN int         ares_set_servers_ports_csv(ares_channel_t *channel,
+                                                    const char     *servers);
 
-CARES_EXTERN int         ares_get_servers(ares_channel            channel,
+CARES_EXTERN int         ares_get_servers(ares_channel_t         *channel,
                                           struct ares_addr_node **servers);
-CARES_EXTERN int         ares_get_servers_ports(ares_channel                 channel,
+CARES_EXTERN int         ares_get_servers_ports(ares_channel_t              *channel,
                                                 struct ares_addr_port_node **servers);
 
 CARES_EXTERN const char *ares_inet_ntop(int af, const void *src, char *dst,

--- a/src/lib/ares__close_sockets.c
+++ b/src/lib/ares__close_sockets.c
@@ -44,7 +44,7 @@ static void ares__requeue_queries(struct server_connection *conn)
 void ares__close_connection(struct server_connection *conn)
 {
   struct server_state *server  = conn->server;
-  ares_channel         channel = server->channel;
+  ares_channel_t      *channel = server->channel;
 
   /* Unlink */
   ares__llist_node_claim(
@@ -79,7 +79,7 @@ void ares__close_sockets(struct server_state *server)
   }
 }
 
-void ares__check_cleanup_conn(ares_channel              channel,
+void ares__check_cleanup_conn(ares_channel_t           *channel,
                               struct server_connection *conn)
 {
   ares_bool_t do_cleanup = ARES_FALSE;

--- a/src/lib/ares__hosts_file.c
+++ b/src/lib/ares__hosts_file.c
@@ -716,8 +716,8 @@ static ares_bool_t ares__hosts_expired(const char              *filename,
   return ARES_FALSE;
 }
 
-static ares_status_t ares__hosts_path(ares_channel channel, ares_bool_t use_env,
-                                      char **path)
+static ares_status_t ares__hosts_path(ares_channel_t *channel,
+                                      ares_bool_t use_env, char **path)
 {
   char *path_hosts = NULL;
 
@@ -786,8 +786,8 @@ static ares_status_t ares__hosts_path(ares_channel channel, ares_bool_t use_env,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares__hosts_update(ares_channel channel,
-                                        ares_bool_t  use_env)
+static ares_status_t ares__hosts_update(ares_channel_t *channel,
+                                        ares_bool_t     use_env)
 {
   ares_status_t status;
   char         *filename = NULL;
@@ -810,7 +810,7 @@ static ares_status_t ares__hosts_update(ares_channel channel,
   return status;
 }
 
-ares_status_t ares__hosts_search_ipaddr(ares_channel channel,
+ares_status_t ares__hosts_search_ipaddr(ares_channel_t *channel,
                                         ares_bool_t use_env, const char *ipaddr,
                                         const ares_hosts_entry_t **entry)
 {
@@ -840,8 +840,8 @@ ares_status_t ares__hosts_search_ipaddr(ares_channel channel,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__hosts_search_host(ares_channel channel, ares_bool_t use_env,
-                                      const char                *host,
+ares_status_t ares__hosts_search_host(ares_channel_t *channel,
+                                      ares_bool_t use_env, const char *host,
                                       const ares_hosts_entry_t **entry)
 {
   ares_status_t status;

--- a/src/lib/ares__socket.c
+++ b/src/lib/ares__socket.c
@@ -59,7 +59,7 @@
 #include "ares.h"
 #include "ares_private.h"
 
-ares_ssize_t ares__socket_recvfrom(ares_channel channel, ares_socket_t s,
+ares_ssize_t ares__socket_recvfrom(ares_channel_t *channel, ares_socket_t s,
                                    void *data, size_t data_len, int flags,
                                    struct sockaddr *from,
                                    ares_socklen_t  *from_len)
@@ -76,7 +76,7 @@ ares_ssize_t ares__socket_recvfrom(ares_channel channel, ares_socket_t s,
 #endif
 }
 
-ares_ssize_t ares__socket_recv(ares_channel channel, ares_socket_t s,
+ares_ssize_t ares__socket_recv(ares_channel_t *channel, ares_socket_t s,
                                void *data, size_t data_len)
 {
   if (channel->sock_funcs && channel->sock_funcs->arecvfrom) {
@@ -159,7 +159,8 @@ static void set_ipv6_v6only(ares_socket_t sockfd, int on)
 #  define set_ipv6_v6only(s, v)
 #endif
 
-static int configure_socket(ares_socket_t s, int family, ares_channel channel)
+static int configure_socket(ares_socket_t s, int family,
+                            ares_channel_t *channel)
 {
   union {
     struct sockaddr     sa;
@@ -231,7 +232,7 @@ static int configure_socket(ares_socket_t s, int family, ares_channel channel)
   return 0;
 }
 
-ares_status_t ares__open_connection(ares_channel         channel,
+ares_status_t ares__open_connection(ares_channel_t      *channel,
                                     struct server_state *server,
                                     ares_bool_t          is_tcp)
 {
@@ -377,7 +378,7 @@ ares_status_t ares__open_connection(ares_channel         channel,
   return ARES_SUCCESS;
 }
 
-ares_socket_t ares__open_socket(ares_channel channel, int af, int type,
+ares_socket_t ares__open_socket(ares_channel_t *channel, int af, int type,
                                 int protocol)
 {
   if (channel->sock_funcs && channel->sock_funcs->asocket) {
@@ -388,7 +389,7 @@ ares_socket_t ares__open_socket(ares_channel channel, int af, int type,
   return socket(af, type, protocol);
 }
 
-int ares__connect_socket(ares_channel channel, ares_socket_t sockfd,
+int ares__connect_socket(ares_channel_t *channel, ares_socket_t sockfd,
                          const struct sockaddr *addr, ares_socklen_t addrlen)
 {
   if (channel->sock_funcs && channel->sock_funcs->aconnect) {
@@ -399,7 +400,7 @@ int ares__connect_socket(ares_channel channel, ares_socket_t sockfd,
   return connect(sockfd, addr, addrlen);
 }
 
-void ares__close_socket(ares_channel channel, ares_socket_t s)
+void ares__close_socket(ares_channel_t *channel, ares_socket_t s)
 {
   if (channel->sock_funcs && channel->sock_funcs->aclose) {
     channel->sock_funcs->aclose(s, channel->sock_func_cb_data);
@@ -416,7 +417,7 @@ struct iovec {
 };
 #endif
 
-ares_ssize_t ares__socket_write(ares_channel channel, ares_socket_t s,
+ares_ssize_t ares__socket_write(ares_channel_t *channel, ares_socket_t s,
                                 const void *data, size_t len)
 {
   if (channel->sock_funcs && channel->sock_funcs->asendv) {
@@ -428,14 +429,14 @@ ares_ssize_t ares__socket_write(ares_channel channel, ares_socket_t s,
   return swrite(s, data, len);
 }
 
-void ares_set_socket_callback(ares_channel              channel,
+void ares_set_socket_callback(ares_channel_t           *channel,
                               ares_sock_create_callback cb, void *data)
 {
   channel->sock_create_cb      = cb;
   channel->sock_create_cb_data = data;
 }
 
-void ares_set_socket_configure_callback(ares_channel              channel,
+void ares_set_socket_configure_callback(ares_channel_t           *channel,
                                         ares_sock_config_callback cb,
                                         void                     *data)
 {
@@ -443,7 +444,7 @@ void ares_set_socket_configure_callback(ares_channel              channel,
   channel->sock_config_cb_data = data;
 }
 
-void ares_set_socket_functions(ares_channel                        channel,
+void ares_set_socket_functions(ares_channel_t                     *channel,
                                const struct ares_socket_functions *funcs,
                                void                               *data)
 {

--- a/src/lib/ares__sortaddrinfo.c
+++ b/src/lib/ares__sortaddrinfo.c
@@ -345,7 +345,7 @@ static int rfc6724_compare(const void *ptr1, const void *ptr2)
  * and -1 if a fatal error occurred. If 0 or 1, the contents of src_addr are
  * undefined.
  */
-static int find_src_addr(ares_channel channel, const struct sockaddr *addr,
+static int find_src_addr(ares_channel_t *channel, const struct sockaddr *addr,
                          struct sockaddr *src_addr)
 {
   ares_socket_t  sock;
@@ -394,7 +394,7 @@ static int find_src_addr(ares_channel channel, const struct sockaddr *addr,
  * Sort the linked list starting at sentinel->ai_next in RFC6724 order.
  * Will leave the list unchanged if an error occurs.
  */
-ares_status_t ares__sortaddrinfo(ares_channel               channel,
+ares_status_t ares__sortaddrinfo(ares_channel_t            *channel,
                                  struct ares_addrinfo_node *list_sentinel)
 {
   struct ares_addrinfo_node *cur;

--- a/src/lib/ares_cancel.c
+++ b/src/lib/ares_cancel.c
@@ -35,7 +35,7 @@
  * on the given channel. It does NOT kill the channel, use ares_destroy() for
  * that.
  */
-void ares_cancel(ares_channel channel)
+void ares_cancel(ares_channel_t *channel)
 {
   if (ares__llist_len(channel->all_queries) > 0) {
     ares__llist_node_t *node = NULL;

--- a/src/lib/ares_destroy.c
+++ b/src/lib/ares_destroy.c
@@ -32,7 +32,7 @@
 #include "ares.h"
 #include "ares_private.h"
 
-void ares_destroy(ares_channel channel)
+void ares_destroy(ares_channel_t *channel)
 {
   size_t              i;
   ares__llist_node_t *node = NULL;
@@ -105,7 +105,7 @@ void ares__destroy_server(struct server_state *server)
   ares_free(server);
 }
 
-void ares__destroy_servers_state(ares_channel channel)
+void ares__destroy_servers_state(ares_channel_t *channel)
 {
   ares__slist_node_t *node;
 

--- a/src/lib/ares_fds.c
+++ b/src/lib/ares_fds.c
@@ -30,7 +30,7 @@
 #include "ares.h"
 #include "ares_private.h"
 
-int ares_fds(ares_channel channel, fd_set *read_fds, fd_set *write_fds)
+int ares_fds(ares_channel_t *channel, fd_set *read_fds, fd_set *write_fds)
 {
   ares_socket_t       nfds;
   ares__slist_node_t *snode;

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -69,7 +69,7 @@
 #endif
 
 struct host_query {
-  ares_channel               channel;
+  ares_channel_t            *channel;
   char                      *name;
   unsigned short             port; /* in host order */
   ares_addrinfo_callback     callback;
@@ -458,8 +458,8 @@ static void terminate_retries(const struct host_query *hquery,
 {
   unsigned short term_qid =
     (qid == hquery->qid_a) ? hquery->qid_aaaa : hquery->qid_a;
-  ares_channel  channel = hquery->channel;
-  struct query *query   = NULL;
+  ares_channel_t *channel = hquery->channel;
+  struct query   *query   = NULL;
 
   /* No other outstanding queries, nothing to do */
   if (!hquery->remaining) {
@@ -527,7 +527,7 @@ static void host_callback(void *arg, int status, int timeouts,
   /* at this point we keep on waiting for the next query to finish */
 }
 
-void ares_getaddrinfo(ares_channel channel, const char *name,
+void ares_getaddrinfo(ares_channel_t *channel, const char *name,
                       const char                       *service,
                       const struct ares_addrinfo_hints *hints,
                       ares_addrinfo_callback callback, void *arg)

--- a/src/lib/ares_gethostbyaddr.c
+++ b/src/lib/ares_gethostbyaddr.c
@@ -50,7 +50,7 @@
 
 struct addr_query {
   /* Arguments passed to ares_gethostbyaddr() */
-  ares_channel       channel;
+  ares_channel_t    *channel;
   struct ares_addr   addr;
   ares_host_callback callback;
   void              *arg;
@@ -64,13 +64,13 @@ static void          addr_callback(void *arg, int status, int timeouts,
                                    unsigned char *abuf, int alen);
 static void          end_aquery(struct addr_query *aquery, ares_status_t status,
                                 struct hostent *host);
-static ares_status_t file_lookup(ares_channel            channel,
+static ares_status_t file_lookup(ares_channel_t         *channel,
                                  const struct ares_addr *addr,
                                  struct hostent        **host);
 static void          ptr_rr_name(char *name, size_t name_size,
                                  const struct ares_addr *addr);
 
-void ares_gethostbyaddr(ares_channel channel, const void *addr, int addrlen,
+void ares_gethostbyaddr(ares_channel_t *channel, const void *addr, int addrlen,
                         int family, ares_host_callback callback, void *arg)
 {
   struct addr_query *aquery;
@@ -174,7 +174,7 @@ static void end_aquery(struct addr_query *aquery, ares_status_t status,
   ares_free(aquery);
 }
 
-static ares_status_t file_lookup(ares_channel            channel,
+static ares_status_t file_lookup(ares_channel_t         *channel,
                                  const struct ares_addr *addr,
                                  struct hostent        **host)
 {

--- a/src/lib/ares_gethostbyname.c
+++ b/src/lib/ares_gethostbyname.c
@@ -61,7 +61,7 @@ static size_t get6_address_index(const struct ares_in6_addr *addr,
 struct host_query {
   ares_host_callback callback;
   void              *arg;
-  ares_channel       channel;
+  ares_channel_t    *channel;
 };
 
 static void ares_gethostbyname_callback(void *arg, int status, int timeouts,
@@ -100,7 +100,7 @@ static void ares_gethostbyname_callback(void *arg, int status, int timeouts,
   ares_free_hostent(hostent);
 }
 
-void ares_gethostbyname(ares_channel channel, const char *name, int family,
+void ares_gethostbyname(ares_channel_t *channel, const char *name, int family,
                         ares_host_callback callback, void *arg)
 {
   const struct ares_addrinfo_hints hints = { ARES_AI_CANONNAME, family, 0, 0 };
@@ -263,8 +263,8 @@ done:
 
 /* I really have no idea why this is exposed as a public function, but since
  * it is, we can't kill this legacy function. */
-int ares_gethostbyname_file(ares_channel channel, const char *name, int family,
-                            struct hostent **host)
+int ares_gethostbyname_file(ares_channel_t *channel, const char *name,
+                            int family, struct hostent **host)
 {
   const ares_hosts_entry_t *entry;
   ares_status_t             status;

--- a/src/lib/ares_getnameinfo.c
+++ b/src/lib/ares_getnameinfo.c
@@ -86,7 +86,7 @@ static void append_scopeid(const struct sockaddr_in6 *addr6,
 #endif
 STATIC_TESTABLE char *ares_striendstr(const char *s1, const char *s2);
 
-void ares_getnameinfo(ares_channel channel, const struct sockaddr *sa,
+void ares_getnameinfo(ares_channel_t *channel, const struct sockaddr *sa,
                       ares_socklen_t salen, int flags_int,
                       ares_nameinfo_callback callback, void *arg)
 {

--- a/src/lib/ares_getsock.c
+++ b/src/lib/ares_getsock.c
@@ -29,7 +29,7 @@
 #include "ares.h"
 #include "ares_private.h"
 
-int ares_getsock(ares_channel channel, ares_socket_t *socks,
+int ares_getsock(ares_channel_t *channel, ares_socket_t *socks,
                  int numsocks) /* size of the 'socks' array */
 {
   ares__slist_node_t *snode;

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -71,7 +71,7 @@
 #endif
 
 
-int ares_init(ares_channel *channelptr)
+int ares_init(ares_channel_t **channelptr)
 {
   return ares_init_options(channelptr, NULL, 0);
 }
@@ -126,7 +126,7 @@ static void server_destroy_cb(void *data)
   ares__destroy_server(data);
 }
 
-static ares_status_t init_by_defaults(ares_channel channel)
+static ares_status_t init_by_defaults(ares_channel_t *channel)
 {
   char         *hostname = NULL;
   ares_status_t rc       = ARES_SUCCESS;
@@ -282,11 +282,11 @@ error:
   return rc;
 }
 
-int ares_init_options(ares_channel *channelptr, struct ares_options *options,
+int ares_init_options(ares_channel_t **channelptr, struct ares_options *options,
                       int optmask)
 {
-  ares_channel  channel;
-  ares_status_t status = ARES_SUCCESS;
+  ares_channel_t *channel;
+  ares_status_t   status = ARES_SUCCESS;
 
   if (ares_library_initialized() != ARES_SUCCESS) {
     return ARES_ENOTINITIALIZED; /* LCOV_EXCL_LINE: n/a on non-WinSock */
@@ -386,7 +386,7 @@ done:
 
 /* ares_dup() duplicates a channel handle with all its options and returns a
    new channel handle */
-int ares_dup(ares_channel *dest, ares_channel src)
+int ares_dup(ares_channel_t **dest, ares_channel_t *src)
 {
   struct ares_options         opts;
   struct ares_addr_port_node *servers;
@@ -456,26 +456,26 @@ int ares_dup(ares_channel *dest, ares_channel src)
   return ARES_SUCCESS; /* everything went fine */
 }
 
-void ares_set_local_ip4(ares_channel channel, unsigned int local_ip)
+void ares_set_local_ip4(ares_channel_t *channel, unsigned int local_ip)
 {
   channel->local_ip4 = local_ip;
 }
 
 /* local_ip6 should be 16 bytes in length */
-void ares_set_local_ip6(ares_channel channel, const unsigned char *local_ip6)
+void ares_set_local_ip6(ares_channel_t *channel, const unsigned char *local_ip6)
 {
   memcpy(&channel->local_ip6, local_ip6, sizeof(channel->local_ip6));
 }
 
 /* local_dev_name should be null terminated. */
-void ares_set_local_dev(ares_channel channel, const char *local_dev_name)
+void ares_set_local_dev(ares_channel_t *channel, const char *local_dev_name)
 {
   ares_strcpy(channel->local_dev_name, local_dev_name,
               sizeof(channel->local_dev_name));
   channel->local_dev_name[sizeof(channel->local_dev_name) - 1] = 0;
 }
 
-int ares_set_sortlist(ares_channel channel, const char *sortstr)
+int ares_set_sortlist(ares_channel_t *channel, const char *sortstr)
 {
   size_t           nsort    = 0;
   struct apattern *sortlist = NULL;

--- a/src/lib/ares_options.c
+++ b/src/lib/ares_options.c
@@ -53,8 +53,8 @@ void ares_destroy_options(struct ares_options *options)
   ares_free(options->hosts_path);
 }
 
-static struct in_addr *ares_save_opt_servers(ares_channel channel,
-                                             int         *nservers)
+static struct in_addr *ares_save_opt_servers(ares_channel_t *channel,
+                                             int            *nservers)
 {
   ares__slist_node_t *snode;
   struct in_addr     *out =
@@ -82,7 +82,7 @@ static struct in_addr *ares_save_opt_servers(ares_channel channel,
 }
 
 /* Save options from initialized channel */
-int ares_save_options(ares_channel channel, struct ares_options *options,
+int ares_save_options(ares_channel_t *channel, struct ares_options *options,
                       int *optmask)
 {
   size_t i;
@@ -222,7 +222,7 @@ int ares_save_options(ares_channel channel, struct ares_options *options,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares__init_options_servers(ares_channel          channel,
+static ares_status_t ares__init_options_servers(ares_channel_t       *channel,
                                                 const struct in_addr *servers,
                                                 size_t                nservers)
 {
@@ -241,7 +241,7 @@ static ares_status_t ares__init_options_servers(ares_channel          channel,
   return status;
 }
 
-ares_status_t ares__init_by_options(ares_channel               channel,
+ares_status_t ares__init_by_options(ares_channel_t            *channel,
                                     const struct ares_options *options,
                                     int                        optmask)
 {

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -194,7 +194,7 @@ struct server_state {
   ares__buf_t              *tcp_send;
 
   /* Link back to owning channel */
-  ares_channel              channel;
+  ares_channel_t           *channel;
 };
 
 /* State to represent a DNS query */
@@ -202,7 +202,7 @@ struct query {
   /* Query ID from qbuf, for faster lookup, and current timeout */
   unsigned short            qid; /* host byte order */
   struct timeval            timeout;
-  ares_channel              channel;
+  ares_channel_t           *channel;
 
   /*
    * Node object for each list entry the query belongs to in order to
@@ -350,16 +350,16 @@ ares_status_t ares__requeue_query(struct query *query, struct timeval *now);
 /* Identical to ares_query, but returns a normal ares return code like
  * ARES_SUCCESS, and can be passed the qid by reference which will be
  * filled in on ARES_SUCCESS */
-ares_status_t ares_query_qid(ares_channel channel, const char *name,
+ares_status_t ares_query_qid(ares_channel_t *channel, const char *name,
                              int dnsclass, int type, ares_callback callback,
                              void *arg, unsigned short *qid);
 /* Identical to ares_send() except returns normal ares return codes like
  * ARES_SUCCESS */
-ares_status_t ares_send_ex(ares_channel channel, const unsigned char *qbuf,
+ares_status_t ares_send_ex(ares_channel_t *channel, const unsigned char *qbuf,
                            size_t qlen, ares_callback callback, void *arg);
 void          ares__close_connection(struct server_connection *conn);
 void          ares__close_sockets(struct server_state *server);
-void          ares__check_cleanup_conn(ares_channel              channel,
+void          ares__check_cleanup_conn(ares_channel_t           *channel,
                                        struct server_connection *conn);
 ares_status_t ares__read_line(FILE *fp, char **buf, size_t *bufsize);
 void          ares__free_query(struct query *query);
@@ -382,11 +382,11 @@ ares_status_t  ares__expand_name_for_response(const unsigned char *encoded,
 ares_status_t  ares_expand_string_ex(const unsigned char *encoded,
                                      const unsigned char *abuf, size_t alen,
                                      unsigned char **s, size_t *enclen);
-ares_status_t  ares__init_servers_state(ares_channel channel);
-ares_status_t  ares__init_by_options(ares_channel               channel,
+ares_status_t  ares__init_servers_state(ares_channel_t *channel);
+ares_status_t  ares__init_by_options(ares_channel_t            *channel,
                                      const struct ares_options *options,
                                      int                        optmask);
-ares_status_t  ares__init_by_sysconfig(ares_channel channel);
+ares_status_t  ares__init_by_sysconfig(ares_channel_t *channel);
 
 typedef struct {
   ares__llist_t   *sconfig;
@@ -403,16 +403,16 @@ typedef struct {
 
 ares_status_t ares__init_by_environment(ares_sysconfig_t *sysconfig);
 
-ares_status_t ares__init_sysconfig_files(ares_channel      channel,
+ares_status_t ares__init_sysconfig_files(ares_channel_t   *channel,
                                          ares_sysconfig_t *sysconfig);
 ares_status_t ares__parse_sortlist(struct apattern **sortlist, size_t *nsort,
                                    const char *str);
 
-void          ares__destroy_servers_state(ares_channel channel);
-ares_status_t ares__single_domain(ares_channel channel, const char *name,
+void          ares__destroy_servers_state(ares_channel_t *channel);
+ares_status_t ares__single_domain(ares_channel_t *channel, const char *name,
                                   char **s);
 ares_status_t ares__cat_domain(const char *name, const char *domain, char **s);
-ares_status_t ares__sortaddrinfo(ares_channel               channel,
+ares_status_t ares__sortaddrinfo(ares_channel_t            *channel,
                                  struct ares_addrinfo_node *ai_node);
 
 void          ares__freeaddrinfo_nodes(struct ares_addrinfo_node *ai_node);
@@ -450,28 +450,28 @@ ares_status_t ares__addrinfo2addrttl(const struct ares_addrinfo *ai, int family,
 ares_status_t ares__addrinfo_localhost(const char *name, unsigned short port,
                                        const struct ares_addrinfo_hints *hints,
                                        struct ares_addrinfo             *ai);
-ares_status_t ares__open_connection(ares_channel         channel,
+ares_status_t ares__open_connection(ares_channel_t      *channel,
                                     struct server_state *server,
                                     ares_bool_t          is_tcp);
-ares_socket_t ares__open_socket(ares_channel channel, int af, int type,
+ares_socket_t ares__open_socket(ares_channel_t *channel, int af, int type,
                                 int protocol);
-ares_ssize_t  ares__socket_write(ares_channel channel, ares_socket_t s,
+ares_ssize_t  ares__socket_write(ares_channel_t *channel, ares_socket_t s,
                                  const void *data, size_t len);
-ares_ssize_t  ares__socket_recvfrom(ares_channel channel, ares_socket_t s,
+ares_ssize_t  ares__socket_recvfrom(ares_channel_t *channel, ares_socket_t s,
                                     void *data, size_t data_len, int flags,
                                     struct sockaddr *from,
                                     ares_socklen_t  *from_len);
-ares_ssize_t  ares__socket_recv(ares_channel channel, ares_socket_t s,
+ares_ssize_t  ares__socket_recv(ares_channel_t *channel, ares_socket_t s,
                                 void *data, size_t data_len);
 void          ares__close_socket(ares_channel, ares_socket_t);
-int           ares__connect_socket(ares_channel channel, ares_socket_t sockfd,
-                                   const struct sockaddr *addr, ares_socklen_t addrlen);
-ares_bool_t   ares__is_hostnamech(int ch);
-void          ares__destroy_server(struct server_state *server);
+int         ares__connect_socket(ares_channel_t *channel, ares_socket_t sockfd,
+                                 const struct sockaddr *addr, ares_socklen_t addrlen);
+ares_bool_t ares__is_hostnamech(int ch);
+void        ares__destroy_server(struct server_state *server);
 
-ares_status_t ares__servers_update(ares_channel   channel,
-                                   ares__llist_t *server_list,
-                                   ares_bool_t    user_specified);
+ares_status_t ares__servers_update(ares_channel_t *channel,
+                                   ares__llist_t  *server_list,
+                                   ares_bool_t     user_specified);
 ares_status_t ares__sconfig_append(ares__llist_t         **sconfig,
                                    const struct ares_addr *addr,
                                    unsigned short          udp_port,
@@ -486,11 +486,11 @@ struct ares_hosts_entry;
 typedef struct ares_hosts_entry ares_hosts_entry_t;
 
 void                            ares__hosts_file_destroy(ares_hosts_file_t *hf);
-ares_status_t                   ares__hosts_search_ipaddr(ares_channel channel,
-                                                          ares_bool_t use_env, const char *ipaddr,
-                                                          const ares_hosts_entry_t **entry);
-ares_status_t ares__hosts_search_host(ares_channel channel, ares_bool_t use_env,
-                                      const char                *host,
+ares_status_t ares__hosts_search_ipaddr(ares_channel_t *channel,
+                                        ares_bool_t use_env, const char *ipaddr,
+                                        const ares_hosts_entry_t **entry);
+ares_status_t ares__hosts_search_host(ares_channel_t *channel,
+                                      ares_bool_t use_env, const char *host,
                                       const ares_hosts_entry_t **entry);
 ares_status_t ares__hosts_entry_to_hostent(const ares_hosts_entry_t *entry,
                                            int                       family,

--- a/src/lib/ares_query.c
+++ b/src/lib/ares_query.c
@@ -50,7 +50,7 @@ static void qcallback(void *arg, int status, int timeouts, unsigned char *abuf,
    performed per id generation. In practice this search should happen only
    once per newly generated id
 */
-static unsigned short generate_unique_id(ares_channel channel)
+static unsigned short generate_unique_id(ares_channel_t *channel)
 {
   unsigned short id;
 
@@ -61,7 +61,7 @@ static unsigned short generate_unique_id(ares_channel channel)
   return id;
 }
 
-ares_status_t ares_query_qid(ares_channel channel, const char *name,
+ares_status_t ares_query_qid(ares_channel_t *channel, const char *name,
                              int dnsclass, int type, ares_callback callback,
                              void *arg, unsigned short *qid)
 {
@@ -106,8 +106,8 @@ ares_status_t ares_query_qid(ares_channel channel, const char *name,
   return status;
 }
 
-void ares_query(ares_channel channel, const char *name, int dnsclass, int type,
-                ares_callback callback, void *arg)
+void ares_query(ares_channel_t *channel, const char *name, int dnsclass,
+                int type, ares_callback callback, void *arg)
 {
   ares_query_qid(channel, name, dnsclass, type, callback, arg, NULL);
 }

--- a/src/lib/ares_search.c
+++ b/src/lib/ares_search.c
@@ -36,17 +36,17 @@
 
 struct search_query {
   /* Arguments passed to ares_search */
-  ares_channel  channel;
-  char         *name; /* copied into an allocated buffer */
-  int           dnsclass;
-  int           type;
-  ares_callback callback;
-  void         *arg;
+  ares_channel_t *channel;
+  char           *name; /* copied into an allocated buffer */
+  int             dnsclass;
+  int             type;
+  ares_callback   callback;
+  void           *arg;
 
-  int           status_as_is;  /* error status from trying as-is */
-  size_t        next_domain;   /* next search domain to try */
-  ares_bool_t   trying_as_is;  /* current query is for name as-is */
-  size_t        timeouts;      /* number of timeouts we saw for this request */
+  int             status_as_is; /* error status from trying as-is */
+  size_t          next_domain;  /* next search domain to try */
+  ares_bool_t     trying_as_is; /* current query is for name as-is */
+  size_t          timeouts;     /* number of timeouts we saw for this request */
   ares_bool_t ever_got_nodata; /* did we ever get ARES_ENODATA along the way? */
 };
 
@@ -55,8 +55,8 @@ static void search_callback(void *arg, int status, int timeouts,
 static void end_squery(struct search_query *squery, ares_status_t status,
                        unsigned char *abuf, size_t alen);
 
-void ares_search(ares_channel channel, const char *name, int dnsclass, int type,
-                 ares_callback callback, void *arg)
+void        ares_search(ares_channel_t *channel, const char *name, int dnsclass,
+                        int type, ares_callback callback, void *arg)
 {
   struct search_query *squery;
   char                *s;
@@ -145,7 +145,7 @@ static void search_callback(void *arg, int status, int timeouts,
                             unsigned char *abuf, int alen)
 {
   struct search_query *squery  = (struct search_query *)arg;
-  ares_channel         channel = squery->channel;
+  ares_channel_t      *channel = squery->channel;
   char                *s;
 
   squery->timeouts += (size_t)timeouts;
@@ -235,7 +235,7 @@ ares_status_t ares__cat_domain(const char *name, const char *domain, char **s)
  * the string we should query, in an allocated buffer.  If not, set *s
  * to NULL.
  */
-ares_status_t ares__single_domain(ares_channel channel, const char *name,
+ares_status_t ares__single_domain(ares_channel_t *channel, const char *name,
                                   char **s)
 {
   size_t        len = ares_strlen(name);

--- a/src/lib/ares_send.c
+++ b/src/lib/ares_send.c
@@ -37,7 +37,7 @@
 #include "ares_dns.h"
 #include "ares_private.h"
 
-ares_status_t ares_send_ex(ares_channel channel, const unsigned char *qbuf,
+ares_status_t ares_send_ex(ares_channel_t *channel, const unsigned char *qbuf,
                            size_t qlen, ares_callback callback, void *arg)
 {
   struct query  *query;
@@ -125,7 +125,7 @@ ares_status_t ares_send_ex(ares_channel channel, const unsigned char *qbuf,
   return ares__send_query(query, &now);
 }
 
-void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
+void ares_send(ares_channel_t *channel, const unsigned char *qbuf, int qlen,
                ares_callback callback, void *arg)
 {
   ares_send_ex(channel, qbuf, (size_t)qlen, callback, arg);

--- a/src/lib/ares_sysconfig.c
+++ b/src/lib/ares_sysconfig.c
@@ -914,7 +914,7 @@ static void ares_sysconfig_free(ares_sysconfig_t *sysconfig)
   memset(sysconfig, 0, sizeof(*sysconfig));
 }
 
-static ares_status_t ares_sysconfig_apply(ares_channel            channel,
+static ares_status_t ares_sysconfig_apply(ares_channel_t         *channel,
                                           const ares_sysconfig_t *sysconfig)
 {
   ares_status_t status;
@@ -984,7 +984,7 @@ static ares_status_t ares_sysconfig_apply(ares_channel            channel,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__init_by_sysconfig(ares_channel channel)
+ares_status_t ares__init_by_sysconfig(ares_channel_t *channel)
 {
   ares_status_t    status;
   ares_sysconfig_t sysconfig;

--- a/src/lib/ares_sysconfig_files.c
+++ b/src/lib/ares_sysconfig_files.c
@@ -476,7 +476,7 @@ ares_status_t ares__init_by_environment(ares_sysconfig_t *sysconfig)
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__init_sysconfig_files(ares_channel      channel,
+ares_status_t ares__init_sysconfig_files(ares_channel_t   *channel,
                                          ares_sysconfig_t *sysconfig)
 {
   char         *p;

--- a/src/lib/ares_timeout.c
+++ b/src/lib/ares_timeout.c
@@ -41,7 +41,7 @@ static long timeoffset(const struct timeval *now, const struct timeval *check)
          (check->tv_usec - now->tv_usec) / 1000;
 }
 
-struct timeval *ares_timeout(ares_channel channel, struct timeval *maxtv,
+struct timeval *ares_timeout(ares_channel_t *channel, struct timeval *maxtv,
                              struct timeval *tvbuf)
 {
   struct query       *query;

--- a/src/lib/ares_update_servers.c
+++ b/src/lib/ares_update_servers.c
@@ -339,7 +339,7 @@ ares_status_t ares__sconfig_append_fromstr(ares__llist_t **sconfig,
   return ARES_SUCCESS;
 }
 
-static unsigned short ares__sconfig_get_port(ares_channel          channel,
+static unsigned short ares__sconfig_get_port(ares_channel_t       *channel,
                                              const ares_sconfig_t *s,
                                              ares_bool_t           is_tcp)
 {
@@ -356,7 +356,7 @@ static unsigned short ares__sconfig_get_port(ares_channel          channel,
   return port;
 }
 
-static ares__slist_node_t *ares__server_find(ares_channel          channel,
+static ares__slist_node_t *ares__server_find(ares_channel_t       *channel,
                                              const ares_sconfig_t *s)
 {
   ares__slist_node_t *node;
@@ -382,7 +382,7 @@ static ares__slist_node_t *ares__server_find(ares_channel          channel,
   return NULL;
 }
 
-static ares_bool_t ares__server_isdup(ares_channel        channel,
+static ares_bool_t ares__server_isdup(ares_channel_t     *channel,
                                       ares__llist_node_t *s)
 {
   /* Scan backwards to see if this is a duplicate */
@@ -413,7 +413,7 @@ static ares_bool_t ares__server_isdup(ares_channel        channel,
   return ARES_FALSE;
 }
 
-static ares_status_t ares__server_create(ares_channel          channel,
+static ares_status_t ares__server_create(ares_channel_t       *channel,
                                          const ares_sconfig_t *sconfig,
                                          size_t                idx)
 {
@@ -475,7 +475,7 @@ static ares_bool_t ares__server_in_newconfig(struct server_state *server,
                                              ares__llist_t       *srvlist)
 {
   ares__llist_node_t *node;
-  ares_channel        channel = server->channel;
+  ares_channel_t     *channel = server->channel;
 
   for (node = ares__llist_node_first(srvlist); node != NULL;
        node = ares__llist_node_next(node)) {
@@ -499,8 +499,8 @@ static ares_bool_t ares__server_in_newconfig(struct server_state *server,
   return ARES_FALSE;
 }
 
-static void ares__servers_remove_stale(ares_channel   channel,
-                                       ares__llist_t *srvlist)
+static void ares__servers_remove_stale(ares_channel_t *channel,
+                                       ares__llist_t  *srvlist)
 {
   ares__slist_node_t *snode = ares__slist_node_first(channel->servers);
 
@@ -516,16 +516,16 @@ static void ares__servers_remove_stale(ares_channel   channel,
   }
 }
 
-static void ares__servers_trim_single(ares_channel channel)
+static void ares__servers_trim_single(ares_channel_t *channel)
 {
   while (ares__slist_len(channel->servers) > 1) {
     ares__slist_node_destroy(ares__slist_node_last(channel->servers));
   }
 }
 
-ares_status_t ares__servers_update(ares_channel   channel,
-                                   ares__llist_t *server_list,
-                                   ares_bool_t    user_specified)
+ares_status_t ares__servers_update(ares_channel_t *channel,
+                                   ares__llist_t  *server_list,
+                                   ares_bool_t     user_specified)
 {
   ares__llist_node_t *node;
   size_t              idx = 0;
@@ -728,7 +728,7 @@ fail:
   return NULL;
 }
 
-int ares_get_servers(ares_channel channel, struct ares_addr_node **servers)
+int ares_get_servers(ares_channel_t *channel, struct ares_addr_node **servers)
 {
   struct ares_addr_node *srvr_head = NULL;
   struct ares_addr_node *srvr_last = NULL;
@@ -778,7 +778,7 @@ int ares_get_servers(ares_channel channel, struct ares_addr_node **servers)
   return (int)status;
 }
 
-int ares_get_servers_ports(ares_channel                 channel,
+int ares_get_servers_ports(ares_channel_t              *channel,
                            struct ares_addr_port_node **servers)
 {
   struct ares_addr_port_node *srvr_head = NULL;
@@ -832,7 +832,7 @@ int ares_get_servers_ports(ares_channel                 channel,
   return (int)status;
 }
 
-int ares_set_servers(ares_channel channel, struct ares_addr_node *servers)
+int ares_set_servers(ares_channel_t *channel, struct ares_addr_node *servers)
 {
   ares__llist_t *slist;
   ares_status_t  status;
@@ -853,7 +853,7 @@ int ares_set_servers(ares_channel channel, struct ares_addr_node *servers)
   return (int)status;
 }
 
-int ares_set_servers_ports(ares_channel                channel,
+int ares_set_servers_ports(ares_channel_t             *channel,
                            struct ares_addr_port_node *servers)
 {
   ares__llist_t *slist;
@@ -877,7 +877,7 @@ int ares_set_servers_ports(ares_channel                channel,
 
 /* Incomming string format: host[:port][,host[:port]]... */
 /* IPv6 addresses with ports require square brackets [fe80::1]:53 */
-static ares_status_t set_servers_csv(ares_channel channel, const char *_csv,
+static ares_status_t set_servers_csv(ares_channel_t *channel, const char *_csv,
                                      int use_port)
 {
   size_t                      i;
@@ -1025,12 +1025,12 @@ out:
   return status;
 }
 
-int ares_set_servers_csv(ares_channel channel, const char *_csv)
+int ares_set_servers_csv(ares_channel_t *channel, const char *_csv)
 {
   return (int)set_servers_csv(channel, _csv, ARES_FALSE);
 }
 
-int ares_set_servers_ports_csv(ares_channel channel, const char *_csv)
+int ares_set_servers_ports_csv(ares_channel_t *channel, const char *_csv)
 {
   return (int)set_servers_csv(channel, _csv, ARES_TRUE);
 }

--- a/src/tools/acountry.c
+++ b/src/tools/acountry.c
@@ -105,7 +105,7 @@ static int         verbose    = 0;
   }                  \
   WHILE_FALSE
 
-static void wait_ares(ares_channel channel);
+static void wait_ares(ares_channel_t *channel);
 static void callback(void *arg, int status, int timeouts, struct hostent *host);
 static void callback2(void *arg, int status, int timeouts,
                       struct hostent *host);
@@ -123,8 +123,8 @@ static void Abort(const char *fmt, ...)
 
 int main(int argc, char **argv)
 {
-  ares_channel channel;
-  int          ch, status;
+  ares_channel_t *channel;
+  int             ch, status;
 
 #if defined(WIN32) && !defined(WATT32)
   WORD    wVersionRequested = MAKEWORD(USE_WINSOCK, USE_WINSOCK);
@@ -213,7 +213,7 @@ int main(int argc, char **argv)
 /*
  * Wait for the queries to complete.
  */
-static void wait_ares(ares_channel channel)
+static void wait_ares(ares_channel_t *channel)
 {
   for (;;) {
     struct timeval *tvp, tv;

--- a/src/tools/adig.c
+++ b/src/tools/adig.c
@@ -190,7 +190,7 @@ static size_t ares_strcpy(char *dest, const char *src, size_t dest_size)
 
 int main(int argc, char **argv)
 {
-  ares_channel           channel;
+  ares_channel_t        *channel;
   int                    c;
   int                    i;
   int                    optmask  = ARES_OPT_FLAGS;

--- a/src/tools/ahost.c
+++ b/src/tools/ahost.c
@@ -65,7 +65,7 @@ int         main(int argc, char **argv)
 {
   struct ares_options  options;
   int                  optmask = 0;
-  ares_channel         channel;
+  ares_channel_t      *channel;
   int                  status;
   int                  nfds;
   int                  c;

--- a/test/ares-test-ai.h
+++ b/test/ares-test-ai.h
@@ -71,7 +71,7 @@ public:
   void Process();
 
 protected:
-  ares_channel channel_;
+  ares_channel_t *channel_;
 };
 
 }  // namespace test

--- a/test/ares-test-init.cc
+++ b/test/ares-test-init.cc
@@ -66,7 +66,7 @@ TEST(LibraryInit, Nested) {
 
 TEST(LibraryInit, BasicChannelInit) {
   EXPECT_EQ(ARES_SUCCESS, ares_library_init(ARES_LIB_INIT_ALL));
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
   EXPECT_NE(nullptr, channel);
   ares_destroy(channel);
@@ -112,11 +112,11 @@ TEST_F(LibraryTest, OptionsChannelInit) {
   opts.hosts_path = strdup("/etc/hosts");
   optmask |= ARES_OPT_HOSTS_FILE;
 
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   EXPECT_EQ(ARES_SUCCESS, ares_init_options(&channel, &opts, optmask));
   EXPECT_NE(nullptr, channel);
 
-  ares_channel channel2 = nullptr;
+  ares_channel_t *channel2 = nullptr;
   EXPECT_EQ(ARES_SUCCESS, ares_dup(&channel2, channel));
   EXPECT_NE(nullptr, channel2);
 
@@ -148,7 +148,7 @@ TEST_F(LibraryTest, OptionsChannelInit) {
 }
 
 TEST_F(LibraryTest, ChannelAllocFail) {
-  ares_channel channel;
+  ares_channel_t *channel;
   for (int ii = 1; ii <= 25; ii++) {
     ClearFails();
     SetAllocFail(ii);
@@ -202,7 +202,7 @@ TEST_F(LibraryTest, OptionsChannelAllocFail) {
   opts.hosts_path = strdup("/etc/hosts");
   optmask |= ARES_OPT_HOSTS_FILE;
 
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   for (int ii = 1; ii <= 8; ii++) {
     ClearFails();
     SetAllocFail(ii);
@@ -225,7 +225,7 @@ TEST_F(LibraryTest, OptionsChannelAllocFail) {
             ares_set_servers_csv(channel, "1.2.3.4,0102:0304:0506:0708:0910:1112:1314:1516,2.3.4.5"));
   EXPECT_EQ(ARES_SUCCESS, ares_set_sortlist(channel, "1.2.3.4 2.3.4.5"));
 
-  ares_channel channel2 = nullptr;
+  ares_channel_t *channel2 = nullptr;
   for (int ii = 1; ii <= 18; ii++) {
     ClearFails();
     SetAllocFail(ii);
@@ -254,7 +254,7 @@ TEST_F(LibraryTest, FailChannelInit) {
                                   &LibraryTest::afree,
                                   &LibraryTest::arealloc));
   SetAllocFail(1);
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   EXPECT_EQ(ARES_ENOMEM, ares_init(&channel));
   EXPECT_EQ(nullptr, channel);
   ares_library_cleanup();
@@ -262,7 +262,7 @@ TEST_F(LibraryTest, FailChannelInit) {
 
 #ifndef WIN32
 TEST_F(LibraryTest, EnvInit) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   EnvValue v1("LOCALDOMAIN", "this.is.local");
   EnvValue v2("RES_OPTIONS", "options debug ndots:3 retry:3 rotate retrans:2");
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
@@ -270,7 +270,7 @@ TEST_F(LibraryTest, EnvInit) {
 }
 
 TEST_F(LibraryTest, EnvInitAllocFail) {
-  ares_channel channel;
+  ares_channel_t *channel;
   EnvValue v1("LOCALDOMAIN", "this.is.local");
   EnvValue v2("RES_OPTIONS", "options debug ndots:3 retry:3 rotate retrans:2");
   for (int ii = 1; ii <= 10; ii++) {
@@ -324,7 +324,7 @@ TEST_F(DefaultChannelTest, SetSortlistAllocFail) {
 
 #ifdef USE_WINSOCK
 TEST(Init, NoLibraryInit) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   EXPECT_EQ(ARES_ENOTINITIALIZED, ares_init(&channel));
 }
 #endif
@@ -364,7 +364,7 @@ NameContentList filelist = {
   {"/etc/nsswitch.conf", "hosts: files\n"}};
 CONTAINED_TEST_F(LibraryTest, ContainerChannelInit,
                  "myhostname", "mydomainname.org", filelist) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
   std::vector<std::string> actual = GetNameServers(channel);
   std::vector<std::string> expected = {"1.2.3.4:53"};
@@ -388,7 +388,7 @@ CONTAINED_TEST_F(LibraryTest, ContainerChannelInit,
 
 CONTAINED_TEST_F(LibraryTest, ContainerSortlistOptionInit,
                  "myhostname", "mydomainname.org", filelist) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   struct ares_options opts = {0};
   int optmask = 0;
   optmask |= ARES_OPT_SORTLIST;
@@ -412,7 +412,7 @@ NameContentList fullresolv = {
                        "sortlist 1.2.3.4/16 2.3.4.5\n"}};
 CONTAINED_TEST_F(LibraryTest, ContainerFullResolvInit,
                  "myhostname", "mydomainname.org", fullresolv) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
 
   EXPECT_EQ(std::string("b"), std::string(channel->lookups));
@@ -432,7 +432,7 @@ NameContentList myresolvconf = {
 CONTAINED_TEST_F(LibraryTest, ContainerMyResolvConfInit,
                  "myhostname", "mydomain.org", myresolvconf) {
   char filename[] = "/tmp/myresolv.cnf";
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   struct ares_options options = {0};
   options.resolvconf_path = strdup(filename);
   int optmask = ARES_OPT_RESOLVCONF;
@@ -458,7 +458,7 @@ NameContentList myhosts = {
 CONTAINED_TEST_F(LibraryTest, ContainerMyHostsInit,
                  "myhostname", "mydomain.org", myhosts) {
   char filename[] = "/tmp/hosts";
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   struct ares_options options = {0};
   options.hosts_path = strdup(filename);
   int optmask = ARES_OPT_HOSTS_FILE;
@@ -484,7 +484,7 @@ NameContentList hostconf = {
   {"/etc/host.conf", "order bind hosts\n"}};
 CONTAINED_TEST_F(LibraryTest, ContainerHostConfInit,
                  "myhostname", "mydomainname.org", hostconf) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
 
   EXPECT_EQ(std::string("bf"), std::string(channel->lookups));
@@ -499,7 +499,7 @@ NameContentList svcconf = {
   {"/etc/svc.conf", "hosts= bind\n"}};
 CONTAINED_TEST_F(LibraryTest, ContainerSvcConfInit,
                  "myhostname", "mydomainname.org", svcconf) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
 
   EXPECT_EQ(std::string("b"), std::string(channel->lookups));
@@ -513,7 +513,7 @@ NameContentList malformedresolvconflookup = {
                        "lookup garbage\n"}};  // malformed line
 CONTAINED_TEST_F(LibraryTest, ContainerMalformedResolvConfLookup,
                  "myhostname", "mydomainname.org", malformedresolvconflookup) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
 
   EXPECT_EQ(std::string("fb"), std::string(channel->lookups));
@@ -536,7 +536,7 @@ class MakeUnreadable {
 
 CONTAINED_TEST_F(LibraryTest, ContainerResolvConfNotReadable,
                  "myhostname", "mydomainname.org", filelist) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   MakeUnreadable hide("/etc/resolv.conf");
   // Unavailable /etc/resolv.conf falls back to defaults
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
@@ -544,7 +544,7 @@ CONTAINED_TEST_F(LibraryTest, ContainerResolvConfNotReadable,
 }
 CONTAINED_TEST_F(LibraryTest, ContainerNsswitchConfNotReadable,
                  "myhostname", "mydomainname.org", filelist) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   // Unavailable /etc/nsswitch.conf falls back to defaults.
   MakeUnreadable hide("/etc/nsswitch.conf");
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
@@ -556,7 +556,7 @@ CONTAINED_TEST_F(LibraryTest, ContainerNsswitchConfNotReadable,
 }
 CONTAINED_TEST_F(LibraryTest, ContainerHostConfNotReadable,
                  "myhostname", "mydomainname.org", hostconf) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   // Unavailable /etc/host.conf falls back to defaults.
   MakeUnreadable hide("/etc/host.conf");
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
@@ -565,7 +565,7 @@ CONTAINED_TEST_F(LibraryTest, ContainerHostConfNotReadable,
 }
 CONTAINED_TEST_F(LibraryTest, ContainerSvcConfNotReadable,
                  "myhostname", "mydomainname.org", svcconf) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   // Unavailable /etc/svc.conf falls back to defaults.
   MakeUnreadable hide("/etc/svc.conf");
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
@@ -579,7 +579,7 @@ NameContentList rotateenv = {
                        "options rotate\n"}};
 CONTAINED_TEST_F(LibraryTest, ContainerRotateInit,
                  "myhostname", "mydomainname.org", rotateenv) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
 
   EXPECT_EQ(ARES_TRUE, channel->rotate);
@@ -590,7 +590,7 @@ CONTAINED_TEST_F(LibraryTest, ContainerRotateInit,
 
 CONTAINED_TEST_F(LibraryTest, ContainerRotateOverride,
                  "myhostname", "mydomainname.org", rotateenv) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   struct ares_options opts = {0};
   int optmask = ARES_OPT_NOROTATE;
   EXPECT_EQ(ARES_SUCCESS, ares_init_options(&channel, &opts, optmask));
@@ -613,7 +613,7 @@ NameContentList blacklistedIpv6 = {
   {"/etc/nsswitch.conf", "hosts: files\n"}};
 CONTAINED_TEST_F(LibraryTest, ContainerBlacklistedIpv6,
                  "myhostname", "mydomainname.org", blacklistedIpv6) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
   std::vector<std::string> actual = GetNameServers(channel);
   std::vector<std::string> expected = {
@@ -635,7 +635,7 @@ NameContentList multiresolv = {
   {"/etc/nsswitch.conf", "hosts: files\n"}};
 CONTAINED_TEST_F(LibraryTest, ContainerMultiResolvInit,
                  "myhostname", "mydomainname.org", multiresolv) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
   std::vector<std::string> actual = GetNameServers(channel);
   std::vector<std::string> expected = {"[0001:0000:0000:0000:0000:0000:0000:0002]:53"};
@@ -654,7 +654,7 @@ NameContentList systemdresolv = {
   {"/etc/nsswitch.conf", "hosts: junk resolve files\n"}};
 CONTAINED_TEST_F(LibraryTest, ContainerSystemdResolvInit,
                  "myhostname", "mydomainname.org", systemdresolv) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
 
   EXPECT_EQ(std::string("bf"), std::string(channel->lookups));
@@ -666,7 +666,7 @@ CONTAINED_TEST_F(LibraryTest, ContainerSystemdResolvInit,
 NameContentList empty = {};  // no files
 CONTAINED_TEST_F(LibraryTest, ContainerEmptyInit,
                  "host.domain.org", "domain.org", empty) {
-  ares_channel channel = nullptr;
+  ares_channel_t *channel = nullptr;
   EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
   std::vector<std::string> actual = GetNameServers(channel);
   std::vector<std::string> expected = {"127.0.0.1:53"};

--- a/test/ares-test-live.cc
+++ b/test/ares-test-live.cc
@@ -688,7 +688,7 @@ VIRT_NONVIRT_TEST_F(DefaultChannelTest, GetSock) {
 }
 
 TEST_F(LibraryTest, GetTCPSock) {
-  ares_channel channel;
+  ares_channel_t *channel;
   struct ares_options opts = {0};
   opts.tcp_port = 53;
   opts.flags = ARES_FLAG_USEVC;
@@ -752,7 +752,7 @@ TEST_F(DefaultChannelTest, VerifySocketFunctionCallback) {
 
   {
     count = 0;
-    ares_channel copy;
+    ares_channel_t *copy;
     EXPECT_EQ(ARES_SUCCESS, ares_dup(&copy, channel_));
 
     HostResult result;

--- a/test/ares-test-misc.cc
+++ b/test/ares-test-misc.cc
@@ -110,7 +110,7 @@ TEST_F(DefaultChannelTest, SetServersCSV) {
   EXPECT_EQ(expected2, GetNameServers(channel_));
 
   // Should survive duplication
-  ares_channel channel2;
+  ares_channel_t *channel2;
   EXPECT_EQ(ARES_SUCCESS, ares_dup(&channel2, channel_));
   EXPECT_EQ(expected2, GetNameServers(channel2));
   ares_destroy(channel2);

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -78,7 +78,7 @@ std::vector<std::pair<int, bool>> families_modes = both_families_both_modes;
 unsigned long long LibraryTest::fails_ = 0;
 std::map<size_t, int> LibraryTest::size_fails_;
 
-void ProcessWork(ares_channel channel,
+void ProcessWork(ares_channel_t *channel,
                  std::function<std::set<int>()> get_extrafds,
                  std::function<void(int)> process_extra) {
   int nfds, count;
@@ -779,7 +779,7 @@ void NameInfoCallback(void *data, int status, int timeouts,
   if (verbose) std::cerr << "NameInfoCallback(" << *result << ")" << std::endl;
 }
 
-std::vector<std::string> GetNameServers(ares_channel channel) {
+std::vector<std::string> GetNameServers(ares_channel_t *channel) {
   struct ares_addr_port_node* servers = nullptr;
   EXPECT_EQ(ARES_SUCCESS, ares_get_servers_ports(channel, &servers));
   struct ares_addr_port_node* server = servers;
@@ -854,7 +854,7 @@ TempFile::TempFile(const std::string& contents)
 
 }
 
-VirtualizeIO::VirtualizeIO(ares_channel c)
+VirtualizeIO::VirtualizeIO(ares_channel_t *c)
   : channel_(c)
 {
   ares_set_socket_functions(channel_, &default_functions, 0);

--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -67,7 +67,7 @@ extern std::vector<std::pair<int, bool>>       families_modes;
 
 // Process all pending work on ares-owned file descriptors, plus
 // optionally the given set-of-FDs + work function.
-void                                           ProcessWork(ares_channel                   channel,
+void                                           ProcessWork(ares_channel_t *                  channel,
                                                            std::function<std::set<int>()> get_extrafds,
                                                            std::function<void(int)>       process_extra);
 std::set<int>                                  NoExtraFDs();
@@ -126,7 +126,7 @@ public:
   void Process();
 
 protected:
-  ares_channel channel_;
+  ares_channel_t *channel_;
 };
 
 // Test fixture that uses a file-only channel.
@@ -152,7 +152,7 @@ public:
   void Process();
 
 protected:
-  ares_channel channel_;
+  ares_channel_t *channel_;
 };
 
 // Test fixture that uses a default channel with the specified lookup mode.
@@ -180,7 +180,7 @@ public:
   void Process();
 
 protected:
-  ares_channel channel_;
+  ares_channel_t *channel_;
 };
 
 // Mock DNS server to allow responses to be scripted by tests.
@@ -278,7 +278,7 @@ protected:
   NiceMockServers        servers_;
   // Convenience reference to first server.
   NiceMockServer        &server_;
-  ares_channel           channel_;
+  ares_channel_t *          channel_;
 };
 
 class MockChannelTest
@@ -435,7 +435,7 @@ void AddrInfoCallback(void *data, int status, int timeouts,
                       struct ares_addrinfo *res);
 
 // Retrieve the name servers used by a channel.
-std::vector<std::string> GetNameServers(ares_channel channel);
+std::vector<std::string> GetNameServers(ares_channel_t *channel);
 
 // RAII class to temporarily create a directory of a given name.
 class TransientDir {
@@ -598,7 +598,7 @@ public:
   static const ares_socket_functions default_functions;
 
 private:
-  ares_channel channel_;
+  ares_channel_t *channel_;
 };
 
 /*


### PR DESCRIPTION
`ares_channel` is defined as `typedef struct ares_channeldata *ares_channel;`.  The problem with this, is it embeds the pointer into the typedef, which means an `ares_channel` can never be declared as `const` as if you write `const ares_channel channel`, that expands to `struct ares_channeldata * const ares_channel` and not `const struct ares_channeldata *channel`.

We will now typedef `ares_channel_t` as `typedef struct ares_channeldata ares_channel_t;`, so if you write `const ares_channel_t *channel`, it properly expands to `const struct ares_channeldata *channel`.

We are maintaining the old typedef for API compatibility with existing integrations, and due to typedef expansion this should not even cause any compiler warnings for existing code.  There are no ABI implications with this change.  I could be convinced to keep existing public functions as `ares_channel` if a sufficient argument exists, but internally we really need make this change for modern best practices.

This change will allow us to internally use `const ares_channel_t *` where appropriate.  Whether or not we decide to change any public interfaces to use `const` may require further discussion on if there might be ABI implications (I don't think so, but I'm also not 100% sure what a compiler internally does with `const` when emitting machine code ... I think more likely ABI implications would occur going the opposite direction).

FYI, This PR was done via a combination of sed and clang-format, the only manual code change was the addition of the new typedef :)

Fix By: Brad House (@bradh352)