### PR TITLE
Automatic query timeout adjustment based on server history

### DIFF
--- a/docs/ares_init_options.3
+++ b/docs/ares_init_options.3
@@ -136,10 +136,7 @@ servers available.  Instead, fail initialization with \fIARES_ENOSERVER\fP.
 .B int \fItimeout\fP;
 .br
 The number of seconds each name server is given to respond to a query on the
-first try.  (After the first try, the timeout algorithm becomes more
-complicated, but scales linearly with the value of \fItimeout\fP.)  The
-default is two seconds. This option is being deprecated by
-\fIARES_OPT_TIMEOUTMS\fP starting in c-ares 1.5.2.
+first try.  See \fIARES_OPT_TIMEOUTMS\fP which this value is converted into.
 .TP 18
 .B ARES_OPT_TIMEOUTMS
 .B int \fItimeout\fP;
@@ -151,6 +148,10 @@ default is two seconds. Note that this option is specified with the same
 struct field as the former \fIARES_OPT_TIMEOUT\fP, it is but the option bits
 that tell c-ares how to interpret the number. This option was added in c-ares
 1.5.2.
+
+As of c-ares 1.32.0, this option is only honored on the first successful query
+to any given server, after that the timeout is automatically calculated based
+on prior query history.
 .TP 18
 .B ARES_OPT_TRIES
 .B int \fItries\fP;

--- a/docs/ares_init_options.3
+++ b/docs/ares_init_options.3
@@ -142,10 +142,11 @@ first try.  See \fIARES_OPT_TIMEOUTMS\fP which this value is converted into.
 .B int \fItimeout\fP;
 .br
 The number of milliseconds each name server is given to respond to a query on
-the first try of any given server. The default is two seconds. Note that this
-option is specified with the same struct field as the former
-\fIARES_OPT_TIMEOUT\fP, it is but the option bits that tell c-ares how to
-interpret the number. This option was added in c-ares 1.5.2.
+the first try of any given server. The default is two seconds, however any
+value below 250ms will automatically be set to 250ms (roughly the RTT half-way
+around the world). Note that this option is specified with the same struct field
+as the former \fIARES_OPT_TIMEOUT\fP, it is but the option bits that tell c-ares
+how to interpret the number. This option was added in c-ares 1.5.2.
 
 As of c-ares 1.32.0, this option is only honored on the first successful query
 to any given server, after that the timeout is automatically calculated based

--- a/docs/ares_init_options.3
+++ b/docs/ares_init_options.3
@@ -142,12 +142,10 @@ first try.  See \fIARES_OPT_TIMEOUTMS\fP which this value is converted into.
 .B int \fItimeout\fP;
 .br
 The number of milliseconds each name server is given to respond to a query on
-the first try.  (After the first try, the timeout algorithm becomes more
-complicated, but scales linearly with the value of \fItimeout\fP.)  The
-default is two seconds. Note that this option is specified with the same
-struct field as the former \fIARES_OPT_TIMEOUT\fP, it is but the option bits
-that tell c-ares how to interpret the number. This option was added in c-ares
-1.5.2.
+the first try of any given server. The default is two seconds. Note that this
+option is specified with the same struct field as the former
+\fIARES_OPT_TIMEOUT\fP, it is but the option bits that tell c-ares how to
+interpret the number. This option was added in c-ares 1.5.2.
 
 As of c-ares 1.32.0, this option is only honored on the first successful query
 to any given server, after that the timeout is automatically calculated based

--- a/src/lib/Makefile.inc
+++ b/src/lib/Makefile.inc
@@ -5,7 +5,7 @@ CSOURCES = ares__addrinfo2hostent.c	\
   ares__addrinfo_localhost.c		\
   ares__buf.c				\
   ares__close_sockets.c			\
-  ares__hosts_file.c		\
+  ares__hosts_file.c			\
   ares__htable.c			\
   ares__htable_asvp.c			\
   ares__htable_strvp.c			\
@@ -28,7 +28,7 @@ CSOURCES = ares__addrinfo2hostent.c	\
   ares_dns_parse.c			\
   ares_dns_record.c			\
   ares_dns_write.c			\
-  ares_event_configchg.c	\
+  ares_event_configchg.c		\
   ares_event_epoll.c			\
   ares_event_kqueue.c			\
   ares_event_poll.c			\
