### PR TITLE
Fix Watt-32 compilation support

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: apt dependencies
         run: sudo apt-get install cmake ninja-build
       - name: Download Coverity Build Tool

--- a/.github/workflows/watcom.yml
+++ b/.github/workflows/watcom.yml
@@ -1,7 +1,9 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: OpenWatcom
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/watcom.yml
+++ b/.github/workflows/watcom.yml
@@ -1,13 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: OpenWatcom
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: push
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/watcom.yml
+++ b/.github/workflows/watcom.yml
@@ -10,8 +10,6 @@ jobs:
       - uses: open-watcom/setup-watcom@v0
       - name: Checkout Source
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: configure
         run: buildconf.bat
         shell: cmd

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -1,13 +1,7 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: WATT32
-on:
-  push:
-    branches:
-      - watt32
-  pull_request:
-    branches:
-      - main
+on: push
 
 jobs:
   build:
@@ -46,7 +40,7 @@ jobs:
       - name: Build c-ares
         run: |
           Copy-Item "include\ares_build.h.dist" -Destination "include\ares_build.h"
-          nmake USE_WATT32=1 /NOLOGO /f .\Makefile.msvc
+          nmake USE_WATT32=0 /NOLOGO /f .\Makefile.msvc
 
 
 

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -28,10 +28,21 @@ jobs:
       - name: Build Watt-32
         run: |
           cd watt-32\src
-          configur.bat visualc
+          & .\configur.bat visualc
           echo "Configured"
           nmake -nologo -f visualc-release_32.mak
-        shell: cmd
+        # Powershell doesn't preserve environment variables set by configur.bat
+        env:
+          MKMAKE: ..\util\win32\mkmake.exe
+          MKDEP: ..\util\win32\mkdep.exe
+          HC_ERR: ..\util\win32\hc_err.exe
+          WC_ERR: ..\util\win32\wc_err.exe
+          BCC_ERR: ..\util\win32\bcc_err.exe
+          W32_BIN2C: ..\util\win32\bin2c.exe
+          W32_BIN2C_: ../util/win32/bin2c.exe
+          W32_NASM: ..\util\win32\nasm.exe
+          W32_NASM_: ../util/win32/nasm.exe
+          DJ_ERR: ..\util\win32\dj_err.exe
       - name: Build c-ares
         run: |
           Copy-Item "include\ares_build.h.dist" -Destination "include\ares_build.h"

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: ilammy/msvc-dev-cmd@v1.4.1
-        arch: x86
+        with:
+          arch: x86
       - name: Checkout Source
         uses: actions/checkout@v4
       - name: Build c-ares

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -9,12 +9,11 @@ on:
     branches:
       - main
 
-env:
-  WATT_ROOT: "${{ runner.temp }}/watt"
-
 jobs:
   build:
     runs-on: windows-latest
+    env:
+      WATT_ROOT: "${{ runner.temp }}/watt"
     steps:
       - uses: ilammy/msvc-dev-cmd@v1
         with:

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+env:
+  WATT_ROOT: "C:\NET\WATT"
+
 jobs:
   build:
     runs-on: windows-latest
@@ -24,8 +27,6 @@ jobs:
           repository: gvanem/Watt-32
           path: watt-32
       - name: Build Watt-32
-        env:
-          WATT_ROOT: "${{ runner.temp }}/watt"
         run: |
           cd watt-32/src
           & .\configur.bat visualc

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -16,8 +16,18 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x86
-      - name: Checkout Source
+      - name: Checkout c-ares
         uses: actions/checkout@v4
+      - name: Checkout Watt-32
+        uses: actions/checkout@v4
+        with:
+          repository: gvanem/Watt-32
+          path: watt-32
+      - name: Build Watt-32
+        run: |
+          cd watt-32/src
+          & .\configur.bat visualc
+          nmake -nologo -f visualc-release_32.mak
       - name: Build c-ares
         run: |
           Copy-Item "include\ares_build.h.dist" -Destination "include\ares_build.h"

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -1,0 +1,25 @@
+# Copyright (C) The c-ares project and its contributors
+# SPDX-License-Identifier: MIT
+name: WATT32
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: ilammy/msvc-dev-cmd@v1.4.1
+        arch: x86
+      - name: Checkout Source
+        uses: actions/checkout@v4
+      - name: Build c-ares
+        run: |
+          nmake /NOLOGO /f .\Makefile.msvc
+
+
+

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  WATT_ROOT: "C:\NET\WATT"
+  WATT_ROOT: "C:\\NET\\WATT"
 
 jobs:
   build:

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -15,6 +15,8 @@ env:
 jobs:
   build:
     runs-on: windows-latest
