### PR TITLE
Fix building c-ares-1.22.0 and higher under Watcom.

### DIFF
--- a/Makefile.Watcom
+++ b/Makefile.Watcom
@@ -42,7 +42,7 @@ RD = rmdir /q /s 2>NUL
 CP = copy
 
 CFLAGS = -3r -mf -hc -zff -zgf -zq -zm -zc -s -fr=con -w2 -fpi -oilrtfm -aa   &
-         -wcd=201 -bt=nt -d+ -dWIN32 -dCARES_BUILDING_LIBRARY -dHAVE_STDINT_H &
+         -wcd=201 -bt=nt -d+ -dWIN32 -dCARES_BUILDING_LIBRARY &
          -dNTDDI_VERSION=0x06000000 -I. -I.\include -I.\src\lib $(SYS_INCL)
 
 LFLAGS = option quiet, map, caseexact, eliminate

--- a/Makefile.Watcom
+++ b/Makefile.Watcom
@@ -41,8 +41,8 @@ MD = mkdir
 RD = rmdir /q /s 2>NUL
 CP = copy
 
-CFLAGS = -3r -mf -hc -zff -zgf -zq -zm -zc -s -fr=con -w2 -fpi -oilrtfm -aa &
-         -wcd=201 -bt=nt -d+ -dWIN32 -dCARES_BUILDING_LIBRARY               &
+CFLAGS = -3r -mf -hc -zff -zgf -zq -zm -zc -s -fr=con -w2 -fpi -oilrtfm -aa   &
+         -wcd=201 -bt=nt -d+ -dWIN32 -dCARES_BUILDING_LIBRARY -dHAVE_STDINT_H &
          -dNTDDI_VERSION=0x06000000 -I. -I.\include -I.\src\lib $(SYS_INCL)
 
 LFLAGS = option quiet, map, caseexact, eliminate

--- a/src/lib/config-win32.h
+++ b/src/lib/config-win32.h
@@ -87,6 +87,12 @@
 #define HAVE_SYS_TYPES_H 1
 #define HAVE_SYS_STAT_H  1
 
+/* If we are building with OpenWatcom, we need to specify that we have
+ * <stdint.h>. */
+#if defined(__WATCOMC__)
+#define HAVE_STDINT_H
+#endif
+
 /* ---------------------------------------------------------------- */
 /*                        OTHER HEADER INFO                         */
 /* ---------------------------------------------------------------- */


### PR DESCRIPTION
This commit fixes building c-ares using the WATCOM compiler by adding -dHAVE_STDINT_H into the CFLAGS. On a configure or CMake based configuration, this would be added in by that process.

This fixes a build error when compiling ares__buf.c, due to not having SIZE_MAX declared.

Tested by linking to the library as well as using adig and ahost.

Fixes #622