### PR TITLE
ares_cancel() could trigger callback with wrong response code

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -26,6 +26,11 @@ Bug Fixes:
    been restored. [7]
  o On linux getrandom() can fail if the kernel doesn't support the syscall,
    fall back to another random source. [8]
+ o ares_cancel() when performing ares_gethostbyname() or ares_getaddrinfo()
+   with AF_UNSPEC, if called after one address class was returned but before
+   the other address class, it would return ARES_SUCCESS rather than
+   ARES_ECANCELLED. [9]
+
 
 Thanks go to these friendly people for their efforts and contributions:
   Brad House (@bradh352)
@@ -41,5 +46,6 @@ References to bug reports and discussions on issues:
  [6] = https://github.com/c-ares/c-ares/pull/655
  [7] = https://github.com/c-ares/c-ares/commit/c982bf4
  [8] = https://github.com/c-ares/c-ares/pull/661
+ [9] = https://github.com/c-ares/c-ares/pull/663
 
 

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -501,7 +501,12 @@ static void host_callback(void *arg, int status, int timeouts,
   }
 
   if (!hquery->remaining) {
-    if (addinfostatus != ARES_SUCCESS && addinfostatus != ARES_ENODATA) {
+    if (status == ARES_EDESTRUCTION || status == ARES_ECANCELLED) {
+      /* must make sure we don't do next_lookup() on destroy or cancel,
+       * and return the appropriate status.  We won't return a partial
+       * result in this case. */
+      end_hquery(hquery, (ares_status_t)status);
+    } else if (addinfostatus != ARES_SUCCESS && addinfostatus != ARES_ENODATA) {
       /* error in parsing result e.g. no memory */
       if (addinfostatus == ARES_EBADRESP && hquery->ai->nodes) {
         /* We got a bad response from server, but at least one query
@@ -513,9 +518,6 @@ static void host_callback(void *arg, int status, int timeouts,
     } else if (hquery->ai->nodes) {
       /* at least one query ended with ARES_SUCCESS */
       end_hquery(hquery, ARES_SUCCESS);
-    } else if (status == ARES_EDESTRUCTION || status == ARES_ECANCELLED) {
-      /* must make sure we don't do next_lookup() on destroy or cancel */
-      end_hquery(hquery, (ares_status_t)status);
     } else if (status == ARES_ENOTFOUND || status == ARES_ENODATA ||
                addinfostatus == ARES_ENODATA) {
       if (status == ARES_ENODATA || addinfostatus == ARES_ENODATA) {

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -364,6 +364,9 @@ void ares__rand_bytes(ares_rand_state *state, unsigned char *buf, size_t len);
 
 unsigned short ares__generate_new_id(ares_rand_state *state);
 struct timeval ares__tvnow(void);
+void ares__timeval_remaining(struct timeval *remaining,
+                             const struct timeval *now,
+                             const struct timeval *tout);
 ares_status_t  ares__expand_name_validated(const unsigned char *encoded,
                                            const unsigned char *abuf,
                                            size_t alen, char **s, size_t *enclen,

--- a/src/lib/ares_timeout.c
+++ b/src/lib/ares_timeout.c
@@ -34,8 +34,9 @@
 #include "ares.h"
 #include "ares_private.h"
 
-static void remaining_time(struct timeval *remaining, const struct timeval *now,
-                           const struct timeval *tout)
+void ares__timeval_remaining(struct timeval *remaining,
+                             const struct timeval *now,
+                             const struct timeval *tout)
 {
   memset(remaining, 0, sizeof(*remaining));
 
@@ -73,7 +74,7 @@ struct timeval *ares_timeout(ares_channel_t *channel, struct timeval *maxtv,
 
   now = ares__tvnow();
 
-  remaining_time(tvbuf, &now, &query->timeout);
+  ares__timeval_remaining(tvbuf, &now, &query->timeout);
 
   if (maxtv == NULL) {
     return tvbuf;

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -1,17 +1,25 @@
-/*
- * Copyright (C) The c-ares project
+/* MIT License
  *
- * Permission to use, copy, modify, and distribute this
- * software and its documentation for any purpose and without
- * fee is hereby granted, provided that the above copyright
- * notice appear in all copies and that both that copyright
- * notice and this permission notice appear in supporting
- * documentation, and that the name of M.I.T. not be used in
- * advertising or publicity pertaining to distribution of the
- * software without specific, written prior permission.
- * M.I.T. makes no representations about the suitability of
- * this software for any purpose.  It is provided "as is"
- * without express or implied warranty.
+ * Copyright (c) The c-ares project and its contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
  * SPDX-License-Identifier: MIT
  */

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -1,17 +1,25 @@
-/*
- * Copyright (C) The c-ares project
+/* MIT License
  *
- * Permission to use, copy, modify, and distribute this
- * software and its documentation for any purpose and without
- * fee is hereby granted, provided that the above copyright
- * notice appear in all copies and that both that copyright
- * notice and this permission notice appear in supporting
- * documentation, and that the name of M.I.T. not be used in
- * advertising or publicity pertaining to distribution of the
- * software without specific, written prior permission.
- * M.I.T. makes no representations about the suitability of
- * this software for any purpose.  It is provided "as is"
- * without express or implied warranty.
+ * Copyright (c) The c-ares project and its contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
  * SPDX-License-Identifier: MIT
  */
@@ -795,7 +803,7 @@ TEST_P(MockChannelTest, SearchHighNdots) {
             ss.str());
 }
 
-TEST_P(MockUDPChannelTest, V4WorksV6Timeout) {
+TEST_P(MockChannelTest, V4WorksV6Timeout) {
   std::vector<byte> nothing;
   DNSPacket reply;
   reply.set_response().set_aa()
@@ -817,6 +825,31 @@ TEST_P(MockUDPChannelTest, V4WorksV6Timeout) {
   ss << result.host_;
   EXPECT_EQ("{'www.google.com' aliases=[] addrs=[1.2.3.4]}", ss.str());
 }
+
+
+// Test case for Issue #662
+TEST_P(MockChannelTest, PartialQueryCancel) {
+  std::vector<byte> nothing;
+  DNSPacket reply;
+  reply.set_response().set_aa()
+    .add_question(new DNSQuestion("www.google.com", T_A))
+    .add_answer(new DNSARR("www.google.com", 0x0100, {0x01, 0x02, 0x03, 0x04}));
+
+  ON_CALL(server_, OnRequest("www.google.com", T_A))
+    .WillByDefault(SetReply(&server_, &reply));
+
+  ON_CALL(server_, OnRequest("www.google.com", T_AAAA))
+    .WillByDefault(SetReplyData(&server_, nothing));
+
+  HostResult result;
+  ares_gethostbyname(channel_, "www.google.com.", AF_UNSPEC, HostCallback, &result);
+  // After 100ms, issues ares_cancel(), this should be enough time for the A
+  // record reply, but before the timeout on the AAAA record.
+  Process(100);
+  EXPECT_TRUE(result.done_);
+  EXPECT_EQ(ARES_ECANCELLED, result.status_);
+}
+
 
 TEST_P(MockChannelTest, UnspecifiedFamilyV6) {
   DNSPacket rsp6;

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -1,17 +1,25 @@
-/*
- * Copyright (C) Brad House
+/* MIT License
  *
- * Permission to use, copy, modify, and distribute this
- * software and its documentation for any purpose and without
- * fee is hereby granted, provided that the above copyright
- * notice appear in all copies and that both that copyright
- * notice and this permission notice appear in supporting
- * documentation, and that the name of M.I.T. not be used in
- * advertising or publicity pertaining to distribution of the
- * software without specific, written prior permission.
- * M.I.T. makes no representations about the suitability of
- * this software for any purpose.  It is provided "as is"
- * without express or implied warranty.
+ * Copyright (c) The c-ares project and its contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
  * SPDX-License-Identifier: MIT
  */
@@ -21,9 +29,22 @@
 #include "ares-test.h"
 #include "ares-test-ai.h"
 #include "dns-proto.h"
-
-// Include ares internal files for DNS protocol details
 #include "ares_dns.h"
+
+extern "C" {
+// Remove command-line defines of package variables for the test project...
+#undef PACKAGE_NAME
+#undef PACKAGE_BUGREPORT
+#undef PACKAGE_STRING
+#undef PACKAGE_TARNAME
+// ... so we can include the library's config without symbol redefinitions.
+#include "ares_setup.h"
+#include "ares_inet_net_pton.h"
+#include "ares_data.h"
+#include "ares_strsplit.h"
+#include "ares_private.h"
+}
+
 
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
@@ -80,11 +101,25 @@ std::map<size_t, int> LibraryTest::size_fails_;
 
 void ProcessWork(ares_channel_t *channel,
                  std::function<std::set<ares_socket_t>()> get_extrafds,
-                 std::function<void(ares_socket_t)> process_extra) {
+                 std::function<void(ares_socket_t)> process_extra,
+                 unsigned int cancel_ms) {
   int nfds, count;
   fd_set readers, writers;
-  struct timeval tv;
+  struct timeval tv_begin  = ares__tvnow();
+  struct timeval tv_cancel = tv_begin;
+
+  if (cancel_ms) {
+    if (verbose) std::cerr << "ares_cancel will be called after " << cancel_ms << "ms" << std::endl;
+    tv_cancel.tv_sec  += (cancel_ms / 1000);
+    tv_cancel.tv_usec += ((cancel_ms % 1000) * 1000);
+  }
+
   while (true) {
+    struct timeval  tv_now = ares__tvnow();
+    struct timeval  tv_remaining;
+    struct timeval  tv;
+    struct timeval *tv_select;
+
     // Retrieve the set of file descriptors that the library wants us to monitor.
     FD_ZERO(&readers);
     FD_ZERO(&writers);
@@ -103,10 +138,27 @@ void ProcessWork(ares_channel_t *channel,
 
     /* If ares_timeout returns NULL, it means there are no requests in queue,
      * so we can break out */
-    if (ares_timeout(channel, NULL, &tv) == NULL)
+    tv_select = ares_timeout(channel, NULL, &tv);
+    if (tv_select == NULL)
       return;
 
-    count = select(nfds, &readers, &writers, nullptr, &tv);
+    if (cancel_ms) {
+      unsigned int remaining_ms;
+      ares__timeval_remaining(&tv_remaining,
+                              &tv_now,
+                              &tv_cancel);
+      remaining_ms = (unsigned int)((tv_remaining.tv_sec * 1000) + (tv_remaining.tv_usec / 1000));
+      if (remaining_ms == 0) {
+        if (verbose) std::cerr << "Issuing ares_cancel()" << std::endl;
+        ares_cancel(channel);
+        cancel_ms = 0; /* Disable issuing cancel again */
+      } else {
+        /* Recalculate proper timeout since we also have a cancel to wait on */
+        tv_select = ares_timeout(channel, &tv_remaining, &tv);
+      }
+    }
+
+    count = select(nfds, &readers, &writers, nullptr, tv_select);
     if (count < 0) {
       fprintf(stderr, "select() failed, errno %d\n", errno);
       return;
@@ -183,16 +235,16 @@ std::set<ares_socket_t> NoExtraFDs() {
   return std::set<ares_socket_t>();
 }
 
-void DefaultChannelTest::Process() {
-  ProcessWork(channel_, NoExtraFDs, nullptr);
+void DefaultChannelTest::Process(unsigned int cancel_ms) {
+  ProcessWork(channel_, NoExtraFDs, nullptr, cancel_ms);
 }
 
-void FileChannelTest::Process() {
-  ProcessWork(channel_, NoExtraFDs, nullptr);
+void FileChannelTest::Process(unsigned int cancel_ms) {
+  ProcessWork(channel_, NoExtraFDs, nullptr, cancel_ms);
 }
 
-void DefaultChannelModeTest::Process() {
-  ProcessWork(channel_, NoExtraFDs, nullptr);
+void DefaultChannelModeTest::Process(unsigned int cancel_ms) {
+  ProcessWork(channel_, NoExtraFDs, nullptr, cancel_ms);
 }
 
 MockServer::MockServer(int family, unsigned short port)
@@ -571,11 +623,12 @@ void MockChannelOptsTest::ProcessFD(ares_socket_t fd) {
   }
 }
 
-void MockChannelOptsTest::Process() {
+void MockChannelOptsTest::Process(unsigned int cancel_ms) {
   using namespace std::placeholders;
   ProcessWork(channel_,
               std::bind(&MockChannelOptsTest::fds, this),
-              std::bind(&MockChannelOptsTest::ProcessFD, this, _1));
+              std::bind(&MockChannelOptsTest::ProcessFD, this, _1),
+              cancel_ms);
 }
 
 std::ostream& operator<<(std::ostream& os, const HostResult& result) {

--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -69,7 +69,8 @@ extern std::vector<std::pair<int, bool>>       families_modes;
 // optionally the given set-of-FDs + work function.
 void                    ProcessWork(ares_channel_t                          *channel,
                                     std::function<std::set<ares_socket_t>()> get_extrafds,
-                                    std::function<void(ares_socket_t)>       process_extra);
+                                    std::function<void(ares_socket_t)>       process_extra,
+                                    unsigned int                             cancel_ms = 0);
 std::set<ares_socket_t> NoExtraFDs();
 
 // Test fixture that ensures library initialization, and allows
@@ -128,7 +129,7 @@ public:
   }
 
   // Process all pending work on ares-owned file descriptors.
-  void Process();
+  void Process(unsigned int cancel_ms = 0);
 
 protected:
   ares_channel_t *channel_;
@@ -155,7 +156,7 @@ public:
   }
 
   // Process all pending work on ares-owned file descriptors.
-  void Process();
+  void Process(unsigned int cancel_ms = 0);
 
 protected:
   ares_channel_t *channel_;
@@ -184,7 +185,7 @@ public:
   }
 
   // Process all pending work on ares-owned file descriptors.
-  void Process();
+  void Process(unsigned int cancel_ms = 0);
 
 protected:
   ares_channel_t *channel_;
@@ -271,7 +272,7 @@ public:
 
   // Process all pending work on ares-owned and mock-server-owned file
   // descriptors.
-  void Process();
+  void Process(unsigned int cancel_ms = 0);
 
 protected:
   // NiceMockServer doesn't complain about uninteresting calls.

--- a/test/dns-proto.cc
+++ b/test/dns-proto.cc
@@ -1,17 +1,25 @@
-/*
- * Copyright (C) The c-ares project
+/* MIT License
  *
- * Permission to use, copy, modify, and distribute this
- * software and its documentation for any purpose and without
- * fee is hereby granted, provided that the above copyright
- * notice appear in all copies and that both that copyright
- * notice and this permission notice appear in supporting
- * documentation, and that the name of M.I.T. not be used in
- * advertising or publicity pertaining to distribution of the
- * software without specific, written prior permission.
- * M.I.T. makes no representations about the suitability of
- * this software for any purpose.  It is provided "as is"
- * without express or implied warranty.
+ * Copyright (c) The c-ares project and its contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
  * SPDX-License-Identifier: MIT
  */


### PR DESCRIPTION
When doing ares_gethostbyname() or ares_getaddrinfo() with AF_UNSPEC, if ares_cancel() was called after one address class was returned but before the other address class, it would return ARES_SUCCESS rather than ARES_ECANCELLED.

Test case has been added for this specific condition.

Fixes Bug: #662
Fix By: Brad House (@bradh352)