+    env:
+      WATT_ROOT: "${{ github.workspace }}/watt-32"
     steps:
       - uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -28,6 +30,7 @@ jobs:
           path: watt-32
       - name: Build Watt-32
         run: |
+          env
           cd watt-32/src
           & .\configur.bat visualc
           nmake -nologo -f visualc-release_32.mak

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -20,7 +20,7 @@ jobs:
           repository: gvanem/Watt-32
           path: watt-32
       - name: "Watt-32: Make sure lang.c timestamp is ahead of checkout time so it doesn't try to rebuild and fail"
-        run: (Get-ChildItem "lang.c").LastWriteTime = Get-Date
+        run: (Get-ChildItem "watt-32/src/lang.c").LastWriteTime = Get-Date
       - name: Build Watt-32
         run: |
           cd watt-32\src

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+env:
+  WATT_ROOT: "${{ RUNNER_TEMP }}/watt"
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -27,11 +27,11 @@ jobs:
           path: watt-32
       - name: Build Watt-32
         run: |
-          env
-          cd watt-32/src
-          & .\configur.bat visualc
+          cd watt-32\src
+          configur.bat visualc
           echo "Configured"
           nmake -nologo -f visualc-release_32.mak
+        shell: cmd
       - name: Build c-ares
         run: |
           Copy-Item "include\ares_build.h.dist" -Destination "include\ares_build.h"

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -12,8 +12,6 @@ on:
 jobs:
   build:
     runs-on: windows-latest
-    env:
-      WATT_ROOT: "${{ runner.temp }}/watt"
     steps:
       - uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -26,6 +24,8 @@ jobs:
           repository: gvanem/Watt-32
           path: watt-32
       - name: Build Watt-32
+        env:
+          WATT_ROOT: "${{ runner.temp }}/watt"
         run: |
           cd watt-32/src
           & .\configur.bat visualc

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -9,14 +9,11 @@ on:
     branches:
       - main
 
-env:
-  WATT_ROOT: "C:\\NET\\WATT"
-
 jobs:
   build:
     runs-on: windows-latest
     env:
-      WATT_ROOT: "${{ github.workspace }}/watt-32"
+      WATT_ROOT: "${{ github.workspace }}\\watt-32"
     steps:
       - uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -33,11 +30,12 @@ jobs:
           env
           cd watt-32/src
           & .\configur.bat visualc
+          echo "Configured"
           nmake -nologo -f visualc-release_32.mak
       - name: Build c-ares
         run: |
           Copy-Item "include\ares_build.h.dist" -Destination "include\ares_build.h"
-          nmake /NOLOGO /f .\Makefile.msvc
+          nmake USE_WATT32=1 /NOLOGO /f .\Makefile.msvc
 
 
 

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -13,13 +13,14 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: ilammy/msvc-dev-cmd@v1.4.1
+      - uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x86
       - name: Checkout Source
         uses: actions/checkout@v4
       - name: Build c-ares
         run: |
+          buildconf.bat
           nmake /NOLOGO /f .\Makefile.msvc
 
 

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           repository: gvanem/Watt-32
           path: watt-32
+      - name: "Watt-32: Make sure lang.c timestamp is ahead of checkout time so it doesn't try to rebuild and fail"
+        run: (Get-ChildItem "lang.c").LastWriteTime = Get-Date
       - name: Build Watt-32
         run: |
           cd watt-32\src

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  WATT_ROOT: "${{ env.RUNNER_TEMP }}/watt"
+  WATT_ROOT: "${{ runner.temp }}/watt"
 
 jobs:
   build:

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  WATT_ROOT: "${{ RUNNER_TEMP }}/watt"
+  WATT_ROOT: "${{ env.RUNNER_TEMP }}/watt"
 
 jobs:
   build:

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Build c-ares
         run: |
