### PR TITLE
Clean up some Windows-only warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,7 +496,7 @@ ENDIF ()
 # defaults.  This should be much quicker and nearly as accurate ... and even
 # if not, it probably won't matter in the least.
 
-IF (HAVE_SSIZE_T AND HAVE_SOCKLEN_T)
+IF (HAVE_SSIZE_T AND HAVE_SOCKLEN_T AND NOT WIN32)
 	# If we have ssize_t and socklen_t, the API is usually sane and uses ssize_t and size_t for lengths
 	SET (RECVFROM_TYPE_RETV ssize_t)
 	SET (RECVFROM_TYPE_ARG3 size_t)

--- a/src/lib/ares__addrinfo2hostent.c
+++ b/src/lib/ares__addrinfo2hostent.c
@@ -144,7 +144,7 @@ ares_status_t ares__addrinfo2hostent(const struct ares_addrinfo *ai, int family,
     }
   }
 
-  (*host)->h_addrtype = family;
+  (*host)->h_addrtype = (HOSTENT_ADDRTYPE_TYPE)family;
 
   if (family == AF_INET) {
     (*host)->h_length = sizeof(struct in_addr);

--- a/src/lib/ares__hosts_file.c
+++ b/src/lib/ares__hosts_file.c
@@ -871,7 +871,7 @@ ares_status_t ares__hosts_entry_to_hostent(const ares_hosts_entry_t *entry,
     goto fail;
   }
 
-  (*hostent)->h_addrtype = family;
+  (*hostent)->h_addrtype = (HOSTENT_ADDRTYPE_TYPE)family;
 
   /* Copy IP addresses that match the address family */
   idx = 0;
@@ -895,7 +895,7 @@ ares_status_t ares__hosts_entry_to_hostent(const ares_hosts_entry_t *entry,
      * conversions as we can only support a single address class */
     if (family == AF_UNSPEC) {
       family                 = addr.family;
-      (*hostent)->h_addrtype = addr.family;
+      (*hostent)->h_addrtype = (HOSTENT_ADDRTYPE_TYPE)addr.family;
     }
 
     temp = ares_realloc_zero((*hostent)->h_addr_list,
@@ -916,7 +916,7 @@ ares_status_t ares__hosts_entry_to_hostent(const ares_hosts_entry_t *entry,
 
     memcpy((*hostent)->h_addr_list[idx], ptr, ptr_len);
     idx++;
-    (*hostent)->h_length = (int)ptr_len;
+    (*hostent)->h_length = (HOSTENT_LENGTH_TYPE)ptr_len;
   }
 
   /* entry didn't match address class */

--- a/src/lib/ares__socket.c
+++ b/src/lib/ares__socket.c
@@ -70,7 +70,8 @@ ares_ssize_t ares__socket_recvfrom(ares_channel_t *channel, ares_socket_t s,
   }
 
 #ifdef HAVE_RECVFROM
-  return recvfrom(s, data, data_len, flags, from, from_len);
+  return (ares_ssize_t)recvfrom(s, data, (RECVFROM_TYPE_ARG3)data_len,
+                                flags, from, from_len);
 #else
   return sread(s, data, data_len);
 #endif
@@ -84,6 +85,7 @@ ares_ssize_t ares__socket_recv(ares_channel_t *channel, ares_socket_t s,
                                           channel->sock_func_cb_data);
   }
 
+  /* sread() is a wrapper for read() or recv() depending on the system */
   return sread(s, data, data_len);
 }
 
@@ -124,7 +126,7 @@ static int setsocknonblock(ares_socket_t sockfd, /* operate on this */
   /* Windows */
   unsigned long flags = nonblock ? 1UL : 0UL;
 #  endif
-  return ioctlsocket(sockfd, FIONBIO, &flags);
+  return ioctlsocket(sockfd, (long)FIONBIO, &flags);
 
 #elif defined(HAVE_IOCTLSOCKET_CAMEL_FIONBIO)
 

--- a/src/lib/ares_parse_ptr_reply.c
+++ b/src/lib/ares_parse_ptr_reply.c
@@ -99,8 +99,8 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen_int,
     }
     memcpy(hostent->h_addr_list[0], addr, (size_t)addrlen);
   }
-  hostent->h_addrtype = family;
-  hostent->h_length   = addrlen;
+  hostent->h_addrtype = (HOSTENT_ADDRTYPE_TYPE)family;
+  hostent->h_length   = (HOSTENT_LENGTH_TYPE)addrlen;
 
   /* Preallocate the maximum number + 1 */
   hostent->h_aliases = ares_malloc((ancount + 1) * sizeof(*hostent->h_aliases));

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -593,4 +593,12 @@ typedef long long          ares_int64_t;
 typedef unsigned long long ares_uint64_t;
 #endif
 
+#ifdef _WIN32
+#  define HOSTENT_ADDRTYPE_TYPE short
+#  define HOSTENT_LENGTH_TYPE short
+#else
+#  define HOSTENT_ADDRTYPE_TYPE int
+#  define HOSTENT_LENGTH_TYPE int
+#endif
+
 #endif /* __ARES_PRIVATE_H */

