### PR TITLE
CI: Move some Appveyor builds to GitHub actions

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -6,14 +6,11 @@ name: Codespell
 
 on:
   push:
-    branches:
-    - main
     paths:
     - 'src/**'
     - 'include/**'
   pull_request:
-    branches:
-    - main
+    paths:
     - 'src/**'
     - 'include/**'
 

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -57,6 +57,7 @@ jobs:
       - name: "CMake: build and test c-ares"
         shell: msys2 {0}
         run: |
+          export
           cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=C:/projects/build-cares/test_install -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON ${{ matrix.cmake_opts }} -Bbuild -G Ninja .
           cmake --build build
           ./build_cmake/bin/adig.exe www.google.com

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -33,7 +33,7 @@ jobs:
             mingw-w64-${{ matrix.env }}-ninja
             mingw-w64-${{ matrix.env }}-gtest
       - uses: msys2/setup-msys2@v2
-        if: ${{ matrix.env == "clang-x86_64" }}
+        if: ${{ matrix.env == 'clang-x86_64' }}
         with:
           install: >-
             mingw-w64-${{ matrix.env }}-clang

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -50,18 +50,16 @@ jobs:
         uses: actions/checkout@v4
       - name: "CMake: build and test c-ares"
         run: |
-          export
-          ls -l /mingw64/bin/
-          cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=C:/projects/build-cares/test_install -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON ${{ matrix.cmake_opts }} -Bbuild -G Ninja .
-          cmake --build build
-          ./build/bin/adig.exe www.google.com
-          ./build/bin/ahost.exe www.google.com
-          ./build/bin/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
+          cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=C:/projects/build-cares/test_install -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON ${{ matrix.cmake_opts }} -Bbuild_cmake -G Ninja .
+          cmake --build build_cmake
+          ./build_cmake/bin/adig.exe www.google.com
+          ./build_cmake/bin/ahost.exe www.google.com
+          ./build_cmake/bin/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
       - name: "Autotools: build and test c-ares"
         run: |
           autoreconf -fi
-          mkdir build
-          cd build
+          mkdir build_autotools
+          cd build_autotools
           ../configure --enable-static --disable-shared --enable-tests
           make
           ./src/tools/adig.exe www.google.com

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -59,7 +59,7 @@ jobs:
           ./build/bin/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
       - name: "Autotools: build and test c-ares"
         run: |
-          ./buildconf
+          autoreconf -fi
           mkdir build
           cd build
           ../configure --enable-static --disable-shared --enable-tests

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,0 +1,39 @@
+# Copyright (C) The c-ares project and its contributors
+# SPDX-License-Identifier: MIT
+name: MSYS2 (Windows)
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - { sys: mingw64, env: x86_64 }
+          - { sys: mingw32, env: i686 }
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            autoconf
+            autoconf-archive
+            automake
+            libtool
+            make
+            git
+            mingw-w64-${{ matrix.env }}-cmake
+            mingw-w64-${{ matrix.env }}-gcc
+            mingw-w64-${{ matrix.env }}-ninja
+            mingw-w64-${{ matrix.env }}-gtest
+      - name: Checkout c-ares
+        uses: actions/checkout@v4
+
+
+
+

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -37,27 +37,22 @@ jobs:
             mingw-w64-${{ matrix.env }}-ninja
             mingw-w64-${{ matrix.env }}-gtest
       - name: Install gcc compiler
-        uses: msys2/setup-msys2@v2
+        shell: msys2 {0}
         if: ${{ matrix.env != 'clang-x86_64' }}
-        with:
-          msystem: ${{ matrix.msystem }}
-          release: false
-          install: >-
-            mingw-w64-${{ matrix.env }}-gcc
+        run: |
+          pacman --noconfirm -S --needed mingw-w64-${{ matrix.env }}-gcc
       - name: Install clang compiler
-        uses: msys2/setup-msys2@v2
+        shell: msys2 {0}
         if: ${{ matrix.env == 'clang-x86_64' }}
-        with:
-          msystem: ${{ matrix.msystem }}
-          release: false
-          install: >-
-            mingw-w64-${{ matrix.env }}-clang
+        run: |
+          pacman --noconfirm -S --needed mingw-w64-${{ matrix.env }}-clang
       - name: Checkout c-ares
         uses: actions/checkout@v4
       - name: "CMake: build and test c-ares"
         shell: msys2 {0}
         run: |
           export
+          ls -l /mingw64/bin/
           cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=C:/projects/build-cares/test_install -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON ${{ matrix.cmake_opts }} -Bbuild -G Ninja .
           cmake --build build
           ./build_cmake/bin/adig.exe www.google.com

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         include:
           - { sys: mingw64, env: x86_64 }
