### PR TITLE
Auto reload config on changes (requires EventThread)

### DIFF
--- a/src/lib/Makefile.inc
+++ b/src/lib/Makefile.inc
@@ -27,6 +27,7 @@ CSOURCES = ares__addrinfo2hostent.c	\
   ares_dns_parse.c			\
   ares_dns_record.c			\
   ares_dns_write.c			\
+  ares_event_configchg.c	\
   ares_event_epoll.c			\
   ares_event_kqueue.c			\
   ares_event_poll.c			\

--- a/src/lib/Makefile.inc
+++ b/src/lib/Makefile.inc
@@ -10,6 +10,7 @@ CSOURCES = ares__addrinfo2hostent.c	\
   ares__htable_asvp.c			\
   ares__htable_strvp.c			\
   ares__htable_szvp.c			\
+  ares__htable_vpvp.c			\
   ares__iface_ips.c			\
   ares__llist.c				\
   ares__parse_into_addrinfo.c		\

--- a/src/lib/ares__htable_vpvp.c
+++ b/src/lib/ares__htable_vpvp.c
@@ -1,0 +1,189 @@
+/* MIT License
+ *
+ * Copyright (c) 2024 Brad House
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "ares_setup.h"
+#include "ares.h"
+#include "ares_private.h"
+#include "ares__htable.h"
+#include "ares__htable_vpvp.h"
+
+struct ares__htable_vpvp {
+  ares__htable_vpvp_val_free_t free_val;
+  ares__htable_t              *hash;
+};
+
+typedef struct {
+  void                *key;
+  void                *val;
+  ares__htable_vpvp_t *parent;
+} ares__htable_vpvp_bucket_t;
+
+void ares__htable_vpvp_destroy(ares__htable_vpvp_t *htable)
+{
+  if (htable == NULL) {
+    return;
+  }
+
+  ares__htable_destroy(htable->hash);
+  ares_free(htable);
+}
+
+static unsigned int hash_func(const void *key, unsigned int seed)
+{
+  return ares__htable_hash_FNV1a((const unsigned char *)&key, sizeof(key),
+                                 seed);
+}
+
+static const void *bucket_key(const void *bucket)
+{
+  const ares__htable_vpvp_bucket_t *arg = bucket;
+  return arg->key;
+}
+
+static void bucket_free(void *bucket)
+{
+  ares__htable_vpvp_bucket_t *arg = bucket;
+
+  if (arg->parent->free_val) {
+    arg->parent->free_val(arg->val);
+  }
+
+  ares_free(arg);
+}
+
+static ares_bool_t key_eq(const void *key1, const void *key2)
+{
+  if (key1 == key2) {
+    return ARES_TRUE;
+  }
+
+  return ARES_FALSE;
+}
+
+ares__htable_vpvp_t *
+  ares__htable_vpvp_create(ares__htable_vpvp_val_free_t val_free)
+{
+  ares__htable_vpvp_t *htable = ares_malloc(sizeof(*htable));
+  if (htable == NULL) {
+    goto fail;
+  }
+
+  htable->hash =
+    ares__htable_create(hash_func, bucket_key, bucket_free, key_eq);
+  if (htable->hash == NULL) {
+    goto fail;
+  }
+
+  htable->free_val = val_free;
+
+  return htable;
+
+fail:
+  if (htable) {
+    ares__htable_destroy(htable->hash);
+    ares_free(htable);
+  }
+  return NULL;
+}
+
+ares_bool_t ares__htable_vpvp_insert(ares__htable_vpvp_t *htable, void *key,
+                                     void *val)
+{
+  ares__htable_vpvp_bucket_t *bucket = NULL;
+
+  if (htable == NULL) {
+    goto fail;
+  }
+
+  bucket = ares_malloc(sizeof(*bucket));
+  if (bucket == NULL) {
+    goto fail;
+  }
+
+  bucket->parent = htable;
+  bucket->key    = key;
+  bucket->val    = val;
+
+  if (!ares__htable_insert(htable->hash, bucket)) {
+    goto fail;
+  }
+
+  return ARES_TRUE;
+
+fail:
+  if (bucket) {
+    ares_free(bucket);
+  }
+  return ARES_FALSE;
+}
+
+ares_bool_t ares__htable_vpvp_get(const ares__htable_vpvp_t *htable, void *key,
+                                  void **val)
+{
+  ares__htable_vpvp_bucket_t *bucket = NULL;
+
+  if (val) {
+    *val = NULL;
+  }
+
+  if (htable == NULL) {
+    return ARES_FALSE;
+  }
+
+  bucket = ares__htable_get(htable->hash, key);
+  if (bucket == NULL) {
+    return ARES_FALSE;
+  }
+
+  if (val) {
+    *val = bucket->val;
+  }
+  return ARES_TRUE;
+}
+
+void *ares__htable_vpvp_get_direct(const ares__htable_vpvp_t *htable,
+                                   void                      *key)
+{
+  void *val = NULL;
+  ares__htable_vpvp_get(htable, key, &val);
+  return val;
+}
+
+ares_bool_t ares__htable_vpvp_remove(ares__htable_vpvp_t *htable, void *key)
+{
+  if (htable == NULL) {
+    return ARES_FALSE;
+  }
+
+  return ares__htable_remove(htable->hash, key);
+}
+
+size_t ares__htable_vpvp_num_keys(const ares__htable_vpvp_t *htable)
+{
+  if (htable == NULL) {
+    return 0;
+  }
+  return ares__htable_num_keys(htable->hash);
+}

--- a/src/lib/ares__htable_vpvp.h
+++ b/src/lib/ares__htable_vpvp.h
@@ -1,0 +1,117 @@
+/* MIT License
+ *
+ * Copyright (c) 2024 Brad House
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef __ARES__HTABLE_VPVP_H
+#define __ARES__HTABLE_VPVP_H
+
+/*! \addtogroup ares__htable_vpvp HashTable with void pointer Key and void pointer
+ * Value
+ *
+ * This data structure wraps the base ares__htable data structure in order to
+ * split the key and value data types as size_t and void pointer, respectively.
+ *
+ * Average time complexity:
+ *  - Insert: O(1)
+ *  - Search: O(1)
+ *  - Delete: O(1)
+ *
+ * @{
+ */
+
+struct ares__htable_vpvp;
+
+/*! Opaque data type for size_t key, void pointer hash table implementation */
+typedef struct ares__htable_vpvp ares__htable_vpvp_t;
+
+/*! Callback to free value stored in hashtable
+ *
+ *  \param[in] val  user-supplied value
+ */
+typedef void (*ares__htable_vpvp_val_free_t)(void *val);
+
+/*! Destroy hashtable
+ *
+ *  \param[in] htable  Initialized hashtable
+ */
+void ares__htable_vpvp_destroy(ares__htable_vpvp_t *htable);
+
+/*! Create size_t key, void pointer value hash table
+ *
+ *  \param[in] val_free  Optional. Call back to free user-supplied value.  If
+ *                       NULL it is expected the caller will clean up any user
+ *                       supplied values.
+ */
+ares__htable_vpvp_t           *
+  ares__htable_vpvp_create(ares__htable_vpvp_val_free_t val_free);
+
+/*! Insert key/value into hash table
+ *
+ *  \param[in] htable Initialized hash table
+ *  \param[in] key    key to associate with value
+ *  \param[in] val    value to store (takes ownership). May be NULL.
+ *  \return ARES_TRUE on success, ARES_FALSE on failure or out of memory
+ */
+ares_bool_t ares__htable_vpvp_insert(ares__htable_vpvp_t *htable, void *key,
+                                     void *val);
+
+/*! Retrieve value from hashtable based on key
+ *
+ *  \param[in]  htable  Initialized hash table
+ *  \param[in]  key     key to use to search
+ *  \param[out] val     Optional.  Pointer to store value.
+ *  \return ARES_TRUE on success, ARES_FALSE on failure
+ */
+ares_bool_t ares__htable_vpvp_get(const ares__htable_vpvp_t *htable, void *key,
+                                  void **val);
+
+/*! Retrieve value from hashtable directly as return value.  Caveat to this
+ *  function over ares__htable_vpvp_get() is that if a NULL value is stored
+ *  you cannot determine if the key is not found or the value is NULL.
+ *
+ *  \param[in] htable  Initialized hash table
+ *  \param[in] key     key to use to search
+ *  \return value associated with key in hashtable or NULL
+ */
+void       *ares__htable_vpvp_get_direct(const ares__htable_vpvp_t *htable,
+                                         void                      *key);
+
+/*! Remove a value from the hashtable by key
+ *
+ *  \param[in] htable  Initialized hash table
+ *  \param[in] key     key to use to search
+ *  \return ARES_TRUE if found, ARES_FALSE if not
+ */
+ares_bool_t ares__htable_vpvp_remove(ares__htable_vpvp_t *htable, void *key);
+
+/*! Retrieve the number of keys stored in the hash table
+ *
+ *  \param[in] htable  Initialized hash table
+ *  \return count
+ */
+size_t      ares__htable_vpvp_num_keys(const ares__htable_vpvp_t *htable);
+
+/*! @} */
+
+#endif /* __ARES__HTABLE_VPVP_H */