--- a/src/lib/ares_qcache.c
+++ b/src/lib/ares_qcache.c
@@ -353,7 +353,7 @@ static ares_status_t ares__qcache_insert(ares__qcache_t      *qcache,
   }
 
   entry->dnsrec    = dnsrec;
-  entry->expire_ts = now->tv_sec + ttl;
+  entry->expire_ts = (time_t)(now->tv_sec + (time_t)ttl);
   entry->insert_ts = now->tv_sec;
 
   /* We can't guarantee the server responded with the same flags as the

--- a/src/lib/ares_sysconfig.c
+++ b/src/lib/ares_sysconfig.c
@@ -401,7 +401,8 @@ static ares_bool_t get_DNS_Windows(char **outptr)
         }
 
         addresses[addressesIndex].metric =
-          getBestRouteMetric(&ipaaEntry->Luid, (SOCKADDR_INET *)(namesrvr.sa),
+          getBestRouteMetric(&ipaaEntry->Luid,
+                             (SOCKADDR_INET *)((void *)(namesrvr.sa)),
                              ipaaEntry->Ipv4Metric);
 
         /* Record insertion index to make qsort stable */
@@ -445,7 +446,8 @@ static ares_bool_t get_DNS_Windows(char **outptr)
         }
 
         addresses[addressesIndex].metric =
-          getBestRouteMetric(&ipaaEntry->Luid, (SOCKADDR_INET *)(namesrvr.sa),
+          getBestRouteMetric(&ipaaEntry->Luid,
+                             (SOCKADDR_INET *)((void *)(namesrvr.sa)),
                              ipaaEntry->Ipv6Metric);
 
         /* Record insertion index to make qsort stable */

--- a/src/lib/ares_sysconfig.c
+++ b/src/lib/ares_sysconfig.c
@@ -309,7 +309,7 @@ static ares_bool_t get_DNS_Windows(char **outptr)
   ULONG                          Bufsz     = IPAA_INITIAL_BUF_SZ;
   ULONG                          AddrFlags = 0;
   int                            trying    = IPAA_MAX_TRIES;
-  int                            res;
+  ULONG                          res;
 
   /* The capacity of addresses, in elements. */
   size_t                         addressesSize;

--- a/src/lib/inet_ntop.c
+++ b/src/lib/inet_ntop.c
@@ -118,7 +118,7 @@ static const char *inet_ntop6(const unsigned char *src, char *dst, size_t size)
   } best, cur;
 
   unsigned int words[NS_IN6ADDRSZ / NS_INT16SZ];
-  int          i;
+  unsigned int i;
 
   /*
    * Preprocess:

--- a/src/lib/inet_ntop.c
+++ b/src/lib/inet_ntop.c
@@ -118,7 +118,7 @@ static const char *inet_ntop6(const unsigned char *src, char *dst, size_t size)
   } best, cur;
 
   unsigned int words[NS_IN6ADDRSZ / NS_INT16SZ];
-  unsigned int i;
+  int i;
 
   /*
    * Preprocess:
@@ -127,7 +127,7 @@ static const char *inet_ntop6(const unsigned char *src, char *dst, size_t size)
    */
   memset(words, '\0', sizeof(words));
   for (i = 0; i < NS_IN6ADDRSZ; i++) {
-    words[i / 2] |= (src[i] << ((1 - (i % 2)) << 3));
+    words[i / 2] |= (unsigned int)(src[i] << ((1 - (i % 2)) << 3));
   }
   best.base = -1;
   best.len  = 0;

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -1003,7 +1003,7 @@ static int configure_socket(ares_socket_t s) {
   /* Windows */
   unsigned long flags = 1UL;
 #endif
-  return ioctlsocket(s, FIONBIO, &flags);
+  return ioctlsocket(s, (long)FIONBIO, &flags);
 #elif defined(HAVE_IOCTLSOCKET_CAMEL_FIONBIO)
   /* Amiga */
   long flags = 1L;

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -96,7 +96,7 @@ void ProcessWork(ares_channel_t *channel,
     std::set<ares_socket_t> extrafds = get_extrafds();
     for (ares_socket_t extrafd : extrafds) {
       FD_SET(extrafd, &readers);
-      if (extrafd >= nfds) {
+      if (extrafd >= (ares_socket_t)nfds) {
         nfds = (int)extrafd + 1;
       }
     }

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -448,7 +448,7 @@ void MockServer::ProcessRequest(ares_socket_t fd, struct sockaddr_storage* addr,
     addrlen = 0;
   }
 
-  ares_ssize_t rc = (ares_ssize_t)sendto(fd, BYTE_CAST reply.data(), reply.size(), 0,
+  ares_ssize_t rc = (ares_ssize_t)sendto(fd, BYTE_CAST reply.data(), (SEND_TYPE_ARG3)reply.size(), 0,
                   (struct sockaddr *)addr, addrlen);
   if (rc < static_cast<ares_ssize_t>(reply.size())) {
     std::cerr << "Failed to send full reply, rc=" << rc << std::endl;


### PR DESCRIPTION
Windows was emitting some warnings due to datatype differences.

Fix By: Brad House (@bradh352)