### PR TITLE
Allow configuration value for NDots to be zero

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -28,6 +28,7 @@ Bugfixes:
 * Fix a potential memory leak in `ares_init()`. [Issue #724](https://github.com/c-ares/c-ares/issues/724)
 * Some platforms don't have the `isascii()` function.  Implement as a macro. [PR #721](https://github.com/c-ares/c-ares/pull/721)
 * CMake: Fix Chain building if CMAKE runtime paths not set
+* NDots configuration should allow a value of zero. [PR #733](https://github.com/c-ares/c-ares/pull/733)
 
 Thanks go to these friendly people for their efforts and contributions for this release:
 

--- a/docs/ares_init_options.3
+++ b/docs/ares_init_options.3
@@ -158,7 +158,7 @@ before giving up.  The default is three tries.
 The number of dots which must be present in a domain name for it to be
 queried for "as is" prior to querying for it with the default domain
 extensions appended.  The default value is 1 unless set otherwise by
-resolv.conf or the RES_OPTIONS environment variable.
+resolv.conf or the RES_OPTIONS environment variable.  Valid range is 0-15.
 .TP 18
 .B ARES_OPT_MAXTIMEOUTMS
 .B int \fImaxtimeout\fP;

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -152,10 +152,6 @@ static ares_status_t init_by_defaults(ares_channel_t *channel)
     channel->tries = DEFAULT_TRIES;
   }
 
-  if (channel->ndots == 0) {
-    channel->ndots = 1;
-  }
-
   if (ares__slist_len(channel->servers) == 0) {
     /* Add a default local named server to the channel unless configured not
      * to (in which case return an error).
@@ -283,6 +279,9 @@ int ares_init_options(ares_channel_t           **channelptr,
     *channelptr = NULL;
     return ARES_ENOMEM;
   }
+
+  /* One option where zero is valid, so set default value here */
+  channel->ndots = 1;
 
   status = ares__channel_threading_init(channel);
   if (status != ARES_SUCCESS) {

--- a/src/lib/ares_options.c
+++ b/src/lib/ares_options.c
@@ -316,7 +316,7 @@ ares_status_t ares__init_by_options(ares_channel_t            *channel,
   }
 
   if (optmask & ARES_OPT_NDOTS) {
-    if (options->ndots <= 0) {
+    if (options->ndots < 0) {
       optmask &= ~(ARES_OPT_NDOTS);
     } else {
       channel->ndots = (size_t)options->ndots;

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -581,7 +581,7 @@ void          ares_queue_notify_empty(ares_channel_t *channel);
   } while (0)
 
 #define ARES_CONFIG_CHECK(x)                                             \
-  (x && x->lookups && ares__slist_len(x->servers) > 0 && x->ndots > 0 && \
+  (x && x->lookups && ares__slist_len(x->servers) > 0 && \
    x->timeout > 0 && x->tries > 0)
 
 ares_bool_t   ares__subnet_match(const struct ares_addr *addr,

--- a/src/lib/ares_sysconfig.c
+++ b/src/lib/ares_sysconfig.c
@@ -954,7 +954,7 @@ static ares_status_t ares__init_sysconfig_libresolv(ares_sysconfig_t *sysconfig)
     }
   }
 
-  if (res.ndots > 0) {
+  if (res.ndots >= 0) {
     sysconfig->ndots = (size_t)res.ndots;
   }
   if (res.retry > 0) {

--- a/src/lib/ares_sysconfig_files.c
+++ b/src/lib/ares_sysconfig_files.c
@@ -414,9 +414,6 @@ static ares_status_t process_option(ares_sysconfig_t *sysconfig,
   }
 
   if (strcmp(key, "ndots") == 0) {
-    if (valint == 0) {
-      return ARES_EFORMERR;
-    }
     sysconfig->ndots = valint;
   } else if (strcmp(key, "retrans") == 0 || strcmp(key, "timeout") == 0) {
     if (valint == 0) {


### PR DESCRIPTION
As per Issue #734 some people use `ndots:0` in their configuration which is allowed by the system resolver but not by c-ares.  Add support for `ndots:0` and add a test case to validate this behavior.

Fixes Issue: #734
Fix By: Brad House (@bradh352)