-          buildconf.bat
+          Copy-Item "include\ares_build.h.dist" -Destination "include\ares_build.h"
           nmake /NOLOGO /f .\Makefile.msvc
 
 

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -1,7 +1,9 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: WATT32
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
   build:
@@ -43,6 +45,7 @@ jobs:
         run: |
           Copy-Item "include\ares_build.h.dist" -Destination "include\ares_build.h"
           nmake USE_WATT32=1 CFG=dll-release /NOLOGO /f .\Makefile.msvc
+          nmake USE_WATT32=1 CFG=lib-release /NOLOGO /f .\Makefile.msvc
 
 
 

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -4,7 +4,7 @@ name: WATT32
 on:
   push:
     branches:
-      - main
+      - watt32
   pull_request:
     branches:
       - main

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build c-ares
         run: |
           Copy-Item "include\ares_build.h.dist" -Destination "include\ares_build.h"
-          nmake USE_WATT32=0 /NOLOGO /f .\Makefile.msvc
+          nmake USE_WATT32=1 /NOLOGO /f .\Makefile.msvc
 
 
 

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build c-ares
         run: |
           Copy-Item "include\ares_build.h.dist" -Destination "include\ares_build.h"
-          nmake USE_WATT32=1 /NOLOGO /f .\Makefile.msvc
+          nmake USE_WATT32=1 CFG=dll-release /NOLOGO /f .\Makefile.msvc
 
 
 

--- a/Makefile.Watcom
+++ b/Makefile.Watcom
@@ -42,7 +42,7 @@ RD = rmdir /q /s 2>NUL
 CP = copy
 
 CFLAGS = -3r -mf -hc -zff -zgf -zq -zm -zc -s -fr=con -w2 -fpi -oilrtfm -aa   &
-         -wcd=201 -bt=nt -d+ -dWIN32 -dCARES_BUILDING_LIBRARY &
+         -wcd=201 -bt=nt -d+ -dCARES_BUILDING_LIBRARY &
          -dNTDDI_VERSION=0x06020000 -I. -I.\include -I.\src\lib $(SYS_INCL)
 
 LFLAGS = option quiet, map, caseexact, eliminate

--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -178,12 +178,11 @@ PROG3_OBJDIR = $(PROG3_OUTDIR)\obj
 # -------------------------------------
 
 !IF "$(USE_WATT32)" == "1"
-CFLAGS  = /DWIN32 /D_WIN32_WINNT=0x0602 /DWATT32 /I$(WATT_ROOT)\inc
-# /DWATT32
+CFLAGS  = /D_WIN32_WINNT=0x0602 /DWATT32 /I$(WATT_ROOT)\inc
 EX_LIBS_REL = $(WATT_ROOT)\lib\$(Platform)\wattcpvc_imp.lib
 EX_LIBS_DBG = $(WATT_ROOT)\lib\$(Platform)\wattcpvc_imp_d.lib
 !ELSE
-CFLAGS  = /DWIN32 /D_WIN32_WINNT=0x0602
+CFLAGS  = /D_WIN32_WINNT=0x0602
 EX_LIBS_REL = ws2_32.lib advapi32.lib kernel32.lib iphlpapi.lib
 EX_LIBS_DBG = ws2_32.lib advapi32.lib kernel32.lib iphlpapi.lib
 !ENDIF

--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -182,8 +182,8 @@ CFLAGS  = /D_WIN32_WINNT=0x0602 /DWATT32 /I$(WATT_ROOT)\inc
 !  IFNDEF PLATFORM
 PLATFORM = x86
 !  ENDIF
-EX_LIBS_REL = $(WATT_ROOT)\lib\$(PLATFORM)\wattcpvc_imp.lib
-EX_LIBS_DBG = $(WATT_ROOT)\lib\$(PLATFORM)\wattcpvc_imp_d.lib
+EX_LIBS_REL = $(WATT_ROOT)\lib\$(PLATFORM)\wattcpvc_imp.lib advapi32.lib
+EX_LIBS_DBG = $(WATT_ROOT)\lib\$(PLATFORM)\wattcpvc_imp_d.lib advapi32.lib
 !ELSE
 CFLAGS  = /D_WIN32_WINNT=0x0602
 EX_LIBS_REL = ws2_32.lib advapi32.lib kernel32.lib iphlpapi.lib

