### PR TITLE
CI: Add Netbsd workflow

### DIFF
--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -17,13 +17,14 @@ jobs:
           BUILD_TYPE: "cmake"
           CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -G Ninja"
           CMAKE_TEST_FLAGS: "-DCARES_BUILD_TESTS=ON"
+          PKG_PATH: https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/amd64/10.0/All/
         with:
           operating_system: netbsd
           version: '10.0'
           shell: 'bash'
-          environment_variables: DIST BUILD_TYPE CMAKE_FLAGS CMAKE_TEST_FLAGS
+          environment_variables: DIST BUILD_TYPE CMAKE_FLAGS CMAKE_TEST_FLAGS PKG_PATH
           run: |
-            sudo pkg_add cmake googletest pkgconf ninja-build
+            pkg_add cmake googletest pkgconf ninja-build
             echo "BUILD_TYPE: $BUILD_TYPE"
             echo "CMAKE_FLAGS: $CMAKE_FLAGS"
             echo "CMAKE_TEST_FLAGS: $CMAKE_TEST_FLAGS"

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -1,0 +1,32 @@
+# Copyright (C) The c-ares project and its contributors
+# SPDX-License-Identifier: MIT
+name: NetBSD
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test
+        uses: cross-platform-actions/action@v0.24.0
+        env:
+          DIST: NETBSD
+          BUILD_TYPE: "cmake"
+          CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -G Ninja"
+          CMAKE_TEST_FLAGS: "-DCARES_BUILD_TESTS=ON"
+        with:
+          operating_system: netbsd
+          version: '10.0'
+          shell: 'bash'
+          environment_variables: DIST BUILD_TYPE CMAKE_FLAGS CMAKE_TEST_FLAGS
+          run: |
+            sudo pkg_add cmake googletest pkgconf ninja-build
+            echo "BUILD_TYPE: $BUILD_TYPE"
+            echo "CMAKE_FLAGS: $CMAKE_FLAGS"
+            echo "CMAKE_TEST_FLAGS: $CMAKE_TEST_FLAGS"
+            ./ci/build.sh
+            ./ci/test.sh
+

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -24,10 +24,15 @@ jobs:
           shell: 'bash'
           environment_variables: DIST BUILD_TYPE CMAKE_FLAGS CMAKE_TEST_FLAGS PKG_PATH
           run: |
-            pkg_add cmake googletest pkgconf ninja-build
+            echo "PATH: $PATH"
             echo "BUILD_TYPE: $BUILD_TYPE"
             echo "CMAKE_FLAGS: $CMAKE_FLAGS"
             echo "CMAKE_TEST_FLAGS: $CMAKE_TEST_FLAGS"
+            echo "/usr/pkg/sbin:"
+            ls -l /usr/pkg/sbin
+            echo "/usr/pkg/bin:"
+            ls -l /usr/pkg/bin
+            pkg_add cmake googletest pkgconf ninja-build
             ./ci/build.sh
             ./ci/test.sh
 

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -27,7 +27,8 @@ jobs:
             echo "BUILD_TYPE: $BUILD_TYPE"
             echo "CMAKE_FLAGS: $CMAKE_FLAGS"
             echo "CMAKE_TEST_FLAGS: $CMAKE_TEST_FLAGS"
-            sudo /usr/pkg/sbin/pkg_add cmake googletest pkgconf ninja-build
+            echo "PKG_PATH: $PKG_PATH"
+            sudo -E /usr/pkg/sbin/pkg_add cmake googletest pkgconf ninja-build
             ./ci/build.sh
             ./ci/test.sh
 

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -24,15 +24,10 @@ jobs:
           shell: 'bash'
           environment_variables: DIST BUILD_TYPE CMAKE_FLAGS CMAKE_TEST_FLAGS PKG_PATH
           run: |
-            echo "PATH: $PATH"
             echo "BUILD_TYPE: $BUILD_TYPE"
             echo "CMAKE_FLAGS: $CMAKE_FLAGS"
             echo "CMAKE_TEST_FLAGS: $CMAKE_TEST_FLAGS"
-            echo "/usr/pkg/sbin:"
-            ls -l /usr/pkg/sbin
-            echo "/usr/pkg/bin:"
-            ls -l /usr/pkg/bin
-            pkg_add cmake googletest pkgconf ninja-build
+            sudo /usr/pkg/sbin/pkg_add cmake googletest pkgconf ninja-build
             ./ci/build.sh
             ./ci/test.sh
 


### PR DESCRIPTION
Add NetBSD as a test target for CI.

Fix By: Brad House (@bradh352)