### PR TITLE
build-time disabled threads breaks c-ares

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -86,6 +86,11 @@ task:
     - name: "CMAKE"
       env:
         BUILD_TYPE: "cmake"
+    - name: "CMAKE no threads"
+      only_if: $DIST == 'DEBIAN'
+      env:
+        BUILD_TYPE: "cmake"
+        CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_THREADS=OFF -G Ninja"
     - name: "CMAKE HIDE SYMBOLS"
       only_if: $TEST_SYMBOL_VISIBILITY == 'yes'
       env:

--- a/src/lib/ares__threads.c
+++ b/src/lib/ares__threads.c
@@ -299,8 +299,9 @@ ares_bool_t ares_threadsafety(void)
 
 ares_status_t ares__channel_threading_init(ares_channel_t *channel)
 {
+  /* Threading is optional! */
   if (!ares_threadsafety()) {
-    return ARES_ENOTIMP;
+    return ARES_SUCCESS;
   }
 
   channel->lock = ares__thread_mutex_create();

--- a/test/ares-test-mock-et.cc
+++ b/test/ares-test-mock-et.cc
@@ -1334,21 +1334,6 @@ static const char *evsys_tostr(ares_evsys_t evsys)
   return "UNKNOWN";
 }
 
-const char *af_tostr(int af)
-{
-  switch (af) {
-    case AF_INET:
-      return "ipv4";
-    case AF_INET6:
-      return "ipv6";
-  }
-  return "ipunknown";
-}
-
-const char *mode_tostr(bool mode)
-{
-  return mode?"ForceTCP":"DefaultUDP";
-}
 
 static std::string PrintEvsysFamilyMode(const testing::TestParamInfo<std::tuple<ares_evsys_t, int, bool>> &info)
 {

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -1442,6 +1442,22 @@ TEST_P(NoRotateMultiMockTest, ServerNoResponseFailover) {
   EXPECT_EQ("{'www.example.com' aliases=[] addrs=[2.3.4.5]}", ss4.str());
 }
 
+const char *af_tostr(int af)
+{
+  switch (af) {
+    case AF_INET:
+      return "ipv4";
+    case AF_INET6:
+      return "ipv6";
+  }
+  return "ipunknown";
+}
+
+const char *mode_tostr(bool mode)
+{
+  return mode?"ForceTCP":"DefaultUDP";
+}
+
 std::string PrintFamilyMode(const testing::TestParamInfo<std::pair<int, bool>> &info)
 {
   std::string name;


### PR DESCRIPTION
Regression introduced in 1.26.0, building c-ares with threading disabled results in ares_init{_options}() failing.

Also adds a new CI test case to prevent this regression in the future.

Fixes Bug: #699
Fix By: Brad House (@bradh352)