### PR TITLE
Use SOCK_DNS extension on socket on OpenBSD

### DIFF
--- a/src/lib/ares__socket.c
+++ b/src/lib/ares__socket.c
@@ -253,6 +253,11 @@ ares_status_t ares__open_connection(ares_channel_t      *channel,
   struct server_connection *conn;
   ares__llist_node_t       *node;
   int                       type = is_tcp ? SOCK_STREAM : SOCK_DGRAM;
+#ifdef __OpenBSD__
+  if(!is_tcp && server->udp_port == 53) {
+    type |= SOCK_DNS;
+  }
+#endif
 
   switch (server->addr.family) {
     case AF_INET:

--- a/src/lib/ares__socket.c
+++ b/src/lib/ares__socket.c
@@ -254,7 +254,7 @@ ares_status_t ares__open_connection(ares_channel_t      *channel,
   ares__llist_node_t       *node;
   int                       type = is_tcp ? SOCK_STREAM : SOCK_DGRAM;
 #ifdef __OpenBSD__
-  if(!is_tcp && server->udp_port == 53) {
+  if(server->udp_port == 53) {
     type |= SOCK_DNS;
   }
 #endif

--- a/src/lib/ares__socket.c
+++ b/src/lib/ares__socket.c
@@ -254,7 +254,7 @@ ares_status_t ares__open_connection(ares_channel_t      *channel,
   ares__llist_node_t       *node;
   int                       type = is_tcp ? SOCK_STREAM : SOCK_DGRAM;
 #ifdef __OpenBSD__
-  if(server->udp_port == 53) {
+  if((is_tcp && server->tcp_port == 53) || (!is_tcp && server->udp_port == 53)) {
     type |= SOCK_DNS;
   }
 #endif


### PR DESCRIPTION
This patch added the SOCK_DNS flag when running on OpenBSD. Allowing a reduced set of pledge(2) promises. Before this patch. The "stdio rpath inet" promises must be used in order to resolve any records. After the patch. `inet` can be replaced with `dns` which only allows communication on destination port 53, instead of on all ports.

Side note: I checked the OpenBSD kernel source code. Even though the socket document says `the DNS port (typically 53).`, The OpenBSD 7.4 kernel only allows 53. Not sure why they say typically.