### PR TITLE
Add ares_queue_wait_empty() for use with EventThreads

### DIFF
--- a/docs/Makefile.inc
+++ b/docs/Makefile.inc
@@ -105,6 +105,7 @@ MANPAGES = ares_cancel.3		\
   ares_parse_uri_reply.3		\
   ares_process.3			\
   ares_query.3				\
+  ares_queue_wait_empty.3		\
   ares_reinit.3				\
   ares_save_options.3			\
   ares_search.3				\

--- a/docs/ares_queue_wait_empty.3
+++ b/docs/ares_queue_wait_empty.3
@@ -1,0 +1,44 @@
+.\"
+.\" SPDX-License-Identifier: MIT
+.\"
+.TH ARES_QUEUE_WAIT_EMPTY 3 "12 February 2024"
+.SH NAME
+ares_queue_wait_empty \- Wait until all queries are complete for channel
+.SH SYNOPSIS
+.nf
+#include <ares.h>
+
+ares_status_t ares_queue_wait_empty(ares_channel_t *channel,
+                                    int timeout_ms);
+.fi
+.SH DESCRIPTION
+The \fBares_queue_wait_empty(3)\fP function blocks until notified that there are
+no longer any queries in queue, or the specified timeout has expired.
+
+The \fBchannel\fP parameter must be set to an initialized channel.
+
+The \fBtimeout_ms\fP parameter is the number of milliseconds to wait for the
+queue to be empty or -1 for Infinite.
+
+.SH RETURN VALUES
+\fIares_queue_wait_empty(3)\fP can return any of the following values:
+.TP 14
+.B ARES_ENOTIMP
+if not built with threading support
+.TP 14
+.B ARES_ETIMEOUT
+if requested timeout expired
+.TP 14
+.B ARES_SUCCESS
+when queue is empty.
+.TP 14
+
+.SH AVAILABILITY
+This function was first introduced in c-ares version 1.27.0, and requires the
+c-ares library to be built with threading support.
+
+.SH SEE ALSO
+.BR ares_init_options (3),
+.BR ares_threadsafety (3)
+.SH AUTHOR
+Copyright (C) 2024 The c-ares project and its members.

--- a/docs/ares_threadsafety.3
+++ b/docs/ares_threadsafety.3
@@ -1,7 +1,7 @@
 .\"
 .\" SPDX-License-Identifier: MIT
 .\"
-.TH ARES_REINIT 3 "26 November 2023"
+.TH ARES_THREADSAFETY 3 "26 November 2023"
 .SH NAME
 ares_threadsafety \- Query if c-ares was built with thread-safety
 .SH SYNOPSIS

--- a/include/ares.h
+++ b/include/ares.h
@@ -773,6 +773,20 @@ CARES_EXTERN int         ares_inet_pton(int af, const char *src, void *dst);
  */
 CARES_EXTERN ares_bool_t ares_threadsafety(void);
 
+
+/*! Block until notified that there are no longer any queries in queue, or
+ *  the specified timeout has expired.
+ *
+ *  \param[in] channel    Initialized ares channel
+ *  \param[in] timeout_ms Number of milliseconds to wait for the queue to be
+ *                        empty. -1 for Infinite.
+ *  \return ARES_ENOTIMP if not built with threading support, ARES_ETIMEOUT
+ *          if requested timeout expires, ARES_SUCCESS when queue is empty.
+ */
+CARES_EXTERN ares_status_t ares_queue_wait_empty(ares_channel_t *channel,
+                                                 int timeout_ms);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/ares__threads.c
+++ b/src/lib/ares__threads.c
@@ -533,6 +533,8 @@ void ares__channel_threading_destroy(ares_channel_t *channel)
 {
   ares__thread_mutex_destroy(channel->lock);
   channel->lock = NULL;
+  ares__thread_cond_destroy(channel->cond_empty);
+  channel->cond_empty = NULL;
 }
 
 void ares__channel_lock(ares_channel_t *channel)