-          - { sys: mingw32, env: i686 }
+          - { sys: mingw64, env: x86_64 }
     defaults:
       run:
         shell: msys2 {0}
@@ -33,6 +33,24 @@ jobs:
             mingw-w64-${{ matrix.env }}-gtest
       - name: Checkout c-ares
         uses: actions/checkout@v4
+      - name: "CMake: build and test c-ares"
+        run: |
+          cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=C:/projects/build-cares/test_install -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON %CMAKE_EXTRA_OPTIONS% -Bbuild_cmake -G Ninja .
+          cmake --build build_cmake
+          ./build_cmake/bin/adig.exe www.google.com
+          ./build_cmake/bin/ahost.exe www.google.com
+          ./build_cmake/bin/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
+      - name: "Autotools: build and test c-ares"
+        run: |
+          ./buildconf
+          mkdir build_autotools
+          cd build_autotools
+          ../configure --enable-static --disable-shared --enable-tests
+          make
+          ./src/tools/adig.exe www.google.com
+          ./src/tools/ahost.exe www.google.com
+          ./test/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
+
 
 
 

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -11,8 +11,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - { sys: mingw64, env: x86_64 }
-          - { sys: mingw64, env: x86_64 }
+          - { sys: mingw64, env: x86_64,       cmake_opts: "" }
+          - { sys: mingw64, env: i686,         cmake_opts: "" }
+          - { sys: clang64, env: clang-x86_64, cmake_opts: "-DCMAKE_CXX_FLAGS=-fsanitize=undefined -DCMAKE_C_FLAGS=-fsanitize=undefined -DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=undefined -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=undefined" }
     defaults:
       run:
         shell: msys2 {0}
@@ -31,20 +32,25 @@ jobs:
             mingw-w64-${{ matrix.env }}-gcc
             mingw-w64-${{ matrix.env }}-ninja
             mingw-w64-${{ matrix.env }}-gtest
+      - uses: msys2/setup-msys2@v2
+        if: ${{ matrix.env == "clang-x86_64" }}
+        with:
+          install: >-
+            mingw-w64-${{ matrix.env }}-clang
       - name: Checkout c-ares
         uses: actions/checkout@v4
       - name: "CMake: build and test c-ares"
         run: |
-          cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=C:/projects/build-cares/test_install -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON %CMAKE_EXTRA_OPTIONS% -Bbuild_cmake -G Ninja .
-          cmake --build build_cmake
+          cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=C:/projects/build-cares/test_install -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON ${{ matrix.cmake_opts }} -Bbuild -G Ninja .
+          cmake --build build
           ./build_cmake/bin/adig.exe www.google.com
           ./build_cmake/bin/ahost.exe www.google.com
           ./build_cmake/bin/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
       - name: "Autotools: build and test c-ares"
         run: |
           ./buildconf
-          mkdir build_autotools
-          cd build_autotools
+          mkdir build
+          cd build
           ../configure --enable-static --disable-shared --enable-tests
           make
           ./src/tools/adig.exe www.google.com

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: true
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         include:
           - { msystem: MINGW64, env: x86_64,       cmake_opts: "" }
@@ -50,16 +50,6 @@ jobs:
           pacman --noconfirm -S --needed mingw-w64-${{ matrix.env }}-clang mingw-w64-${{ matrix.env }}-clang-analyzer
       - name: Checkout c-ares
         uses: actions/checkout@v4
-      - name: "Autotools: build and test c-ares"
-        run: |
-          autoreconf -fi
-          mkdir build_autotools
-          cd build_autotools
-          ../configure --enable-static --disable-shared --enable-tests
-          make
-          ./src/tools/adig.exe www.google.com
-          ./src/tools/ahost.exe www.google.com
-          ./test/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
       - name: "CMake: build and test c-ares"
         run: |
           cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=C:/projects/build-cares/test_install -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON ${{ matrix.cmake_opts }} -Bbuild_cmake -G Ninja .
@@ -67,3 +57,13 @@ jobs:
           ./build_cmake/bin/adig.exe www.google.com
           ./build_cmake/bin/ahost.exe www.google.com
           ./build_cmake/bin/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
+      - name: "Autotools: build and test c-ares"
+        run: |
+          autoreconf -fi
+          mkdir build_autotools
+          cd build_autotools
+          ../configure --enable-static --disable-shared --enable-tests
+          make -j3
+          ./src/tools/adig.exe www.google.com
+          ./src/tools/ahost.exe www.google.com
+          ./test/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -38,6 +38,7 @@ jobs:
         if: ${{ matrix.env != 'clang-x86_64' }}
         with:
           msystem: ${{ matrix.sys }}