--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -179,8 +179,11 @@ PROG3_OBJDIR = $(PROG3_OUTDIR)\obj
 
 !IF "$(USE_WATT32)" == "1"
 CFLAGS  = /D_WIN32_WINNT=0x0602 /DWATT32 /I$(WATT_ROOT)\inc
-EX_LIBS_REL = $(WATT_ROOT)\lib\$(Platform)\wattcpvc_imp.lib
-EX_LIBS_DBG = $(WATT_ROOT)\lib\$(Platform)\wattcpvc_imp_d.lib
+!  IFNDEF PLATFORM
+PLATFORM = x86
+!  ENDIF
+EX_LIBS_REL = $(WATT_ROOT)\lib\$(PLATFORM)\wattcpvc_imp.lib
+EX_LIBS_DBG = $(WATT_ROOT)\lib\$(PLATFORM)\wattcpvc_imp_d.lib
 !ELSE
 CFLAGS  = /D_WIN32_WINNT=0x0602
 EX_LIBS_REL = ws2_32.lib advapi32.lib kernel32.lib iphlpapi.lib

--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -71,7 +71,9 @@ RTLIBD = /MTd
 # otherwise Winsock tcp/ip stack will be used as default.
 # --------------------------------------------------------
 
+!IFNDEF USE_WATT32
 USE_WATT32 = 0
+!ENDIF
 
 # --------------------------------------------------------
 # Detect compiler version.

--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -178,7 +178,8 @@ PROG3_OBJDIR = $(PROG3_OUTDIR)\obj
 # -------------------------------------
 
 !IF "$(USE_WATT32)" == "1"
-CFLAGS  = /DWIN32 /DWATT32 /I$(WATT_ROOT)\inc
+CFLAGS  = /DWIN32 /D_WIN32_WINNT=0x0602  /I$(WATT_ROOT)\inc
+# /DWATT32
 EX_LIBS_REL = $(WATT_ROOT)\lib\wattcpvc_imp.lib
 EX_LIBS_DBG = $(WATT_ROOT)\lib\wattcpvc_imp_d.lib
 !ELSE

--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -178,7 +178,7 @@ PROG3_OBJDIR = $(PROG3_OUTDIR)\obj
 # -------------------------------------
 
 !IF "$(USE_WATT32)" == "1"
-CFLAGS  = /UWIN32 /DWATT32 /I$(WATT_ROOT)\inc
+CFLAGS  = /DWIN32 /DWATT32 /I$(WATT_ROOT)\inc
 EX_LIBS_REL = $(WATT_ROOT)\lib\wattcpvc_imp.lib
 EX_LIBS_DBG = $(WATT_ROOT)\lib\wattcpvc_imp_d.lib
 !ELSE

--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -178,10 +178,10 @@ PROG3_OBJDIR = $(PROG3_OUTDIR)\obj
 # -------------------------------------
 
 !IF "$(USE_WATT32)" == "1"
-CFLAGS  = /DWIN32 /D_WIN32_WINNT=0x0602  /I$(WATT_ROOT)\inc
+CFLAGS  = /DWIN32 /D_WIN32_WINNT=0x0602 /DWATT32 /I$(WATT_ROOT)\inc
 # /DWATT32
-EX_LIBS_REL = $(WATT_ROOT)\lib\wattcpvc_imp.lib
-EX_LIBS_DBG = $(WATT_ROOT)\lib\wattcpvc_imp_d.lib
+EX_LIBS_REL = $(WATT_ROOT)\lib\$(Platform)\wattcpvc_imp.lib
+EX_LIBS_DBG = $(WATT_ROOT)\lib\$(Platform)\wattcpvc_imp_d.lib
 !ELSE
 CFLAGS  = /DWIN32 /D_WIN32_WINNT=0x0602
 EX_LIBS_REL = ws2_32.lib advapi32.lib kernel32.lib iphlpapi.lib

--- a/include/ares.h
+++ b/include/ares.h
@@ -32,15 +32,6 @@
 #include "ares_build.h"   /* c-ares build definitions */
 #include "ares_rules.h"   /* c-ares rules enforcement */
 