--- a/src/lib/ares_event.h
+++ b/src/lib/ares_event.h
@@ -79,6 +79,8 @@ typedef struct {
   size_t (*wait)(ares_event_thread_t *e, unsigned long timeout_ms);
 } ares_event_sys_t;
 
+ares_status_t ares_event_configchg_init(ares_event_thread_t *e);
+
 struct ares_event_thread {
   /*! Whether the event thread should be online or not.  Checked on every wake
    *  event before sleeping. */
@@ -106,6 +108,7 @@ struct ares_event_thread {
   /* Event subsystem private data */
   void                   *ev_sys_data;
 };
+
 
 /*! Queue an update for the event handle.
  *

--- a/src/lib/ares_event.h
+++ b/src/lib/ares_event.h
@@ -79,7 +79,12 @@ typedef struct {
   size_t (*wait)(ares_event_thread_t *e, unsigned long timeout_ms);
 } ares_event_sys_t;
 
-ares_status_t ares_event_configchg_init(ares_event_thread_t *e);
+struct ares_event_configchg;
+typedef struct ares_event_configchg ares_event_configchg_t;
+
+ares_status_t ares_event_configchg_init(ares_event_configchg_t **configchg, ares_event_thread_t *e);
+
+void ares_event_configchg_destroy(ares_event_configchg_t *configchg);
 
 struct ares_event_thread {
   /*! Whether the event thread should be online or not.  Checked on every wake
@@ -105,6 +110,8 @@ struct ares_event_thread {
    *  file descriptors being waited on and to wake the event subsystem during
    *  shutdown */
   ares_event_t           *ev_signal;
+  /*! Handle for configuration change monitoring */
+  ares_event_configchg_t *configchg;
   /* Event subsystem callbacks */
   const ares_event_sys_t *ev_sys;
   /* Event subsystem private data */

--- a/src/lib/ares_event.h
+++ b/src/lib/ares_event.h
@@ -96,8 +96,10 @@ struct ares_event_thread {
    *  thread other than the event thread itself. The event thread will then
    *  be woken then process these updates itself */
   ares__llist_t          *ev_updates;
-  /*! Registered event handles. */
-  ares__htable_asvp_t    *ev_handles;
+  /*! Registered socket event handles */
+  ares__htable_asvp_t    *ev_sock_handles;
+  /*! Registered custom event handles. Typically used for external triggering. */
+  ares__htable_vpvp_t    *ev_cust_handles;
   /*! Pointer to the event handle which is used to signal and wake the event
    *  thread itself.  This is needed to be able to do things like update the
    *  file descriptors being waited on and to wake the event subsystem during

--- a/src/lib/ares_event_configchg.c
+++ b/src/lib/ares_event_configchg.c
@@ -1,0 +1,235 @@
+/* MIT License
+ *
+ * Copyright (c) 2024 Brad House
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "ares_setup.h"
+#include "ares.h"
+#include "ares_private.h"
+#include "ares_event.h"
+
+static void ares_event_configchg_reload(ares_channel_t *channel)
+{
+  /* XXX: dispatch via thread so we don't block events */
+  printf("%s(): config change detected\n", __FUNCTION__);
+  ares_reinit(channel);
+}
+
+#ifdef __LINUX__
+
+#  include <sys/inotify.h>
+
+typedef struct {
+  int inotify_fd;
+} ares_event_configchg_t;
+
+static void ares_event_configchg_free(void *data)
+{
+  ares_event_configchg_t *configchg = data;
+  if (configchg == NULL)
+    return;
+
+  if (configchg->inotify_fd >= 0) {
+    close(configchg->inotify_fd);
+    configchg->inotify_fd = -1;
+  }
+
+  ares_free(configchg);
+}
+
+static void ares_event_configchg_cb(ares_event_thread_t *e, ares_socket_t fd,
+                                    void *data, ares_event_flags_t flags)
+{
+  ares_event_configchg_t *configchg = data;
+
+  /* Some systems cannot read integer variables if they are not
+   * properly aligned. On other systems, incorrect alignment may
+   * decrease performance. Hence, the buffer used for reading from
+   * the inotify file descriptor should have the same alignment as
+   * struct inotify_event. */
+  unsigned char               buf[4096] __attribute__ ((aligned(__alignof__(struct inotify_event))));
+  const struct inotify_event *event;
+  ssize_t                     len;
+  ares_bool_t                 triggered = ARES_FALSE;
+
+  (void)fd;
+  (void)flags;
+
+  while (1) {
+    const unsigned char *ptr;
+
+    len = read(configchg->inotify_fd, buf, sizeof(buf));
+    if (len <= 0) {
+      break;
+    }
+
+    /* Loop over all events in the buffer. Says kernel will check the buffer
+     * size provided, so I assume it won't ever return partial events. */
+    for (ptr = buf; ptr < buf + len;
+         ptr += sizeof(struct inotify_event) + event->len) {
+
+      event = (const struct inotify_event *)ptr;
+
+      if (event->name == NULL)
+        continue;
+
+      if (strcasecmp(event->name, "resolv.conf") == 0 ||
+          strcasecmp(event->name, "nsswitch.conf") == 0) {
+        triggered = ARES_TRUE;
+      }
+    }
+  }
+
+  /* Only process after all events are read.  No need to process more often as
+   * we don't want to reload the config back to back */
+  if (triggered) {
+    ares_event_configchg_reload(e->channel);
+  }
+}
+
+
+ares_status_t ares_event_configchg_init(ares_event_thread_t *e)
+{
+  ares_status_t           status = ARES_SUCCESS;
+  ares_event_configchg_t *configchg;
+
+  configchg = ares_malloc_zero(sizeof(*configchg));
+  if (configchg == NULL) {
+    return ARES_ENOMEM;
+  }
+
+  configchg->inotify_fd = inotify_init1(IN_NONBLOCK|IN_CLOEXEC);
+  if (configchg->inotify_fd == -1) {
+    status = ARES_ESERVFAIL;
+    goto done;
+  }
+
+  /* We need to monitor /etc/resolv.conf, /etc/nsswitch.conf */
+  if (inotify_add_watch(configchg->inotify_fd, "/etc", IN_CREATE|IN_MODIFY|IN_MOVED_TO|IN_ONLYDIR) == -1) {
+    status = ARES_ESERVFAIL;
+    goto done;
+  }
+
+  status = ares_event_update(NULL, e, ARES_EVENT_FLAG_READ,
+                             ares_event_configchg_cb, configchg->inotify_fd,
+                             configchg,ares_event_configchg_free, NULL);
+
+done:
+  if (status != ARES_SUCCESS) {
+    ares_event_configchg_free(configchg);
+  }
+  return status;
+}
+
+#elif defined(_WIN32)
+
+
+
+#elif defined(__APPLE__)
+
+#  include <sys/types.h>
+#  include <unistd.h>
+#  include <notify.h>
+
+typedef struct {
+  int fd;
+  int token;
+} ares_event_configchg_t;
+
+static void ares_event_configchg_free(void *data)
+{
+  ares_event_configchg_t *configchg = data;
+  if (configchg == NULL)
+    return;
+
+  if (configchg->fd >= 0) {
+    notify_cancel(configchg->token);
+    /* automatically closes fd */
+    configchg->fd = -1;
+  }
+
+  ares_free(configchg);
+}
+
+static void ares_event_configchg_cb(ares_event_thread_t *e, ares_socket_t fd,
+                                    void *data, ares_event_flags_t flags)
+{
+  ares_event_configchg_t *configchg = data;
+  ares_bool_t             triggered = ARES_FALSE;
+
+  (void)fd;
+  (void)flags;
+
+  while (1) {
+    int     t;
+    ssize_t len;
+
+    len = read(configchg->fd, &t, sizeof(t));
+
+    if (len < (ssize_t)sizeof(t))
+      break;
+
+    if (t != configchg->token) {
+      continue;
+    }
+
+    triggered = ARES_TRUE;
+  }
+
+  /* Only process after all events are read.  No need to process more often as
+   * we don't want to reload the config back to back */
+  if (triggered) {
+    ares_event_configchg_reload(e->channel);
+  }
+}
+
+ares_status_t ares_event_configchg_init(ares_event_thread_t *e)
+{
+  ares_status_t           status = ARES_SUCCESS;
+  ares_event_configchg_t *configchg;
+
+  configchg = ares_malloc_zero(sizeof(*configchg));
+  if (configchg == NULL) {
+    return ARES_ENOMEM;
+  }
+
+  if (notify_register_file_descriptor("com.apple.system.SystemConfiguration.dns_configuration",
+    &configchg->fd, 0, &configchg->token) != NOTIFY_STATUS_OK) {
+    status = ARES_ESERVFAIL;
+    goto done;
+  }
+
+  status = ares_event_update(NULL, e, ARES_EVENT_FLAG_READ,
+                             ares_event_configchg_cb, configchg->fd, configchg,
+                             ares_event_configchg_free, NULL);
+
+done:
+  if (status != ARES_SUCCESS) {
+    ares_event_configchg_free(configchg);
+  }
+  return status;
+}
+
+#else
+
+#endif

--- a/src/lib/ares_event_configchg.c
+++ b/src/lib/ares_event_configchg.c
@@ -230,4 +230,10 @@ done:
 
 #else
 
+ares_status_t ares_event_configchg_init(ares_event_thread_t *e)
+{
+  /* Not implemented yet, need to spawn thread */
+  return ARES_SUCCESS;
+}
+
 #endif

--- a/src/lib/ares_event_configchg.c
+++ b/src/lib/ares_event_configchg.c
@@ -28,11 +28,9 @@
 #include "ares_private.h"
 #include "ares_event.h"
 
-static void ares_event_configchg_reload(ares_channel_t *channel)
+static void ares_event_configchg_reload(ares_event_thread_t *e)
 {
-  /* XXX: dispatch via thread so we don't block events */
-  printf("%s(): config change detected\n", __FUNCTION__);
-  ares_reinit(channel);
+  ares_reinit(e->channel);
 }
 
 #ifdef __LINUX__
@@ -103,7 +101,7 @@ static void ares_event_configchg_cb(ares_event_thread_t *e, ares_socket_t fd,
   /* Only process after all events are read.  No need to process more often as
    * we don't want to reload the config back to back */
   if (triggered) {
-    ares_event_configchg_reload(e->channel);
+    ares_event_configchg_reload(e);
   }
 }
 
@@ -199,7 +197,7 @@ static void ares_event_configchg_cb(ares_event_thread_t *e, ares_socket_t fd,
   /* Only process after all events are read.  No need to process more often as
    * we don't want to reload the config back to back */
   if (triggered) {
-    ares_event_configchg_reload(e->channel);
+    ares_event_configchg_reload(e);
   }
 }
 

--- a/src/lib/ares_event_epoll.c
+++ b/src/lib/ares_event_epoll.c
@@ -167,7 +167,7 @@ static size_t ares_evsys_epoll_wait(ares_event_thread_t *e,
     ares_event_t      *ev;
     ares_event_flags_t flags = 0;
 
-    ev = ares__htable_asvp_get_direct(e->ev_handles,
+    ev = ares__htable_asvp_get_direct(e->ev_sock_handles,
                                       (ares_socket_t)events[i].data.fd);
     if (ev == NULL || ev->cb == NULL) {
       continue;

--- a/src/lib/ares_event_kqueue.c
+++ b/src/lib/ares_event_kqueue.c
@@ -218,7 +218,7 @@ static size_t ares_evsys_kqueue_wait(ares_event_thread_t *e,
     ares_event_t      *ev;
     ares_event_flags_t flags = 0;
 
-    ev = ares__htable_asvp_get_direct(e->ev_handles,
+    ev = ares__htable_asvp_get_direct(e->ev_sock_handles,
                                       (ares_socket_t)events[i].ident);
     if (ev == NULL || ev->cb == NULL) {
       continue;

--- a/src/lib/ares_event_poll.c
+++ b/src/lib/ares_event_poll.c
@@ -69,7 +69,7 @@ static size_t ares_evsys_poll_wait(ares_event_thread_t *e,
                                    unsigned long        timeout_ms)
 {
   size_t         num_fds = 0;
-  ares_socket_t *fdlist  = ares__htable_asvp_keys(e->ev_handles, &num_fds);
+  ares_socket_t *fdlist  = ares__htable_asvp_keys(e->ev_sock_handles, &num_fds);
   struct pollfd *pollfd  = NULL;
   int            rv;
   size_t         cnt = 0;
@@ -82,7 +82,7 @@ static size_t ares_evsys_poll_wait(ares_event_thread_t *e,
     }
     for (i = 0; i < num_fds; i++) {
       const ares_event_t *ev =
-        ares__htable_asvp_get_direct(e->ev_handles, fdlist[i]);
+        ares__htable_asvp_get_direct(e->ev_sock_handles, fdlist[i]);
       pollfd[i].fd = ev->fd;
       if (ev->flags & ARES_EVENT_FLAG_READ) {
         pollfd[i].events |= POLLIN;
@@ -109,7 +109,7 @@ static size_t ares_evsys_poll_wait(ares_event_thread_t *e,
 
     cnt++;
 
-    ev = ares__htable_asvp_get_direct(e->ev_handles, pollfd[i].fd);
+    ev = ares__htable_asvp_get_direct(e->ev_sock_handles, pollfd[i].fd);
     if (ev == NULL || ev->cb == NULL) {
       continue;
     }

--- a/src/lib/ares_event_select.c
+++ b/src/lib/ares_event_select.c
@@ -71,7 +71,7 @@ static size_t ares_evsys_select_wait(ares_event_thread_t *e,
                                      unsigned long        timeout_ms)
 {
   size_t          num_fds = 0;
-  ares_socket_t  *fdlist  = ares__htable_asvp_keys(e->ev_handles, &num_fds);
+  ares_socket_t  *fdlist  = ares__htable_asvp_keys(e->ev_sock_handles, &num_fds);
   int             rv;
   size_t          cnt = 0;
   size_t          i;
@@ -86,7 +86,7 @@ static size_t ares_evsys_select_wait(ares_event_thread_t *e,
 
   for (i = 0; i < num_fds; i++) {
     const ares_event_t *ev =
-      ares__htable_asvp_get_direct(e->ev_handles, fdlist[i]);
+      ares__htable_asvp_get_direct(e->ev_sock_handles, fdlist[i]);
     if (ev->flags & ARES_EVENT_FLAG_READ) {
       FD_SET(ev->fd, &read_fds);
     }
@@ -110,7 +110,7 @@ static size_t ares_evsys_select_wait(ares_event_thread_t *e,
       ares_event_t      *ev;
       ares_event_flags_t flags = 0;
 
-      ev = ares__htable_asvp_get_direct(e->ev_handles, fdlist[i]);
+      ev = ares__htable_asvp_get_direct(e->ev_sock_handles, fdlist[i]);
       if (ev == NULL || ev->cb == NULL) {
         continue;
       }

--- a/src/lib/ares_event_thread.c
+++ b/src/lib/ares_event_thread.c
@@ -391,6 +391,7 @@ static const ares_event_sys_t *ares_event_fetch_sys(ares_evsys_t evsys)
 ares_status_t ares_event_thread_init(ares_channel_t *channel)
 {
   ares_event_thread_t *e;
+  ares_status_t        status;
 
   e = ares_malloc_zero(sizeof(*e));
   if (e == NULL) {
@@ -431,6 +432,15 @@ ares_status_t ares_event_thread_init(ares_channel_t *channel)
     channel->sock_state_cb      = NULL;
     channel->sock_state_cb_data = NULL;
     return ARES_ESERVFAIL;
+  }
+
+  /* Initialize monitor for configuration changes */
+  status = ares_event_configchg_init(e);
+  if (status != ARES_SUCCESS) {
+    ares_event_thread_destroy_int(e);
+    channel->sock_state_cb      = NULL;
+    channel->sock_state_cb_data = NULL;
+    return status;
   }
 
   /* Before starting the thread, process any possible events the initialization

--- a/src/lib/ares_event_thread.c
+++ b/src/lib/ares_event_thread.c
@@ -298,6 +298,10 @@ static void ares_event_thread_destroy_int(ares_event_thread_t *e)
 {
   ares__llist_node_t *node;
 
+  /* Disable configuration change monitoring */
+  ares_event_configchg_destroy(e->configchg);
+  e->configchg = NULL;
+
   /* Wake thread and tell it to shutdown if it exists */
   ares__thread_mutex_lock(e->mutex);
   if (e->isup) {
@@ -457,7 +461,7 @@ ares_status_t ares_event_thread_init(ares_channel_t *channel)
   }
 
   /* Initialize monitor for configuration changes */
-  status = ares_event_configchg_init(e);
+  status = ares_event_configchg_init(&e->configchg, e);
   if (status != ARES_SUCCESS) {
     ares_event_thread_destroy_int(e);
     channel->sock_state_cb      = NULL;

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -114,6 +114,7 @@ typedef struct ares_rand_state ares_rand_state;
 #include "ares__htable_strvp.h"
 #include "ares__htable_szvp.h"
 #include "ares__htable_asvp.h"
+#include "ares__htable_vpvp.h"
 #include "ares__buf.h"
 #include "ares_dns_private.h"
 #include "ares__iface_ips.h"

--- a/src/lib/ares_sysconfig_mac.c
+++ b/src/lib/ares_sysconfig_mac.c
@@ -58,7 +58,6 @@
 
 typedef struct {
   void *handle;
-  const char *(*dns_configuration_notify_key)(void);
   dns_config_t *(*dns_configuration_copy)(void);
   void (*dns_configuration_free)(dns_config_t *config);
 } dnsinfo_t;
@@ -101,15 +100,12 @@ static ares_status_t dnsinfo_init(dnsinfo_t **dnsinfo_out)
     goto done;
   }
 
-  dnsinfo->dns_configuration_notify_key =
-    dlsym(dnsinfo->handle, "dns_configuration_notify_key");
   dnsinfo->dns_configuration_copy =
     dlsym(dnsinfo->handle, "dns_configuration_copy");
   dnsinfo->dns_configuration_free =
     dlsym(dnsinfo->handle, "dns_configuration_free");
 
-  if (dnsinfo->dns_configuration_notify_key == NULL ||
-      dnsinfo->dns_configuration_copy == NULL ||
+  if (dnsinfo->dns_configuration_copy == NULL ||
       dnsinfo->dns_configuration_free == NULL) {
     status = ARES_ESERVFAIL;
     goto done;


### PR DESCRIPTION
Automatically detect configuration changes and reload.  On systems which provide notification mechanisms, use those, otherwise fallback to polling.