### PR TITLE
Start annotating code for coverage exclusions

### DIFF
--- a/src/lib/ares__buf.c
+++ b/src/lib/ares__buf.c
@@ -87,7 +87,7 @@ void ares__buf_destroy(ares__buf_t *buf)
 static ares_bool_t ares__buf_is_const(const ares__buf_t *buf)
 {
   if (buf == NULL) {
-    return ARES_FALSE;
+    return ARES_FALSE; /* LCOV_EXCL_LINE: defensive coding */
   }
 
   if (buf->data != NULL && buf->alloc_buf == NULL) {
@@ -107,7 +107,7 @@ void ares__buf_reclaim(ares__buf_t *buf)
   }
 
   if (ares__buf_is_const(buf)) {
-    return;
+    return; /* LCOV_EXCL_LINE: defensive coding */
   }
 
   /* Silence coverity.  All lengths are zero so would bail out later but
@@ -151,7 +151,7 @@ static ares_status_t ares__buf_ensure_space(ares__buf_t *buf,
   }
 
   if (ares__buf_is_const(buf)) {
-    return ARES_EFORMERR;
+    return ARES_EFORMERR; /* LCOV_EXCL_LINE: defensive coding */
   }
 
   /* When calling ares__buf_finish_str() we end up adding a null terminator,
@@ -201,11 +201,11 @@ static ares_status_t ares__buf_ensure_space(ares__buf_t *buf,
 ares_status_t ares__buf_set_length(ares__buf_t *buf, size_t len)
 {
   if (buf == NULL || ares__buf_is_const(buf)) {
-    return ARES_EFORMERR;
+    return ARES_EFORMERR; /* LCOV_EXCL_LINE: defensive coding */
   }
 
   if (len >= buf->alloc_buf_len - buf->offset) {
-    return ARES_EFORMERR;
+    return ARES_EFORMERR; /* LCOV_EXCL_LINE: defensive coding */
   }
 
   buf->data_len = len;