+          release: false
           install: >-
             mingw-w64-${{ matrix.env }}-gcc
       - name: Install clang compiler
@@ -45,11 +46,14 @@ jobs:
         if: ${{ matrix.env == 'clang-x86_64' }}
         with:
           msystem: ${{ matrix.sys }}
+          release: false
           install: >-
             mingw-w64-${{ matrix.env }}-clang
       - name: Checkout c-ares
         uses: actions/checkout@v4
       - name: "CMake: build and test c-ares"
+        env:
+          MSYSTEM: ${{ matrix.sys }}
         run: |
           cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=C:/projects/build-cares/test_install -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON ${{ matrix.cmake_opts }} -Bbuild -G Ninja .
           cmake --build build
@@ -57,6 +61,8 @@ jobs:
           ./build_cmake/bin/ahost.exe www.google.com
           ./build_cmake/bin/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
       - name: "Autotools: build and test c-ares"
+        env:
+          MSYSTEM: ${{ matrix.sys }}
         run: |
           ./buildconf
           mkdir build

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -5,18 +5,20 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - { msystem: MINGW64, env: x86_64,       cmake_opts: "" }
           - { msystem: MINGW32, env: i686,         cmake_opts: "" }
           - { msystem: CLANG64, env: clang-x86_64, cmake_opts: "-DCMAKE_CXX_FLAGS=-fsanitize=undefined -DCMAKE_C_FLAGS=-fsanitize=undefined -DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=undefined -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=undefined" }
-    defaults:
-      run:
-        shell: msys2 {0}
     name: ${{ matrix.msystem }}
     steps:
       - name: Install MSYS2 and base packages

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -19,6 +19,9 @@ jobs:
           - { msystem: MINGW64, env: x86_64,       cmake_opts: "" }
           - { msystem: MINGW32, env: i686,         cmake_opts: "" }
           - { msystem: CLANG64, env: clang-x86_64, cmake_opts: "-DCMAKE_CXX_FLAGS=-fsanitize=undefined -DCMAKE_C_FLAGS=-fsanitize=undefined -DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=undefined -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=undefined" }
+    defaults:
+      run:
+        shell: msys2 {0}
     name: ${{ matrix.msystem }}
     steps:
       - name: Install MSYS2 and base packages
@@ -32,34 +35,29 @@ jobs:
             automake
             libtool
             make
-            git
             mingw-w64-${{ matrix.env }}-cmake
             mingw-w64-${{ matrix.env }}-ninja
             mingw-w64-${{ matrix.env }}-gtest
       - name: Install gcc compiler
-        shell: msys2 {0}
         if: ${{ matrix.env != 'clang-x86_64' }}
         run: |
           pacman --noconfirm -S --needed mingw-w64-${{ matrix.env }}-gcc
       - name: Install clang compiler
-        shell: msys2 {0}
         if: ${{ matrix.env == 'clang-x86_64' }}
         run: |
-          pacman --noconfirm -S --needed mingw-w64-${{ matrix.env }}-clang
+          pacman --noconfirm -S --needed mingw-w64-${{ matrix.env }}-clang mingw-w64-${{ matrix.env }}-clang-analyzer
       - name: Checkout c-ares
         uses: actions/checkout@v4
       - name: "CMake: build and test c-ares"
-        shell: msys2 {0}
         run: |
           export
           ls -l /mingw64/bin/
           cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=C:/projects/build-cares/test_install -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON ${{ matrix.cmake_opts }} -Bbuild -G Ninja .
           cmake --build build
-          ./build_cmake/bin/adig.exe www.google.com
-          ./build_cmake/bin/ahost.exe www.google.com
-          ./build_cmake/bin/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
+          ./build/bin/adig.exe www.google.com
+          ./build/bin/ahost.exe www.google.com
+          ./build/bin/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
       - name: "Autotools: build and test c-ares"
-        shell: msys2 {0}
         run: |
           ./buildconf
           mkdir build
@@ -69,8 +67,3 @@ jobs:
           ./src/tools/adig.exe www.google.com
           ./src/tools/ahost.exe www.google.com
           ./test/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
-
-
-
-
-

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -18,6 +18,7 @@ jobs:
         include:
           - { msystem: MINGW64, env: x86_64,       cmake_opts: "" }
           - { msystem: MINGW32, env: i686,         cmake_opts: "" }
