### PR TITLE
MSVC: enable strict warnings

### DIFF
--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -119,7 +119,33 @@ if (MSVC)
 	# * warning C4201: nonstandard extension used : nameless struct/union
 	#     Triggered by system includes (commctrl.h, shtypes.h, Shlobj.h)
 	set(_flags
-		/W3
+		# Enable warnings
+		/W4 # Baseline reasonable warnings
+		/w14242 # 'identifier': conversion from 'type1' to 'type2', possible loss of data
+		/w14254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
+		/w14263 # 'function': member function does not override any base class virtual member function
+		/w14265 # 'classname': class has virtual functions, but destructor is not virtual instances of this class may not
+		        # be destructed correctly
+		/w14287 # 'operator': unsigned/negative constant mismatch
+		/we4289 # nonstandard extension used: 'variable': loop control variable declared in the for-loop is used outside
+		        # the for-loop scope
+		/w14296 # 'operator': expression is always 'boolean_value'
+		/w14311 # 'variable': pointer truncation from 'type1' to 'type2'
+		/w14545 # expression before comma evaluates to a function which is missing an argument list
+		/w14546 # function call before comma missing argument list
+		/w14547 # 'operator': operator before comma has no effect; expected operator with side-effect
+		/w14549 # 'operator': operator before comma has no effect; did you intend 'operator'?
+		/w14555 # expression has no effect; expected expression with side- effect
+		/w14619 # pragma warning: there is no warning number 'number'
+		/w14640 # Enable warning on thread un-safe static member initialization
+		/w14826 # Conversion from 'type1' to 'type2' is sign-extended. This may cause unexpected runtime behavior.
+		/w14905 # wide string literal cast to 'LPSTR'
+		/w14906 # string literal cast to 'LPWSTR'
+		/w14928 # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
+
+		# Disable some warnings
+
+		# Turn some warnings into errors
 		/we4013 # Treat "function undefined, assuming extern returning int" warning as an error. https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4013
 	)
 

--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -109,6 +109,9 @@ set(_debug_flags_C)
 set(_debug_flags_CXX)
 
 if (MSVC)
+	# Don't automatically set /W3
+	CMAKE_POLICY (SET CMP0092 NEW)
+
 	# Visual Studio uses a completely different nomenclature for warnings than gcc/mingw/clang, so none of the
 	# "-W[name]" warnings will work.
 

--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -242,8 +242,8 @@ if (MSVC)
 		/w14242 # 'identifier': conversion from 'type1' to 'type2', possible loss of data
 		/w14254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
 		/w14263 # 'function': member function does not override any base class virtual member function
-		/w14265 # 'classname': class has virtual functions, but destructor is not virtual instances of this class may not
-		        # be destructed correctly
+		/w14265 # 'classname': class has virtual functions, but destructor is not virtual instances of this class may
+		        # not be destructed correctly
 		/w14287 # 'operator': unsigned/negative constant mismatch
 		/we4289 # nonstandard extension used: 'variable': loop control variable declared in the for-loop is used outside
 		        # the for-loop scope
@@ -262,6 +262,10 @@ if (MSVC)
 		/w14928 # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
 
 		# Disable some warnings
+		/wd4201 # nonstandard extension used: nameless struct/union. Used in some windows headers, e.g. IO_STATUS_BLOCK,
+		        # disable.
+		/wd4206 # nonstandard extension used: translation unit is empty. All files in c-ares are compiled even if not
+		        # used, so we need to ignore this.
 
 		# Turn some warnings into errors
 		/we4013 # Treat "function undefined, assuming extern returning int" warning as an error. https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4013

--- a/src/lib/ares__addrinfo_localhost.c
+++ b/src/lib/ares__addrinfo_localhost.c
@@ -140,7 +140,7 @@ static ares_status_t
   !defined(__WATCOMC__)
   PMIB_UNICASTIPADDRESS_TABLE table;
   unsigned int                i;
-  ares_status_t               status;
+  ares_status_t               status = ARES_ENOTFOUND;
 
   *nodes = NULL;
 

--- a/src/lib/ares__buf.c
+++ b/src/lib/ares__buf.c
@@ -944,7 +944,7 @@ static ares_status_t ares__buf_parse_dns_binstr_int(
   ares_bool_t allow_multiple, ares_bool_t validate_printable)
 {
   unsigned char len;
-  ares_status_t status;
+  ares_status_t status   = ARES_EBADRESP;
   ares__buf_t  *binbuf   = NULL;
   size_t        orig_len = ares__buf_len(buf);
 

--- a/src/lib/ares_event_thread.c
+++ b/src/lib/ares_event_thread.c
@@ -391,22 +391,23 @@ static const ares_event_sys_t *ares_event_fetch_sys(ares_evsys_t evsys)
 
     /* case ARES_EVSYS_DEFAULT: */
     default:
-#if defined(USE_WINSOCK)
-      return &ares_evsys_win32;
-#elif defined(HAVE_KQUEUE)
-      return &ares_evsys_kqueue;
-#elif defined(HAVE_EPOLL)
-      return &ares_evsys_epoll;
-#elif defined(HAVE_POLL)
-      return &ares_evsys_poll;
-#elif defined(HAVE_PIPE)
-      return &ares_evsys_select;
-#else
       break;
-#endif
   }
 
