### PR TITLE
Support jitter and maxtimeout for retry penalties

### DIFF
--- a/docs/ares_init_options.3
+++ b/docs/ares_init_options.3
@@ -28,6 +28,8 @@ struct ares_options {
   int timeout; /* in seconds or milliseconds, depending on options */
   int tries;
   int ndots;
+  int maxtimeout; /* in milliseconds */
+  int jitter; /* in 0.001 */
   unsigned short udp_port;
   unsigned short tcp_port;
   int socket_send_buffer_size;
@@ -101,6 +103,19 @@ The number of dots which must be present in a domain name for it to be
 queried for "as is" prior to querying for it with the default domain
 extensions appended.  The default value is 1 unless set otherwise by
 resolv.conf or the RES_OPTIONS environment variable.
+.TP 18
+.B ARES_OPT_MAXTIMEOUTMS
+.B int \fImaxtimeout\fP;
+.br
+The upper bound for timeout between sequential retry attempts.
+.TP 18
+.B ARES_OPT_JITTER
+.B int \fIjitter\fP;
+.br
+This option allows to add random noise for timeout between sequential retry attempts.
+It is used to smooth over time DNS requests from multiple processes. The value added
+to the retry timeout is choosen randomly from the range [-timeout * jitter / 1000.0,
+timeout * jitter / 1000.0]. The default value is 0.
 .TP 18
 .B ARES_OPT_UDP_PORT
 .B unsigned short \fIudp_port\fP;

--- a/docs/ares_init_options.3
+++ b/docs/ares_init_options.3
@@ -29,7 +29,6 @@ struct ares_options {
   int tries;
   int ndots;
   int maxtimeout; /* in milliseconds */
-  int jitter; /* in 0.001 */
   unsigned short udp_port;
   unsigned short tcp_port;
   int socket_send_buffer_size;
@@ -108,14 +107,6 @@ resolv.conf or the RES_OPTIONS environment variable.
 .B int \fImaxtimeout\fP;
 .br
 The upper bound for timeout between sequential retry attempts.
-.TP 18
-.B ARES_OPT_JITTER
-.B int \fIjitter\fP;
-.br
-This option allows to add random noise for timeout between sequential retry attempts.
-It is used to smooth over time DNS requests from multiple processes. The value added
-to the retry timeout is choosen randomly from the range [-timeout * jitter / 1000.0,
-timeout * jitter / 1000.0]. The default value is 0.
 .TP 18
 .B ARES_OPT_UDP_PORT
 .B unsigned short \fIudp_port\fP;

--- a/include/ares.h
+++ b/include/ares.h
@@ -195,7 +195,6 @@ typedef enum {
 #define ARES_OPT_HOSTS_FILE      (1 << 18)
 #define ARES_OPT_UDP_MAX_QUERIES (1 << 19)
 #define ARES_OPT_MAXTIMEOUTMS    (1 << 20)
-#define ARES_OPT_JITTER          (1 << 21)
 
 /* Nameinfo flag values */
 #define ARES_NI_NOFQDN        (1 << 0)
@@ -290,7 +289,6 @@ struct ares_options {
   int            tries;
   int            ndots;
   int            maxtimeout; /* in milliseconds */
-  int            jitter; /* in 0.001 */
   unsigned short udp_port;
   unsigned short tcp_port;
   int            socket_send_buffer_size;

--- a/include/ares.h
+++ b/include/ares.h
@@ -194,6 +194,8 @@ typedef enum {
 #define ARES_OPT_RESOLVCONF      (1 << 17)
 #define ARES_OPT_HOSTS_FILE      (1 << 18)
 #define ARES_OPT_UDP_MAX_QUERIES (1 << 19)
+#define ARES_OPT_MAXTIMEOUTMS    (1 << 20)
+#define ARES_OPT_JITTER          (1 << 21)
 
 /* Nameinfo flag values */
 #define ARES_NI_NOFQDN        (1 << 0)
@@ -287,6 +289,8 @@ struct ares_options {
   int            timeout; /* in seconds or milliseconds, depending on options */
   int            tries;
   int            ndots;
+  int            maxtimeout; /* in milliseconds */
+  int            jitter; /* in 0.001 */
   unsigned short udp_port;
   unsigned short tcp_port;
   int            socket_send_buffer_size;

--- a/src/lib/ares_options.c
+++ b/src/lib/ares_options.c
@@ -126,6 +126,14 @@ int ares_save_options(ares_channel_t *channel, struct ares_options *options,
     options->ndots = (int)channel->ndots;
   }
 
+  if (channel->maxtimeout & ARES_OPT_MAXTIMEOUTMS) {
+    options->maxtimeout = (int)channel->maxtimeout;
+  }
+
+  if (channel->jitter & ARES_OPT_JITTER) {
+    options->jitter = (int)channel->jitter;
+  }
+
   if (channel->optmask & ARES_OPT_UDP_PORT) {
     options->udp_port = ntohs(channel->udp_port);
   }
@@ -278,6 +286,14 @@ ares_status_t ares__init_by_options(ares_channel_t            *channel,
 
   if (optmask & ARES_OPT_NDOTS) {
     channel->ndots = (size_t)options->ndots;
+  }
+
+  if (optmask & ARES_OPT_MAXTIMEOUTMS) {
+    channel->maxtimeout = (size_t)options->maxtimeout;
+  }
+
+  if (optmask & ARES_OPT_JITTER) {
+    channel->jitter = (size_t)options->jitter;
   }
 
   if (optmask & ARES_OPT_ROTATE) {

--- a/src/lib/ares_options.c
+++ b/src/lib/ares_options.c
@@ -126,11 +126,11 @@ int ares_save_options(ares_channel_t *channel, struct ares_options *options,
     options->ndots = (int)channel->ndots;
   }
 
-  if (channel->maxtimeout & ARES_OPT_MAXTIMEOUTMS) {
+  if (channel->optmask & ARES_OPT_MAXTIMEOUTMS) {
     options->maxtimeout = (int)channel->maxtimeout;
   }
 
-  if (channel->jitter & ARES_OPT_JITTER) {
+  if (channel->optmask & ARES_OPT_JITTER) {
     options->jitter = (int)channel->jitter;
   }
 

--- a/src/lib/ares_options.c
+++ b/src/lib/ares_options.c
@@ -130,10 +130,6 @@ int ares_save_options(ares_channel_t *channel, struct ares_options *options,
     options->maxtimeout = (int)channel->maxtimeout;
   }
 
-  if (channel->optmask & ARES_OPT_JITTER) {
-    options->jitter = (int)channel->jitter;
-  }
-
   if (channel->optmask & ARES_OPT_UDP_PORT) {
     options->udp_port = ntohs(channel->udp_port);
   }
@@ -290,10 +286,6 @@ ares_status_t ares__init_by_options(ares_channel_t            *channel,
 
   if (optmask & ARES_OPT_MAXTIMEOUTMS) {
     channel->maxtimeout = (size_t)options->maxtimeout;
-  }
-
-  if (optmask & ARES_OPT_JITTER) {
-    channel->jitter = (size_t)options->jitter;
   }
 
   if (optmask & ARES_OPT_ROTATE) {

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -261,7 +261,6 @@ struct ares_channeldata {
   size_t               tries;
   size_t               ndots;
   size_t               maxtimeout; /* in milliseconds */
-  size_t               jitter; /* in 0.001 */
   ares_bool_t          rotate;
   unsigned short       udp_port;                   /* stored in network order */
   unsigned short       tcp_port;                   /* stored in network order */
@@ -286,7 +285,7 @@ struct ares_channeldata {
    * failures, followed by the configuration order if failures are equal. */
   ares__slist_t       *servers;
 
-  /* random state to use when generating new ids and generating retry penalties with jitter */
+  /* random state to use when generating new ids and generating retry penalties */
   ares_rand_state     *rand_state;
 
   /* All active queries in a single list */

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -260,6 +260,8 @@ struct ares_channeldata {
   size_t               timeout; /* in milliseconds */
   size_t               tries;
   size_t               ndots;
+  size_t               maxtimeout; /* in milliseconds */
+  size_t               jitter; /* in 0.001 */
   ares_bool_t          rotate;
   unsigned short       udp_port;                   /* stored in network order */
   unsigned short       tcp_port;                   /* stored in network order */
@@ -284,7 +286,7 @@ struct ares_channeldata {
    * failures, followed by the configuration order if failures are equal. */
   ares__slist_t       *servers;
 
-  /* random state to use when generating new ids */
+  /* random state to use when generating new ids and generating retry penalties with jitter */
   ares_rand_state     *rand_state;
 
   /* All active queries in a single list */

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -37,7 +37,7 @@
 #ifdef NETWARE
 #  include <sys/filio.h>
 #endif
-#ifdef HAVE_SYS_STDINT_H
+#ifdef HAVE_STDINT_H
 #  include <stdint.h>
 #endif
 

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -37,6 +37,9 @@
 #ifdef NETWARE
 #  include <sys/filio.h>
 #endif
+#ifdef HAVE_SYS_STDINT_H
+#  include <stdint.h>
+#endif
 
 #include <assert.h>
 #include <fcntl.h>

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -798,7 +798,7 @@ static ares_status_t ares__append_tcpbuf(struct server_state *server,
   return ares__buf_append(server->tcp_send, query->qbuf, query->qlen);
 }
 
-static size_t ares__retry_penalty(struct query *query)
+static size_t ares__calc_query_timeout(struct query *query)
 {
   const ares_channel_t *channel  = query->channel;
   size_t                timeplus = channel->timeout;
@@ -829,7 +829,7 @@ static size_t ares__retry_penalty(struct query *query)
   if (channel->maxtimeout && timeplus > channel->maxtimeout)
     timeplus = channel->maxtimeout;
 
-  /* Add some jitter to the retry penalty.
+  /* Add some jitter to the retry timeout.
    *
    * Jitter is needed in situation when resolve requests are performed
    * simultaneously from multiple hosts and DNS server throttle these requests.
@@ -837,13 +837,19 @@ static size_t ares__retry_penalty(struct query *query)
    *
    * Value of timeplus adjusted randomly to the range [0.5 * timeplus, timeplus].
    */
-  if (timeplus > 0) {
+  if (query->try_count > 0) {
     unsigned short r;
     float delta_multiplier;
 
     ares__rand_bytes(channel->rand_state, (unsigned char *)&r, sizeof(r));
-    delta_multiplier = ((float)r / USHRT_MAX) * 0.5;
+    delta_multiplier = ((float)r / USHRT_MAX) * 0.5f;
     timeplus -= (size_t)((float)timeplus * delta_multiplier);
+
+    // With shift that doubles each iteration and constant 0.5 above this situation
+    // is impossible, but we want explicitly guarantee that timeplus
+    // is greater or equal to timeout specified in channel options.
+    if (timeplus < channel->timeout)
+      timeplus = channel->timeout;
   }
 
   return timeplus;
@@ -972,7 +978,7 @@ ares_status_t ares__send_query(struct query *query, struct timeval *now)
     }
   }
 
-  timeplus = ares__retry_penalty(query);
+  timeplus = ares__calc_query_timeout(query);
 
   /* Keep track of queries bucketed by timeout, so we can process
    * timeout events quickly.

--- a/test/ares-test-init.cc
+++ b/test/ares-test-init.cc
@@ -87,8 +87,6 @@ TEST_F(LibraryTest, OptionsChannelInit) {
   opts.udp_port = 54;
   optmask |= ARES_OPT_MAXTIMEOUTMS;
   opts.maxtimeout = 10000;
-  optmask |= ARES_OPT_JITTER;
-  opts.jitter = 42;
   optmask |= ARES_OPT_UDP_PORT;
   opts.tcp_port = 54;
   optmask |= ARES_OPT_TCP_PORT;
@@ -135,7 +133,6 @@ TEST_F(LibraryTest, OptionsChannelInit) {
   EXPECT_EQ(opts.tries, opts2.tries);
   EXPECT_EQ(opts.ndots, opts2.ndots);
   EXPECT_EQ(opts.maxtimeout, opts2.maxtimeout);
-  EXPECT_EQ(opts.jitter, opts2.jitter);
   EXPECT_EQ(opts.udp_port, opts2.udp_port);
   EXPECT_EQ(opts.tcp_port, opts2.tcp_port);
   EXPECT_EQ(1, opts2.nservers);  // Truncated by ARES_FLAG_PRIMARY

--- a/test/ares-test-init.cc
+++ b/test/ares-test-init.cc
@@ -85,6 +85,10 @@ TEST_F(LibraryTest, OptionsChannelInit) {
   opts.ndots = 4;
   optmask |= ARES_OPT_NDOTS;
   opts.udp_port = 54;
+  optmask |= ARES_OPT_MAXTIMEOUTMS;
+  opts.maxtimeout = 10000;
+  optmask |= ARES_OPT_JITTER;
+  opts.jitter = 42;
   optmask |= ARES_OPT_UDP_PORT;
   opts.tcp_port = 54;
   optmask |= ARES_OPT_TCP_PORT;
@@ -130,6 +134,8 @@ TEST_F(LibraryTest, OptionsChannelInit) {
   EXPECT_EQ(opts.timeout, opts2.timeout);
   EXPECT_EQ(opts.tries, opts2.tries);
   EXPECT_EQ(opts.ndots, opts2.ndots);
+  EXPECT_EQ(opts.maxtimeout, opts2.maxtimeout);
+  EXPECT_EQ(opts.jitter, opts2.jitter);
   EXPECT_EQ(opts.udp_port, opts2.udp_port);
   EXPECT_EQ(opts.tcp_port, opts2.tcp_port);
   EXPECT_EQ(1, opts2.nservers);  // Truncated by ARES_FLAG_PRIMARY


### PR DESCRIPTION
We use c-ares for DNS resolving at the project https://github.com/YTsaurus/YTsaurus 

In our installations we face a problem with synchronized request to the DNS from hundreds of thousands of processes and I want to add jitter for retry backoffs to smooth these requests over time.