-/*
- * Define WIN32 when build target is Win32 API
- */
-
-#if (defined(_WIN32) || defined(__WIN32__)) && !defined(WIN32) && \
-  !defined(__SYMBIAN32__)
-#  define WIN32
-#endif
-
 #include <sys/types.h>
 
 /* HP-UX systems version 9, 10 and 11 lack sys/select.h and so does oldish
@@ -56,20 +47,20 @@
 #  include <sys/bsdskt.h>
 #endif
 
+#if defined(_WIN32)
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#endif
+
 #if defined(WATT32)
 #  include <netinet/in.h>
 #  include <sys/socket.h>
 #  include <tcp.h>
 #elif defined(_WIN32_WCE)
-#  ifndef WIN32_LEAN_AND_MEAN
-#    define WIN32_LEAN_AND_MEAN
-#  endif
 #  include <windows.h>
 #  include <winsock.h>
-#elif defined(WIN32)
-#  ifndef WIN32_LEAN_AND_MEAN
-#    define WIN32_LEAN_AND_MEAN
-#  endif
+#elif defined(_WIN32)
 #  include <windows.h>
 #  include <winsock2.h>
 #  include <ws2tcpip.h>
@@ -315,7 +306,7 @@ typedef enum {
  */
 
 #ifndef ares_socket_typedef
-#  ifdef WIN32
+#  if defined(_WIN32) && !defined(WATT32)
 typedef SOCKET ares_socket_t;
 #    define ARES_SOCKET_BAD INVALID_SOCKET
 #  else

--- a/src/lib/ares__addrinfo2hostent.c
+++ b/src/lib/ares__addrinfo2hostent.c
@@ -39,8 +39,6 @@
 #  include <arpa/inet.h>
 #endif
 
-#include "ares_nameser.h"
-
 #ifdef HAVE_STRINGS_H
 #  include <strings.h>
 #endif
@@ -50,8 +48,6 @@
 #endif
 
 #include "ares.h"
