### PR TITLE
Autotools allow make to override CFLAGS/CPPFLAGS/CXXFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,8 +76,6 @@ dnl Disable static builds by default on Windows unless overwritten since Windows
 dnl can't simultaneously build shared and static with autotools.
 AS_IF([test "x$ac_cv_windows" = "xyes"], [AC_DISABLE_STATIC], [AC_ENABLE_STATIC])
 
-
-
 AC_ARG_ENABLE(warnings,
   AS_HELP_STRING([--disable-warnings],[Disable strict compiler warnings]),
   [ enable_warnings=${enableval} ],
@@ -193,8 +191,8 @@ if test "$ac_cv_native_windows" = "yes" ; then
 fi
 
 dnl Windows can only build shared or static, not both at the same time
-if test "x$enable_shared" = "xno" -a "x$enable_static" = "xyes" ; then
-  AC_MSG_ERROR([Windows cannot build both static and shared simultaneously])
+if test "x$enable_shared" = "xyes" -a "x$enable_static" = "xyes" ; then
+  AC_MSG_ERROR([Windows cannot build both static and shared simultaneously, specify --disable-shared or --disable-static])
 fi
 
 dnl Only windows requires CARES_STATICLIB definition

--- a/configure.ac
+++ b/configure.ac
@@ -42,8 +42,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_USE_SYSTEM_EXTENSIONS
 AX_CXX_COMPILE_STDCXX_14([noext],[optional])
 AM_INIT_AUTOMAKE([foreign subdir-objects 1.9.6])
-AC_ENABLE_SHARED
-LT_INIT([win32-dll,shared,pic,disable-fast-install,aix-soname=svr4])
+LT_INIT([win32-dll,pic,disable-fast-install,aix-soname=svr4])
 AC_LANG([C])
 AC_PROG_CC
 AM_PROG_CC_C_O
@@ -51,6 +50,33 @@ AC_PROG_EGREP
 AC_PROG_INSTALL
 AC_CANONICAL_HOST
 AX_COMPILER_VENDOR
+
+AC_MSG_CHECKING([whether this is native windows])
+ac_cv_native_windows=no
+ac_cv_windows=no
+case $host_os in
+  mingw*)
+    ac_cv_native_windows=yes
+    ac_cv_windows=yes
+    ;;
+  cygwin*)
+    ac_cv_windows=yes
+    ;;
+esac
+if test "$ax_cv_c_compiler_vendor" = "microsoft" ; then
+  ac_cv_native_windows=yes
+  ac_cv_windows=yes
+fi
+AC_MSG_RESULT($ac_cv_native_windows)
+
+
+AC_ENABLE_SHARED
+
+dnl Disable static builds by default on Windows unless overwritten since Windows
+dnl can't simultaneously build shared and static with autotools.
+AS_IF([test "x$ac_cv_windows" = "xyes"], [AC_DISABLE_STATIC], [AC_ENABLE_STATIC])
+
+
 
 AC_ARG_ENABLE(warnings,
   AS_HELP_STRING([--disable-warnings],[Disable strict compiler warnings]),
@@ -162,31 +188,8 @@ esac
 AM_CONDITIONAL([CARES_USE_NO_UNDEFINED], [test "$cares_use_no_undefined" = 'yes'])
 
 
-AC_MSG_CHECKING([whether this is native windows])
-ac_cv_native_windows=no
-ac_cv_windows=no
-case $host_os in
-  mingw*)
-    ac_cv_native_windows=yes
-    ac_cv_windows=yes
-    ;;
-  cygwin*)
-    ac_cv_windows=yes
-    ;;
-esac
-if test "$ax_cv_c_compiler_vendor" = "microsoft" ; then
-  ac_cv_native_windows=yes
-  ac_cv_windows=yes
-fi
 if test "$ac_cv_native_windows" = "yes" ; then
   AM_CPPFLAGS="$AM_CPPFLAGS -D_WIN32_WINNT=0x0602 -DWIN32_LEAN_AND_MEAN"
-fi
-AC_MSG_RESULT($ac_cv_native_windows)
-
-dnl Disable static builds by default on Windows unless overwritten since Windows
-dnl can't simultaneously build shared and static with autotools.
-if test "x$ac_cv_windows" = "xyes" ; then
-  AC_DISABLE_STATIC
 fi
 
 dnl Windows can only build shared or static, not both at the same time

--- a/configure.ac
+++ b/configure.ac
@@ -191,7 +191,7 @@ if test "$ac_cv_native_windows" = "yes" ; then
 fi
 
 dnl Windows can only build shared or static, not both at the same time
