### PR TITLE
Update public prototypes with `const` where appropriate

### DIFF
--- a/docs/ares_dup.3
+++ b/docs/ares_dup.3
@@ -22,7 +22,7 @@ ares_dup \- Duplicate a resolver channel
 .nf
 #include <ares.h>
 
-int ares_dup(ares_channel_t **\fIdest\fP, ares_channel_t *\fIsource\fP)
+int ares_dup(ares_channel_t **\fIdest\fP, const ares_channel_t *\fIsource\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_dup(3)\fP function duplicates an existing communications channel

--- a/docs/ares_fds.3
+++ b/docs/ares_fds.3
@@ -22,9 +22,9 @@ ares_fds \- return file descriptors to select on
 .nf
 #include <ares.h>
 
-int ares_fds(ares_channel_t *\fIchannel\fP,
+int ares_fds(const ares_channel_t *\fIchannel\fP,
              fd_set *\fIread_fds\fP,
-	     fd_set *\fIwrite_fds\fP)
+             fd_set *\fIwrite_fds\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_fds(3)\fP function retrieves the set of file descriptors which the

--- a/docs/ares_get_servers.3
+++ b/docs/ares_get_servers.3
@@ -23,10 +23,10 @@ ares_get_servers, ares_get_servers_ports \- Retrieve name servers from an initia
 .nf
 #include <ares.h>
 
-int ares_get_servers(ares_channel_t *\fIchannel\fP,
+int ares_get_servers(const ares_channel_t *\fIchannel\fP,
                      struct ares_addr_node **\fIservers\fP)
 
-int ares_get_servers_ports(ares_channel_t *\fIchannel\fP,
+int ares_get_servers_ports(const ares_channel_t *\fIchannel\fP,
                            struct ares_addr_port_node **\fIservers\fP)
 .fi
 .SH DESCRIPTION

--- a/docs/ares_getsock.3
+++ b/docs/ares_getsock.3
@@ -22,8 +22,8 @@ ares_getsock \- get socket descriptors to wait on
 .nf
 #include <ares.h>
 
-int ares_getsock(ares_channel_t *\fIchannel\fP, ares_socket_t *\fIsocks\fP,
-                 int \fInumsocks\fP);
+int ares_getsock(const ares_channel_t *\fIchannel\fP,
+                 ares_socket_t *\fIsocks\fP, int \fInumsocks\fP);
 .fi
 .SH DESCRIPTION
 The

--- a/docs/ares_init_options.3
+++ b/docs/ares_init_options.3
@@ -48,7 +48,7 @@ struct ares_options {
 };
 
 int ares_init_options(ares_channel_t **\fIchannelptr\fP,
-                      struct ares_options *\fIoptions\fP,
+                      const struct ares_options *\fIoptions\fP,
                       int \fIoptmask\fP)
 .fi
 .SH DESCRIPTION

--- a/docs/ares_save_options.3
+++ b/docs/ares_save_options.3
@@ -22,7 +22,7 @@ ares_save_options \- Save configuration values obtained from initialized ares_ch
 .nf
 #include <ares.h>
 
-int ares_save_options(ares_channel_t *\fIchannel\fP,
+int ares_save_options(const ares_channel_t *\fIchannel\fP,
                       struct ares_options *\fIoptions\fP, int *\fIoptmask\fP)
 .fi
 .SH DESCRIPTION

--- a/docs/ares_set_servers.3
+++ b/docs/ares_set_servers.3
@@ -24,10 +24,10 @@ for an ares channel.
 #include <ares.h>
 
 int ares_set_servers(ares_channel_t *\fIchannel\fP,
-                     struct ares_addr_node *\fIservers\fP)
+                     const struct ares_addr_node *\fIservers\fP)
 
 int ares_set_servers_ports(ares_channel_t *\fIchannel\fP,
-                           struct ares_addr_port_node *\fIservers\fP)
+                           const struct ares_addr_port_node *\fIservers\fP)
 .fi
 .SH DESCRIPTION
 The \fBares_set_servers(3)\fP function initializes name servers configuration

--- a/docs/ares_timeout.3
+++ b/docs/ares_timeout.3
@@ -22,7 +22,7 @@ ares_timeout \- return maximum time to wait
 .nf
 #include <ares.h>
 
-struct timeval *ares_timeout(ares_channel_t *\fIchannel\fP,
+struct timeval *ares_timeout(const ares_channel_t *\fIchannel\fP,
                              struct timeval *\fImaxtv\fP,
                              struct timeval *\fItv\fP)
 .fi

--- a/include/ares.h
+++ b/include/ares.h
@@ -317,7 +317,7 @@ struct ares_addrinfo_hints;
 typedef struct ares_channeldata *ares_channel;
 
 /* Current main channel typedef */
-typedef struct ares_channeldata ares_channel_t;
+typedef struct ares_channeldata  ares_channel_t;
 
 
 typedef void     (*ares_callback)(void *arg, int status, int timeouts,
@@ -359,41 +359,42 @@ CARES_EXTERN const char *ares_version(int *version);
 
 CARES_EXTERN int         ares_init(ares_channel_t **channelptr);
 
-CARES_EXTERN int         ares_init_options(ares_channel_t     **channelptr,
-                                           struct ares_options *options, int optmask);
+CARES_EXTERN int         ares_init_options(ares_channel_t           **channelptr,
+                                           const struct ares_options *options,
+                                           int                        optmask);
 
-CARES_EXTERN int         ares_save_options(ares_channel_t      *channel,
+CARES_EXTERN int         ares_save_options(const ares_channel_t *channel,
                                            struct ares_options *options, int *optmask);
 
 CARES_EXTERN void        ares_destroy_options(struct ares_options *options);
 
-CARES_EXTERN int         ares_dup(ares_channel_t **dest, ares_channel_t *src);
+CARES_EXTERN int  ares_dup(ares_channel_t **dest, const ares_channel_t *src);
 
-CARES_EXTERN void        ares_destroy(ares_channel_t *channel);
+CARES_EXTERN void ares_destroy(ares_channel_t *channel);
 
-CARES_EXTERN void        ares_cancel(ares_channel_t *channel);
+CARES_EXTERN void ares_cancel(ares_channel_t *channel);
 
 /* These next 3 configure local binding for the out-going socket
  * connection.  Use these to specify source IP and/or network device
  * on multi-homed systems.
  */
-CARES_EXTERN void        ares_set_local_ip4(ares_channel_t *channel,
-                                            unsigned int    local_ip);
+CARES_EXTERN void ares_set_local_ip4(ares_channel_t *channel,
+                                     unsigned int    local_ip);
 
 /* local_ip6 should be 16 bytes in length */
-CARES_EXTERN void        ares_set_local_ip6(ares_channel_t      *channel,
-                                            const unsigned char *local_ip6);
+CARES_EXTERN void ares_set_local_ip6(ares_channel_t      *channel,
+                                     const unsigned char *local_ip6);
 
 /* local_dev_name should be null terminated. */
-CARES_EXTERN void        ares_set_local_dev(ares_channel_t *channel,
-                                            const char     *local_dev_name);
+CARES_EXTERN void ares_set_local_dev(ares_channel_t *channel,
+                                     const char     *local_dev_name);
 
-CARES_EXTERN void        ares_set_socket_callback(ares_channel_t           *channel,
-                                                  ares_sock_create_callback callback,
-                                                  void                     *user_data);
+CARES_EXTERN void ares_set_socket_callback(ares_channel_t           *channel,
+                                           ares_sock_create_callback callback,
+                                           void                     *user_data);
 
-CARES_EXTERN void        ares_set_socket_configure_callback(
-         ares_channel_t *channel, ares_sock_config_callback callback, void *user_data);
+CARES_EXTERN void ares_set_socket_configure_callback(
+  ares_channel_t *channel, ares_sock_config_callback callback, void *user_data);
 
 CARES_EXTERN int  ares_set_sortlist(ares_channel_t *channel,
                                     const char     *sortstr);
@@ -458,15 +459,15 @@ CARES_EXTERN void ares_getnameinfo(ares_channel_t        *channel,
                                    ares_socklen_t salen, int flags,
                                    ares_nameinfo_callback callback, void *arg);
 
-CARES_EXTERN int  ares_fds(ares_channel_t *channel, fd_set *read_fds,
+CARES_EXTERN int  ares_fds(const ares_channel_t *channel, fd_set *read_fds,
                            fd_set *write_fds);
 
-CARES_EXTERN int  ares_getsock(ares_channel_t *channel, ares_socket_t *socks,
-                               int numsocks);
+CARES_EXTERN int  ares_getsock(const ares_channel_t *channel,
+                               ares_socket_t *socks, int numsocks);
 
-CARES_EXTERN struct timeval *ares_timeout(ares_channel_t *channel,
-                                          struct timeval *maxtv,
-                                          struct timeval *tv);
+CARES_EXTERN struct timeval *ares_timeout(const ares_channel_t *channel,
+                                          struct timeval       *maxtv,
+                                          struct timeval       *tv);
 
 CARES_EXTERN void ares_process(ares_channel_t *channel, fd_set *read_fds,
                                fd_set *write_fds);
@@ -702,10 +703,11 @@ struct ares_addr_port_node {
   int tcp_port;
 };
 
-CARES_EXTERN int         ares_set_servers(ares_channel_t        *channel,
-                                          struct ares_addr_node *servers);
-CARES_EXTERN int         ares_set_servers_ports(ares_channel_t             *channel,
-                                                struct ares_addr_port_node *servers);
+CARES_EXTERN int ares_set_servers(ares_channel_t              *channel,
+                                  const struct ares_addr_node *servers);
+CARES_EXTERN int
+                         ares_set_servers_ports(ares_channel_t                   *channel,
+                                                const struct ares_addr_port_node *servers);
 
 /* Incomming string format: host[:port][,host[:port]]... */
 CARES_EXTERN int         ares_set_servers_csv(ares_channel_t *channel,
@@ -713,9 +715,9 @@ CARES_EXTERN int         ares_set_servers_csv(ares_channel_t *channel,
 CARES_EXTERN int         ares_set_servers_ports_csv(ares_channel_t *channel,
                                                     const char     *servers);
 
-CARES_EXTERN int         ares_get_servers(ares_channel_t         *channel,
+CARES_EXTERN int         ares_get_servers(const ares_channel_t   *channel,
                                           struct ares_addr_node **servers);
-CARES_EXTERN int         ares_get_servers_ports(ares_channel_t              *channel,
+CARES_EXTERN int         ares_get_servers_ports(const ares_channel_t        *channel,
                                                 struct ares_addr_port_node **servers);
 
 CARES_EXTERN const char *ares_inet_ntop(int af, const void *src, char *dst,

--- a/src/lib/ares_fds.c
+++ b/src/lib/ares_fds.c
@@ -30,7 +30,7 @@
 #include "ares.h"
 #include "ares_private.h"
 
-int ares_fds(ares_channel_t *channel, fd_set *read_fds, fd_set *write_fds)
+int ares_fds(const ares_channel_t *channel, fd_set *read_fds, fd_set *write_fds)
 {
   ares_socket_t       nfds;
   ares__slist_node_t *snode;

--- a/src/lib/ares_getsock.c
+++ b/src/lib/ares_getsock.c
@@ -29,7 +29,7 @@
 #include "ares.h"
 #include "ares_private.h"
 
-int ares_getsock(ares_channel_t *channel, ares_socket_t *socks,
+int ares_getsock(const ares_channel_t *channel, ares_socket_t *socks,
                  int numsocks) /* size of the 'socks' array */
 {
   ares__slist_node_t *snode;

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -286,8 +286,8 @@ error:
   return rc;
 }
 
-int ares_init_options(ares_channel_t **channelptr, struct ares_options *options,
-                      int optmask)
+int ares_init_options(ares_channel_t **channelptr,
+                      const struct ares_options *options, int optmask)
 {
   ares_channel_t *channel;
   ares_status_t   status = ARES_SUCCESS;
@@ -390,7 +390,7 @@ done:
 
 /* ares_dup() duplicates a channel handle with all its options and returns a
    new channel handle */
-int ares_dup(ares_channel_t **dest, ares_channel_t *src)
+int ares_dup(ares_channel_t **dest, const ares_channel_t *src)
 {
   struct ares_options         opts;
   struct ares_addr_port_node *servers;

--- a/src/lib/ares_options.c
+++ b/src/lib/ares_options.c
@@ -53,8 +53,8 @@ void ares_destroy_options(struct ares_options *options)
   ares_free(options->hosts_path);
 }
 
-static struct in_addr *ares_save_opt_servers(ares_channel_t *channel,
-                                             int            *nservers)
+static struct in_addr *ares_save_opt_servers(const ares_channel_t *channel,
+                                             int                  *nservers)
 {
   ares__slist_node_t *snode;
   struct in_addr     *out =
@@ -82,8 +82,8 @@ static struct in_addr *ares_save_opt_servers(ares_channel_t *channel,
 }
 
 /* Save options from initialized channel */
-int ares_save_options(ares_channel_t *channel, struct ares_options *options,
-                      int *optmask)
+int ares_save_options(const ares_channel_t *channel,
+                      struct ares_options *options, int *optmask)
 {
   size_t i;
 

--- a/src/lib/ares_timeout.c
+++ b/src/lib/ares_timeout.c
@@ -41,7 +41,8 @@ static long timeoffset(const struct timeval *now, const struct timeval *check)
          (check->tv_usec - now->tv_usec) / 1000;
 }
 
-struct timeval *ares_timeout(ares_channel_t *channel, struct timeval *maxtv,
+struct timeval *ares_timeout(const ares_channel_t *channel,
+                             struct timeval *maxtv,
                              struct timeval *tvbuf)
 {
   const struct query *query;

--- a/src/lib/ares_update_servers.c
+++ b/src/lib/ares_update_servers.c
@@ -728,7 +728,8 @@ fail:
   return NULL;
 }
 
-int ares_get_servers(ares_channel_t *channel, struct ares_addr_node **servers)
+int ares_get_servers(const ares_channel_t *channel,
+                     struct ares_addr_node **servers)
 {
   struct ares_addr_node *srvr_head = NULL;
   struct ares_addr_node *srvr_last = NULL;
@@ -778,8 +779,8 @@ int ares_get_servers(ares_channel_t *channel, struct ares_addr_node **servers)
   return (int)status;
 }
 
-int ares_get_servers_ports(ares_channel_t              *channel,
-                           struct ares_addr_port_node **servers)
+int ares_get_servers_ports(const ares_channel_t              *channel,
+                           struct ares_addr_port_node       **servers)
 {
   struct ares_addr_port_node *srvr_head = NULL;
   struct ares_addr_port_node *srvr_last = NULL;
@@ -832,7 +833,8 @@ int ares_get_servers_ports(ares_channel_t              *channel,
   return (int)status;
 }
 
-int ares_set_servers(ares_channel_t *channel, struct ares_addr_node *servers)
+int ares_set_servers(ares_channel_t *channel,
+                     const struct ares_addr_node *servers)
 {
   ares__llist_t *slist;
   ares_status_t  status;
@@ -853,8 +855,8 @@ int ares_set_servers(ares_channel_t *channel, struct ares_addr_node *servers)
   return (int)status;
 }
 
-int ares_set_servers_ports(ares_channel_t             *channel,
-                           struct ares_addr_port_node *servers)
+int ares_set_servers_ports(ares_channel_t                   *channel,
+                           const struct ares_addr_port_node *servers)
 {
   ares__llist_t *slist;
   ares_status_t  status;


### PR DESCRIPTION
Some existing public prototypes do not modify the provided parameters and therefore should mark such parameters as `const`.  This is considered a best practice as per MISRA-C, and will not impact API nor ABI compatibility.  No existing code should emit warnings due to this.

There are some other changes that _should_ be done, and would maintain ABI compatibility, but would cause warnings to be emitted (such as the callback structures for things like `ares_gethostbyname`, where `hostent` should be marked as `const`), this has not been done.

Fix By: Brad House (@bradh352)