@@ -242,12 +242,12 @@ ares_status_t ares__buf_append_be16(ares__buf_t *buf, unsigned short u16)
 
   status = ares__buf_append_byte(buf, (unsigned char)((u16 >> 8) & 0xff));
   if (status != ARES_SUCCESS) {
-    return status;
+    return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   status = ares__buf_append_byte(buf, (unsigned char)(u16 & 0xff));
   if (status != ARES_SUCCESS) {
-    return status;
+    return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   return ARES_SUCCESS;
@@ -259,22 +259,22 @@ ares_status_t ares__buf_append_be32(ares__buf_t *buf, unsigned int u32)
 
   status = ares__buf_append_byte(buf, ((unsigned char)(u32 >> 24) & 0xff));
   if (status != ARES_SUCCESS) {
-    return status;
+    return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   status = ares__buf_append_byte(buf, ((unsigned char)(u32 >> 16) & 0xff));
   if (status != ARES_SUCCESS) {
-    return status;
+    return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   status = ares__buf_append_byte(buf, ((unsigned char)(u32 >> 8) & 0xff));
   if (status != ARES_SUCCESS) {
-    return status;
+    return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   status = ares__buf_append_byte(buf, ((unsigned char)u32 & 0xff));
   if (status != ARES_SUCCESS) {
-    return status;
+    return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   return ARES_SUCCESS;
@@ -319,7 +319,7 @@ unsigned char *ares__buf_finish_bin(ares__buf_t *buf, size_t *len)
   /* We don't want to return NULL except on failure, may be zero-length */
   if (buf->alloc_buf == NULL &&
       ares__buf_ensure_space(buf, 1) != ARES_SUCCESS) {
-    return NULL;
+    return NULL; /* LCOV_EXCL_LINE: OutOfMemory */
   }
   ptr  = buf->alloc_buf;
   *len = buf->data_len;
@@ -540,7 +540,7 @@ ares_status_t ares__buf_fetch_bytes_dup(ares__buf_t *buf, size_t len,
 
   *bytes = ares_malloc(null_term ? len + 1 : len);
   if (*bytes == NULL) {
-    return ARES_ENOMEM;
+    return ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   memcpy(*bytes, ptr, len);
@@ -561,7 +561,7 @@ ares_status_t ares__buf_fetch_str_dup(ares__buf_t *buf, size_t len, char **str)
 
   *str = ares_malloc(len + 1);
   if (*str == NULL) {
-    return ARES_ENOMEM;
+    return ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   memcpy(*str, ptr, len);
@@ -787,7 +787,7 @@ ares_status_t ares__buf_split(ares__buf_t *buf, const unsigned char *delims,
   ares_bool_t   first  = ARES_TRUE;
 
   if (buf == NULL || delims == NULL || delims_len == 0 || list == NULL) {
-    return ARES_EFORMERR;
+    return ARES_EFORMERR; /* LCOV_EXCL_LINE: defensive coding */
   }
 
   *list = ares__llist_create(ares__buf_destroy_cb);
@@ -825,7 +825,7 @@ ares_status_t ares__buf_split(ares__buf_t *buf, const unsigned char *delims,
 
     /* Shouldn't be possible */
     if (ptr == NULL) {
-      status = ARES_EFORMERR;
+      status = ARES_EFORMERR; /* LCOV_EXCL_LINE: defensive coding */
       goto done;
     }
 
@@ -934,7 +934,7 @@ ares_status_t ares__buf_set_position(ares__buf_t *buf, size_t idx)
   }
 
   if (idx > buf->data_len) {
-    return ARES_EFORMERR;
+    return ARES_EFORMERR; /* LCOV_EXCL_LINE: defensive coding */
   }
 
   buf->offset = idx;
@@ -966,7 +966,7 @@ static ares_status_t ares__buf_parse_dns_binstr_int(
   while (orig_len - ares__buf_len(buf) < remaining_len) {
     status = ares__buf_fetch_bytes(buf, &len, 1);
     if (status != ARES_SUCCESS) {
-      break;
+      break; /* LCOV_EXCL_LINE: defensive coding */
     }
 
     if (len) {
@@ -1049,13 +1049,13 @@ ares_status_t ares__buf_append_num_dec(ares__buf_t *buf, size_t num, size_t len)
 
     /* Silence coverity.  Shouldn't be possible since we calculate it above */
     if (mod == 0) {
-      return ARES_EFORMERR;
+      return ARES_EFORMERR; /* LCOV_EXCL_LINE: defensive coding */
     }
 
     digit  /= mod;
     status  = ares__buf_append_byte(buf, '0' + (unsigned char)(digit & 0xFF));
     if (status != ARES_SUCCESS) {
-      return status;
+      return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
   return ARES_SUCCESS;
@@ -1074,7 +1074,7 @@ ares_status_t ares__buf_append_num_hex(ares__buf_t *buf, size_t num, size_t len)
     ares_status_t status;
     status = ares__buf_append_byte(buf, hexbytes[(num >> ((i - 1) * 4)) & 0xF]);
     if (status != ARES_SUCCESS) {
-      return status;
+      return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
   return ARES_SUCCESS;
@@ -1095,13 +1095,13 @@ static ares_status_t ares__buf_hexdump_line(ares__buf_t *buf, size_t idx,
   /* Address */
   status = ares__buf_append_num_hex(buf, idx, 6);
   if (status != ARES_SUCCESS) {
-    return status;
+    return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   /* | */
   status = ares__buf_append_str(buf, " | ");
   if (status != ARES_SUCCESS) {
-    return status;
+    return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   for (i = 0; i < 16; i++) {
@@ -1111,19 +1111,19 @@ static ares_status_t ares__buf_hexdump_line(ares__buf_t *buf, size_t idx,
       status = ares__buf_append_num_hex(buf, data[i], 2);
     }
     if (status != ARES_SUCCESS) {
-      return status;
+      return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
     status = ares__buf_append_byte(buf, ' ');
     if (status != ARES_SUCCESS) {
-      return status;
+      return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
 
   /* | */
   status = ares__buf_append_str(buf, " | ");
   if (status != ARES_SUCCESS) {
-    return status;
+    return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   for (i = 0; i < 16; i++) {
@@ -1132,7 +1132,7 @@ static ares_status_t ares__buf_hexdump_line(ares__buf_t *buf, size_t idx,
     }
     status = ares__buf_append_byte(buf, ares__isprint(data[i]) ? data[i] : '.');
     if (status != ARES_SUCCESS) {
-      return status;
+      return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
 
@@ -1149,7 +1149,7 @@ ares_status_t ares__buf_hexdump(ares__buf_t *buf, const unsigned char *data,
     ares_status_t status;
     status = ares__buf_hexdump_line(buf, i, data + i, len - i);
     if (status != ARES_SUCCESS) {
-      return status;
+      return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
 
@@ -1166,7 +1166,7 @@ ares_status_t ares__buf_load_file(const char *filename, ares__buf_t *buf)
   ares_status_t  status;
 
   if (filename == NULL || buf == NULL) {
-    return ARES_EFORMERR;
+    return ARES_EFORMERR; /* LCOV_EXCL_LINE: defensive coding */
   }
 
   fp = fopen(filename, "rb");
@@ -1188,39 +1188,39 @@ ares_status_t ares__buf_load_file(const char *filename, ares__buf_t *buf)
 
   /* Get length portably, fstat() is POSIX, not C */
   if (fseek(fp, 0, SEEK_END) != 0) {
-    status = ARES_EFILE;
-    goto done;
+    status = ARES_EFILE; /* LCOV_EXCL_LINE: defensive coding */
+    goto done; /* LCOV_EXCL_LINE: defensive coding */
   }
 
   ftell_len = ftell(fp);
   if (ftell_len < 0) {
-    status = ARES_EFILE;
-    goto done;
+    status = ARES_EFILE; /* LCOV_EXCL_LINE: defensive coding */
+    goto done; /* LCOV_EXCL_LINE: defensive coding */
   }
   len = (size_t)ftell_len;
 
   if (fseek(fp, 0, SEEK_SET) != 0) {
-    status = ARES_EFILE;
-    goto done;
+    status = ARES_EFILE; /* LCOV_EXCL_LINE: defensive coding */
+    goto done; /* LCOV_EXCL_LINE: defensive coding */
   }
 
   if (len == 0) {
-    status = ARES_SUCCESS;
-    goto done;
+    status = ARES_SUCCESS; /* LCOV_EXCL_LINE: defensive coding */
+    goto done; /* LCOV_EXCL_LINE: defensive coding */
   }
 
   /* Read entire data into buffer */
   ptr_len = len;
   ptr     = ares__buf_append_start(buf, &ptr_len);
   if (ptr == NULL) {
-    status = ARES_ENOMEM;
-    goto done;
+    status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
+    goto done; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   ptr_len = fread(ptr, 1, len, fp);
   if (ptr_len != len) {
-    status = ARES_EFILE;
-    goto done;
+    status = ARES_EFILE; /* LCOV_EXCL_LINE: defensive coding */
+    goto done; /* LCOV_EXCL_LINE: defensive coding */
   }
 
   ares__buf_append_finish(buf, len);


### PR DESCRIPTION
Defensive Coding and Out Of Memory are often lines of code that can't be covered.  Annotate the code to add exclusions for these.