--- a/src/lib/ares__threads.c
+++ b/src/lib/ares__threads.c
@@ -86,55 +86,63 @@ ares__thread_cond_t *ares__thread_cond_create(void)
 
 void ares__thread_cond_destroy(ares__thread_cond_t *cond)
 {
-  if (cond == NULL)
+  if (cond == NULL) {
     return;
+  }
   ares_free(cond);
 }
 
 void ares__thread_cond_signal(ares__thread_cond_t *cond)
 {
-  if (cond == NULL)
+  if (cond == NULL) {
     return;
+  }
   WakeConditionVariable(&cond->cond);
 }
 
 void ares__thread_cond_broadcast(ares__thread_cond_t *cond)
 {
-  if (cond == NULL)
+  if (cond == NULL) {
     return;
+  }
   WakeAllConditionVariable(&cond->cond);
 }
 
-ares_status_t ares__thread_cond_wait(ares__thread_cond_t *cond, ares__thread_mutex_t *mut)
+ares_status_t ares__thread_cond_wait(ares__thread_cond_t  *cond,
+                                     ares__thread_mutex_t *mut)
 {
-  if (cond == NULL || mut == NULL)
+  if (cond == NULL || mut == NULL) {
     return ARES_EFORMERR;
+  }
 
   SleepConditionVariableCS(&cond->cond, &mut->mutex, INFINITE);
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t *cond, ares__thread_mutex_t *mut, unsigned long timeout_ms)
+ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t  *cond,
+                                          ares__thread_mutex_t *mut,
+                                          unsigned long         timeout_ms)
 {
   struct timespec ts;
 
-  if (cond == NULL || mut == NULL)
+  if (cond == NULL || mut == NULL) {
     return ARES_EFORMERR;
+  }
 
-  if (!SleepConditionVariableCS(&cond->cond, &mut->mutex, timeout_ms))
+  if (!SleepConditionVariableCS(&cond->cond, &mut->mutex, timeout_ms)) {
     return ARES_ETIMEOUT;
+  }
 
   return ARES_SUCCESS;
 }
-
 
 struct ares__thread {
   HANDLE thread;
   DWORD  id;
 
-  void *(*func)(void *arg);
-  void   *arg;
-  void   *rv;
+  void  *(*func)(void *arg);
+  void  *arg;
+  void  *rv;
 };
 
 /* Wrap for pthread compatibility */
@@ -197,15 +205,15 @@ ares_status_t ares__thread_join(ares__thread_t *thread, void **rv)
 #  else /* !WIN32 == PTHREAD */
 #    include <pthread.h>
 
-   /* for clock_gettime() */
-#  ifdef HAVE_TIME_H
-#    include <time.h>
-#  endif
+/* for clock_gettime() */
+#    ifdef HAVE_TIME_H
+#      include <time.h>
+#    endif
 
-   /* for gettimeofday() */
-#  ifdef HAVE_SYS_TIME_H
-#    include <sys/time.h>
-#  endif
+/* for gettimeofday() */
+#    ifdef HAVE_SYS_TIME_H
+#      include <sys/time.h>
+#    endif
 
 struct ares__thread_mutex {
   pthread_mutex_t mutex;
@@ -266,7 +274,6 @@ void ares__thread_mutex_unlock(ares__thread_mutex_t *mut)
   pthread_mutex_unlock(&mut->mutex);
 }
 
-
 struct ares__thread_cond {
   pthread_cond_t cond;
 };
@@ -283,30 +290,35 @@ ares__thread_cond_t *ares__thread_cond_create(void)
 
 void ares__thread_cond_destroy(ares__thread_cond_t *cond)
 {
-  if (cond == NULL)
+  if (cond == NULL) {
     return;
+  }
   pthread_cond_destroy(&cond->cond);
   ares_free(cond);
 }
 
 void ares__thread_cond_signal(ares__thread_cond_t *cond)
 {
-  if (cond == NULL)
+  if (cond == NULL) {
     return;
+  }
   pthread_cond_signal(&cond->cond);
 }
 
 void ares__thread_cond_broadcast(ares__thread_cond_t *cond)
 {
-  if (cond == NULL)
+  if (cond == NULL) {
     return;
+  }
   pthread_cond_broadcast(&cond->cond);
 }
 
