### PR TITLE
optimize inet_ntop method

### DIFF
--- a/src/lib/inet_ntop.c
+++ b/src/lib/inet_ntop.c
@@ -60,9 +60,9 @@ const char        *ares_inet_ntop(int af, const void *src, char *dst,
 {
   switch (af) {
     case AF_INET:
-      return (inet_ntop4(src, dst, (size_t)size));
+      return (inet_ntop4((const unsigned char *)&((struct sockaddr_in  *)src)->sin_addr, dst, (size_t)size));
     case AF_INET6:
-      return (inet_ntop6(src, dst, (size_t)size));
+      return (inet_ntop6((const unsigned char *)&((struct sockaddr_in6 *)src)->sin6_addr, dst, (size_t)size));
     default:
       SET_ERRNO(EAFNOSUPPORT);
       return (NULL);


### PR DESCRIPTION
It can reduce the amount of external calling code.
when dealing with IPv4 and IPv6 externally, it can effectively reduce their business code volume.