-#include "ares_dns.h"
-#include "ares_inet_net_pton.h"
 #include "ares_private.h"
 
 ares_status_t ares__addrinfo2hostent(const struct ares_addrinfo *ai, int family,

--- a/src/lib/ares__addrinfo_localhost.c
+++ b/src/lib/ares__addrinfo_localhost.c
@@ -37,11 +37,10 @@
 #  include <arpa/inet.h>
 #endif
 
-#if defined(_WIN32) && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600
-#  include <ws2ipdef.h>
-#endif
-
 #if defined(USE_WINSOCK)
+#  if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600
+#    include <ws2ipdef.h>
+#  endif
 #  if defined(HAVE_IPHLPAPI_H)
 #    include <iphlpapi.h>
 #  endif
@@ -137,7 +136,7 @@ static ares_status_t
   ares__system_loopback_addrs(int aftype, unsigned short port,
                               struct ares_addrinfo_node **nodes)
 {
-#if defined(_WIN32) && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600 && \
+#if defined(USE_WINSOCK) && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600 && \
   !defined(__WATCOMC__)
   PMIB_UNICASTIPADDRESS_TABLE table;
   unsigned int                i;

--- a/src/lib/ares__buf.c
+++ b/src/lib/ares__buf.c
@@ -229,9 +229,9 @@ ares_status_t ares__buf_append(ares__buf_t *buf, const unsigned char *data,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__buf_append_byte(ares__buf_t *buf, unsigned char byte)
+ares_status_t ares__buf_append_byte(ares__buf_t *buf, unsigned char b)
 {
-  return ares__buf_append(buf, &byte, 1);
+  return ares__buf_append(buf, &b, 1);
 }
 
 ares_status_t ares__buf_append_be16(ares__buf_t *buf, unsigned short u16)

--- a/src/lib/ares__buf.h
+++ b/src/lib/ares__buf.h
@@ -85,10 +85,10 @@ ares_status_t  ares__buf_append(ares__buf_t *buf, const unsigned char *data,
 /*! Append a single byte to the dynamic buffer object
  *
  *  \param[in] buf      Initialized buffer object
- *  \param[in] byte     Single byte to append to buffer object.
+ *  \param[in] b        Single byte to append to buffer object.
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-ares_status_t  ares__buf_append_byte(ares__buf_t *buf, unsigned char byte);
+ares_status_t  ares__buf_append_byte(ares__buf_t *buf, unsigned char b);
 
 /*! Append a null-terminated string to the dynamic buffer object
  *

--- a/src/lib/ares__hosts_file.c
+++ b/src/lib/ares__hosts_file.c
@@ -658,7 +658,7 @@ static ares_status_t ares__hosts_path(const ares_channel_t *channel,
   }
 
   if (!path_hosts) {
-#ifdef WIN32
+#if defined(USE_WINSOCK)
     char  PATH_HOSTS[MAX_PATH] = "";
     char  tmp[MAX_PATH];
     HKEY  hkeyHosts;

--- a/src/lib/ares__socket.c
+++ b/src/lib/ares__socket.c
@@ -145,7 +145,7 @@ static int setsocknonblock(ares_socket_t sockfd, /* operate on this */
 #endif
 }
 
-#if defined(IPV6_V6ONLY) && defined(WIN32)
+#if defined(IPV6_V6ONLY) && defined(USE_WINSOCK)
 /* It makes support for IPv4-mapped IPv6 addresses.
  * Linux kernel, NetBSD, FreeBSD and Darwin: default is off;
  * Windows Vista and later: default is on;

--- a/src/lib/ares__timeval.c
+++ b/src/lib/ares__timeval.c
@@ -28,7 +28,7 @@
 #include "ares.h"
 #include "ares_private.h"
 
-#if defined(WIN32) && !defined(MSDOS)
+#if defined(_WIN32) && !defined(MSDOS)
 
 ares_timeval_t ares__tvnow(void)
 {

--- a/src/lib/ares_event_configchg.c
+++ b/src/lib/ares_event_configchg.c
@@ -173,7 +173,7 @@ done:
   return status;
 }
 
-#elif defined(_WIN32)
+#elif defined(USE_WINSOCK)
 
 #  include <winsock2.h>
 #  include <iphlpapi.h>
@@ -388,7 +388,7 @@ done:
   return status;
 }
 
-#elif defined(HAVE_STAT)
+#elif defined(HAVE_STAT) && !defined(_WIN32)
 #  ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #  endif

--- a/src/lib/ares_event_thread.c
+++ b/src/lib/ares_event_thread.c
@@ -355,7 +355,7 @@ static const ares_event_sys_t *ares_event_fetch_sys(ares_evsys_t evsys)
 {
   switch (evsys) {
     case ARES_EVSYS_WIN32:
-#if defined(_WIN32)
+#if defined(USE_WINSOCK)
       return &ares_evsys_win32;
 #else
       return NULL;
@@ -391,7 +391,7 @@ static const ares_event_sys_t *ares_event_fetch_sys(ares_evsys_t evsys)
 
     /* case ARES_EVSYS_DEFAULT: */
     default:
-#if defined(_WIN32)
+#if defined(USE_WINSOCK)
       return &ares_evsys_win32;
 #elif defined(HAVE_KQUEUE)
       return &ares_evsys_kqueue;

--- a/src/lib/ares_event_win32.c
+++ b/src/lib/ares_event_win32.c
@@ -33,7 +33,7 @@
 #  include <limits.h>
 #endif
 
-#ifdef _WIN32
+#if defined(USE_WINSOCK)
 
 /* IMPLEMENTATION NOTES
  * ====================

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -60,10 +60,7 @@
 #include "ares_private.h"
 #include "ares_dns.h"
 
-#ifdef WATT32
-#  undef WIN32
-#endif
-#ifdef WIN32
+#ifdef _WIN32
 #  include "ares_platform.h"
 #endif
 

--- a/src/lib/ares_gethostbyaddr.c
+++ b/src/lib/ares_gethostbyaddr.c
@@ -44,10 +44,6 @@
 #include "ares_platform.h"
 #include "ares_private.h"
 
-#ifdef WATT32
-#  undef WIN32
-#endif
-
 struct addr_query {
   /* Arguments passed to ares_gethostbyaddr() */
   ares_channel_t    *channel;

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -67,11 +67,6 @@
 #include "ares_private.h"
 #include "ares_event.h"
 
-#ifdef WATT32
-#  undef WIN32 /* Redefined in MingW/MSVC headers */
-#endif
-
-
 int ares_init(ares_channel_t **channelptr)
 {
   return ares_init_options(channelptr, NULL, 0);

--- a/src/lib/ares_library_init.c
+++ b/src/lib/ares_library_init.c
@@ -55,7 +55,7 @@ static void        *default_malloc(size_t size)
   return malloc(size);
 }
 
-#if defined(WIN32)
+#if defined(_WIN32)
 /* We need indirections to handle Windows DLL rules. */
 static void *default_realloc(void *p, size_t size)
 {

--- a/src/lib/ares_platform.c
+++ b/src/lib/ares_platform.c
@@ -31,7 +31,7 @@
 #include "ares_platform.h"
 #include "ares_private.h"
 
-#if defined(WIN32) && !defined(MSDOS)
+#if defined(_WIN32) && !defined(MSDOS)
 
 #  define V_PLATFORM_WIN32s        0
 #  define V_PLATFORM_WIN32_WINDOWS 1
@@ -78,7 +78,7 @@ win_platform ares__getplatform(void)
   }
 }
 
-#endif /* WIN32 && ! MSDOS */
+#endif /* _WIN32 && ! MSDOS */
 
 #if defined(_WIN32_WCE)
 

--- a/src/lib/ares_platform.h
+++ b/src/lib/ares_platform.h
@@ -29,7 +29,7 @@
 
 #include "ares_setup.h"
 
-#if defined(WIN32) && !defined(MSDOS)
+#if defined(_WIN32) && !defined(MSDOS)
 
 typedef enum {
   WIN_UNKNOWN,

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -27,14 +27,6 @@
 #ifndef __ARES_PRIVATE_H
 #define __ARES_PRIVATE_H
 
-/*
- * Define WIN32 when build target is Win32 API
- */
-
-#if (defined(_WIN32) || defined(__WIN32__)) && !defined(WIN32)
-#  define WIN32
-#endif
-
 #ifdef HAVE_NETINET_IN_H
 #  include <netinet/in.h>
 #endif
@@ -56,7 +48,7 @@
  */
 #define CARES_INADDR_CAST(type, var) ((type)((void *)var))
 
-#if defined(WIN32) && !defined(WATT32)
+#if defined(USE_WINSOCK)
 
 #  define WIN_NS_9X     "System\\CurrentControlSet\\Services\\VxD\\MSTCP"
 #  define WIN_NS_NT_KEY "System\\CurrentControlSet\\Services\\Tcpip\\Parameters"

--- a/src/lib/ares_setup.h
+++ b/src/lib/ares_setup.h
@@ -27,14 +27,6 @@
 #define HEADER_CARES_SETUP_H
 
 /*
- * Define WIN32 when build target is Win32 API
- */
-
-#if (defined(_WIN32) || defined(__WIN32__)) && !defined(WIN32)
-#  define WIN32
-#endif
-
-/*
  * Include configuration script results or hand-crafted
  * configuration file for platforms which lack config tool.
  */
@@ -43,7 +35,7 @@
 #  include "ares_config.h"
 #else
 
-#  ifdef WIN32
+#  ifdef _WIN32
 #    include "config-win32.h"
 #  endif
 
@@ -163,7 +155,7 @@
 #    define HAVE_UNISTD_H 1
 #  endif
 
-#  if !defined(HAVE_SYS_UIO_H) && !defined(WIN32) && !defined(MSDOS)
+#  if !defined(HAVE_SYS_UIO_H) && !defined(_WIN32) && !defined(MSDOS)
 #    define HAVE_SYS_UIO_H
 #  endif
 

--- a/src/lib/ares_sysconfig.c
+++ b/src/lib/ares_sysconfig.c
@@ -71,12 +71,7 @@
 #include "ares_platform.h"
 #include "ares_private.h"
 
-#ifdef WATT32
-#  undef WIN32 /* Redefined in MingW/MSVC headers */
-#endif
-
-
-#ifdef WIN32
+#if defined(USE_WINSOCK)
 /*
  * get_REG_SZ()
  *
@@ -1074,7 +1069,7 @@ ares_status_t ares__init_by_sysconfig(ares_channel_t *channel)
 
   memset(&sysconfig, 0, sizeof(sysconfig));
 
-#ifdef _WIN32
+#if defined(USE_WINSOCK)
   status = ares__init_sysconfig_windows(&sysconfig);
 #elif defined(__MVS__)
   status = ares__init_sysconfig_mvs(&sysconfig);

--- a/src/lib/config-win32.h
+++ b/src/lib/config-win32.h
@@ -224,6 +224,7 @@
 #  define HAVE_PF_INET6            1
 #  define HAVE_STRUCT_IN6_ADDR     1
 #  define HAVE_STRUCT_SOCKADDR_IN6 1
+#  define HAVE_WRITEV              1
 #  undef HAVE_WINSOCK_H
 #  undef HAVE_WINSOCK2_H
 #  undef HAVE_WS2TCPIP_H

--- a/src/lib/config-win32.h
+++ b/src/lib/config-win32.h
@@ -88,7 +88,7 @@
 #define HAVE_IPHLPAPI_H 1
 
 /* Define if you have <netioapi.h> header file */
-#ifndef __WATCOMC__
+#if !defined(__WATCOMC__) && !defined(WATT32)
 #  define HAVE_NETIOAPI_H 1
 #endif
 
@@ -207,7 +207,12 @@
 
 /* Specifics for the Watt-32 tcp/ip stack. */
 #ifdef WATT32
-#  define SOCKET                   int
+#  undef RECV_TYPE_ARG1
+#  define RECV_TYPE_ARG1 int
+#  undef SEND_TYPE_ARG1
+#  define SEND_TYPE_ARG1 int
+#  undef RECVFROM_TYPE_ARG1
+#  define RECVFROM_TYPE_ARG1 int
 #  define NS_INADDRSZ              4
 #  define HAVE_ARPA_NAMESER_H      1
 #  define HAVE_ARPA_INET_H         1
@@ -222,6 +227,8 @@
 #  undef HAVE_WINSOCK_H
 #  undef HAVE_WINSOCK2_H
 #  undef HAVE_WS2TCPIP_H
+#  undef HAVE_IPHLPAPI_H
+#  undef HAVE_NETIOAPI_H
 #endif
 
 /* Threading support enabled */
@@ -342,7 +349,8 @@
 #  define HAVE_STRUCT_SOCKADDR_IN6_SIN6_SCOPE_ID 1
 #endif
 
-#if defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0600) && !defined(__WATCOMC__)
+#if defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0600) && \
+   !defined(__WATCOMC__) && !defined(WATT32)
 /* Define if you have if_nametoindex() */
 #  define HAVE_IF_NAMETOINDEX 1
 /* Define if you have if_indextoname() */

--- a/src/lib/setup_once.h
+++ b/src/lib/setup_once.h
@@ -75,11 +75,6 @@
 #  include <time.h>
 #endif
 
-#ifdef WIN32
-#  include <io.h>
-#  include <fcntl.h>
-#endif
-
 #ifdef HAVE_UNISTD_H
 #  include <unistd.h>
 #endif

--- a/src/lib/windows_port.c
+++ b/src/lib/windows_port.c
@@ -11,7 +11,7 @@
 
 /* only do the following on windows
  */
-#if (defined(WIN32) || defined(WATT32)) && !defined(MSDOS)
+#if defined(_WIN32) && !defined(MSDOS)
 
 #  ifdef __WATCOMC__
 /*

--- a/src/tools/adig.c
+++ b/src/tools/adig.c
@@ -62,11 +62,6 @@
 
 #include "ares_getopt.h"
 
-#ifdef WATT32
-#  undef WIN32 /* Redefined in MingW headers */
-#endif
-
-
 typedef struct {
   ares_bool_t         is_help;
   struct ares_options options;

--- a/src/tools/ahost.c
+++ b/src/tools/ahost.c
@@ -27,7 +27,7 @@
 
 #include "ares_setup.h"
 
-#if !defined(WIN32) || defined(WATT32)
+#if !defined(_WIN32) || defined(WATT32)
 #  include <netinet/in.h>
 #  include <arpa/inet.h>
 #  include <netdb.h>


### PR DESCRIPTION
Watt-32 (https://www.watt-32.net/) support has been broken for a long time.  Patch c-ares to fix Watt-32 support and also gets rid of the `WIN32` macro which adds confusion, only use `USE_WINSOCK` macro.

Add a CI/CD task to build c-ares on Windows using MSVC with Watt-32.

Fixes Issue: #780
Fix By: Brad House (@bradh352)