+          - { msystem: UCRT64,  env: ucrt-x86_64,  cmake_opts: "" }
           - { msystem: CLANG64, env: clang-x86_64, cmake_opts: "-DCMAKE_CXX_FLAGS=-fsanitize=undefined -DCMAKE_C_FLAGS=-fsanitize=undefined -DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=undefined -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=undefined" }
     defaults:
       run:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -18,8 +18,10 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: msys2/setup-msys2@v2
+      - name: Install MSYS2 and base packages
+        uses: msys2/setup-msys2@v2
         with:
+          msystem: ${{ matrix.sys }}
           update: true
           install: >-
             autoconf
@@ -29,12 +31,20 @@ jobs:
             make
             git
             mingw-w64-${{ matrix.env }}-cmake
-            mingw-w64-${{ matrix.env }}-gcc
             mingw-w64-${{ matrix.env }}-ninja
             mingw-w64-${{ matrix.env }}-gtest
-      - uses: msys2/setup-msys2@v2
+      - name: Install gcc compiler
+        uses: msys2/setup-msys2@v2
+        if: ${{ matrix.env != 'clang-x86_64' }}
+        with:
+          msystem: ${{ matrix.sys }}
+          install: >-
+            mingw-w64-${{ matrix.env }}-gcc
+      - name: Install clang compiler
+        uses: msys2/setup-msys2@v2
         if: ${{ matrix.env == 'clang-x86_64' }}
         with:
+          msystem: ${{ matrix.sys }}
           install: >-
             mingw-w64-${{ matrix.env }}-clang
       - name: Checkout c-ares

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -13,7 +13,8 @@ jobs:
   build:
     runs-on: windows-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
+      max-parallel: 1
       matrix:
         include:
           - { msystem: MINGW64, env: x86_64,       cmake_opts: "" }
@@ -49,13 +50,6 @@ jobs:
           pacman --noconfirm -S --needed mingw-w64-${{ matrix.env }}-clang mingw-w64-${{ matrix.env }}-clang-analyzer
       - name: Checkout c-ares
         uses: actions/checkout@v4
-      - name: "CMake: build and test c-ares"
-        run: |
-          cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=C:/projects/build-cares/test_install -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON ${{ matrix.cmake_opts }} -Bbuild_cmake -G Ninja .
-          cmake --build build_cmake
-          ./build_cmake/bin/adig.exe www.google.com
-          ./build_cmake/bin/ahost.exe www.google.com
-          ./build_cmake/bin/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
       - name: "Autotools: build and test c-ares"
         run: |
           autoreconf -fi
@@ -66,3 +60,10 @@ jobs:
           ./src/tools/adig.exe www.google.com
           ./src/tools/ahost.exe www.google.com
           ./test/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
+      - name: "CMake: build and test c-ares"
+        run: |
+          cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=C:/projects/build-cares/test_install -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON ${{ matrix.cmake_opts }} -Bbuild_cmake -G Ninja .
+          cmake --build build_cmake
+          ./build_cmake/bin/adig.exe www.google.com
+          ./build_cmake/bin/ahost.exe www.google.com
+          ./build_cmake/bin/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -11,17 +11,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - { sys: mingw64, env: x86_64,       cmake_opts: "" }
-          - { sys: mingw64, env: i686,         cmake_opts: "" }
-          - { sys: clang64, env: clang-x86_64, cmake_opts: "-DCMAKE_CXX_FLAGS=-fsanitize=undefined -DCMAKE_C_FLAGS=-fsanitize=undefined -DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=undefined -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=undefined" }
+          - { msystem: MINGW64, env: x86_64,       cmake_opts: "" }
+          - { msystem: MINGW32, env: i686,         cmake_opts: "" }
+          - { msystem: CLANG64, env: clang-x86_64, cmake_opts: "-DCMAKE_CXX_FLAGS=-fsanitize=undefined -DCMAKE_C_FLAGS=-fsanitize=undefined -DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=undefined -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=undefined" }
     defaults:
       run:
         shell: msys2 {0}
+    name: ${{ matrix.msystem }}
     steps:
       - name: Install MSYS2 and base packages
         uses: msys2/setup-msys2@v2
         with:
-          msystem: ${{ matrix.sys }}
+          msystem: ${{ matrix.msystem }}
           update: true
           install: >-
             autoconf
@@ -37,7 +38,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         if: ${{ matrix.env != 'clang-x86_64' }}
         with:
-          msystem: ${{ matrix.sys }}
+          msystem: ${{ matrix.msystem }}
           release: false
           install: >-
             mingw-w64-${{ matrix.env }}-gcc
