### PR TITLE
CI: OpenBSD

### DIFF
--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -20,7 +20,10 @@ jobs:
           version: '7.5'
           shell: 'bash'
           run: |
-            sudo pkg_add cmake gtest pkgconf
+            sudo pkg_add cmake gtest pkgconf ninja
+            echo "BUILD_TYPE: $BUILD_TYPE"
+            echo "CMAKE_FLAGS: $CMAKE_FLAGS"
+            echo "CMAKE_TEST_FLAGS: $CMAKE_TEST_FLAGS"
             ./ci/build.sh
             ./ci/test.sh
 

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -1,0 +1,26 @@
+name: OpenBSD
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test
+        uses: cross-platform-actions/action@v0.24.0
+        env:
+          DIST: OPENBSD
+          BUILD_TYPE: "cmake"
+          CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -G Ninja"
+          CMAKE_TEST_FLAGS: "-DCARES_BUILD_TESTS=ON"
+        with:
+          operating_system: openbsd
+          version: '7.5'
+          shell: 'bash'
+          run: |
+            pkg_add cmake gtest pkgconf
+            ./ci/build.sh
+            ./ci/test.sh
+

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -20,7 +20,7 @@ jobs:
           version: '7.5'
           shell: 'bash'
           run: |
-            pkg_add cmake gtest pkgconf
+            sudo pkg_add cmake gtest pkgconf
             ./ci/build.sh
             ./ci/test.sh
 

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -1,3 +1,5 @@
+# Copyright (C) The c-ares project and its contributors
+# SPDX-License-Identifier: MIT
 name: OpenBSD
 
 on: [push]

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -19,6 +19,7 @@ jobs:
           operating_system: openbsd
           version: '7.5'
           shell: 'bash'
+          environment_variables: DIST BUILD_TYPE CMAKE_FLAGS CMAKE_TEST_FLAGS
           run: |
             sudo pkg_add cmake gtest pkgconf ninja
             echo "BUILD_TYPE: $BUILD_TYPE"


### PR DESCRIPTION
Github actions appears to support building on a few "unsupported" platforms these days:
https://github.com/cross-platform-actions/action

Lets go ahead and add OpenBSD to try to prevent issues like #754 

Fix By: Brad House (@bradh352)