### PR TITLE
Revert PR #659

### DIFF
--- a/src/lib/ares__socket.c
+++ b/src/lib/ares__socket.c
@@ -253,12 +253,6 @@ ares_status_t ares__open_connection(ares_channel_t      *channel,
   struct server_connection *conn;
   ares__llist_node_t       *node;
   int                       type = is_tcp ? SOCK_STREAM : SOCK_DGRAM;
-#ifdef __OpenBSD__
-  if ((is_tcp && server->tcp_port == 53) ||
-      (!is_tcp && server->udp_port == 53)) {
-    type |= SOCK_DNS;
-  }
-#endif
 
   switch (server->addr.family) {
     case AF_INET:


### PR DESCRIPTION
As described in https://github.com/c-ares/c-ares/issues/753 the change merged with https://github.com/c-ares/c-ares/pull/659 is ill-advised and leads to breakage in applications using c-ares on OpenBSD. 

See also https://github.com/nodejs/node/issues/52439