### PR TITLE
Use EDNS by default

### DIFF
--- a/docs/ares_init_options.3
+++ b/docs/ares_init_options.3
@@ -185,7 +185,7 @@ The receive buffer size to set for the socket.
 .br
 The message size to be advertized in EDNS; only takes effect if the
 .B ARES_FLAG_EDNS
-flag is set.
+flag is set.  Defaults to 1280, the recommended size.
 .TP 18
 .B ARES_OPT_RESOLVCONF
 .B char *\fIresolvconf_path\fP;
@@ -270,7 +270,8 @@ in the request.  Primarily useful for writing clients which might be
 used to test or debug name servers.
 .TP 23
 .B ARES_FLAG_EDNS
-Include an EDNS pseudo-resource record (RFC 2671) in generated requests.
+Include an EDNS pseudo-resource record (RFC 2671) in generated requests.  As of
+v1.22, this is on by default if flags are otherwise not set.
 .SH RETURN VALUES
 \fBares_init_options(3)\fP can return any of the following values:
 .TP 14

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -134,6 +134,15 @@ static ares_status_t init_by_defaults(ares_channel_t *channel)
   const char *dot;
 #endif
 
+  /* Enable EDNS by default */
+  if (channel->optmask == 0) {
+    channel->flags = ARES_FLAG_EDNS;
+
+  }
+  if (channel->ednspsz == 0) {
+    channel->ednspsz = EDNSPACKETSZ;
+  }
+
   if (channel->timeout == 0) {
     channel->timeout = DEFAULT_TIMEOUT;
   }
@@ -144,10 +153,6 @@ static ares_status_t init_by_defaults(ares_channel_t *channel)
 
   if (channel->ndots == 0) {
     channel->ndots = 1;
-  }
-
-  if (channel->ednspsz == 0) {
-    channel->ednspsz = EDNSPACKETSZ;
   }
 
   if (ares__slist_len(channel->servers) == 0) {

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -135,9 +135,8 @@ static ares_status_t init_by_defaults(ares_channel_t *channel)
 #endif
 
   /* Enable EDNS by default */
-  if (channel->optmask == 0) {
+  if (!(channel->optmask & ARES_OPT_FLAGS)) {
     channel->flags = ARES_FLAG_EDNS;
-
   }
   if (channel->ednspsz == 0) {
     channel->ednspsz = EDNSPACKETSZ;


### PR DESCRIPTION
All DNS servers support EDNS, by using this by default, it will allow larger responses without the need to switch to TCP.  If by chance a DNS server is hit that doesn't support EDNS, this is detected due to the lack of the OPT RR in the response and will be automatically retried without EDNS.

Fix By: Brad House (@bradh352)