### PR TITLE
simple implementation for isascii where stdlib isascii is not available

### DIFF
--- a/src/lib/setup_once.h
+++ b/src/lib/setup_once.h
@@ -274,7 +274,12 @@ Error Missing_definition_of_macro_sread
 #define ISPRINT(x)  (isprint((int)((unsigned char)x)))
 #define ISUPPER(x)  (isupper((int)((unsigned char)x)))
 #define ISLOWER(x)  (islower((int)((unsigned char)x)))
-#define ISASCII(x)  (isascii((int)((unsigned char)x)))
+
+#ifdef NO_STDLIB_ISASCII
+#  define ISASCII(c) (((c) >= 0 && (c) <= 127) ? 1 : 0)
+#else
+#  define ISASCII(x) (isascii((int)((unsigned char)x)))
+#endif
 
 #define ISBLANK(x) \
   (int)((((unsigned char)x) == ' ') || (((unsigned char)x) == '\t'))


### PR DESCRIPTION
I had a similar patch for wolfssl as well.
https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/wolfcrypt/types.h#L934