### PR TITLE
Windows: Reload config on manual DNS changes

### DIFF
--- a/src/lib/ares_event_configchg.c
+++ b/src/lib/ares_event_configchg.c
@@ -311,7 +311,7 @@ ares_status_t ares_event_configchg_init(ares_event_configchg_t **configchg,
    *       that didn't get triggered either.
    */
   if (NotifyIpInterfaceChange(
-        AF_UNSPEC, (PIPINTERFACE_CHANGE_CALLBACK)ares_event_ipchg_cb,
+        AF_UNSPEC, (PIPINTERFACE_CHANGE_CALLBACK)ares_event_configchg_ip_cb,
         *configchg, FALSE, &c->ifchg_hnd) != NO_ERROR) {
     status = ARES_ESERVFAIL;
     goto done;
@@ -347,13 +347,13 @@ ares_status_t ares_event_configchg_init(ares_event_configchg_t **configchg,
   }
 
   if (!RegisterWaitForSingleObject(&c->regip4_wait, c->regip4_event,
-    ares_event_regchg_cb, c, INFINITE, WT_EXECUTEDEFAULT)) {
+    ares_event_configchg_reg_cb, c, INFINITE, WT_EXECUTEDEFAULT)) {
     status = ARES_ESERVFAIL;
     goto done;
   }
 
   if (!RegisterWaitForSingleObject(&c->regip6_wait, c->regip6_event,
-    ares_event_regchg_cb, c, INFINITE, WT_EXECUTEDEFAULT)) {
+    ares_event_configchg_reg_cb, c, INFINITE, WT_EXECUTEDEFAULT)) {
     status = ARES_ESERVFAIL;
     goto done;
   }

--- a/src/lib/ares_event_configchg.c
+++ b/src/lib/ares_event_configchg.c
@@ -252,6 +252,9 @@ static void ares_event_configchg_ip_cb(PVOID                 CallerContext,
 
 static ares_bool_t ares_event_configchg_regnotify(ares_event_configchg_t *configchg)
 {
+#  if defined(__WATCOMC__) && !defined(REG_NOTIFY_THREAD_AGNOSTIC)
+#    define REG_NOTIFY_THREAD_AGNOSTIC 0x10000000L
+#  endif
   DWORD flags =
     REG_NOTIFY_CHANGE_NAME|REG_NOTIFY_CHANGE_LAST_SET|REG_NOTIFY_THREAD_AGNOSTIC;
 


### PR DESCRIPTION
The `NotifyIpInterfaceChange()` method only notifies of automatic changes, such as via DHCP or interfaces going up or down.  However, someone editing the DNS settings manually would not trigger a notification. 

Use `RegNotifyChangeKeyValue()` to monitor `HKLM\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters\Interfaces` and `HKLM\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces` to pick up these changes.

This new check also works when using the OpenWatcom compiler as the symbols are available, so they have been enabled (though `NotifyIpInterfaceChange()` method is disabled for OpenWatcom still due to the linker libraries missing this symbol).

NOTE: it does appear that about 5 events get triggered for some reason, it doesn't seem to hurt anything, but it will actually cause it to re-read the configuration multiple times.

Fixes Issue: #761 
Fix By: Brad House (@bradh352)