### PR TITLE
ahost should use ares_getaddrinfo() these days

### DIFF
--- a/docs/ahost.1
+++ b/docs/ahost.1
@@ -39,11 +39,14 @@ Print some extra debugging output.
 Display this help and exit.
 .TP
 \fB\-t\fR type
-If type is "a", print the A record (default).
+If type is "a", print the A record.
 If type is "aaaa", print the AAAA record.
-If type is "u", look for either AAAA or A record (in that order).
+If type is "u", look for both AAAA and A records (default).
 .TP
-\fB\-s\fR \fIdomain\fP
+\fB\-s\fR server
+Set the server list to use for DNS lookups.
+.TP
+\fB\-D\fR \fIdomain\fP
 Specify the \fIdomain\fP to search instead of using the default values from
 .br
 /etc/resolv.conf. This option only has an effect on platforms that use

--- a/src/tools/ahost.c
+++ b/src/tools/ahost.c
@@ -150,6 +150,7 @@ int         main(int argc, char **argv)
 
   status = ares_init_options(&channel, &options, optmask);
   if (status != ARES_SUCCESS) {
+    free(servers);
     fprintf(stderr, "ares_init: %s\n", ares_strerror(status));
     return 1;
   }
@@ -158,6 +159,7 @@ int         main(int argc, char **argv)
     status = ares_set_servers_csv(channel, servers);
     if (status != ARES_SUCCESS) {
       fprintf(stderr, "ares_set_serveres_csv: %s\n", ares_strerror(status));
+      free(servers);
       usage();
       return 1;
     }

--- a/src/tools/ahost.c
+++ b/src/tools/ahost.c
@@ -254,6 +254,8 @@ static void ai_callback(void *arg, int status, int timeouts,
       struct sockaddr_in6 *in_addr =
         (struct sockaddr_in6 *)((void *)node->ai_addr);
       ptr = &in_addr->sin6_addr;
+    } else {
+      continue;
     }
     ares_inet_ntop(node->ai_family, ptr, addr_buf, sizeof(addr_buf));
     printf("%-32s\t%s\n", result->name, addr_buf);


### PR DESCRIPTION
ahost wasn't printing both ipv4 and ipv6 addresses.  This day and age, it really should.

This PR also adds the ability to specify the servers to use.

Fix By: Brad House (@bradh352)