### PR TITLE
ares_getaddrinfo(): do not use search domains if ARES_FLAG_NOSEARCH is set

### DIFF
--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -743,7 +743,7 @@ static ares_bool_t as_is_first(const struct host_query *hquery)
       ndots++;
     }
   }
-  if (hquery->name != NULL && nname && hquery->name[nname - 1] == '.') {
+  if (as_is_only(hquery)) {
     /* prevent ARES_EBADNAME for valid FQDN, where ndots < channel->ndots  */
     return ARES_TRUE;
   }

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -752,6 +752,9 @@ static ares_bool_t as_is_first(const struct host_query *hquery)
 
 static ares_bool_t as_is_only(const struct host_query *hquery)
 {
+  if(hquery->channel->flags & ARES_FLAG_NOSEARCH) {
+    return ARES_TRUE;
+  }
   size_t nname = ares_strlen(hquery->name);
   if (hquery->name != NULL && nname && hquery->name[nname - 1] == '.') {
     return ARES_TRUE;

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -737,7 +737,6 @@ static ares_bool_t as_is_first(const struct host_query *hquery)
 {
   const char *p;
   size_t      ndots = 0;
-  size_t      nname = ares_strlen(hquery->name);
   for (p = hquery->name; p && *p; p++) {
     if (*p == '.') {
       ndots++;
@@ -752,10 +751,10 @@ static ares_bool_t as_is_first(const struct host_query *hquery)
 
 static ares_bool_t as_is_only(const struct host_query *hquery)
 {
+  size_t nname = ares_strlen(hquery->name);
   if(hquery->channel->flags & ARES_FLAG_NOSEARCH) {
     return ARES_TRUE;
   }
-  size_t nname = ares_strlen(hquery->name);
   if (hquery->name != NULL && nname && hquery->name[nname - 1] == '.') {
     return ARES_TRUE;
   }


### PR DESCRIPTION
c-ares init options defines a flag ARES_FLAG_NOSEARCH that is supposed to prevent search using configured domain suffixes.

however when using ares_getaddrinfo() the flag was ignored and domain suffixes were used anyway.

Unfortunately explicitly configuring zero domains to search also does not work (if ndomains == 0 default domain search list is loaded regardless of the flag ARES_OPT_DOMAINS being set).

this change adds a check for the ARES_FLAG_NOSEARCH in as_is_only() function that is used by ares_getaddrinfo() to decide if to try to query next possible name ( next_dns_lookup() )