### PR TITLE
SIG(0) record class

### DIFF
--- a/src/lib/ares_dns_record.c
+++ b/src/lib/ares_dns_record.c
@@ -412,7 +412,7 @@ ares_status_t ares_dns_record_rr_add(ares_dns_rr_t    **rr_out,
   if (dnsrec == NULL || name == NULL || rr_out == NULL ||
       !ares_dns_section_isvalid(sect) ||
       !ares_dns_rec_type_isvalid(type, ARES_FALSE) ||
-      !ares_dns_class_isvalid(rclass, ARES_FALSE)) {
+      !ares_dns_class_isvalid(rclass, ARES_TRUE)) {
     return ARES_EFORMERR;
   }
 


### PR DESCRIPTION
I am using c-ares with a resolver that supports: SIG(0) record class, according to https://datatracker.ietf.org/doc/html/rfc2931#section-3

> For all SIG(0) RRs, the owner name, class, TTL, and original TTL, are
meaningless. The TTL fields SHOULD be zero and the CLASS field
SHOULD be ANY.

--

This PR enables `ANY` records. Alternatively we could have different method that accepts type + rclass to do class validation and that could narrow ANY + SIG.