### PR TITLE
Regression: increment server failures on timeout

### DIFF
--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -562,6 +562,7 @@ static void process_timeouts(ares_channel_t *channel, struct timeval *now)
     query->timeouts++;
 
     conn = query->conn;
+    server_increment_failures(conn->server);
     ares__requeue_query(query, now);
     ares__check_cleanup_conn(channel, conn);
 


### PR DESCRIPTION
As of c-ares 1.22.0, server timeouts were erroneously not incrementing server failures meaning the server in use wouldn't rotate.  There was apparently never a test case for this condition.

This PR fixes the bug and adds a test case to ensure it behaves properly.

Fixes Bug: #650 
Fix By: Brad House (@bradh352)