### PR TITLE
Improve reliability in the server retry delay regression tests

### DIFF
--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -1429,7 +1429,7 @@ class ServerFailoverOptsMultiMockTest : public MockMultiServerChannelTest {
   static struct ares_options* FillOptions(struct ares_options *opts) {
     memset(opts, 0, sizeof(struct ares_options));
     opts->server_failover_opts.retry_chance = 1;
-    opts->server_failover_opts.retry_delay = 100;
+    opts->server_failover_opts.retry_delay = 250;
     return opts;
   }
  private:
@@ -1556,7 +1556,7 @@ TEST_P(NoRotateMultiMockTest, ServerNoResponseFailover) {
 }
 
 // Test case to trigger server failover behavior. We use a retry chance of
-// 100% and a retry delay of 100ms so that we can test behavior reliably.
+// 100% and a retry delay of 250ms so that we can test behavior reliably.
 TEST_P(ServerFailoverOptsMultiMockTest, ServerFailoverOpts) {
   DNSPacket servfailrsp;
   servfailrsp.set_response().set_aa().set_rcode(SERVFAIL)
@@ -1580,9 +1580,10 @@ TEST_P(ServerFailoverOptsMultiMockTest, ServerFailoverOpts) {
     .WillOnce(SetReply(servers_[1].get(), &okrsp));
   CheckExample();
 
-  // Sleep for the retry delay and send in another query. Server #0 should be
-  // retried.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Sleep for the retry delay (actually a little more than 250ms to account
+  // for unreliable timing, e.g. NTP slew) and send in another query. Server #0
+  // should be retried.
+  std::this_thread::sleep_for(std::chrono::milliseconds(260));
   EXPECT_CALL(*servers_[0], OnRequest("www.example.com", T_A))
     .WillOnce(SetReply(servers_[0].get(), &okrsp));
   CheckExample();
@@ -1605,7 +1606,7 @@ TEST_P(ServerFailoverOptsMultiMockTest, ServerFailoverOpts) {
   // At this point the sorted servers look like [1] (f0) [2] (f1) [0] (f2).
   // Sleep for the retry delay and send in another query. Server #2 should be
   // retried first, and then server #0.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::milliseconds(260));
   EXPECT_CALL(*servers_[2], OnRequest("www.example.com", T_A))
     .WillOnce(SetReply(servers_[2].get(), &servfailrsp));
   EXPECT_CALL(*servers_[0], OnRequest("www.example.com", T_A))
@@ -1618,7 +1619,7 @@ TEST_P(ServerFailoverOptsMultiMockTest, ServerFailoverOpts) {
   // The sorted servers currently look like [0] (f0) [1] (f0) [2] (f2) and
   // server #2 has just been retried.
   // Sleep for half the retry delay and trigger a failure on server #0.
-  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  std::this_thread::sleep_for(std::chrono::milliseconds(130));
   EXPECT_CALL(*servers_[0], OnRequest("www.example.com", T_A))
     .WillOnce(SetReply(servers_[0].get(), &servfailrsp));
   EXPECT_CALL(*servers_[1], OnRequest("www.example.com", T_A))
@@ -1629,7 +1630,7 @@ TEST_P(ServerFailoverOptsMultiMockTest, ServerFailoverOpts) {
   // has just failed whilst server #2 is halfway through the retry delay.
   // Sleep for another half the retry delay and check that server #2 is retried
   // whilst server #0 is not.
-  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  std::this_thread::sleep_for(std::chrono::milliseconds(130));
   EXPECT_CALL(*servers_[2], OnRequest("www.example.com", T_A))
     .WillOnce(SetReply(servers_[2].get(), &servfailrsp));
   EXPECT_CALL(*servers_[1], OnRequest("www.example.com", T_A))


### PR DESCRIPTION
Improve reliability in the server retry delay regression tests by increasing the retry delay and sleeping for a little more than the retry delay when attempting to force retries.

This helps to account for unreliable timing (e.g. NTP slew) intermittently breaking pipelines.