@@ -50,7 +50,8 @@ CSOURCES = ares__addrinfo2hostent.c	\
   ares_getsock.c			\
   ares_init.c				\
   ares_library_init.c			\
-  ares_math.c			\
+  ares_math.c				\
+  ares_metrics.c			\
   ares_create_query.c			\
   ares_options.c			\
   ares_parse_a_reply.c			\
@@ -66,7 +67,7 @@ CSOURCES = ares__addrinfo2hostent.c	\
   ares_parse_uri_reply.c		\
   ares_platform.c			\
   ares_process.c			\
-  ares_qcache.c			\
+  ares_qcache.c				\
   ares_query.c				\
   ares_rand.c				\
   ares_search.c				\
@@ -75,12 +76,12 @@ CSOURCES = ares__addrinfo2hostent.c	\
   ares_str.c				\
   ares_strerror.c			\
   ares_strsplit.c			\
-  ares_sysconfig.c		\
-  ares_sysconfig_files.c	\
-  ares_sysconfig_mac.c	\
-  ares_sysconfig_win.c	\
+  ares_sysconfig.c			\
+  ares_sysconfig_files.c		\
+  ares_sysconfig_mac.c			\
+  ares_sysconfig_win.c			\
   ares_timeout.c			\
-  ares_update_servers.c	\
+  ares_update_servers.c			\
   ares_version.c			\
   inet_net_pton.c			\
   inet_ntop.c				\