-if test "x$enable_shared" = "xyes" -a "x$enable_static" = "xyes" ; then
+if test "$ac_cv_native_windows" = "yes" -a "x$enable_shared" = "xyes" -a "x$enable_static" = "xyes" ; then
   AC_MSG_ERROR([Windows cannot build both static and shared simultaneously, specify --disable-shared or --disable-static])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -215,13 +215,13 @@ if test "$symbol_hiding" != "no" ; then
   else
     case "$ax_cv_c_compiler_vendor" in
       clang|gnu|intel)
-        AX_APPEND_COMPILE_FLAGS([-fvisibility=hidden], [CARES_SYMBOL_HIDING_CFLAG], [AM_CFLAGS])
+        AX_APPEND_COMPILE_FLAGS([-fvisibility=hidden], [CARES_SYMBOL_HIDING_CFLAG])
         if test "x$CARES_SYMBOL_HIDING_CFLAG" != "x" ; then
           compiler_supports_symbol_hiding="yes"
         fi
         ;;
       sun)
-        AX_APPEND_COMPILE_FLAGS([-xldscope=hidden], [CARES_SYMBOL_HIDING_CFLAG], [AM_CFLAGS])
+        AX_APPEND_COMPILE_FLAGS([-xldscope=hidden], [CARES_SYMBOL_HIDING_CFLAG])
         if test "x$CARES_SYMBOL_HIDING_CFLAG" != "x" ; then
           compiler_supports_symbol_hiding="yes"
         fi

--- a/configure.ac
+++ b/configure.ac
@@ -179,7 +179,7 @@ if test "$ax_cv_c_compiler_vendor" = "microsoft" ; then
   ac_cv_windows=yes
 fi
 if test "$ac_cv_native_windows" = "yes" ; then
-  CPPFLAGS="$CPPFLAGS -D_WIN32_WINNT=0x0602 -DWIN32_LEAN_AND_MEAN"
+  AM_CPPFLAGS="$AM_CPPFLAGS -D_WIN32_WINNT=0x0602 -DWIN32_LEAN_AND_MEAN"
 fi
 AC_MSG_RESULT($ac_cv_native_windows)
 
@@ -189,12 +189,16 @@ if test "x$ac_cv_windows" = "xyes" ; then
   AC_DISABLE_STATIC
 fi
 
+dnl Windows can only build shared or static, not both at the same time
+if test "x$enable_shared" = "xno" -a "x$enable_static" = "xyes" ; then
+  AC_MSG_ERROR([Windows cannot build both static and shared simultaneously])
+fi
 
 dnl Only windows requires CARES_STATICLIB definition
 if test "x$enable_shared" = "xno" -a "x$enable_static" = "xyes" ; then
   AC_MSG_CHECKING([whether we need CARES_STATICLIB definition])
   if test "$ac_cv_native_windows" = "yes" ; then
-    AX_APPEND_FLAG([-DCARES_STATICLIB], [CPPFLAGS])
+    AX_APPEND_FLAG([-DCARES_STATICLIB], [AM_CPPFLAGS])
     AC_MSG_RESULT([yes])
   else
     AC_MSG_RESULT([no])
@@ -210,13 +214,13 @@ if test "$symbol_hiding" != "no" ; then
   else
     case "$ax_cv_c_compiler_vendor" in
       clang|gnu|intel)
-        AX_APPEND_COMPILE_FLAGS([-fvisibility=hidden], [CARES_SYMBOL_HIDING_CFLAG])
+        AX_APPEND_COMPILE_FLAGS([-fvisibility=hidden], [CARES_SYMBOL_HIDING_CFLAG], [AM_CFLAGS])
         if test "x$CARES_SYMBOL_HIDING_CFLAG" != "x" ; then
           compiler_supports_symbol_hiding="yes"
         fi
         ;;
       sun)
-        AX_APPEND_COMPILE_FLAGS([-xldscope=hidden], [CARES_SYMBOL_HIDING_CFLAG])
+        AX_APPEND_COMPILE_FLAGS([-xldscope=hidden], [CARES_SYMBOL_HIDING_CFLAG], [AM_CFLAGS])
         if test "x$CARES_SYMBOL_HIDING_CFLAG" != "x" ; then
           compiler_supports_symbol_hiding="yes"
         fi
@@ -274,11 +278,11 @@ if test "$enable_warnings" = "yes"; then
     -Werror=implicit-int \
     -Werror=implicit-function-declaration \
     -Werror=partial-availability \
-  ], [CFLAGS], [-Werror])
+  ], [AM_CFLAGS], [-Werror])
 fi
 
 if test "$ax_cv_c_compiler_vendor" = "intel"; then
-  CFLAGS="$CFLAGS -shared-intel"
+  AX_APPEND_COMPILE_FLAGS([-shared-intel], [AM_CFLAGS])
 fi
 
 if test "$ac_cv_native_windows" = "yes" ; then