@@ -45,15 +46,14 @@ jobs:
         uses: msys2/setup-msys2@v2
         if: ${{ matrix.env == 'clang-x86_64' }}
         with:
-          msystem: ${{ matrix.sys }}
+          msystem: ${{ matrix.msystem }}
           release: false
           install: >-
             mingw-w64-${{ matrix.env }}-clang
       - name: Checkout c-ares
         uses: actions/checkout@v4
       - name: "CMake: build and test c-ares"
-        env:
-          MSYSTEM: ${{ matrix.sys }}
+        shell: msys2 {0}
         run: |
           cmake -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=C:/projects/build-cares/test_install -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON ${{ matrix.cmake_opts }} -Bbuild -G Ninja .
           cmake --build build
@@ -61,8 +61,7 @@ jobs:
           ./build_cmake/bin/ahost.exe www.google.com
           ./build_cmake/bin/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
       - name: "Autotools: build and test c-ares"
-        env:
-          MSYSTEM: ${{ matrix.sys }}
+        shell: msys2 {0}
         run: |
           ./buildconf
           mkdir build

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -4,11 +4,7 @@ name: NetBSD
 
 on:
   push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
 
 jobs:
   test:

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -3,11 +3,7 @@
 name: OpenBSD
 on:
   push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
 
 jobs:
   test:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -6,12 +6,7 @@ name: REUSE compliance
 
 on:
   push:
-    branches:
-    - main
-    - '*/ci'
   pull_request:
-    branches:
-    - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,48 +47,6 @@ environment:
       CMAKE_EXTRA_OPTIONS: -GNinja -DCARES_BUILD_TESTS=ON -DGTEST_ROOT=C:\projects\googletest -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebugDLL
       BUILD_GOOGLETEST: yes
 
-    # MinGW gcc via MSYS2 (latest version)
-    - COMPILER: MINGW
-      CONFTOOL: CMAKE
-      SYSTEM: MSYS2
-      SKIP_TESTS: no
-      MSYSTEM: MINGW64
-      TOOLSDIR: ./build/bin
-      TESTDIR: ./build/bin
-      CMAKE_EXTRA_OPTIONS: -GNinja
-      CHERE_INVOKING: YES
-
-    # MinGW gcc via MSYS2 using autotools
-    - COMPILER: MINGW
-      CONFTOOL: AUTOTOOLS
-      SKIP_TESTS: no
-      SYSTEM: MSYS2
-      MSYSTEM: MINGW64
-      TOOLSDIR: ./src/tools
-      TESTDIR: ./test
-      CHERE_INVOKING: YES
-
-    # MinGW clang UBSAN via MSYS2
-    - COMPILER: MINGW
-      CONFTOOL: CMAKE
-      SKIP_TESTS: no
-      SYSTEM: MSYS2
-      MSYSTEM: CLANG64
-      TOOLSDIR: ./build/bin
-      TESTDIR: ./build/bin
-      CMAKE_EXTRA_OPTIONS: -GNinja -DCMAKE_CXX_FLAGS=-fsanitize=undefined -DCMAKE_C_FLAGS=-fsanitize=undefined -DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=undefined -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=undefined
-      CHERE_INVOKING: YES
-
-    # MinGW clang ASAN via MSYS2 -- doesn't work due to some issue with clang itself
-    # - COMPILER: MINGW
-    #   CONFTOOL: CMAKE
-    #   SKIP_TESTS: no
-    #   SYSTEM: MSYS2
-    #   MSYSTEM: CLANG64
-    #   TESTDIR: ./cmakebld/bin
-    #   CMAKE_EXTRA_OPTIONS: -GNinja -DCMAKE_CXX_FLAGS=-fsanitize=address -DCMAKE_C_FLAGS=-fsanitize=address -DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=address -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=address
-    #   CHERE_INVOKING: YES
-
     # MSVC 2022, 64-bit x86 (nmake)
     - COMPILER: MSVC
       CONFTOOL: NMAKE
@@ -145,9 +103,6 @@ before_build:
   # Setup build environment for the selected compiler (not all compilers need to do anything here).
   #  -- Visual Studio --
   - if "%COMPILER%" == "MSVC" call "%MSVC_SETUP_PATH%" %MSVC_SETUP_ARG%