--- a/src/lib/ares_metrics.c
+++ b/src/lib/ares_metrics.c
@@ -116,7 +116,7 @@ static time_t ares_metric_timestamp(ares_server_bucket_t bucket,
                                     const ares_timeval_t *now,
                                     ares_bool_t is_previous)
 {
-  time_t divisor;
+  time_t divisor = 1; /* Silence bogus MSVC warning by setting default value */
 
   switch (bucket) {
     case ARES_METRIC_1MINUTE:

--- a/src/lib/ares_metrics.c
+++ b/src/lib/ares_metrics.c
@@ -82,8 +82,8 @@
  * On each query reply where the response is legitimate (proper response or
  * NXDOMAIN) and not something like a server error:
  * - Cycle through each bucket in order
- * - Check timestamp of bucket against current timestamp, if out of date clear
- *   all values
+ * - Check timestamp of bucket against current timestamp, if out of date
+ *   overwrite previous entry with values, clear current values
  * - Compare current minimum and maximum recorded latency against query time and
  *   adjust if necessary
  * - Increment "count" by 1 and "total time" by the query time

--- a/src/lib/ares_metrics.c
+++ b/src/lib/ares_metrics.c
@@ -29,7 +29,7 @@
  * ====================
  *
  * With very little effort we should be able to determine fairly proper timeouts
- * we can use based on prior query history.  We can also track in order to
+ * we can use based on prior query history.  We track in order to be able to
  * auto-scale when network conditions change (e.g. maybe there is a provider
  * failover and timings change due to that).  Apple appears to do this within
  * their system resolver in MacOS.  Obviously we should have a minimum, maximum,

--- a/src/lib/ares_metrics.c
+++ b/src/lib/ares_metrics.c
@@ -1,0 +1,159 @@
+/* MIT License
+ *
+ * Copyright (c) 2024 Brad House
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "ares_setup.h"
+#include "ares.h"
+#include "ares_private.h"
+
+/*! Minimum timeout value. Chosen due to it being approximately RTT half-way
+ *  around the world */
+#define MIN_TIMEOUT_MS         250
+
+/*! Multiplier to apply to average latency to come up with an initial timeout */
+#define AVG_TIMEOUT_MULTIPLIER 5
+
+/*! Upper timeout bounds, only used if channel->maxtimeout not set */
+#define MAX_TIMEOUT_MS         5000
+
+static time_t ares_metric_timestamp(ares_server_bucket_t bucket,
+                                    const ares_timeval_t *now)
+{
+  time_t divisor;
+
+  switch (bucket) {
+    case ARES_METRIC_1MINUTE:
+      divisor = 60;
+      break;
+    case ARES_METRIC_15MINUTES:
+      divisor = 15 * 60;
+      break;
+    case ARES_METRIC_1HOUR:
+      divisor = 60 * 60;
+      break;
+    case ARES_METRIC_1DAY:
+      divisor = 24 * 60 * 60;
+      break;
+    case ARES_METRIC_INCEPTION:
+      return 1;
+    case ARES_METRIC_COUNT:
+      return 0; /* Invalid! */
+  }
+
+  return (time_t)(now->sec / divisor);
+}
+
+void ares_metrics_record(const struct query *query, struct server_state *server,
+                         ares_status_t status, const ares_dns_record_t *dnsrec)
+{
+  ares_timeval_t       now    = ares__tvnow();
+  ares_timeval_t       tvdiff;
+  unsigned int         query_ms;
+  ares_dns_rcode_t     rcode;
+  ares_server_bucket_t i;
+
+  if (status != ARES_SUCCESS) {
+    return;
+  }
+
+  if (server == NULL) {
+    return;
+  }
+
+  rcode = ares_dns_record_get_rcode(dnsrec);
+  if (rcode != ARES_RCODE_NOERROR && rcode != ARES_RCODE_NXDOMAIN) {
+    return;
+  }
+
+  ares__timeval_diff(&tvdiff, &query->ts, &now);
+  query_ms = (unsigned int)(tvdiff.sec + (tvdiff.usec / 1000));
+  if (query_ms == 0) {
+    query_ms = 1;
+  }
+
+  /* Place in each bucket */
+  for (i=0; i<ARES_METRIC_COUNT; i++) {
+    time_t ts = ares_metric_timestamp(i, &now);
+    if (ts != server->metrics[i].ts) {
+      memset(&server->metrics[i], 0, sizeof(server->metrics[i]));
+      server->metrics[i].ts = ts;
+    }
+
+    if (server->metrics[i].latency_min_ms == 0 ||
+        server->metrics[i].latency_min_ms > query_ms) {
+      server->metrics[i].latency_min_ms = query_ms;
+    }
+
+    if (query_ms > server->metrics[i].latency_max_ms) {
+      server->metrics[i].latency_min_ms = query_ms;
+    }
+
+    server->metrics[i].total_count++;
+    server->metrics[i].total_ms += (ares_uint64_t)query_ms;
+  }
+}
+
+
+
+size_t ares_metrics_server_timeout(const struct server_state *server,
+                                   const ares_timeval_t      *now)
+{
+  const ares_channel_t *channel = server->channel;
+  ares_server_bucket_t  i;
+
+  for (i=0; i<ARES_METRIC_COUNT; i++) {
+    time_t ts = ares_metric_timestamp(i, now);
+    size_t timeout_ms;
+
+    /* This ts has been invalidated, go to the next */
+    if (ts != server->metrics[i].ts || server->metrics[i].total_count == 0) {
+      continue;
+    }
+
+    /* Calculate average time */
+    timeout_ms = (size_t)(server->metrics[i].total_ms / server->metrics[i].total_count);
+
+    /* Multiply average by constant to get timeout value */
+    timeout_ms *= AVG_TIMEOUT_MULTIPLIER;
+
+    /* don't go below lower bounds */
+    if (timeout_ms < MIN_TIMEOUT_MS) {
+      timeout_ms = MIN_TIMEOUT_MS;
+    }
+
+    /* don't go above upper bounds */
+    if (channel->maxtimeout && timeout_ms > channel->maxtimeout) {
+      timeout_ms = (size_t)channel->maxtimeout;
+    } else if (timeout_ms > MAX_TIMEOUT_MS) {
+      timeout_ms = MAX_TIMEOUT_MS;
+    }
+
+    return timeout_ms;
+  }
+
+  /* If we're here, that means its the first query for the server, so we just
+   * use the initial default timeout */
+  return channel->timeout;
+}

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -182,11 +182,15 @@ typedef enum {
 
 /*! Data metrics collected for each bucket */
 typedef struct {
-  time_t        ts;
-  unsigned int  latency_min_ms;
-  unsigned int  latency_max_ms;
-  ares_uint64_t total_ms;
-  ares_uint64_t total_count;
+  time_t        ts;             /*!< Timestamp divided by bucket divisor */
+  unsigned int  latency_min_ms; /*!< Minimum latency for queries */
+  unsigned int  latency_max_ms; /*!< Maximum latency for queries */
+  ares_uint64_t total_ms;       /*!< Cumulative query time for bucket */
+  ares_uint64_t total_count;    /*!< Number of queries for bucket */
+
+  time_t        prev_ts;        /*!< Previous period bucket timestamp */
+  ares_uint64_t prev_total_ms;  /*!< Previous period bucket cumulative query time */
+  ares_uint64_t prev_total_count; /*!< Previous period bucket query count */
 } ares_server_metrics_t;
 
 struct server_state {

--- a/src/lib/ares_timeout.c
+++ b/src/lib/ares_timeout.c
@@ -55,6 +55,19 @@ void ares__timeval_remaining(ares_timeval_t       *remaining,
   }
 }
 
+void ares__timeval_diff(ares_timeval_t       *tvdiff,
+                        const ares_timeval_t *tvstart,
+                        const ares_timeval_t *tvstop)
+{
+  tvdiff->sec = tvstop->sec - tvstart->sec;
+  if (tvstop->usec > tvstart->usec) {
+    tvdiff->usec = tvstop->usec - tvstart->usec;
+  } else {
+    tvdiff->sec -= 1;
+    tvdiff->usec = tvstop->usec + 1000000 - tvstart->usec;
+  }
+}
+
 static struct timeval ares_timeval_to_struct_timeval(const ares_timeval_t *atv)
 {
   struct timeval tv;


### PR DESCRIPTION
With very little effort we should be able to determine fairly proper timeouts we can use based on prior query history.  We track in order to be able to auto-scale when network conditions change (e.g. maybe there is a provider failover and timings change due to that).  Apple appears to do this within their system resolver in MacOS.  Obviously we should have a minimum, maximum, and initial value to make sure the algorithm doesn't somehow go off the rails.

Values:
 - Minimum Timeout: 250ms (approximate RTT half-way around the globe)
 - Maximum Timeout: 5000ms (Recommended timeout in RFC 1123), can be reduced by ARES_OPT_MAXTIMEOUTMS, but otherwise the bound specified by the option caps the retry timeout.
 - Initial Timeout: User-specified via configuration or ARES_OPT_TIMEOUTMS
 - Average latency multiplier: 5x (a local DNS server returning a cached value will be quicker than if it needs to recurse so we need to account for this)
 - Minimum Count for Average: 3.  This is the minimum number of queries we need to form an average for the bucket.

Per-server buckets for tracking latency over time (these are ephemeral meaning they don't persist once a channel is destroyed).  We record both the current timespan for the bucket and the immediate preceding timespan in case of roll-overs we can still maintain recent metrics for calculations:
 - 1 minute
 - 15 minutes
 - 1 hr
 - 1 day
 - since inception

Each bucket contains:
 - timestamp (divided by interval)
 - minimum latency
 - maximum latency
 - total time
 - count

NOTE: average latency is (total time / count), we will calculate this dynamically when needed

Basic algorithm for calculating timeout to use would be:
 - Scan from most recent bucket to least recent
 - Check timestamp of bucket, if doesn't match current time, continue to next bucket
 - Check count of bucket, if its not at least the "Minimum Count for Average", check the previous bucket, otherwise continue to next bucket
 - If we reached the end with no bucket match, use "Initial Timeout"
 - If bucket is selected, take ("total time" / count) as Average latency, multiply by "Average Latency Multiplier", bound by "Minimum Timeout" and "Maximum Timeout"

NOTE: The timeout calculated may not be the timeout used.  If we are retrying
the query on the same server another time, then it will use a larger value

On each query reply where the response is legitimate (proper response or NXDOMAIN) and not something like a server error:
 - Cycle through each bucket in order
 - Check timestamp of bucket against current timestamp, if out of date overwrite previous entry with values, clear current values
 - Compare current minimum and maximum recorded latency against query time and adjust if necessary
 - Increment "count" by 1 and "total time" by the query time

Other Notes:
 - This is always-on, the only user-configurable value is the initial timeout which will simply re-uses the current option.
 - Minimum and Maximum latencies for a bucket are currently unused but are there in case we find a need for them in the future.

Fixes Issue: #736
Fix By: Brad House (@bradh352)