### PR TITLE
fix leaking DNS suffix search list on Windows

### DIFF
--- a/src/lib/ares_sysconfig.c
+++ b/src/lib/ares_sysconfig.c
@@ -624,6 +624,7 @@ static ares_status_t ares__init_sysconfig_windows(ares_sysconfig_t *sysconfig)
 
   if (get_SuffixList_Windows(&line)) {
     sysconfig->domains = ares__strsplit(line, ", ", &sysconfig->ndomains);
+    ares_free(line);
     if (sysconfig->domains == NULL) {
       status = ARES_EFILE;
     }


### PR DESCRIPTION
ares__strsplit provides a newly allocated buffer, so suffix list in line variable isn't referenced anymore. Related ares_free seems to have gone missing during refactoring made in #594