+  /* default */
+#if defined(USE_WINSOCK)
+  return &ares_evsys_win32;
+#elif defined(HAVE_KQUEUE)
+  return &ares_evsys_kqueue;
+#elif defined(HAVE_EPOLL)
+  return &ares_evsys_epoll;
+#elif defined(HAVE_POLL)
+  return &ares_evsys_poll;
+#elif defined(HAVE_PIPE)
+  return &ares_evsys_select;
+#else
   return NULL;
+#endif
 }
 
 ares_status_t ares_event_thread_init(ares_channel_t *channel)

--- a/src/lib/ares_math.c
+++ b/src/lib/ares_math.c
@@ -57,7 +57,7 @@ static ares_int64_t ares__round_up_pow2_u64(ares_int64_t n)
   return n;
 }
 
-ares_bool ares__is_64bit(void)
+ares_bool_t ares__is_64bit(void)
 {
 #ifdef _MSC_VER
 #  pragma warning( push )

--- a/src/lib/ares_math.c
+++ b/src/lib/ares_math.c
@@ -57,9 +57,23 @@ static ares_int64_t ares__round_up_pow2_u64(ares_int64_t n)
   return n;
 }
 
+ares_bool ares__is_64bit(void)
+{
+#ifdef _MSC_VER
+#  pragma warning( push )
+#  pragma warning( disable : 4127 )
+#endif
+
+  return (sizeof(size_t) == 4)?ARES_FALSE:ARES_TRUE;
+
+#ifdef _MSC_VER
+#  pragma warning( pop )
+#endif
+}
+
 size_t ares__round_up_pow2(size_t n)
 {
-  if (sizeof(size_t) > 4) {
+  if (ares__is_64bit()) {
     return (size_t)ares__round_up_pow2_u64((ares_int64_t)n);
   }
 
@@ -79,7 +93,7 @@ size_t ares__log2(size_t n)
     56, 45, 25, 31, 35, 16, 9,  12, 44, 24, 15, 8,  23, 7,  6,  5
   };
 
-  if (sizeof(size_t) == 4) {
+  if (!ares__is_64bit()) {
     return tab32[(n * 0x077CB531) >> 27];
   }
 

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -627,6 +627,7 @@ ares_bool_t   ares__subnet_match(const struct ares_addr *addr,
                                  unsigned char           netmask);
 ares_bool_t   ares__addr_is_linklocal(const struct ares_addr *addr);
 
+ares_bool_t   ares__is_64bit(void);
 size_t        ares__round_up_pow2(size_t n);
 size_t        ares__log2(size_t n);
 size_t        ares__pow(size_t x, size_t y);

--- a/src/lib/ares_rand.c
+++ b/src/lib/ares_rand.c
@@ -57,7 +57,7 @@ typedef struct ares_rand_rc4 {
 static unsigned int ares_u32_from_ptr(void *addr)
 {
   /* LCOV_EXCL_START: FallbackCode */
-  if (sizeof(void *) == 8) {
+  if (ares__is_64bit()) {
     return (unsigned int)((((ares_uint64_t)addr >> 32) & 0xFFFFFFFF) |
                           ((ares_uint64_t)addr & 0xFFFFFFFF));
   }

--- a/src/lib/ares_timeout.c
+++ b/src/lib/ares_timeout.c
@@ -59,7 +59,12 @@ static struct timeval ares_timeval_to_struct_timeval(const ares_timeval_t *atv)
 {
   struct timeval tv;
 
+#ifdef USE_WINSOCK
+  tv.tv_sec  = (long)atv->sec;
+#else
   tv.tv_sec  = (time_t)atv->sec;
+#endif
+
   tv.tv_usec = (int)atv->usec;
 
   return tv;

--- a/test/ares-test-mock-ai.cc
+++ b/test/ares-test-mock-ai.cc
@@ -40,6 +40,7 @@ namespace ares {
 namespace test {
 
 MATCHER_P(IncludesNumAddresses, n, "") {
+  (void)result_listener;
   if(!arg)
     return false;
   int cnt = 0;
@@ -49,6 +50,7 @@ MATCHER_P(IncludesNumAddresses, n, "") {
 }
 
 MATCHER_P(IncludesV4Address, address, "") {
+  (void)result_listener;
   if(!arg)
     return false;
   in_addr addressnum = {};
@@ -67,6 +69,7 @@ MATCHER_P(IncludesV4Address, address, "") {
 }
 
 MATCHER_P(IncludesV6Address, address, "") {
+  (void)result_listener;
   if(!arg)
     return false;
   in6_addr addressnum = {};

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -140,6 +140,7 @@ TEST_P(MockUDPChannelTest, TruncationRetry) {
 static int sock_cb_count = 0;
 static int SocketConnectCallback(ares_socket_t fd, int type, void *data) {
   int rc = *(int*)data;
+  (void)type;
   if (verbose) std::cerr << "SocketConnectCallback(" << fd << ") invoked" << std::endl;
   sock_cb_count++;
   return rc;
@@ -185,6 +186,7 @@ TEST_P(MockChannelTest, SockFailCallback) {
 static int sock_config_cb_count = 0;
 static int SocketConfigureCallback(ares_socket_t fd, int type, void *data) {
   int rc = *(int*)data;
+  (void)type;
   if (verbose) std::cerr << "SocketConfigureCallback(" << fd << ") invoked" << std::endl;
   sock_config_cb_count++;
   return rc;

--- a/test/dns-proto.cc
+++ b/test/dns-proto.cc
@@ -341,21 +341,21 @@ std::string RRToString(const std::vector<byte>& packet,
     case T_TXT: {
       const byte* p = *data;
       while (p < (*data + rdatalen)) {
-        int len = *p++;
-        if ((p + len) <= (*data + rdatalen)) {
-          std::string txt(p, p + len);
-          ss << " " << len << ":'" << txt << "'";
+        int tlen = *p++;
+        if ((p + tlen) <= (*data + rdatalen)) {
+          std::string txt(p, p + tlen);
+          ss << " " << tlen << ":'" << txt << "'";
         } else {
           ss << "(string too long)";
         }
-        p += len;
+        p += tlen;
       }
       break;
     }
     case T_CNAME:
     case T_NS:
     case T_PTR: {
-      int rc = ares_expand_name(*data, packet.data(), (int)packet.size(), &name, &enclen);
+      rc = ares_expand_name(*data, packet.data(), (int)packet.size(), &name, &enclen);
       if (rc != ARES_SUCCESS) {
         ss << "(error from ares_expand_name)";
         break;
@@ -366,7 +366,7 @@ std::string RRToString(const std::vector<byte>& packet,
     }
     case T_MX:
       if (rdatalen > 2) {
-        int rc = ares_expand_name(*data + 2, packet.data(), (int)packet.size(), &name, &enclen);
+        rc = ares_expand_name(*data + 2, packet.data(), (int)packet.size(), &name, &enclen);
         if (rc != ARES_SUCCESS) {
           ss << "(error from ares_expand_name)";
           break;
@@ -384,7 +384,7 @@ std::string RRToString(const std::vector<byte>& packet,
         unsigned long weight = DNS__16BIT(p + 2);
         unsigned long port = DNS__16BIT(p + 4);
         p += 6;
-        int rc = ares_expand_name(p, packet.data(), (int)packet.size(), &name, &enclen);
+        rc = ares_expand_name(p, packet.data(), (int)packet.size(), &name, &enclen);
         if (rc != ARES_SUCCESS) {
           ss << "(error from ares_expand_name)";
           break;
@@ -411,7 +411,7 @@ std::string RRToString(const std::vector<byte>& packet,
     }
     case T_SOA: {
       const byte* p = *data;
-      int rc = ares_expand_name(p, packet.data(), (int)packet.size(), &name, &enclen);
+      rc = ares_expand_name(p, packet.data(), (int)packet.size(), &name, &enclen);
       if (rc != ARES_SUCCESS) {
         ss << "(error from ares_expand_name)";
         break;
@@ -447,22 +447,22 @@ std::string RRToString(const std::vector<byte>& packet,
         p += 4;
         ss << order << " " << pref;
 
-        int len = *p++;
-        std::string flags(p, p + len);
+        int nlen = *p++;
+        std::string flags(p, p + nlen);
         ss << " " << flags;
-        p += len;
+        p += nlen;
 
-        len = *p++;
-        std::string service(p, p + len);
+        nlen = *p++;
+        std::string service(p, p + nlen);
         ss << " '" << service << "'";
-        p += len;
+        p += nlen;
 
-        len = *p++;
-        std::string regexp(p, p + len);
+        nlen = *p++;
+        std::string regexp(p, p + nlen);
         ss << " '" << regexp << "'";
-        p += len;
+        p += nlen;
 
-        int rc = ares_expand_name(p, packet.data(), (int)packet.size(), &name, &enclen);
+        rc = ares_expand_name(p, packet.data(), (int)packet.size(), &name, &enclen);
         if (rc != ARES_SUCCESS) {
           ss << "(error from ares_expand_name)";
           break;


### PR DESCRIPTION
MSVC has been building with /W3 which isn't considered a safe level for modern code.  /W4 is recommended, but it too is lacking some recommended options, so we enable /W4 and also the recommended options.  We do, however, have to disable a couple of options due to Windows headers not being fully compliant sometimes as well as some things we do in c-ares that it doesn't like, but aren't actually bad.

Fix By: Brad House (@bradh352)