### PR TITLE
Added flags to are_dns_parse to force RAW packet parsing

### DIFF
--- a/docs/ares_dns_record.3
+++ b/docs/ares_dns_record.3
@@ -255,14 +255,23 @@ zone denoted by the Zone Section.
 .B ares_dns_parse_flags_t -
 Flags for altering \fIares_dns_parse(3)\fP behaviour:
 .RS 4
-.B ARES_DNS_PARSE_ANSWER_RR_RAW
-- Parse Answer Section as RAW RR type
+.B ARES_DNS_PARSE_AN_BASE_RAW
+- Parse Answer Section from RFC 1035 that allow name compression as RAW RR type
 .br
-.B ARES_DNS_PARSE_AUTHORITY_RR_RAW
-- Parse Authority Section as RAW RR type
+.B ARES_DNS_PARSE_NS_BASE_RAW
+- Parse Authority Section from RFC 1035 that allow name compression as RAW RR type
 .br
-.B ARES_DNS_PARSE_ADDITIONAL_RR_RAW
-- Parse Additional Section as RAW RR type
+.B ARES_DNS_PARSE_AR_BASE_RAW
+- Parse Additional Section from RFC 1035 that allow name compression as RAW RR type
+.br
+.B ARES_DNS_PARSE_AN_EXT_RAW
+- Parse Answer Section from later RFCs (no name compression) as RAW RR type
+.br
+.B ARES_DNS_PARSE_NS_EXT_RAW
+- Parse Authority Section from later RFCs (no name compression) as RAW RR type
+.br
+.B ARES_DNS_PARSE_AR_EXT_RAW
+- Parse Additional Section from later RFCs (no name compression) as RAW RR type
 .br
 .RE
 

--- a/docs/ares_dns_record.3
+++ b/docs/ares_dns_record.3
@@ -252,6 +252,19 @@ zone denoted by the Zone Section.
 .br
 .RE
 
+.B ares_dns_parse_flags_t -
+Flags for altering \fIares_dns_parse(3)\fP behaviour:
+.RS 4
+.B ARES_DNS_PARSE_ANSWER_RR_RAW
+- Parse Answer Section as RAW RR type
+.br
+.B ARES_DNS_PARSE_AUTHORITY_RR_RAW
+- Parse Authority Section as RAW RR type
+.br
+.B ARES_DNS_PARSE_ADDITIONAL_RR_RAW
+- Parse Additional Section as RAW RR type
+.br
+.RE
 
 .SH DESCRIPTION
 

