### PR TITLE
sonarcloud: fix minor codesmells

### DIFF
--- a/src/lib/ares__buf.c
+++ b/src/lib/ares__buf.c
@@ -802,7 +802,7 @@ static ares_bool_t ares__buf_split_isduplicate(ares__llist_t       *list,
 
   for (node = ares__llist_node_first(list); node != NULL;
        node = ares__llist_node_next(node)) {
-    ares__buf_t         *buf  = ares__llist_node_val(node);
+    const ares__buf_t   *buf  = ares__llist_node_val(node);
     size_t               plen = 0;
     const unsigned char *ptr  = ares__buf_peek(buf, &plen);
 

--- a/src/lib/ares_event_epoll.c
+++ b/src/lib/ares_event_epoll.c
@@ -94,9 +94,9 @@ static ares_bool_t ares_evsys_epoll_init(ares_event_thread_t *e)
 
 static ares_bool_t ares_evsys_epoll_event_add(ares_event_t *event)
 {
-  ares_event_thread_t *e  = event->e;
-  ares_evsys_epoll_t  *ep = e->ev_sys_data;
-  struct epoll_event   epev;
+  const ares_event_thread_t *e  = event->e;
+  const ares_evsys_epoll_t  *ep = e->ev_sys_data;
+  struct epoll_event         epev;
 
   memset(&epev, 0, sizeof(epev));
   epev.data.fd = event->fd;
@@ -115,9 +115,9 @@ static ares_bool_t ares_evsys_epoll_event_add(ares_event_t *event)
 
 static void ares_evsys_epoll_event_del(ares_event_t *event)
 {
-  ares_event_thread_t *e  = event->e;
-  ares_evsys_epoll_t  *ep = e->ev_sys_data;
-  struct epoll_event   epev;
+  const ares_event_thread_t *e  = event->e;
+  const ares_evsys_epoll_t  *ep = e->ev_sys_data;
+  struct epoll_event         epev;
 
   memset(&epev, 0, sizeof(epev));
   epev.data.fd = event->fd;
@@ -127,9 +127,9 @@ static void ares_evsys_epoll_event_del(ares_event_t *event)
 static void ares_evsys_epoll_event_mod(ares_event_t      *event,
                                        ares_event_flags_t new_flags)
 {
-  ares_event_thread_t *e  = event->e;
-  ares_evsys_epoll_t  *ep = e->ev_sys_data;
-  struct epoll_event   epev;
+  const ares_event_thread_t *e  = event->e;
+  const ares_evsys_epoll_t  *ep = e->ev_sys_data;
+  struct epoll_event         epev;
 
   memset(&epev, 0, sizeof(epev));
   epev.data.fd = event->fd;
@@ -146,12 +146,12 @@ static void ares_evsys_epoll_event_mod(ares_event_t      *event,
 static size_t ares_evsys_epoll_wait(ares_event_thread_t *e,
                                     unsigned long        timeout_ms)
 {
-  struct epoll_event  events[8];
-  size_t              nevents = sizeof(events) / sizeof(*events);
-  ares_evsys_epoll_t *ep      = e->ev_sys_data;
-  int                 rv;
-  size_t              i;
-  size_t              cnt = 0;
+  struct epoll_event        events[8];
+  size_t                    nevents = sizeof(events) / sizeof(*events);
+  const ares_evsys_epoll_t *ep      = e->ev_sys_data;
+  int                       rv;
+  size_t                    i;
+  size_t                    cnt = 0;
 
   memset(events, 0, sizeof(events));
 

--- a/src/lib/ares_event_poll.c
+++ b/src/lib/ares_event_poll.c
@@ -78,8 +78,9 @@ static size_t ares_evsys_poll_wait(ares_event_thread_t *e,
   if (num_fds) {
     pollfd = ares_malloc_zero(sizeof(*pollfd) * num_fds);
     for (i = 0; i < num_fds; i++) {
-      ares_event_t *ev = ares__htable_asvp_get_direct(e->ev_handles, fdlist[i]);
-      pollfd[i].fd     = ev->fd;
+      const ares_event_t *ev =
+        ares__htable_asvp_get_direct(e->ev_handles, fdlist[i]);
+      pollfd[i].fd = ev->fd;
       if (ev->flags & ARES_EVENT_FLAG_READ) {
         pollfd[i].events |= POLLIN;
       }

--- a/src/lib/ares_event_select.c
+++ b/src/lib/ares_event_select.c
@@ -85,7 +85,8 @@ static size_t ares_evsys_select_wait(ares_event_thread_t *e,
   FD_ZERO(&write_fds);
 
   for (i = 0; i < num_fds; i++) {
-    ares_event_t *ev = ares__htable_asvp_get_direct(e->ev_handles, fdlist[i]);
+    const ares_event_t *ev =
+      ares__htable_asvp_get_direct(e->ev_handles, fdlist[i]);
     if (ev->flags & ARES_EVENT_FLAG_READ) {
       FD_SET(ev->fd, &read_fds);
     }

--- a/src/lib/ares_event_thread.c
+++ b/src/lib/ares_event_thread.c
@@ -37,7 +37,7 @@ static void ares_event_destroy_cb(void *arg)
 
   /* Unregister from the event thread if it was registered with one */
   if (event->e) {
-    ares_event_thread_t *e = event->e;
+    const ares_event_thread_t *e = event->e;
     e->ev_sys->event_del(event);
     event->e = NULL;
   }
@@ -54,7 +54,7 @@ static void ares_event_destroy_cb(void *arg)
  * of updates already enqueued.  In the future, it might make sense to make
  * this O(1) with a hashtable. */
 static ares_event_t *ares_event_update_find(ares_event_thread_t *e,
-                                            ares_socket_t fd, void *data)
+                                            ares_socket_t fd, const void *data)
 {
   ares__llist_node_t *node;
 
@@ -152,7 +152,7 @@ static void ares_event_signal(const ares_event_t *event)
   event->signal_cb(event);
 }
 
-static void ares_event_thread_wake(ares_event_thread_t *e)
+static void ares_event_thread_wake(const ares_event_thread_t *e)
 {
   if (e == NULL) {
     return;
@@ -247,9 +247,9 @@ static void *ares_event_thread(void *arg)
   ares__thread_mutex_lock(e->mutex);
 
   while (e->isup) {
-    struct timeval  tv;
-    struct timeval *tvout;
-    unsigned long   timeout_ms = 0; /* 0 = unlimited */
+    struct timeval        tv;
+    const struct timeval *tvout;
+    unsigned long         timeout_ms = 0; /* 0 = unlimited */
 
     tvout = ares_timeout(e->channel, NULL, &tv);
     if (tvout != NULL) {
@@ -363,7 +363,7 @@ static const ares_event_sys_t *ares_event_fetch_sys(ares_evsys_t evsys)
       return NULL;
 #endif
 
-    case ARES_EVSYS_DEFAULT:
+    /* case ARES_EVSYS_DEFAULT: */
     default:
 #if defined(_WIN32)
       return &ares_evsys_win32;

--- a/src/lib/ares_event_wake_pipe.c
+++ b/src/lib/ares_event_wake_pipe.c
@@ -110,7 +110,7 @@ static ares_pipeevent_t *ares_pipeevent_init(void)
 
 static void ares_pipeevent_signal(const ares_event_t *e)
 {
-  ares_pipeevent_t *p;
+  const ares_pipeevent_t *p;
 
   if (e == NULL || e->data == NULL) {
     return;
@@ -123,8 +123,8 @@ static void ares_pipeevent_signal(const ares_event_t *e)
 static void ares_pipeevent_cb(ares_event_thread_t *e, ares_socket_t fd,
                               void *data, ares_event_flags_t flags)
 {
-  unsigned char     buf[32];
-  ares_pipeevent_t *p = NULL;
+  unsigned char           buf[32];
+  const ares_pipeevent_t *p = NULL;
 
   (void)e;
   (void)fd;


### PR DESCRIPTION
Fix minor codesmells, mostly related to missing 'const' in the new event system.

Fix By: Brad House (@bradh352)