### PR TITLE
Support attempts and timeout options from resolv.conf

### DIFF
--- a/src/lib/ares_sysconfig_files.c
+++ b/src/lib/ares_sysconfig_files.c
@@ -339,13 +339,26 @@ static ares_status_t set_options(ares_sysconfig_t *sysconfig, const char *str)
       sysconfig->ndots = strtoul(val, NULL, 10);
     }
 
+    // Outdated option.
     val = try_option(p, q, "retrans:");
     if (val) {
       sysconfig->timeout_ms = strtoul(val, NULL, 10);
     }
 
+    val = try_option(p, q, "timeout:");
+    if (val) {
+      sysconfig->timeout_ms = strtoul(val, NULL, 10) * 1000;
+    }
+
+    // Outdated option.
     val = try_option(p, q, "retry:");
     if (val) {
+      sysconfig->tries = strtoul(val, NULL, 10);
+    }
+
+    val = try_option(p, q, "attempts:");
+    if (val) {
+      fprintf(stderr, "ATTEMPTS: %d", (int)strtoul(val, NULL, 10));
       sysconfig->tries = strtoul(val, NULL, 10);
     }
 

--- a/test/ares-test-init.cc
+++ b/test/ares-test-init.cc
@@ -275,6 +275,25 @@ TEST_F(LibraryTest, EnvInit) {
   ares_destroy(channel);
 }
 
+TEST_F(LibraryTest, EnvInitModernOptions) {
+  ares_channel_t *channel = nullptr;
+  EnvValue v1("LOCALDOMAIN", "this.is.local");
+  EnvValue v2("RES_OPTIONS", "options debug retrans:2 ndots:3 attempts:4 timeout:5 rotate");
+  EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
+
+  channel->optmask |= ARES_OPT_TRIES;
+  channel->optmask |= ARES_OPT_TIMEOUTMS;
+
+  struct ares_options opts;
+  memset(&opts, 0, sizeof(opts));
+  int optmask = 0;
+  EXPECT_EQ(ARES_SUCCESS, ares_save_options(channel, &opts, &optmask));
+  EXPECT_EQ(5000, opts.timeout);
+  EXPECT_EQ(4, opts.tries);
+
+  ares_destroy(channel);
+}
+
 TEST_F(LibraryTest, EnvInitAllocFail) {
   ares_channel_t *channel;
   EnvValue v1("LOCALDOMAIN", "this.is.local");


### PR DESCRIPTION
c-ares parses only antique version of options for timeout and number of retries from resolv.conf (`retrans` and `retry` are missing in modern documentation https://man7.org/linux/man-pages/man5/resolv.conf.5.html).

I add support of `attempts` and `timeout` options