### PR TITLE
Rewrite softlist hand parser for memory safety and bugs

### DIFF
--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -227,24 +227,9 @@ struct query {
                            * when a query is to be canceled */
 };
 
-/* An IP address pattern; matches an IP address X if X & mask == addr */
-#define PATTERN_MASK 0x1
-#define PATTERN_CIDR 0x2
-
 struct apattern {
-  union {
-    struct in_addr       addr4;
-    struct ares_in6_addr addr6;
-  } addr;
-
-  union {
-    struct in_addr       addr4;
-    struct ares_in6_addr addr6;
-    unsigned short       bits;
-  } mask;
-
-  int            family;
-  unsigned short type;
+  struct ares_addr addr;
+  unsigned char    mask;
 };
 
 struct ares__qcache;

--- a/src/lib/ares_sysconfig_files.c
+++ b/src/lib/ares_sysconfig_files.c
@@ -567,8 +567,14 @@ ares_status_t ares__init_sysconfig_files(const ares_channel_t *channel,
         status =
           ares__sconfig_append_fromstr(&sysconfig->sconfig, p, ARES_TRUE);
       } else if ((p = try_config(line, "sortlist", ';'))) {
+        /* Ignore all failures except ENOMEM.  If the sysadmin set a bad
+         * sortlist, just ignore the sortlist, don't cause an inoperable
+         * channel */
         status =
           ares__parse_sortlist(&sysconfig->sortlist, &sysconfig->nsortlist, p);
+        if (status != ARES_ENOMEM) {
+          status = ARES_SUCCESS;
+        }
       } else if ((p = try_config(line, "options", ';'))) {
         status = set_options(sysconfig, p);
       } else {

--- a/test/ares-test-init.cc
+++ b/test/ares-test-init.cc
@@ -326,13 +326,15 @@ TEST_F(DefaultChannelTest, SetSortlistFailures) {
   EXPECT_EQ(ARES_EBADSTR, ares_set_sortlist(channel_, "111.111.111.111/255.255.255.240*"));
   EXPECT_EQ(ARES_EBADSTR, ares_set_sortlist(channel_, "1 0123456789012345"));
   EXPECT_EQ(ARES_EBADSTR, ares_set_sortlist(channel_, "1 /01234567890123456789012345678901"));
-  EXPECT_EQ(ARES_SUCCESS, ares_set_sortlist(channel_, "xyzzy ; lwk"));
-  EXPECT_EQ(ARES_SUCCESS, ares_set_sortlist(channel_, "xyzzy ; 0x123"));
+  EXPECT_EQ(ARES_EBADSTR, ares_set_sortlist(channel_, "xyzzy ; lwk"));
+  EXPECT_EQ(ARES_EBADSTR, ares_set_sortlist(channel_, "xyzzy ; 0x123"));
 }
 
 TEST_F(DefaultChannelTest, SetSortlistVariants) {
   EXPECT_EQ(ARES_SUCCESS, ares_set_sortlist(channel_, "1.2.3.4"));
   EXPECT_EQ(ARES_SUCCESS, ares_set_sortlist(channel_, "1.2.3.4 ; 2.3.4.5"));
+  EXPECT_EQ(ARES_SUCCESS, ares_set_sortlist(channel_, "1.2.3.4/26;1234::5678/126;4.5.6.7;5678::1234"));
+  EXPECT_EQ(ARES_SUCCESS, ares_set_sortlist(channel_, " 1.2.3.4/26 1234::5678/126   4.5.6.7 5678::1234  "));
   EXPECT_EQ(ARES_SUCCESS, ares_set_sortlist(channel_, "129.1.1.1"));
   EXPECT_EQ(ARES_SUCCESS, ares_set_sortlist(channel_, "192.1.1.1"));
   EXPECT_EQ(ARES_SUCCESS, ares_set_sortlist(channel_, "224.1.1.1"));


### PR DESCRIPTION
The parser for the sortlist has been rewritten to use the ares__buf_*() functions.  This also resolves some known bugs in accepting invalid sortlist entries which should have caused parse failures.

Fixes Bug: #501
Fix By: Brad House (@bradh352)