-  - if "%SYSTEM%" == "MSYS2" C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu"
-  - if "%SYSTEM%" == "MSYS2" if "%MSYSTEM%" == "MINGW64" C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syu autoconf autoconf-archive automake libtool make git mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja mingw-w64-x86_64-gtest"
-  - if "%SYSTEM%" == "MSYS2" if "%MSYSTEM%" == "CLANG64" C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syu autoconf autoconf-archive automake libtool make git mingw-w64-clang-x86_64-clang mingw-w64-clang-x86_64-clang-analyzer mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-ninja mingw-w64-clang-x86_64-gtest"
   - if "%BUILD_GOOGLETEST%" == "yes" git clone --depth=1 https://github.com/google/googletest googletest
   - if "%BUILD_GOOGLETEST%" == "yes" cd googletest
   - if "%BUILD_GOOGLETEST%" == "yes" cmake -DCMAKE_INSTALL_PREFIX=C:\projects\googletest -DCMAKE_POLICY_DEFAULT_CMP0091:STRING=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebugDLL -GNinja -Bbuild
@@ -156,11 +111,6 @@ before_build:
   - if "%BUILD_GOOGLETEST%" == "yes" cd ..
 
 build_script:
-  - if "%SYSTEM%" == "MSYS2"   if "%CONFTOOL%" == "CMAKE"     C:\msys64\usr\bin\bash -lc "%ANALYZE_PREFIX% cmake -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=C:/projects/build-cares/test_install -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON %CMAKE_EXTRA_OPTIONS% -Bbuild ."
-  - if "%SYSTEM%" == "MSYS2"   if "%CONFTOOL%" == "CMAKE"     C:\msys64\usr\bin\bash -lc "%ANALYZE_PREFIX% cmake --build build"
-  - if "%SYSTEM%" == "MSYS2"   if "%CONFTOOL%" == "AUTOTOOLS" C:\msys64\usr\bin\bash -lc "./buildconf"
-  - if "%SYSTEM%" == "MSYS2"   if "%CONFTOOL%" == "AUTOTOOLS" C:\msys64\usr\bin\bash -lc "%ANALYZE_PREFIX% ./configure --enable-static --disable-shared --enable-tests"
-  - if "%SYSTEM%" == "MSYS2"   if "%CONFTOOL%" == "AUTOTOOLS" C:\msys64\usr\bin\bash -lc "%ANALYZE_PREFIX% make"
   - if "%SYSTEM%" == "CONSOLE" if "%CONFTOOL%" == "NMAKE"     copy .\include\ares_build.h.dist .\include\ares_build.h
   - if "%SYSTEM%" == "CONSOLE" if "%CONFTOOL%" == "NMAKE"     nmake /NOLOGO /f .\Makefile.msvc
   - if "%SYSTEM%" == "CONSOLE" if "%CONFTOOL%" == "CMAKE"     cmake -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=C:\projects\build-cares\test_install -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON %CMAKE_EXTRA_OPTIONS% -Bbuild
@@ -171,9 +121,6 @@ build_script:
 
 test_script:
   # We can't use powershell for tests due to treating stderr as an error
-  - if "%SYSTEM%" == "MSYS2"                              if not "%SKIP_TESTS%" == "yes" C:\msys64\usr\bin\bash -lc "%TOOLSDIR%/adig.exe www.google.com"
-  - if "%SYSTEM%" == "MSYS2"                              if not "%SKIP_TESTS%" == "yes" C:\msys64\usr\bin\bash -lc "%TOOLSDIR%/ahost.exe www.google.com"
-  - if "%SYSTEM%" == "MSYS2"                              if not "%SKIP_TESTS%" == "yes" C:\msys64\usr\bin\bash -lc "%TESTDIR%/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*"
   - if "%SYSTEM%" == "CONSOLE" if "%CONFTOOL%" == "NMAKE" if not "%SKIP_TESTS%" == "yes" cd test
   - if "%SYSTEM%" == "CONSOLE" if "%CONFTOOL%" == "NMAKE" if not "%SKIP_TESTS%" == "yes" nmake GTEST_ROOT=C:\projects\googletest /NOLOGO /f .\Makefile.msvc vtest
   - if "%SYSTEM%" == "CONSOLE" if "%CONFTOOL%" == "NMAKE" if not "%SKIP_TESTS%" == "yes" nmake GTEST_ROOT=C:\projects\googletest /NOLOGO /f .\Makefile.msvc aresfuzz aresfuzzname dnsdump

--- a/configure.ac
+++ b/configure.ac
@@ -902,12 +902,12 @@ AC_SUBST(AM_CPPFLAGS)
 AC_SUBST(PKGCONFIG_CFLAGS)
 AC_SUBST(BUILD_SUBDIRS)
 