-ares_status_t ares__thread_cond_wait(ares__thread_cond_t *cond, ares__thread_mutex_t *mut)
+ares_status_t ares__thread_cond_wait(ares__thread_cond_t  *cond,
+                                     ares__thread_mutex_t *mut)
 {
-  if (cond == NULL || mut == NULL)
+  if (cond == NULL || mut == NULL) {
     return ARES_EFORMERR;
+  }
 
   pthread_cond_wait(&cond->cond, &mut->mutex);
   return ARES_SUCCESS;
@@ -314,16 +326,16 @@ ares_status_t ares__thread_cond_wait(ares__thread_cond_t *cond, ares__thread_mut
 
 static void ares__timespec_timeout(struct timespec *ts, unsigned long add_ms)
 {
-#if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_REALTIME)
+#    if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_REALTIME)
   clock_gettime(CLOCK_REALTIME, ts);
-#elif defined(HAVE_GETTIMEOFDAY)
+#    elif defined(HAVE_GETTIMEOFDAY)
   struct timeval tv;
   gettimeofday(&tv, NULL);
   ts->tv_sec  = tv.tv_sec;
   ts->tv_nsec = tv.tv_usec * 1000;
-#else
-#  error cannot determine current system time
-#endif
+#    else
+#      error cannot determine current system time
+#    endif
 
   ts->tv_sec  += add_ms / 1000;
   ts->tv_nsec += (add_ms % 1000) * 1000000;
@@ -335,21 +347,24 @@ static void ares__timespec_timeout(struct timespec *ts, unsigned long add_ms)
   }
 }
 
-ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t *cond, ares__thread_mutex_t *mut, unsigned long timeout_ms)
+ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t  *cond,
+                                          ares__thread_mutex_t *mut,
+                                          unsigned long         timeout_ms)
 {
   struct timespec ts;
 
-  if (cond == NULL || mut == NULL)
+  if (cond == NULL || mut == NULL) {
     return ARES_EFORMERR;
+  }
 
   ares__timespec_timeout(&ts, timeout_ms);
 
-  if (pthread_cond_timedwait(&cond->cond, &mut->mutex, &ts) != 0)
+  if (pthread_cond_timedwait(&cond->cond, &mut->mutex, &ts) != 0) {
     return ARES_ETIMEOUT;
+  }
 
   return ARES_SUCCESS;
 }
-
 
 struct ares__thread {
   pthread_t thread;
@@ -447,21 +462,23 @@ void ares__thread_cond_broadcast(ares__thread_cond_t *cond)
   (void)cond;
 }
 
-ares_status_t ares__thread_cond_wait(ares__thread_cond_t *cond, ares__thread_mutex_t *mut)
+ares_status_t ares__thread_cond_wait(ares__thread_cond_t  *cond,
+                                     ares__thread_mutex_t *mut)
 {
   (void)cond;
   (void)mut;
   return ARES_ENOTIMP;
 }
 
-ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t *cond, ares__thread_mutex_t *mut, unsigned long timeout_ms)
+ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t  *cond,
+                                          ares__thread_mutex_t *mut,
+                                          unsigned long         timeout_ms)
 {
   (void)cond;
   (void)mut;
   (void)timeout_ms;
   return ARES_ENOTIMP;
 }
-
 
 ares_status_t ares__thread_create(ares__thread_t    **thread,
                                   ares__thread_func_t func, void *arg)

