### PR TITLE
Enable QueryCache by default

### DIFF
--- a/docs/ares_init_options.3
+++ b/docs/ares_init_options.3
@@ -291,13 +291,15 @@ or less will be considered unlimited, and is the default.
 .B ARES_OPT_QUERY_CACHE
 .B unsigned int \fIqcache_max_ttl\fP;
 .br
-Enable the built-in query cache.  Will cache queries based on the returned TTL
-in the DNS message.  Only fully successful and NXDOMAIN query results will be
-cached.  Fill in the \fIqcache_max_ttl\fP with the maximum number of seconds
-a query result may be cached which will override a larger TTL in the response
-message. This must be a non-zero value otherwise the cache will be disabled.
-Choose a reasonable value for your application such as 300 (5 minutes) or
-3600 (1 hour).
+As of c-ares 1.31.0, the query cache is enabled by default with a TTL of 1hr.
+To disable the query cache, specify this option with a TTL of 0.  The query
+cache is based on the returned TTL in the DNS message.  Only fully successful
+and NXDOMAIN query results will be cached.  Fill in the \fIqcache_max_ttl\fP
+with the maximum number of seconds a query result may be cached which will
+override a larger TTL in the response message. This must be a non-zero value
+otherwise the cache will be disabled. Choose a reasonable value for your
+application such as 300 (5 minutes) or 3600 (1 hour).  The query cache is
+automatically flushed if a server configuration change is made.
 .br
 .TP 18
 .B ARES_OPT_EVENT_THREAD

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -346,12 +346,13 @@ int ares_init_options(ares_channel_t           **channelptr,
     goto done;
   }
 
-  if (channel->qcache_max_ttl > 0) {
-    status = ares__qcache_create(channel->rand_state, channel->qcache_max_ttl,
-                                 &channel->qcache);
-    if (status != ARES_SUCCESS) {
-      goto done; /* LCOV_EXCL_LINE: OutOfMemory */
-    }
+  /* Go ahead and let it initialize the query cache even if the ttl is 0 and
+   * completely unused.  This reduces the number of different code paths that
+   * might be followed even if there is a minor performance hit. */
+  status = ares__qcache_create(channel->rand_state, channel->qcache_max_ttl,
+                               &channel->qcache);
+  if (status != ARES_SUCCESS) {
+    goto done; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   if (status == ARES_SUCCESS) {

--- a/src/lib/ares_options.c
+++ b/src/lib/ares_options.c
@@ -457,13 +457,15 @@ ares_status_t ares__init_by_options(ares_channel_t            *channel,
     }
   }
 
+  /* As of c-ares 1.31.0, the Query Cache is on by default.  The only way to
+   * disable it is to set options->qcache_max_ttl = 0 while specifying the
+   * ARES_OPT_QUERY_CACHE which will actually disable it alltogether. */
   if (optmask & ARES_OPT_QUERY_CACHE) {
     /* qcache_max_ttl is unsigned unlike the others */
-    if (options->qcache_max_ttl == 0) {
-      optmask &= ~(ARES_OPT_QUERY_CACHE);
-    } else {
-      channel->qcache_max_ttl = options->qcache_max_ttl;
-    }
+    channel->qcache_max_ttl = options->qcache_max_ttl;
+  } else {
+    optmask                |= ARES_OPT_QUERY_CACHE;
+    channel->qcache_max_ttl = 3600;
   }
 
   /* Initialize the ipv4 servers if provided */

--- a/src/lib/ares_options.c
+++ b/src/lib/ares_options.c
@@ -459,7 +459,7 @@ ares_status_t ares__init_by_options(ares_channel_t            *channel,
 
   /* As of c-ares 1.31.0, the Query Cache is on by default.  The only way to
    * disable it is to set options->qcache_max_ttl = 0 while specifying the
-   * ARES_OPT_QUERY_CACHE which will actually disable it alltogether. */
+   * ARES_OPT_QUERY_CACHE which will actually disable it completely. */
   if (optmask & ARES_OPT_QUERY_CACHE) {
     /* qcache_max_ttl is unsigned unlike the others */
     channel->qcache_max_ttl = options->qcache_max_ttl;

--- a/src/lib/ares_qcache.c
+++ b/src/lib/ares_qcache.c
@@ -352,13 +352,13 @@ static ares_status_t ares__qcache_insert(ares__qcache_t      *qcache,
     ttl = ares__qcache_calc_minttl(dnsrec);
   }
 
+  if (ttl > qcache->max_ttl) {
+    ttl = qcache->max_ttl;
+  }
+
   /* Don't cache something that is already expired */
   if (ttl == 0) {
     return ARES_EREFUSED;
-  }
-
-  if (ttl > qcache->max_ttl) {
-    ttl = qcache->max_ttl;
   }
 
   entry = ares_malloc_zero(sizeof(*entry));

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -763,9 +763,19 @@ MockChannelOptsTest::MockChannelOptsTest(int count,
     optmask |= ARES_OPT_FLAGS;
   }
 
+  /* Tests expect ndots=1 in general, the system config may not default to this
+   * so we don't want to inherit that. */
   if (!(optmask & ARES_OPT_NDOTS)) {
     opts.ndots = 1;
     optmask |= ARES_OPT_NDOTS;
+  }
+
+  /* Disable the query cache for tests unless explicitly enabled. As of
+   * c-ares 1.31.0, the query cache is enabled by default so we have to set
+   * the option and set the TTL to 0 to effectively disable it. */
+  if (!(optmask & ARES_OPT_QUERY_CACHE)) {
+    opts.qcache_max_ttl = 0;
+    optmask |= ARES_OPT_QUERY_CACHE;
   }
 
   EXPECT_EQ(ARES_SUCCESS, ares_init_options(&channel_, &opts, optmask));


### PR DESCRIPTION
The query cache should be enabled by default.  This will help with determining proper timeouts for #736.  It can still be disabled by setting the ttl to 0.  There should be no negative consequences of this in real-world scenarios since DNS is based on the TTL concept and upstream servers will cache results and not recurse based on this information anyhow.  DNS queries and responses are very small, this should have negligible impact on memory consumption.

Fix By: Brad House (@bradh352)