@@ -818,7 +822,7 @@ if test "${CARES_THREADS}" = "yes" -a "x${ac_cv_native_windows}" != "xyes" ; the
   if test "${CARES_THREADS}" = "yes" ; then
     AC_CHECK_HEADERS([pthread.h pthread_np.h])
     LIBS="$PTHREAD_LIBS $LIBS"
-    CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+    AM_CFLAGS="$AM_CFLAGS $PTHREAD_CFLAGS"
     CC="$PTHREAD_CC"
     CXX="$PTHREAD_CXX"
   fi
@@ -876,9 +880,10 @@ fi
 AC_MSG_CHECKING([whether to build tests])
 AC_MSG_RESULT([$build_tests])
 
-
 AM_CONDITIONAL(BUILD_TESTS, test "x$build_tests" = "xyes")
 
+AC_SUBST(AM_CFLAGS)
+AC_SUBST(AM_CPPFLAGS)
 AC_SUBST(BUILD_SUBDIRS)
 
 AC_CONFIG_FILES([Makefile           \

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -8,10 +8,10 @@ ACLOCAL_AMFLAGS = -I m4 --install
 # being currently built and tested are searched before the library which
 # might possibly already be installed in the system.
 
-AM_CPPFLAGS = -I$(top_builddir)/include \
-              -I$(top_builddir)/src/lib \
-              -I$(top_srcdir)/include \
-              -I$(top_srcdir)/src/lib
+AM_CPPFLAGS += -I$(top_builddir)/include \
+               -I$(top_builddir)/src/lib \
+               -I$(top_srcdir)/include \
+               -I$(top_srcdir)/src/lib
 
 lib_LTLIBRARIES = libcares.la
 

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -12,10 +12,10 @@ noinst_PROGRAMS =$(PROGS)
 # being currently built and tested are searched before the library which
 # might possibly already be installed in the system.
 
-AM_CPPFLAGS = -I$(top_builddir)/include \
-              -I$(top_builddir)/src/lib \
-              -I$(top_srcdir)/include \
-              -I$(top_srcdir)/src/lib
+AM_CPPFLAGS += -I$(top_builddir)/include \
+               -I$(top_builddir)/src/lib \
+               -I$(top_srcdir)/include \
+               -I$(top_srcdir)/src/lib
 
 include Makefile.inc
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -2,15 +2,17 @@
 # SPDX-License-Identifier: MIT
 AUTOMAKE_OPTIONS = foreign subdir-objects nostdinc 1.9.6
 
-AM_CPPFLAGS = -I$(top_builddir)/include \
-              -I$(top_builddir)/src/lib \
-              -I$(top_srcdir)/include   \
-              -I$(top_srcdir)/src/lib   \
-              -I$(top_srcdir)/test      \
-              -I$(top_builddir)/test    \
-              -I$(top_builddir)
-AM_CXXFLAGS = $(PTHREAD_CFLAGS)
-AM_CFLAGS   = $(PTHREAD_CFLAGS)
+AM_CPPFLAGS += -I$(top_builddir)/include \
+               -I$(top_builddir)/src/lib \
+               -I$(top_srcdir)/include   \
+               -I$(top_srcdir)/src/lib   \
+               -I$(top_srcdir)/test      \
+               -I$(top_builddir)/test    \
+               -I$(top_builddir)
+
+AM_CXXFLAGS :=
+AM_CXXFLAGS += $(PTHREAD_CFLAGS)
+AM_CFLAGS   += $(PTHREAD_CFLAGS)
 
 # Makefile.inc provides the various *SOURCES and *HEADERS defines
 include Makefile.inc
@@ -22,7 +24,7 @@ EXTRA_DIST = fuzzcheck.sh CMakeLists.txt Makefile.m32 Makefile.msvc README.md $(
 arestest_SOURCES = $(TESTSOURCES) $(TESTHEADERS)
 
 # Not interested in coverage of test code, but linking the test binary needs the coverage option
-arestest_CXXFLAGS = $(GMOCK_CFLAGS)
+arestest_CXXFLAGS = $(AM_CXXFLAGS) $(GMOCK_CFLAGS)
 arestest_LDADD = $(GMOCK_LIBS) $(top_builddir)/src/lib/libcares.la $(PTHREAD_LIBS) $(CODE_COVERAGE_LIBS)
 
 aresfuzz_SOURCES = $(FUZZSOURCES)


### PR DESCRIPTION
The previous build system allowed overwriting of CFLAGS/CPPFLAGS/CXXFLAGS on the make command line.  Switch to using AM_CFLAGS/AM_CPPFLAGS/AM_CXXFLAGS when we set our own flags for building which ensures they are kept even when a user tries to override.

Fixes Bug: #694
Fix By: Brad House (@bradh352)