### PR TITLE
Fix warning about ignoring result of write

### DIFF
--- a/src/lib/ares_event_wake_pipe.c
+++ b/src/lib/ares_event_wake_pipe.c
@@ -117,7 +117,7 @@ static void ares_pipeevent_signal(const ares_event_t *e)
   }
 
   p = e->data;
-  write(p->filedes[1], "1", 1);
+  (void)write(p->filedes[1], "1", 1);
 }
 
 static void ares_pipeevent_cb(ares_event_thread_t *e, ares_socket_t fd,


### PR DESCRIPTION
Fix the compiler warning from clang:

```
ares_event_wake_pipe.c:120:3: error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]
  120 |   write(p->filedes[1], "1", 1);
      |   ^~~~~ ~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```