--- a/src/lib/ares__threads.h
+++ b/src/lib/ares__threads.h
@@ -34,6 +34,18 @@ void ares__thread_mutex_destroy(ares__thread_mutex_t *mut);
 void ares__thread_mutex_lock(ares__thread_mutex_t *mut);
 void ares__thread_mutex_unlock(ares__thread_mutex_t *mut);
 
+
+struct ares__thread_cond;
+typedef struct ares__thread_cond ares__thread_cond_t;
+
+ares__thread_cond_t *ares__thread_cond_create(void);
+void ares__thread_cond_destroy(ares__thread_cond_t *cond);
+void ares__thread_cond_signal(ares__thread_cond_t *cond);
+void ares__thread_cond_broadcast(ares__thread_cond_t *cond);
+ares_status_t ares__thread_cond_wait(ares__thread_cond_t *cond, ares__thread_mutex_t *mut);
+ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t *cond, ares__thread_mutex_t *mut, unsigned long timeout_ms);
+
+
 struct ares__thread;
 typedef struct ares__thread ares__thread_t;
 

--- a/src/lib/ares__threads.h
+++ b/src/lib/ares__threads.h
@@ -38,12 +38,15 @@ void ares__thread_mutex_unlock(ares__thread_mutex_t *mut);
 struct ares__thread_cond;
 typedef struct ares__thread_cond ares__thread_cond_t;
 
-ares__thread_cond_t *ares__thread_cond_create(void);
-void ares__thread_cond_destroy(ares__thread_cond_t *cond);
-void ares__thread_cond_signal(ares__thread_cond_t *cond);
-void ares__thread_cond_broadcast(ares__thread_cond_t *cond);
-ares_status_t ares__thread_cond_wait(ares__thread_cond_t *cond, ares__thread_mutex_t *mut);
-ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t *cond, ares__thread_mutex_t *mut, unsigned long timeout_ms);
+ares__thread_cond_t             *ares__thread_cond_create(void);
+void          ares__thread_cond_destroy(ares__thread_cond_t *cond);
+void          ares__thread_cond_signal(ares__thread_cond_t *cond);
+void          ares__thread_cond_broadcast(ares__thread_cond_t *cond);
+ares_status_t ares__thread_cond_wait(ares__thread_cond_t  *cond,
+                                     ares__thread_mutex_t *mut);
+ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t  *cond,
+                                          ares__thread_mutex_t *mut,
+                                          unsigned long         timeout_ms);
 
 
 struct ares__thread;

--- a/src/lib/ares_cancel.c
+++ b/src/lib/ares_cancel.c
@@ -85,6 +85,9 @@ void ares_cancel(ares_channel_t *channel)
 
     ares__llist_destroy(list_copy);
   }
+
+  ares_queue_notify_empty(channel);
+
 done:
   ares__channel_unlock(channel);
 }

--- a/src/lib/ares_destroy.c
+++ b/src/lib/ares_destroy.c
@@ -57,6 +57,8 @@ void ares_destroy(ares_channel_t *channel)
     node = next;
   }
 
+  ares_queue_notify_empty(channel);
+
 #ifndef NDEBUG
   /* Freeing the query should remove it from all the lists in which it sits,
    * so all query lists should be empty now.

--- a/src/lib/ares_event_thread.c
+++ b/src/lib/ares_event_thread.c
@@ -120,6 +120,8 @@ ares_status_t ares_event_update(ares_event_t **event, ares_event_thread_t *e,
       ares_free(ev);
       return ARES_ENOMEM;
     }
+  } else {
+printf("%s(): fd %d already exists in update table, updating\n", __FUNCTION__, fd);
   }
 
   ev->flags = flags;
@@ -188,7 +190,7 @@ static void ares_event_thread_sockstate_cb(void *data, ares_socket_t socket_fd,
 
   /* Update channel fd */
   ares__thread_mutex_lock(e->mutex);
