### PR TITLE
Fix building with UNICODE

### DIFF
--- a/src/lib/ares_event_configchg.c
+++ b/src/lib/ares_event_configchg.c
@@ -313,17 +313,17 @@ ares_status_t ares_event_configchg_init(ares_event_configchg_t **configchg,
   /* Monitor HKLM\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters\Interfaces
    * and HKLM\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces
    * for changes via RegNotifyChangeKeyValue() */
-  if (RegOpenKeyEx(
+  if (RegOpenKeyExW(
         HKEY_LOCAL_MACHINE,
-        "SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\Interfaces", 0,
+        L"SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\Interfaces", 0,
         KEY_NOTIFY, &c->regip4) != ERROR_SUCCESS) {
     status = ARES_ESERVFAIL;
     goto done;
   }
 
-  if (RegOpenKeyEx(
+  if (RegOpenKeyExW(
         HKEY_LOCAL_MACHINE,
-        "SYSTEM\\CurrentControlSet\\Services\\Tcpip6\\Parameters\\Interfaces",
+        L"SYSTEM\\CurrentControlSet\\Services\\Tcpip6\\Parameters\\Interfaces",
         0, KEY_NOTIFY, &c->regip6) != ERROR_SUCCESS) {
     status = ARES_ESERVFAIL;
     goto done;


### PR DESCRIPTION
Use the unicode version of `RegOpenKeyEx` to avoid compilation error caused by string type like:

```
../../node/deps/cares/src/lib/ares_event_configchg.c(322,9): error: incompatible pointer types passing 'char[62]' to parameter of type 'LPCWSTR' (aka 'const unsigned short *') [-Werror,-Wincompatible-pointer-types]
  322 |         "SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\Interfaces",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```