--- a/include/ares_dns_record.h
+++ b/include/ares_dns_record.h
@@ -386,9 +386,12 @@ typedef enum {
 
 /*! Data type for flags to ares_dns_parse() */
 typedef enum {
-  ARES_DNS_PARSE_ANSWER_RR_RAW = 1 << 0,  /*!< Parse RR(s) as RAW */
-  ARES_DNS_PARSE_AUTHORITY_RR_RAW = 1 << 1,  /*!< Parse RR(s) as RAW */
-  ARES_DNS_PARSE_ADDITIONAL_RR_RAW = 1 << 2,  /*!< Parse RR(s) as RAW */
+  ARES_DNS_PARSE_AN_BASE_RAW = 1 << 0,  /*!< Parse Answers from RFC 1035 that allow name compression as RAW */
+  ARES_DNS_PARSE_NS_BASE_RAW = 1 << 1,  /*!< Parse Authority from RFC 1035 that allow name compression as RAW */
+  ARES_DNS_PARSE_AR_BASE_RAW = 1 << 2,  /*!< Parse Additional from RFC 1035 that allow name compression as RAW */
+  ARES_DNS_PARSE_AN_EXT_RAW = 1 << 3,  /*!< Parse Answers from later RFCs (no name compression) RAW */
+  ARES_DNS_PARSE_NS_EXT_RAW = 1 << 4,  /*!< Parse Authority from later RFCs (no name compression) as RAW */
+  ARES_DNS_PARSE_AR_EXT_RAW = 1 << 5,  /*!< Parse Additional from later RFCs (no name compression) as RAW */
 } ares_dns_parse_flags_t;
 
 /*! String representation of DNS Record Type

--- a/include/ares_dns_record.h
+++ b/include/ares_dns_record.h
@@ -384,6 +384,13 @@ typedef enum {
   ARES_OPT_DATATYPE_NAME = 11
 } ares_dns_opt_datatype_t;
 
+/*! Data type for flags to ares_dns_parse() */
+typedef enum {
+  ARES_DNS_PARSE_ANSWER_RR_RAW = 1 << 0,  /*!< Parse RR(s) as RAW */
+  ARES_DNS_PARSE_AUTHORITY_RR_RAW = 1 << 1,  /*!< Parse RR(s) as RAW */
+  ARES_DNS_PARSE_ADDITIONAL_RR_RAW = 1 << 2,  /*!< Parse RR(s) as RAW */
+} ares_dns_parse_flags_t;
+
 /*! String representation of DNS Record Type
  *
  *  \param[in] type  DNS Record Type
@@ -926,7 +933,7 @@ CARES_EXTERN ares_bool_t   ares_dns_rr_get_opt_byid(const ares_dns_rr_t  *dns_rr
  *
  *  \param[in]  buf      pointer to bytes to be parsed
  *  \param[in]  buf_len  Length of buf provided
- *  \param[in]  flags    Flags dictating how the message should be parsed. TBD.
+ *  \param[in]  flags    Flags dictating how the message should be parsed.
  *  \param[out] dnsrec   Pointer passed by reference for a new DNS record object
  *                       that must be ares_dns_record_destroy()'d by caller.
  *  \return ARES_SUCCESS on success

--- a/src/lib/ares_dns_parse.c
+++ b/src/lib/ares_dns_parse.c
@@ -1004,8 +1004,6 @@ static ares_status_t ares_dns_parse_rr(ares__buf_t *buf, unsigned int flags,
   size_t              remaining_len = 0;
   size_t              processed_len = 0;
 
-  (void)flags; /* currently unused */
-
   /* All RRs have the same top level format shown below:
    *                                 1  1  1  1  1  1
    *   0  1  2  3  4  5  6  7  8  9  0  1  2  3  4  5
@@ -1064,6 +1062,16 @@ static ares_status_t ares_dns_parse_rr(ares__buf_t *buf, unsigned int flags,
   rdlength = u16;
 
   if (!ares_dns_rec_type_isvalid(type, ARES_FALSE)) {
+    type = ARES_REC_TYPE_RAW_RR;
+  }
+
+  if (sect == ARES_SECTION_ANSWER && (flags & ARES_DNS_PARSE_ANSWER_RR_RAW)) {
+    type = ARES_REC_TYPE_RAW_RR;
+  }
+  if (sect == ARES_SECTION_AUTHORITY && (flags & ARES_DNS_PARSE_AUTHORITY_RR_RAW)) {
+    type = ARES_REC_TYPE_RAW_RR;
+  }
+  if (sect == ARES_SECTION_ADDITIONAL && (flags & ARES_DNS_PARSE_ADDITIONAL_RR_RAW)) {
     type = ARES_REC_TYPE_RAW_RR;
   }
 

--- a/src/lib/ares_dns_parse.c
+++ b/src/lib/ares_dns_parse.c
@@ -1003,6 +1003,7 @@ static ares_status_t ares_dns_parse_rr(ares__buf_t *buf, unsigned int flags,
   ares_dns_rr_t      *rr            = NULL;
   size_t              remaining_len = 0;
   size_t              processed_len = 0;
+  ares_bool_t         namecomp;
 
   /* All RRs have the same top level format shown below:
    *                                 1  1  1  1  1  1
@@ -1065,7 +1066,7 @@ static ares_status_t ares_dns_parse_rr(ares__buf_t *buf, unsigned int flags,
     type = ARES_REC_TYPE_RAW_RR;
   }
 
-  ares_bool_t namecomp = ares_dns_rec_type_allow_name_compression(type);
+  namecomp = ares_dns_rec_type_allow_name_compression(type);
   if (sect == ARES_SECTION_ANSWER && (flags & (namecomp ? ARES_DNS_PARSE_AN_BASE_RAW : ARES_DNS_PARSE_AN_EXT_RAW))) {
     type = ARES_REC_TYPE_RAW_RR;
   }

--- a/src/lib/ares_dns_parse.c
+++ b/src/lib/ares_dns_parse.c
@@ -1065,13 +1065,14 @@ static ares_status_t ares_dns_parse_rr(ares__buf_t *buf, unsigned int flags,
     type = ARES_REC_TYPE_RAW_RR;
   }
 
-  if (sect == ARES_SECTION_ANSWER && (flags & ARES_DNS_PARSE_ANSWER_RR_RAW)) {
+  ares_bool_t namecomp = ares_dns_rec_type_allow_name_compression(type);
+  if (sect == ARES_SECTION_ANSWER && (flags & (namecomp ? ARES_DNS_PARSE_AN_BASE_RAW : ARES_DNS_PARSE_AN_EXT_RAW))) {
     type = ARES_REC_TYPE_RAW_RR;
   }
-  if (sect == ARES_SECTION_AUTHORITY && (flags & ARES_DNS_PARSE_AUTHORITY_RR_RAW)) {
+  if (sect == ARES_SECTION_AUTHORITY && (flags & (namecomp ? ARES_DNS_PARSE_NS_BASE_RAW : ARES_DNS_PARSE_NS_EXT_RAW))) {
     type = ARES_REC_TYPE_RAW_RR;
   }
-  if (sect == ARES_SECTION_ADDITIONAL && (flags & ARES_DNS_PARSE_ADDITIONAL_RR_RAW)) {
+  if (sect == ARES_SECTION_ADDITIONAL && (flags & (namecomp ? ARES_DNS_PARSE_AR_BASE_RAW : ARES_DNS_PARSE_AR_EXT_RAW))) {
     type = ARES_REC_TYPE_RAW_RR;
   }
 

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -871,6 +871,9 @@ TEST_F(LibraryTest, DNSParseFlags) {
   /* Write */
   EXPECT_EQ(ARES_SUCCESS, ares_dns_write(dnsrec, &msg, &msglen));
 
+  /* Cleanup - before reuse */
+  ares_dns_record_destroy(dnsrec);
+
   /* Parse */
   EXPECT_EQ(ARES_SUCCESS, ares_dns_parse(msg, msglen, ARES_DNS_PARSE_ANSWER_RR_RAW |
     ARES_DNS_PARSE_AUTHORITY_RR_RAW | ARES_DNS_PARSE_ADDITIONAL_RR_RAW, &dnsrec));


### PR DESCRIPTION
This pull request adds three flags to control parsing behaviour of RR types in various sections. This addresses the feature request in https://github.com/c-ares/c-ares/issues/686.