-AC_CONFIG_FILES([Makefile           \
-                 include/Makefile   \
-                 src/Makefile       \
-                 src/lib/Makefile   \
-                 src/tools/Makefile \
-                 docs/Makefile      \
+AC_CONFIG_FILES([Makefile
+                 include/Makefile
+                 src/Makefile
+                 src/lib/Makefile
+                 src/tools/Makefile
+                 docs/Makefile
                  libcares.pc ])
 AM_COND_IF([BUILD_TESTS],
            [AC_CONFIG_FILES([test/Makefile])])

--- a/configure.ac
+++ b/configure.ac
@@ -396,7 +396,9 @@ AS_HELP_STRING([--enable-libgcc],[use libgcc when linking]),
        AC_MSG_RESULT(no)
 )
 
-dnl check for a few basic system headers we need
+dnl check for a few basic system headers we need.  It would be nice if we could
+dnl split these on separate lines, but for some reason autotools on Windows doesn't
+dnl allow this, even tried ending lines with a backslash.
 AC_CHECK_HEADERS([malloc.h memory.h AvailabilityMacros.h sys/types.h sys/time.h sys/select.h sys/socket.h sys/filio.h sys/ioctl.h sys/param.h sys/uio.h sys/random.h sys/event.h sys/epoll.h assert.h iphlpapi.h netioapi.h netdb.h netinet/in.h netinet6/in6.h netinet/tcp.h net/if.h ifaddrs.h fcntl.h errno.h socket.h strings.h stdbool.h time.h poll.h limits.h arpa/nameser.h arpa/nameser_compat.h arpa/inet.h ],
 dnl to do if not found
 [],

--- a/configure.ac
+++ b/configure.ac
@@ -294,17 +294,18 @@ if test "$ac_cv_native_windows" = "yes" ; then
   dnl other headers, AC_CHECK_HEADERS only allows you to specify headers that
   dnl must be included *before* the header being checked.
 
-  AC_CHECK_HEADERS(
-    windows.h  \
-    winsock2.h \
-    ws2tcpip.h \
-    iphlpapi.h \
-    netioapi.h \
-    ws2ipdef.h \
-    winternl.h \
-    ntdef.h    \
-    ntstatus.h \
-    mswsock.h,
+  AC_CHECK_HEADERS([
+    windows.h
+    winsock2.h
+    ws2tcpip.h
+    iphlpapi.h
+    netioapi.h
+    ws2ipdef.h
+    winternl.h
+    ntdef.h
+    ntstatus.h
+    mswsock.h
+    ],
     [], [], [-])
 
   dnl Windows builds require linking to iphlpapi
@@ -407,7 +408,7 @@ AS_HELP_STRING([--enable-libgcc],[use libgcc when linking]),
 )
 
 dnl check for a few basic system headers we need
-AC_CHECK_HEADERS(
+AC_CHECK_HEADERS([
        malloc.h
        memory.h
        AvailabilityMacros.h
@@ -441,7 +442,8 @@ AC_CHECK_HEADERS(
        limits.h
        arpa/nameser.h
        arpa/nameser_compat.h
-       arpa/inet.h,
+       arpa/inet.h
+],
 dnl to do if not found
 [],
 dnl to do if found

--- a/configure.ac
+++ b/configure.ac
@@ -408,39 +408,39 @@ AS_HELP_STRING([--enable-libgcc],[use libgcc when linking]),
 
 dnl check for a few basic system headers we need
 AC_CHECK_HEADERS(
-       malloc.h \
-       memory.h \
-       AvailabilityMacros.h \
-       sys/types.h \
-       sys/time.h \
-       sys/select.h \
-       sys/socket.h \
-       sys/filio.h \
-       sys/ioctl.h \
-       sys/param.h \
-       sys/uio.h \
-       sys/random.h \
-       sys/event.h \
-       sys/epoll.h \
-       assert.h \
-       iphlpapi.h \
-       netioapi.h \
-       netdb.h \
-       netinet/in.h \
-       netinet6/in6.h \
-       netinet/tcp.h \
-       net/if.h \
-       ifaddrs.h \
-       fcntl.h \
-       errno.h \
-       socket.h \
-       strings.h \
-       stdbool.h \
-       time.h \
-       poll.h \
-       limits.h \
-       arpa/nameser.h \
-       arpa/nameser_compat.h \
+       malloc.h
+       memory.h
+       AvailabilityMacros.h
+       sys/types.h
+       sys/time.h
+       sys/select.h
+       sys/socket.h
+       sys/filio.h
+       sys/ioctl.h
+       sys/param.h
+       sys/uio.h
+       sys/random.h
+       sys/event.h
+       sys/epoll.h
+       assert.h
+       iphlpapi.h
+       netioapi.h
+       netdb.h
+       netinet/in.h
+       netinet6/in6.h
+       netinet/tcp.h
+       net/if.h
+       ifaddrs.h
+       fcntl.h
+       errno.h
+       socket.h
+       strings.h
+       stdbool.h
+       time.h
+       poll.h
+       limits.h
+       arpa/nameser.h
+       arpa/nameser_compat.h
        arpa/inet.h,
 dnl to do if not found
 [],

--- a/configure.ac
+++ b/configure.ac
@@ -294,8 +294,7 @@ if test "$ac_cv_native_windows" = "yes" ; then
   dnl other headers, AC_CHECK_HEADERS only allows you to specify headers that
   dnl must be included *before* the header being checked.
 
-  AC_CHECK_HEADERS([
-    windows.h
+  AC_CHECK_HEADERS([windows.h
     winsock2.h
     ws2tcpip.h
     iphlpapi.h
@@ -304,8 +303,7 @@ if test "$ac_cv_native_windows" = "yes" ; then
     winternl.h
     ntdef.h
     ntstatus.h
-    mswsock.h
-    ],
+    mswsock.h ],
     [], [], [-])
 
   dnl Windows builds require linking to iphlpapi
@@ -408,8 +406,7 @@ AS_HELP_STRING([--enable-libgcc],[use libgcc when linking]),
 )
 
 dnl check for a few basic system headers we need
-AC_CHECK_HEADERS([
-       malloc.h
+AC_CHECK_HEADERS([malloc.h
        memory.h
        AvailabilityMacros.h
        sys/types.h
@@ -442,8 +439,7 @@ AC_CHECK_HEADERS([
        limits.h
        arpa/nameser.h
        arpa/nameser_compat.h
-       arpa/inet.h
-],
+       arpa/inet.h ],
 dnl to do if not found
 [],
 dnl to do if found

--- a/configure.ac
+++ b/configure.ac
@@ -294,16 +294,7 @@ if test "$ac_cv_native_windows" = "yes" ; then
   dnl other headers, AC_CHECK_HEADERS only allows you to specify headers that
   dnl must be included *before* the header being checked.
 
-  AC_CHECK_HEADERS([windows.h
-    winsock2.h
-    ws2tcpip.h
-    iphlpapi.h
-    netioapi.h
-    ws2ipdef.h
-    winternl.h
-    ntdef.h
-    ntstatus.h
-    mswsock.h ],
+  AC_CHECK_HEADERS([windows.h winsock2.h ws2tcpip.h iphlpapi.h netioapi.h ws2ipdef.h winternl.h ntdef.h ntstatus.h mswsock.h ],
     [], [], [-])
 
   dnl Windows builds require linking to iphlpapi
@@ -406,40 +397,7 @@ AS_HELP_STRING([--enable-libgcc],[use libgcc when linking]),
 )
 
 dnl check for a few basic system headers we need
-AC_CHECK_HEADERS([malloc.h
-       memory.h
-       AvailabilityMacros.h
-       sys/types.h
-       sys/time.h
-       sys/select.h
-       sys/socket.h
-       sys/filio.h
-       sys/ioctl.h
-       sys/param.h
-       sys/uio.h
-       sys/random.h
-       sys/event.h
-       sys/epoll.h
-       assert.h
-       iphlpapi.h
-       netioapi.h
-       netdb.h
-       netinet/in.h
-       netinet6/in6.h
-       netinet/tcp.h
-       net/if.h
-       ifaddrs.h
-       fcntl.h
-       errno.h
-       socket.h
-       strings.h
-       stdbool.h
-       time.h
-       poll.h
-       limits.h
-       arpa/nameser.h
-       arpa/nameser_compat.h
-       arpa/inet.h ],
+AC_CHECK_HEADERS([malloc.h memory.h AvailabilityMacros.h sys/types.h sys/time.h sys/select.h sys/socket.h sys/filio.h sys/ioctl.h sys/param.h sys/uio.h sys/random.h sys/event.h sys/epoll.h assert.h iphlpapi.h netioapi.h netdb.h netinet/in.h netinet6/in6.h netinet/tcp.h net/if.h ifaddrs.h fcntl.h errno.h socket.h strings.h stdbool.h time.h poll.h limits.h arpa/nameser.h arpa/nameser_compat.h arpa/inet.h ],
 dnl to do if not found
 [],
 dnl to do if found


### PR DESCRIPTION
AppVeyor has gotten progressively slower over the last year or so.  Move some Windows builds to GitHub actions which is considerably faster.

Fix By: Brad House (@bradh352)