-
+printf("%s(): fd: %d, readable: %d, writable: %d\n", __FUNCTION__, socket_fd, readable, writable);
   ares_event_update(NULL, e, flags, ares_event_thread_process_fd, socket_fd,
                     NULL, NULL, NULL);
 

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -262,6 +262,9 @@ struct ares_channeldata {
   /* Thread safety lock */
   ares__thread_mutex_t *lock;
 
+  /* Conditional to wake waiters when queue is empty */
+  ares__thread_cond_t  *cond_empty;
+
   /* Server addresses and communications state. Sorted by least consecutive
    * failures, followed by the configuration order if failures are equal. */
   ares__slist_t        *servers;
@@ -529,6 +532,16 @@ ares_status_t ares__dns_name_parse(ares__buf_t *buf, char **name,
 ares_status_t ares__dns_name_write(ares__buf_t *buf, ares__llist_t **list,
                                    ares_bool_t validate_hostname,
                                    const char *name);
+
+/*! Check if the queue is empty, if so, wake any waiters.  This is only
+ *  effective if built with threading support.
+ *
+ *  Must be holding a channel lock when calling this function.
+ *
+ *  \param[in]  channel Initialized ares channel object
+ */
+void ares_queue_notify_empty(ares_channel_t *channel);
+
 
 #define ARES_SWAP_BYTE(a, b)           \
   do {                                 \

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -67,7 +67,7 @@ static ares_bool_t   same_questions(const ares_dns_record_t *qrec,
                                     const ares_dns_record_t *arec);
 static ares_bool_t   same_address(const struct sockaddr  *sa,
                                   const struct ares_addr *aa);
-static void end_query(const ares_channel_t *channel, struct query *query,
+static void end_query(ares_channel_t *channel, struct query *query,
                       ares_status_t status, const unsigned char *abuf,
                       size_t alen);
 
@@ -759,7 +759,7 @@ static void handle_conn_error(struct server_connection *conn,
 
 ares_status_t ares__requeue_query(struct query *query, struct timeval *now)
 {
-  const ares_channel_t *channel = query->channel;
+  ares_channel_t *channel = query->channel;
   size_t max_tries = ares__slist_len(channel->servers) * channel->tries;
 
   query->try_count++;
@@ -1122,18 +1122,23 @@ static void ares_detach_query(struct query *query)
   query->node_all_queries        = NULL;
 }
 
-static void end_query(const ares_channel_t *channel, struct query *query,
+static void end_query(ares_channel_t *channel, struct query *query,
                       ares_status_t status, const unsigned char *abuf,
                       size_t alen)
 {
-  (void)channel;
-
   /* Invoke the callback. */
   query->callback(query->arg, (int)status, (int)query->timeouts,
                   /* due to prior design flaws, abuf isn't meant to be modified,
                    * but bad prototypes, ugh.  Lets cast off constfor compat. */
                   (unsigned char *)((void *)((size_t)abuf)), (int)alen);
   ares__free_query(query);
+
+  /* Check and notify if no other queries are enqueued on the channel.  This
+   * must come after the callback and freeing the query for 2 reasons.
+   *  1) The callback itself may enqueue a new query
+   *  2) Technically the current query isn't detached until it is free()'d.
+   */
+  ares_queue_notify_empty(channel);
 }
 
 void ares__free_query(struct query *query)

--- a/test/ares-test-mock-et.cc
+++ b/test/ares-test-mock-et.cc
@@ -213,9 +213,10 @@ class MockUDPEventThreadMaxQueriesTest
   MockUDPEventThreadMaxQueriesTest()
     : MockEventThreadOptsTest(1, std::get<0>(GetParam()), std::get<1>(GetParam()), false,
                           FillOptions(&opts_),
-                          ARES_OPT_UDP_MAX_QUERIES) {}
+                          ARES_OPT_UDP_MAX_QUERIES|ARES_OPT_FLAGS) {}
   static struct ares_options* FillOptions(struct ares_options * opts) {
     memset(opts, 0, sizeof(struct ares_options));
+    opts->flags = ARES_FLAG_STAYOPEN|ARES_FLAG_EDNS;
     opts->udp_max_queries = MAXUDPQUERIES_LIMIT;
     return opts;
   }

--- a/test/ares-test-mock-et.cc
+++ b/test/ares-test-mock-et.cc
@@ -307,7 +307,25 @@ TEST_P(CacheQueriesEventThreadTest, GetHostByNameCache) {
 }
 
 #define TCPPARALLELLOOKUPS 32
-TEST_P(MockTCPEventThreadTest, GetHostByNameParallelLookups) {
+
+class MockTCPEventThreadStayOpenTest
+    : public MockEventThreadOptsTest,
+      public ::testing::WithParamInterface<std::tuple<ares_evsys_t,int>> {
+ public:
+  MockTCPEventThreadStayOpenTest()
+    : MockEventThreadOptsTest(1, std::get<0>(GetParam()), std::get<1>(GetParam()), true /* tcp */,
+                          FillOptions(&opts_),
+                          ARES_OPT_FLAGS) {}
+  static struct ares_options* FillOptions(struct ares_options * opts) {
+    memset(opts, 0, sizeof(struct ares_options));
+    opts->flags = ARES_FLAG_STAYOPEN|ARES_FLAG_EDNS;
+    return opts;
+  }
+ private:
+  struct ares_options opts_;
+};
+
+TEST_P(MockTCPEventThreadStayOpenTest, GetHostByNameParallelLookups) {
   DNSPacket rsp;
   rsp.set_response().set_aa()
     .add_question(new DNSQuestion("www.google.com", T_A))
@@ -1367,6 +1385,8 @@ INSTANTIATE_TEST_SUITE_P(AddressFamilies, MockUDPEventThreadMaxQueriesTest, ::te
 INSTANTIATE_TEST_SUITE_P(AddressFamilies, CacheQueriesEventThreadTest, ::testing::ValuesIn(ares::test::evsys_families), ares::test::PrintEvsysFamily);
 
 INSTANTIATE_TEST_SUITE_P(AddressFamilies, MockTCPEventThreadTest, ::testing::ValuesIn(ares::test::evsys_families), ares::test::PrintEvsysFamily);
+
+INSTANTIATE_TEST_SUITE_P(AddressFamilies, MockTCPEventThreadStayOpenTest, ::testing::ValuesIn(ares::test::evsys_families), ares::test::PrintEvsysFamily);
 
 INSTANTIATE_TEST_SUITE_P(AddressFamilies, MockExtraOptsEventThreadTest, ::testing::ValuesIn(ares::test::evsys_families_modes), ares::test::PrintEvsysFamilyMode);
 

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -820,12 +820,10 @@ void MockChannelOptsTest::Process(unsigned int cancel_ms) {
 }
 
 void MockEventThreadOptsTest::ProcessThread() {
-  int nfds=0, count;
-  fd_set readers;
   std::set<ares_socket_t> fds;
-  bool has_cancel_ms = false;
 
 #ifndef CARES_SYMBOL_HIDING
+  bool has_cancel_ms = false;
   struct timeval tv_begin;
   struct timeval tv_cancel;
 #endif
@@ -833,6 +831,8 @@ void MockEventThreadOptsTest::ProcessThread() {
   mutex.lock();
 
   while (isup) {
+    int nfds = 0;
+    fd_set readers;
 #ifndef CARES_SYMBOL_HIDING
     struct timeval  tv_now = ares__tvnow();
     struct timeval  tv_remaining;
@@ -879,14 +879,12 @@ void MockEventThreadOptsTest::ProcessThread() {
     }
 #endif
 
-    /* We just always wait 50ms then recheck. Not doing any complex signalling. */
+    /* We just always wait 20ms then recheck. Not doing any complex signaling. */
     tv.tv_sec  = 0;
-    tv.tv_usec = 50000;
+    tv.tv_usec = 20000;
 
     mutex.unlock();
-    count = select(nfds, &readers, nullptr, nullptr, &tv);
-    mutex.lock();
-    if (count < 0) {
+    if (select(nfds, &readers, nullptr, nullptr, &tv) < 0) {
       fprintf(stderr, "select() failed, errno %d\n", errno);
       return;
     }
@@ -897,6 +895,7 @@ void MockEventThreadOptsTest::ProcessThread() {
         ProcessFD(fd);
       }
     }
+    mutex.lock();
   }
   mutex.unlock();
 

--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -361,7 +361,9 @@ public:
   }
   ~MockEventThreadOptsTest()
   {
+    mutex.lock();
     isup = false;
+    mutex.unlock();
     thread.join();
   }
 
@@ -376,12 +378,16 @@ public:
   }
 
   void Process(unsigned int cancel_ms = 0) {
+    mutex.lock();
+    cancel_ms_ = cancel_ms;
+    mutex.unlock();
     ares_queue_wait_empty(channel_, -1);
   }
 
 private:
   void ProcessThread();
   struct ares_options evopts_;
+  unsigned int cancel_ms_;
   bool isup;
   std::mutex mutex;
   std::thread thread;

--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -352,6 +352,7 @@ public:
                           struct ares_options *givenopts, int optmask)
     : MockChannelOptsTest(count, family, force_tcp, FillOptionsET(&evopts_, givenopts, evsys), optmask | ARES_OPT_EVENT_THREAD)
   {
+    cancel_ms_ = 0;
     isup = true;
     thread = std::thread(&MockEventThreadOptsTest::ProcessThread, this);
   }

--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -50,6 +50,7 @@
 #include <set>
 #include <string>
 #include <mutex>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -355,9 +356,14 @@ public:
                           struct ares_options *givenopts, int optmask)
     : MockChannelOptsTest(count, family, force_tcp, FillOptionsET(&evopts_, givenopts, evsys), optmask | ARES_OPT_EVENT_THREAD)
   {
+    isup = true;
+    thread = std::thread(&MockEventThreadOptsTest::ProcessThread, this);
   }
-
-  void Process(unsigned int cancel_ms = 0);
+  ~MockEventThreadOptsTest()
+  {
+    isup = false;
+    thread.join();
+  }
 
   static struct ares_options *FillOptionsET(struct ares_options *opts, struct ares_options *givenopts, ares_evsys_t evsys) {
     if (givenopts) {
@@ -369,8 +375,16 @@ public:
     return opts;
   }
 
+  void Process(unsigned int cancel_ms = 0) {
+    ares_queue_wait_empty(channel_, -1);
+  }
+
 private:
+  void ProcessThread();
   struct ares_options evopts_;
+  bool isup;
+  std::mutex mutex;
+  std::thread thread;
 };
 
 class MockEventThreadTest
@@ -381,6 +395,7 @@ public:
     : MockEventThreadOptsTest(1, std::get<0>(GetParam()), std::get<1>(GetParam()), std::get<2>(GetParam()), nullptr, 0)
   {
   }
+
 };
 
 class MockUDPEventThreadTest : public MockEventThreadOptsTest,

--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -91,10 +91,6 @@ void                    ProcessWork(ares_channel_t                          *cha
                                     std::function<std::set<ares_socket_t>()> get_extrafds,
                                     std::function<void(ares_socket_t)>       process_extra,
                                     unsigned int                             cancel_ms = 0);
-void ProcessWorkEventThread(ares_channel_t *channel,
-                            std::function<std::set<ares_socket_t>()> get_extrafds,
-                            std::function<void(ares_socket_t)> process_extra,
-                            unsigned int cancel_ms);
 std::set<ares_socket_t> NoExtraFDs();
 
 const char *af_tostr(int af);


### PR DESCRIPTION
It may be useful to wait for the queue to be empty under certain conditions (mainly test cases), expose a function to efficiently do this and rework test cases to use it.