### PR TITLE
Rework WinAFD event code

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  GTEST_ARGS: "-4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*"
+
 jobs:
   build:
     runs-on: windows-latest
@@ -42,6 +45,7 @@ jobs:
             mingw-w64-${{ matrix.env }}-cmake
             mingw-w64-${{ matrix.env }}-ninja
             mingw-w64-${{ matrix.env }}-gtest
+            mingw-w64-${{ matrix.env }}-lldb
             ${{ matrix.extra_packages }}
       - name: Checkout c-ares
         uses: actions/checkout@v4
@@ -51,7 +55,7 @@ jobs:
           cmake --build build_cmake
           ./build_cmake/bin/adig.exe www.google.com
           ./build_cmake/bin/ahost.exe www.google.com
-          GTEST_INSTALL_FAILURE_SIGNAL_HANDLER=1 ./build_cmake/bin/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
+          lldb --batch -o 'run ${{ env.GTEST_ARGS }}' -k 'thread backtrace all' -k 'quit 1' ./build_cmake/bin/arestest.exe
       - name: "Autotools: build and test c-ares"
         run: |
           autoreconf -fi
@@ -61,7 +65,7 @@ jobs:
           make -j3
           ./src/tools/adig.exe www.google.com
           ./src/tools/ahost.exe www.google.com
-          GTEST_INSTALL_FAILURE_SIGNAL_HANDLER=1 ./test/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
+          lldb --batch -o 'run ${{ env.GTEST_ARGS }}' -k 'thread backtrace all' -k 'quit 1' ./test/arestest.exe
       - name: "CMake: UBSAN: build and test c-ares"
         if: ${{ matrix.env == 'clang-x86_64' || matrix.env == 'clang-i686' }}
         env:
@@ -71,7 +75,7 @@ jobs:
           cmake --build build_ubsan
           ./build_ubsan/bin/adig.exe www.google.com
           ./build_ubsan/bin/ahost.exe www.google.com
-          GTEST_INSTALL_FAILURE_SIGNAL_HANDLER=1 ./build_ubsan/bin/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
+          lldb --batch -o 'run ${{ env.GTEST_ARGS }}' -k 'thread backtrace all' -k 'quit 1' ./build_usban/bin/arestest.exe
       - name: "CMake: ASAN: build and test c-ares"
         if: ${{ matrix.env == 'clang-x86_64' || matrix.env == 'clang-i686' }}
         env:
@@ -81,7 +85,7 @@ jobs:
           cmake --build build_asan
           ./build_asan/bin/adig.exe www.google.com
           ./build_asan/bin/ahost.exe www.google.com
-          GTEST_INSTALL_FAILURE_SIGNAL_HANDLER=1 ./build_asan/bin/arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
+          lldb --batch -o 'run ${{ env.GTEST_ARGS }}' -k 'thread backtrace all' -k 'quit 1' ./build_asan/bin/arestest.exe
       - name: "Autotools: Static Analyzer: build c-ares"
         if: ${{ matrix.env == 'clang-x86_64' || matrix.env == 'clang-i686' }}
         # Cmake won't work because it somehow mangles linker args and it can't find core windows libraries

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -55,7 +55,11 @@ jobs:
           cmake --build build_cmake
           ./build_cmake/bin/adig.exe www.google.com
           ./build_cmake/bin/ahost.exe www.google.com
-          lldb --batch -o 'run ${{ env.GTEST_ARGS }}' -k 'thread backtrace all' -k 'quit 1' ./build_cmake/bin/arestest.exe
+          if [ "${{ matrix.msystem }}" != "MINGW32" ] ; then
+            lldb --batch -o 'run ${{ env.GTEST_ARGS }}' -k 'thread backtrace all' -k 'quit 1' ./build_cmake/bin/arestest.exe
+          else
+            ./build_cmake/bin/arestest.exe ${{ env.GTEST_ARGS }}
+          fi
       - name: "Autotools: build and test c-ares"
         run: |
           autoreconf -fi
@@ -65,9 +69,14 @@ jobs:
           make -j3
           ./src/tools/adig.exe www.google.com
           ./src/tools/ahost.exe www.google.com
-          lldb --batch -o 'run ${{ env.GTEST_ARGS }}' -k 'thread backtrace all' -k 'quit 1' ./test/arestest.exe
+          if [ "${{ matrix.msystem }}" != "MINGW32" ] ; then
+            lldb --batch -o 'run ${{ env.GTEST_ARGS }}' -k 'thread backtrace all' -k 'quit 1' ./test/arestest.exe
+          else
+            ./test/arestest.exe ${{ env.GTEST_ARGS }}
+          fi
       - name: "CMake: UBSAN: build and test c-ares"
-        if: ${{ matrix.env == 'clang-x86_64' || matrix.env == 'clang-i686' }}
+        # Bogus alignment errors on i686, so lets not run UBSAN on i686.
+        if: ${{ matrix.env == 'clang-x86_64' }}
         env:
           CMAKE_OPTS: "-DCMAKE_CXX_FLAGS=-fsanitize=undefined -DCMAKE_C_FLAGS=-fsanitize=undefined -DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=undefined -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=undefined"
         run: |
@@ -75,7 +84,8 @@ jobs:
           cmake --build build_ubsan
           ./build_ubsan/bin/adig.exe www.google.com
           ./build_ubsan/bin/ahost.exe www.google.com
-          lldb --batch -o 'run ${{ env.GTEST_ARGS }}' -k 'thread backtrace all' -k 'quit 1' ./build_usban/bin/arestest.exe
+          lldb --batch -o 'run ${{ env.GTEST_ARGS }}' -k 'thread backtrace all' -k 'quit 1' ./build_ubsan/bin/arestest.exe
+#          ./build_ubsan/bin/arestest.exe ${{ env.GTEST_ARGS }}
       - name: "CMake: ASAN: build and test c-ares"
         if: ${{ matrix.env == 'clang-x86_64' || matrix.env == 'clang-i686' }}
         env:
@@ -86,6 +96,7 @@ jobs:
           ./build_asan/bin/adig.exe www.google.com
           ./build_asan/bin/ahost.exe www.google.com
           lldb --batch -o 'run ${{ env.GTEST_ARGS }}' -k 'thread backtrace all' -k 'quit 1' ./build_asan/bin/arestest.exe
+#          ./build_asan/bin/arestest.exe ${{ env.GTEST_ARGS }}
       - name: "Autotools: Static Analyzer: build c-ares"
         if: ${{ matrix.env == 'clang-x86_64' || matrix.env == 'clang-i686' }}
         # Cmake won't work because it somehow mangles linker args and it can't find core windows libraries

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GTEST_ARGS: "-4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*"
+  GTEST_ARGS: "-4 --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*"
 
 jobs:
   build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -138,7 +138,7 @@ test_script:
   - if "%SYSTEM%" == "CONSOLE" if "%CONFTOOL%" == "CMAKE" if not "%SKIP_TESTS%" == "yes" cd %TESTDIR%
   - if "%SYSTEM%" == "CONSOLE" if "%CONFTOOL%" == "CMAKE" if not "%SKIP_TESTS%" == "yes" .\adig.exe www.google.com
   - if "%SYSTEM%" == "CONSOLE" if "%CONFTOOL%" == "CMAKE" if not "%SKIP_TESTS%" == "yes" .\ahost.exe www.google.com
-  - if "%SYSTEM%" == "CONSOLE" if "%CONFTOOL%" == "CMAKE" if not "%SKIP_TESTS%" == "yes" .\arestest.exe -4 -v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
+  - if "%SYSTEM%" == "CONSOLE" if "%CONFTOOL%" == "CMAKE" if not "%SKIP_TESTS%" == "yes" .\arestest.exe --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*
   - if "%SYSTEM%" == "CONSOLE" if "%CONFTOOL%" == "CMAKE" if not "%SKIP_TESTS%" == "yes" .\dnsdump.exe "%APPVEYOR_BUILD_FOLDER%\test\fuzzinput\answer_a" "%APPVEYOR_BUILD_FOLDER%\test\fuzzinput\answer_aaaa"
 
 #on_finish:

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -36,7 +36,7 @@ export GTEST_INSTALL_FAILURE_SIGNAL_HANDLER
 $TEST_WRAP "${TOOLSBIN}/adig" www.google.com
 $TEST_WRAP "${TOOLSBIN}/ahost" www.google.com
 cd "${TESTSBIN}"
-$TEST_WRAP ./arestest -4 -v $TEST_FILTER
+$TEST_WRAP ./arestest -4 $TEST_FILTER
 ./aresfuzz ${TESTDIR}/fuzzinput/*
 ./aresfuzzname ${TESTDIR}/fuzznames/*
 ./dnsdump "${TESTDIR}/fuzzinput/answer_a" "${TESTDIR}/fuzzinput/answer_aaaa"

--- a/src/lib/ares_event_kqueue.c
+++ b/src/lib/ares_event_kqueue.c
@@ -93,7 +93,7 @@ static ares_bool_t ares_evsys_kqueue_init(ares_event_thread_t *e)
 
   kq->nchanges_alloc = 8;
   kq->changelist =
-    ares_malloc_zero(sizeof(*kq->changelist) * kq->nchanges_alloc);
+    ares_malloc_zero(kq->nchanges_alloc * sizeof(*kq->changelist));
   if (kq->changelist == NULL) {
     ares_evsys_kqueue_destroy(e);
     return ARES_FALSE;
@@ -123,8 +123,11 @@ static void ares_evsys_kqueue_enqueue(ares_evsys_kqueue_t *kq, int fd,
 
   if (kq->nchanges > kq->nchanges_alloc) {
     kq->nchanges_alloc <<= 1;
-    kq->changelist = ares_realloc_zero(kq->changelist, kq->nchanges_alloc >> 1,
-                                       kq->nchanges_alloc);
+    kq->changelist = ares_realloc_zero(
+      kq->changelist,
+      (kq->nchanges_alloc >> 1) * sizeof(*kq->changelist),
+      kq->nchanges_alloc        * sizeof(*kq->changelist)
+    );
   }
 
   EV_SET(&kq->changelist[idx], fd, filter, flags, 0, 0, 0);

--- a/src/lib/ares_event_thread.c
+++ b/src/lib/ares_event_thread.c
@@ -268,8 +268,6 @@ static void ares_event_thread_cleanup(ares_event_thread_t *e)
   if (e->ev_updates != NULL) {
     ares__llist_node_t *node;
 
-fprintf(stderr, "** cleaning up unprocessed updates\n"); fflush(stderr);
-
     while ((node = ares__llist_node_first(e->ev_updates)) != NULL) {
       ares_event_destroy_cb(ares__llist_node_claim(node));
     }
@@ -278,13 +276,11 @@ fprintf(stderr, "** cleaning up unprocessed updates\n"); fflush(stderr);
   }
 
   if (e->ev_sock_handles != NULL) {
-fprintf(stderr, "** cleaning up sockets\n"); fflush(stderr);
     ares__htable_asvp_destroy(e->ev_sock_handles);
     e->ev_sock_handles = NULL;
   }
 
   if (e->ev_cust_handles != NULL) {
-fprintf(stderr, "** cleaning up data handles\n"); fflush(stderr);
     ares__htable_vpvp_destroy(e->ev_cust_handles);
     e->ev_cust_handles = NULL;
   }
@@ -292,7 +288,6 @@ fprintf(stderr, "** cleaning up data handles\n"); fflush(stderr);
   if (e->ev_sys != NULL && e->ev_sys->destroy != NULL) {
     e->ev_sys->destroy(e);
     e->ev_sys = NULL;
-fprintf(stderr, "** cleaning up complete\n"); fflush(stderr);
   }
 }
 
@@ -335,8 +330,6 @@ static void *ares_event_thread(void *arg)
 
   ares__thread_mutex_unlock(e->mutex);
 
-  fprintf(stderr, "** EventThread shutdown\n"); fflush(stderr);
-
   return NULL;
 }
 
@@ -356,7 +349,6 @@ static void ares_event_thread_destroy_int(ares_event_thread_t *e)
     ares__thread_join(e->thread, &rv);
     e->thread = NULL;
   }
-  fprintf(stderr, "** Event Thread closed\n"); fflush(stderr);
 
   /* If the event thread ever got to the point of starting, this is a no-op
    * as it runs this same cleanup when it shuts down */
@@ -366,7 +358,6 @@ static void ares_event_thread_destroy_int(ares_event_thread_t *e)
   e->mutex = NULL;
 
   ares_free(e);
-  fprintf(stderr, "** Event Thread cleanup complete\n"); fflush(stderr);
 }
 
 void ares_event_thread_destroy(ares_channel_t *channel)

--- a/src/lib/ares_event_win32.c
+++ b/src/lib/ares_event_win32.c
@@ -52,60 +52,62 @@
  * which means we can hook in non-socket related events.
  *
  * The information for this implementation was gathered from "wepoll" and
- * "libuv" which both use slight variants on this, but this implementation
- * doesn't directly follow either methodology.
+ * "libuv" which both use slight variants on this.  We originally went with
+ * an implementation methodology more similar to "libuv", but we had a few
+ * user reports of crashes during shutdown and memory leaks due to some
+ * events not being delivered for cleanup of closed sockets.
  *
  * Initialization:
- *   1. Dynamically load the NtDeviceIoControlFile internal symbol from
- *      ntdll.dll.  This function is used to submit the AFD POLL request.
+ *   1. Dynamically load the NtDeviceIoControlFile, NtCreateFile, and
+ *      NtCancelIoFileEx internal symbols from ntdll.dll. (Don't believe
+ *      Microsoft's documentation for NtCancelIoFileEx as it documents an
+ *      invalid prototype). These functions are to open a reference to the
+ *      Ancillary Function Driver (AFD), and to submit and cancel POLL
+ *      requests.
  *   2. Create an IO Completion Port base handle via CreateIoCompletionPort()
  *      that all socket events will be delivered through.
- *   3. Create a callback to be used to be able to interrupt waiting for IOCP
+ *   3. Open a reference to the Ancillary function driver with NtCreateFile()
+ *      with path \Device\Afd .
+ *   4. Add the AFD handle from the prior step to the IO Completion Port,
+ *      we can leave the completion key as blank since events for multiple
+ *      sockets will be delivered through this and we need to differentiate via
+ *      the OVERLAPPED member returned.
+ *   5. Create a callback to be used to be able to interrupt waiting for IOCP
  *      events, this may be called for allowing enqueuing of additional socket
  *      events or removing socket events. PostQueuedCompletionStatus() is the
  *      obvious choice.  We can use the same container format, the event
- *      delivered won't have an OVERLAPPED pointer so we can differentiate.
+ *      delivered won't have an OVERLAPPED pointer so we can differentiate from
+ *      socket events.  Use the container as the completion key.
  *
  * Socket Add:
- *   1. Create/Allocate a container for holding metadata about a socket:
+ *   1. Create/Allocate a container for holding metadata about a socket
+ *      including:
  *      - SOCKET base_socket;
- *      - SOCKET peer_socket;
- *      - OVERLAPPED overlapped; -- Used by AFD POLL
+ *      - IO_STATUS_BLOCK iosb; -- Used by AFD POLL, returned as OVERLAPPED
  *      - AFD_POLL_INFO afd_poll_info; -- Used by AFD POLL
  *   2. Call WSAIoctl(..., SIO_BASE_HANDLE, ...) to unwrap the SOCKET and get
  *      the "base socket" we can use for polling.  It appears this may fail so
  *      we should call WSAIoctl(..., SIO_BSP_HANDLE_POLL, ...) as a fallback.
- *   3. The SOCKET handle we have is most likely not capable of supporting
- *      OVERLAPPED, and we need to have a way to unbind a socket from IOCP
- *      (which is done via a simple closesocket()) so we need to duplicate the
- *      "base socket" using WSADuplicateSocketW() followed by
- *      WSASocketW(..., WSA_FLAG_OVERLAPPED) to create this "peer socket" for
- *      submitting AFD POLL requests.
- *   4. Bind to IOCP using CreateIoCompletionPort() referencing the "peer
- *      socket" and the base IOCP handle from "Initialization".  Use the
- *      "peer socket" as the "CompletionKey" which will be returned when an
- *      event occurs.
- *   5. Submit AFD POLL request (see "AFD POLL Request" section)
- *   6. Record a mapping between the "peer socket" and the socket container.
- *   NOTE: We use the "peer socket" as the completion key due to observation of
- *         events being delivered for sockets that have already been closed. If
- *         we used the container, we'd be referencing free'd memory if this
- *         occurs.
+ *   3. Submit AFD POLL request (see "AFD POLL Request" section)
+ *   4. Record a mapping between the "IO Status Block" and the socket container
+ *      so when events are delivered we can dereference.
  *
  * Socket Delete:
  *   1. Call
- *      NtCancelIoFileEx((HANDLE)peer_socket, iosb, &temp_iosb);
+ *      NtCancelIoFileEx(afd, iosb, &temp_iosb);
  *      to cancel any pending operations.
- *   2. Call closesocket(peer_socket) to close the socket
- *   3. remove the mapping between the peer_socket and the container.
- *   4. free() the container
- *   NOTE: We have to use the container mapping due to stale events being
- *         delivered.
+ *   2. Tag the socket container as being queued for deletion
+ *   3. Wait for an event to be delivered for the socket (cancel isn't
+ *      immediate, it delivers an event to know its complete). Delete only once
+ *      that event has been delivered.  If we don't do this we could try to
+ *      access free()'d memory at a later point.
  *
  * Socket Modify:
- *   1. Submit AFD POLL request (see "AFD POLL Request" section), it will
- *      automatically cancel any prior poll request so there's no reason to
- *      call an explicit cancel.
+ *   1. Call
+ *      NtCancelIoFileEx(afd, iosb, &temp_iosb)
+ *      to cancel any pending operation.
+ *   2. When the event comes through that the cancel is complete, enqueue
+ *      another "AFD Poll Request" for the desired events.
  *
  * Event Wait:
  *   1. Call GetQueuedCompletionStatusEx() with the base IOCP handle, a
@@ -113,41 +115,35 @@
  *      timeout.
  *   2. Iterate across returned events, if the lpOverlapped is NULL, then the
  *      the CompletionKey is a pointer to the container registered via
- *      PostQueuedCompletionStatus(), otherwise it is the "peer socket"
- *      registered with CreateIoCompletionPort() which needs to be dereferenced
+ *      PostQueuedCompletionStatus(), otherwise it is the "IO Status Block"
+ *      registered with the "AFD Poll Request" which needs to be dereferenced
  *      to the "socket container".
- *      NOTE: the dereference may fail if the connection was already cleaned up!
- *   4. If it is a "socket container" Submit AFD POLL Request
- *      (see "AFD POLL Request"). We must re-enable the request each time we
- *      receive a response, it is not persistent.
+ *   3. If it is a "socket container" check to see if we are cleaning up, if so,
+ *      clean it up.
+ *   4. If it is a "socket container" that is still valid, Submit an
+ *      AFD POLL Request (see "AFD POLL Request"). We must re-enable the request
+ *      each time we receive a response, it is not persistent.
  *   5. Notify of any events received as indicated in the AFD_POLL_INFO
- *      Handles[0].Events (NOTE: check NumberOfHandles first, make sure it is
- *      > 0, otherwise we might not have events such as if our last request
- *      was cancelled).  Also need to check the IO_STATUS_BUFFER status member
- *      is STATUS_SUCCESS as otherwise it may simply advertise back to you the
- *      requested events.  This can happen during an automatic cancel such as
- *      when we are modifying the conditions we want to wait on.
+ *      Handles[0].Events (NOTE: check NumberOfHandles > 0, and the status in
+ *      the IO_STATUS_BLOCK.  If we received an AFD_POLL_LOCAL_CLOSE, clean up
+ *      the connection like the integrator requested it to be cleaned up.
  *
  * AFD Poll Request:
  *   1. Initialize the AFD_POLL_INFO structure:
- *      Exclusive         = TRUE; // Auto cancel duplicates for same socket
+ *      Exclusive         = FALSE; // allow multiple requests
  *      NumberOfHandles   = 1;
  *      Timeout.QuadPart  = LLONG_MAX;
  *      Handles[0].Handle = (HANDLE)base_socket;
  *      Handles[0].Status = 0;
- *      Handles[0].Events = ... set as appropriate AFD_POLL_RECEIVE, etc;
- *   2. Zero out the OVERLAPPED and IO_STATUS_BLOCK structures
+ *      Handles[0].Events = AFD_POLL_LOCAL_CLOSE + additional events to wait for
+ *                          such as AFD_POLL_RECEIVE, etc;
+ *   2. Zero out the IO_STATUS_BLOCK structures
  *   3. Set the "Status" member of IO_STATUS_BLOCK to STATUS_PENDING
  *   4. Call
- *      NtDeviceIoControlFile((HANDLE)peer_socket, NULL, NULL, &overlapped,
+ *      NtDeviceIoControlFile(afd, NULL, NULL, &iosb,
  *                            &iosb, IOCTL_AFD_POLL
  *                            &afd_poll_info, sizeof(afd_poll_info),
  *                            &afd_poll_info, sizeof(afd_poll_info));
- *   NOTE: libuv used the memory starting at overlapped.Internal for the
- *         AFD_POLL_INFO pointer, no idea why.  Via testing we know its not
- *         needed.  That said the data in the OVERLAPPED structure seems
- *         meaningless so maybe they were just trying to align it to be
- *         meaningful.
  *
  *
  * References:
@@ -157,7 +153,16 @@
 
 #  include <stdarg.h>
 
-#  define CARES_DEBUG 1
+/* #  define CARES_DEBUG 1 */
+
+#  ifdef __GNUC__
+#    define CARES_PRINTF_LIKE(fmt, args) \
+      __attribute__((format(printf, fmt, args)))
+#  else
+#    define CARES_PRINTF_LIKE(fmt, args)
+#  endif
+
+static void CARES_DEBUG_LOG(const char *fmt, ...) CARES_PRINTF_LIKE(1, 2);
 
 static void CARES_DEBUG_LOG(const char *fmt, ...)
 {
@@ -173,47 +178,70 @@ static void CARES_DEBUG_LOG(const char *fmt, ...)
 
 typedef struct {
   /* Dynamically loaded symbols */
+  NtCreateFile_t          NtCreateFile;
   NtDeviceIoControlFile_t NtDeviceIoControlFile;
   NtCancelIoFileEx_t      NtCancelIoFileEx;
 
   /* Implementation details */
+  HANDLE                  afd_handle;
   HANDLE                  iocp_handle;
 
-  /* peer_socket -> ares_evsys_win32_eventdata_t * mapping for safe lookups
-   * of events.  We can't just pass the data structure for event notifications
-   * due to stale events being delivered thus causing use-after-free.
-   * Also we can't use the existing socket mapping because if there is fast
-   * recycling of ids, we may not detect that, but due to the way the
-   * peer_socket is delayed being destroyed until the event thread can handle
-   * it, the likelihood it will cycle too quickly is very small. */
-  ares__htable_asvp_t    *peer_socket_handles;
+  /* IO_STATUS_BLOCK * -> ares_evsys_win32_eventdata_t * mapping.  There is
+   * no completion key passed to IOCP with this method so we have to look
+   * up based on the lpOverlapped returned (which is mapped to IO_STATUS_BLOCK)
+   */
+  ares__htable_vpvp_t    *sockets;
+
+  /* Flag about whether or not we are shutting down */
+  ares_bool_t             is_shutdown;
 } ares_evsys_win32_t;
+
+typedef enum {
+  POLL_STATUS_NONE    = 0,
+  POLL_STATUS_PENDING = 1,
+  POLL_STATUS_CANCEL  = 2,
+  POLL_STATUS_DESTROY = 3
+} poll_status_t;
 
 typedef struct {
   /*! Pointer to parent event container */
-  ares_event_t *event;
+  ares_event_t         *event;
   /*! Socket passed in to monitor */
-  SOCKET        socket;
+  SOCKET                socket;
   /*! Base socket derived from provided socket */
-  SOCKET        base_socket;
-  /*! New socket (duplicate base_socket handle) supporting OVERLAPPED operation
-   */
-  SOCKET        peer_socket;
+  SOCKET                base_socket;
   /*! Structure for submitting AFD POLL requests (Internals!) */
-  AFD_POLL_INFO afd_poll_info;
-  /*! Overlapped structure submitted with AFD POLL requests and returned with
-   * IOCP results */
-  OVERLAPPED    overlapped;
+  AFD_POLL_INFO         afd_poll_info;
+  /*! Status of current polling operation */
+  poll_status_t         poll_status;
+  /*! IO Status Block structure submitted with AFD POLL requests and returned
+   *  with IOCP results as lpOverlapped (even though its a different structure)
+   */
+  IO_STATUS_BLOCK       iosb;
+  /* Lock is only for PostQueuedCompletionStatus() to prevent multiple
+   * signals. Tracking via POLL_STATUS_PENDING/POLL_STATUS_NONE */
+  ares__thread_mutex_t *lock;
 } ares_evsys_win32_eventdata_t;
 
-static void ares_iocpevent_signal(const ares_event_t *event)
-{
-  ares_event_thread_t *e  = event->e;
-  ares_evsys_win32_t  *ew = e->ev_sys_data;
+static size_t ares_evsys_win32_wait(ares_event_thread_t *e,
+                                    unsigned long        timeout_ms);
 
-  if (e == NULL) {
-    return;
+static void   ares_iocpevent_signal(const ares_event_t *event)
+{
+  ares_event_thread_t          *e           = event->e;
+  ares_evsys_win32_t           *ew          = e->ev_sys_data;
+  ares_evsys_win32_eventdata_t *ed          = event->data;
+  ares_bool_t                   queue_event = ARES_FALSE;
+
+  ares__thread_mutex_lock(ed->lock);
+  if (ed->poll_status != POLL_STATUS_PENDING) {
+    ed->poll_status = POLL_STATUS_PENDING;
+    queue_event     = ARES_TRUE;
   }
+  ares__thread_mutex_unlock(ed->lock);
+
+  if (!queue_event)
+    return;
 
   PostQueuedCompletionStatus(ew->iocp_handle, 0, (ULONG_PTR)event->data, NULL);
 }
@@ -221,10 +249,13 @@ static void ares_iocpevent_signal(const ares_event_t *event)
 static void ares_iocpevent_cb(ares_event_thread_t *e, ares_socket_t fd,
                               void *data, ares_event_flags_t flags)
 {
+  ares_evsys_win32_eventdata_t *ed = data;
   (void)e;
-  (void)data;
   (void)fd;
   (void)flags;
+  ares__thread_mutex_lock(ed->lock);
+  ed->poll_status = POLL_STATUS_NONE;
+  ares__thread_mutex_unlock(ed->lock);
 }
 
 static ares_event_t *ares_iocpevent_create(ares_event_thread_t *e)
@@ -257,20 +288,49 @@ static void ares_evsys_win32_destroy(ares_event_thread_t *e)
     return;
   }
 
+  ew->is_shutdown = ARES_TRUE;
+  CARES_DEBUG_LOG("  ** waiting on %lu remaining sockets to be destroyed\n",
+                  (unsigned long)ares__htable_vpvp_num_keys(ew->sockets));
+  while (ares__htable_vpvp_num_keys(ew->sockets)) {
+    ares_evsys_win32_wait(e, 0);
+  }
+  CARES_DEBUG_LOG("  ** all sockets cleaned up\n");
+
+
   if (ew->iocp_handle != NULL) {
     CloseHandle(ew->iocp_handle);
   }
 
-  ares__htable_asvp_destroy(ew->peer_socket_handles);
+  if (ew->afd_handle != NULL) {
+    CloseHandle(ew->afd_handle);
+  }
+
+  ares__htable_vpvp_destroy(ew->sockets);
 
   ares_free(ew);
   e->ev_sys_data = NULL;
 }
 
+static void fill_object_attributes(OBJECT_ATTRIBUTES *attr,
+                                   UNICODE_STRING *name, ULONG attributes)
+{
+  memset(attr, 0, sizeof(*attr));
+  attr->Length     = sizeof(*attr);
+  attr->ObjectName = name;
+  attr->Attributes = attributes;
+}
+
+#  define UNICODE_STRING_CONSTANT(s) \
+    { (sizeof(s) - 1) * sizeof(wchar_t), sizeof(s) * sizeof(wchar_t), L##s }
+
 static ares_bool_t ares_evsys_win32_init(ares_event_thread_t *e)
 {
   ares_evsys_win32_t *ew = NULL;
   HMODULE             ntdll;
+  NTSTATUS            status;
+  IO_STATUS_BLOCK     iosb;
+  UNICODE_STRING    afd_device_name = UNICODE_STRING_CONSTANT("\\Device\\Afd");
+  OBJECT_ATTRIBUTES afd_attributes;
 
   CARES_DEBUG_LOG("** Win32 Event Init\n");
 
@@ -299,8 +359,9 @@ static ares_bool_t ares_evsys_win32_init(ares_event_thread_t *e)
  */
 #  endif
 
-
   /* Load Internal symbols not typically accessible */
+  ew->NtCreateFile =
+    (NtCreateFile_t)(void *)GetProcAddress(ntdll, "NtCreateFile");
   ew->NtDeviceIoControlFile = (NtDeviceIoControlFile_t)(void *)GetProcAddress(
     ntdll, "NtDeviceIoControlFile");
   ew->NtCancelIoFileEx =
@@ -310,7 +371,8 @@ static ares_bool_t ares_evsys_win32_init(ares_event_thread_t *e)
 #    pragma GCC diagnostic pop
 #  endif
 
-  if (ew->NtCancelIoFileEx == NULL || ew->NtDeviceIoControlFile == NULL) {
+  if (ew->NtCreateFile == NULL || ew->NtCancelIoFileEx == NULL ||
+      ew->NtDeviceIoControlFile == NULL) {
     goto fail;
   }
 
@@ -319,13 +381,35 @@ static ares_bool_t ares_evsys_win32_init(ares_event_thread_t *e)
     goto fail;
   }
 
+  /* Open a handle to the AFD subsystem */
+  fill_object_attributes(&afd_attributes, &afd_device_name, 0);
+  memset(&iosb, 0, sizeof(iosb));
+  iosb.Status = STATUS_PENDING;
+  status      = ew->NtCreateFile(&ew->afd_handle, SYNCHRONIZE, &afd_attributes,
+                                 &iosb, NULL, 0, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                 FILE_OPEN, 0, NULL, 0);
+  if (status != STATUS_SUCCESS) {
+    CARES_DEBUG_LOG("** Failed to create AFD endpoint\n");
+    goto fail;
+  }
+
+  if (CreateIoCompletionPort(ew->afd_handle, ew->iocp_handle,
+                             0 /* CompletionKey */, 0) == NULL) {
+    goto fail;
+  }
+
+  if (!SetFileCompletionNotificationModes(ew->afd_handle,
+                                          FILE_SKIP_SET_EVENT_ON_HANDLE)) {
+    goto fail;
+  }
+
   e->ev_signal = ares_iocpevent_create(e);
   if (e->ev_signal == NULL) {
     goto fail;
   }
 
-  ew->peer_socket_handles = ares__htable_asvp_create(NULL);
-  if (ew->peer_socket_handles == NULL) {
+  ew->sockets = ares__htable_vpvp_create(NULL, NULL);
+  if (ew->sockets == NULL) {
     goto fail;
   }
 
@@ -384,14 +468,17 @@ static ares_bool_t ares_evsys_win32_afd_enqueue(ares_event_t      *event,
   ares_evsys_win32_t           *ew = e->ev_sys_data;
   ares_evsys_win32_eventdata_t *ed = event->data;
   NTSTATUS                      status;
-  IO_STATUS_BLOCK              *iosb_ptr;
 
   if (e == NULL || ed == NULL || ew == NULL) {
     return ARES_FALSE;
   }
 
+  if (ed->poll_status != POLL_STATUS_NONE) {
+    return ARES_FALSE;
+  }
+
   /* Enqueue AFD Poll */
-  ed->afd_poll_info.Exclusive         = TRUE;
+  ed->afd_poll_info.Exclusive         = FALSE;
   ed->afd_poll_info.NumberOfHandles   = 1;
   ed->afd_poll_info.Timeout.QuadPart  = LLONG_MAX;
   ed->afd_poll_info.Handles[0].Handle = (HANDLE)ed->base_socket;
@@ -411,25 +498,19 @@ static ares_bool_t ares_evsys_win32_afd_enqueue(ares_event_t      *event,
     ed->afd_poll_info.Handles[0].Events |= AFD_POLL_DISCONNECT;
   }
 
-  memset(&ed->overlapped, 0, sizeof(ed->overlapped));
-  /* Mapping the IO_STATUS_BLOCK pointer to the first member in the
-   * OVERLAPPED structure is something that libuv does. This sort of
-   * tracks since the Status member for the IO_STATUS_BLOCK is the
-   * first member and the "Internal" member for OVERLAPPED has a meaning
-   * of status.  The OVERLAPPED structure appears to be otherwise unused when
-   * testing using independent structures. I'm not actually sure if using this
-   * provides any real benefits other than memory efficiency but maybe there
-   * is some internal edge case they know about. */
-  iosb_ptr         = (IO_STATUS_BLOCK *)&ed->overlapped.Internal;
-  iosb_ptr->Status = STATUS_PENDING;
+  memset(&ed->iosb, 0, sizeof(ed->iosb));
+  ed->iosb.Status = STATUS_PENDING;
 
   status = ew->NtDeviceIoControlFile(
-    (HANDLE)ed->peer_socket, NULL, NULL, &ed->overlapped, iosb_ptr,
-    IOCTL_AFD_POLL, &ed->afd_poll_info, sizeof(ed->afd_poll_info),
-    &ed->afd_poll_info, sizeof(ed->afd_poll_info));
+    ew->afd_handle, NULL, NULL, &ed->iosb, &ed->iosb, IOCTL_AFD_POLL,
+    &ed->afd_poll_info, sizeof(ed->afd_poll_info), &ed->afd_poll_info,
+    sizeof(ed->afd_poll_info));
   if (status != STATUS_SUCCESS && status != STATUS_PENDING) {
+    CARES_DEBUG_LOG("** afd_enqueue ed=%p FAILED\n", (void *)ed);
     return ARES_FALSE;
   }
+
+  ed->poll_status = POLL_STATUS_PENDING;
   CARES_DEBUG_LOG("++ afd_enqueue ed=%p flags=%X\n", (void *)ed,
                   (unsigned int)flags);
   return ARES_TRUE;
@@ -437,28 +518,26 @@ static ares_bool_t ares_evsys_win32_afd_enqueue(ares_event_t      *event,
 
 static ares_bool_t ares_evsys_win32_afd_cancel(ares_evsys_win32_eventdata_t *ed)
 {
-  IO_STATUS_BLOCK    *iosb_ptr;
   IO_STATUS_BLOCK     cancel_iosb;
   ares_evsys_win32_t *ew;
   NTSTATUS            status;
 
   ew = ed->event->e->ev_sys_data;
 
-  /* See discussion in ares_evsys_win32_afd_enqueue() */
-  iosb_ptr = (IO_STATUS_BLOCK *)&ed->overlapped.Internal;
+  ed->poll_status = POLL_STATUS_CANCEL;
 
   /* Not pending, nothing to do. Most likely that means there is a pending
    * event that hasn't yet been delivered otherwise it would be re-armed
    * already */
-  if (iosb_ptr->Status != STATUS_PENDING) {
-CARES_DEBUG_LOG("** cancel not needed for ed=%p\n", (void *)ed);
+  if (ed->iosb.Status != STATUS_PENDING) {
+    CARES_DEBUG_LOG("** cancel not needed for ed=%p\n", (void *)ed);
     return ARES_FALSE;
   }
 
-  status =
-    ew->NtCancelIoFileEx((HANDLE)ed->peer_socket, iosb_ptr, &cancel_iosb);
+  status = ew->NtCancelIoFileEx(ew->afd_handle, &ed->iosb, &cancel_iosb);
 
-CARES_DEBUG_LOG("** Enqueued cancel for ed=%p, status = %lX\n", (void *)ed, status);
+  CARES_DEBUG_LOG("** Enqueued cancel for ed=%p, status = %lX\n", (void *)ed,
+                  status);
 
   /* NtCancelIoFileEx() may return STATUS_NOT_FOUND if the operation completed
    * just before calling NtCancelIoFileEx(), but we have not yet received the
@@ -477,11 +556,16 @@ static void ares_evsys_win32_eventdata_destroy(ares_evsys_win32_t           *ew,
     return;
   }
   CARES_DEBUG_LOG("-- deleting ed=%p (%s)\n", (void *)ed,
-    (ed->peer_socket == ARES_SOCKET_BAD)?"data":"socket");
+                  (ed->socket == ARES_SOCKET_BAD) ? "data" : "socket");
   /* These type of handles are deferred destroy. Update tracking. */
-  if (ed->peer_socket != ARES_SOCKET_BAD) {
-    ares__htable_asvp_remove(ew->peer_socket_handles, ed->peer_socket);
-    closesocket(ed->peer_socket);
+  if (ed->socket != ARES_SOCKET_BAD) {
+    ares__htable_vpvp_remove(ew->sockets, &ed->iosb);
+  }
+
+  ares__thread_mutex_destroy(ed->lock);
+
+  if (ed->event != NULL) {
+    ed->event->data = NULL;
   }
 
   ares_free(ed);
@@ -492,14 +576,12 @@ static ares_bool_t ares_evsys_win32_event_add(ares_event_t *event)
   ares_event_thread_t          *e  = event->e;
   ares_evsys_win32_t           *ew = e->ev_sys_data;
   ares_evsys_win32_eventdata_t *ed;
-  WSAPROTOCOL_INFOW             protocol_info;
   ares_bool_t                   rc = ARES_FALSE;
 
   ed              = ares_malloc_zero(sizeof(*ed));
   ed->event       = event;
   ed->socket      = event->fd;
   ed->base_socket = ARES_SOCKET_BAD;
-  ed->peer_socket = ARES_SOCKET_BAD;
   event->data     = ed;
 
   CARES_DEBUG_LOG("++ add ed=%p (%s) flags=%X\n", (void *)ed,
@@ -510,6 +592,10 @@ static ares_bool_t ares_evsys_win32_event_add(ares_event_t *event)
    * the ares_evsys_win32_eventdata_t as the placeholder to use as the
    * IOCP Completion Key */
   if (ed->socket == ARES_SOCKET_BAD) {
+    ed->lock = ares__thread_mutex_create();
+    if (ed->lock == NULL) {
+      goto done;
+    }
     rc = ARES_TRUE;
     goto done;
   }
@@ -519,34 +605,7 @@ static ares_bool_t ares_evsys_win32_event_add(ares_event_t *event)
     goto done;
   }
 
-  /* Create a peer socket that supports OVERLAPPED so we can use IOCP on the
-   * socket handle */
-  if (WSADuplicateSocketW(ed->base_socket, GetCurrentProcessId(),
-                          &protocol_info) != 0) {
-    goto done;
-  }
-
-  ed->peer_socket =
-    WSASocketW(protocol_info.iAddressFamily, protocol_info.iSocketType,
-               protocol_info.iProtocol, &protocol_info, 0, WSA_FLAG_OVERLAPPED);
-  if (ed->peer_socket == ARES_SOCKET_BAD) {
-    goto done;
-  }
-
-  SetHandleInformation((HANDLE)ed->peer_socket, HANDLE_FLAG_INHERIT, 0);
-
-/*
-  SetFileCompletionNotificationModes((HANDLE)ed->peer_socket,
-                                     FILE_SKIP_SET_EVENT_ON_HANDLE);
-*/
-
-  if (CreateIoCompletionPort((HANDLE)ed->peer_socket, ew->iocp_handle,
-                             (ULONG_PTR)ed->peer_socket, 0) == NULL) {
-    goto done;
-  }
-
-
-  if (!ares__htable_asvp_insert(ew->peer_socket_handles, ed->peer_socket, ed)) {
+  if (!ares__htable_vpvp_insert(ew->sockets, &ed->iosb, ed)) {
     goto done;
   }
 
@@ -568,16 +627,24 @@ static void ares_evsys_win32_event_del(ares_event_t *event)
 {
   ares_evsys_win32_eventdata_t *ed = event->data;
 
-  CARES_DEBUG_LOG("-- DELETE called on ed=%p\n", ed);
-
-  /*
-   * Cancel pending AFD Poll operation.  Not sure this is absolutely necessary.
-   */
-  if (ed && ed->peer_socket != ARES_SOCKET_BAD) {
-    ares_evsys_win32_afd_cancel(ed);
+  /* Already cleaned up, likely a LOCAL_CLOSE */
+  if (ed == NULL) {
+    return;
   }
 
-  ares_evsys_win32_eventdata_destroy(event->e->ev_sys_data, ed);
+  CARES_DEBUG_LOG("-- DELETE requested for ed=%p (%s)\n", (void *)ed,
+                  (ed->socket != ARES_SOCKET_BAD) ? "socket" : "data");
+
+  /*
+   * Cancel pending AFD Poll operation.
+   */
+  if (ed->socket != ARES_SOCKET_BAD) {
+    ares_evsys_win32_afd_cancel(ed);
+    ed->poll_status = POLL_STATUS_DESTROY;
+    ed->event       = NULL;
+  } else {
+    ares_evsys_win32_eventdata_destroy(event->e->ev_sys_data, ed);
+  }
 
   event->data = NULL;
 }
@@ -629,50 +696,51 @@ static size_t ares_evsys_win32_wait(ares_event_thread_t *e,
       break;
     }
 
-    CARES_DEBUG_LOG("\t** GetQueuedCompletionStatusEx returned %zu entries\n",
-                    (size_t)nentries);
+    CARES_DEBUG_LOG("\t** GetQueuedCompletionStatusEx returned %lu entries\n",
+                    (unsigned long)nentries);
     for (i = 0; i < (size_t)nentries; i++) {
       ares_event_flags_t            flags = 0;
       ares_evsys_win32_eventdata_t *ed    = NULL;
       ares_event_t                 *event = NULL;
 
-      /* We have to dereference the data structure from peer_socket because we
-       * have seen events delivered for closed connections.  We determine socket
-       * vs non-socket (triggered via PostQueuedCompletionStatus) by the
-       * existence of entries[i].lpOverlapped. */
-      if (entries[i].lpOverlapped != NULL) {
-        ed = ares__htable_asvp_get_direct(
-          ew->peer_socket_handles, (ares_socket_t)entries[i].lpCompletionKey);
-
-        /* If memory address for overlapped structure doesn't match expected,
-         * that means the peer socket id was reused and this event is for the
-         * old peer socket using the same id.  Discard */
-        if (&ed->overlapped != entries[i].lpOverlapped) {
-          ed = NULL;
+      /* For things triggered via PostQueuedCompletionStatus() we have an
+       * lpCompletionKey we can just use.  Otherwise we need to dereference the
+       * pointer returned in lpOverlapped to determine the referenced
+       * socket */
+      if (entries[i].lpCompletionKey) {
+        if (ew->is_shutdown) {
+          CARES_DEBUG_LOG(
+            "\t\t** i=%lu, skip non-socket handle during shutdown\n",
+            (unsigned long)i);
+          continue;
         }
-      } else {
         /* non-socket */
         ed = (ares_evsys_win32_eventdata_t *)entries[i].lpCompletionKey;
+      } else {
+        /* socket */
+        ed = ares__htable_vpvp_get_direct(ew->sockets, entries[i].lpOverlapped);
       }
 
       /* Must be a deleted handle, lets skip */
       if (ed == NULL) {
-        CARES_DEBUG_LOG("\t\t** i=%zu, skip deleted handle\n", i);
+        CARES_DEBUG_LOG("\t\t** i=%lu, skip deleted handle\n",
+                        (unsigned long)i);
         continue;
       }
+
       event = ed->event;
 
-      CARES_DEBUG_LOG("\t\t** i=%zu, ed=%p, overlapped=%p (%s)\n", i,
-                      (void *)ed, (void *)entries[i].lpOverlapped,
+      CARES_DEBUG_LOG("\t\t** i=%lu, ed=%p, overlapped=%p (%s)\n",
+                      (unsigned long)i, (void *)ed,
+                      (void *)entries[i].lpOverlapped,
                       (ed->socket == ARES_SOCKET_BAD) ? "data" : "socket");
       if (ed->socket == ARES_SOCKET_BAD) {
         /* Some sort of signal event */
         flags = ARES_EVENT_FLAG_OTHER;
       } else {
-        IO_STATUS_BLOCK *iosb_ptr = (IO_STATUS_BLOCK *)&ed->overlapped.Internal;
-
         /* Process events */
-        if (iosb_ptr->Status == STATUS_SUCCESS &&
+        if (ed->poll_status == POLL_STATUS_PENDING &&
+            ed->iosb.Status == STATUS_SUCCESS &&
             ed->afd_poll_info.NumberOfHandles > 0) {
           if (ed->afd_poll_info.Handles[0].Events &
               (AFD_POLL_RECEIVE | AFD_POLL_DISCONNECT | AFD_POLL_ACCEPT |
@@ -684,24 +752,41 @@ static size_t ares_evsys_win32_wait(ares_event_thread_t *e,
             flags |= ARES_EVENT_FLAG_WRITE;
           }
           if (ed->afd_poll_info.Handles[0].Events & AFD_POLL_LOCAL_CLOSE) {
-            CARES_DEBUG_LOG("\n\n*-*-*-*-*-\nLOCAL CLOSE on ed=%p\n*-*-*-*-*-\n\n", ed);
+            CARES_DEBUG_LOG("\t\t** ed=%p LOCAL CLOSE\n", (void *)ed);
+            ed->poll_status = POLL_STATUS_DESTROY;
           }
-          /* Mask flags against current desired flags.  We could have an event
-           * queued that is outdated. */
-          flags &= event->flags;
         }
-        CARES_DEBUG_LOG("\t\t** ed=%p, iosb status=%lX, flags=%X\n",
-                        (void *)ed, (void *)event,
-                        (unsigned long)iosb_ptr->Status, (unsigned int)flags);
 
+        CARES_DEBUG_LOG(
+          "\t\t** ed=%p, iosb status=%lX, poll_status=%d, flags=%X\n",
+          (void *)ed, (unsigned long)ed->iosb.Status, (int)ed->poll_status,
+          (unsigned int)flags);
+
+        if (ed->poll_status == POLL_STATUS_DESTROY) {
+          ares_evsys_win32_eventdata_destroy(ew, ed);
+          continue;
+        }
+
+        ed->poll_status = POLL_STATUS_NONE;
+
+        /* Mask flags against current desired flags.  We could have an event
+         * queued that is outdated. */
+        flags &= event->flags;
 
         /* Re-enqueue so we can get more events on the socket, we either
          * received a real event, or a cancellation notice.  Both cases we
          * re-queue. */
-        ares_evsys_win32_afd_enqueue(event, event->flags);
+        if (!ew->is_shutdown) {
+          /* If we can't re-enqueue, that likely means the socket has been
+           * closed, so we want to kill our reference to it */
+          if (!ares_evsys_win32_afd_enqueue(event, event->flags)) {
+            ares_evsys_win32_eventdata_destroy(ew, ed);
+            continue;
+          }
+        }
       }
 
-      if (flags != 0) {
+      if (flags != 0 && !ew->is_shutdown) {
         cnt++;
         event->cb(e, event->fd, event->data, flags);
       }

--- a/src/lib/ares_event_win32.h
+++ b/src/lib/ares_event_win32.h
@@ -70,14 +70,31 @@ typedef VOID(NTAPI *PIO_APC_ROUTINE)(PVOID            ApcContext,
 /* Not sure what headers might have these */
 #  define IOCTL_AFD_POLL 0x00012024
 
-#  define AFD_POLL_RECEIVE           0x0001
-#  define AFD_POLL_RECEIVE_EXPEDITED 0x0002
-#  define AFD_POLL_SEND              0x0004
-#  define AFD_POLL_DISCONNECT        0x0008
-#  define AFD_POLL_ABORT             0x0010
-#  define AFD_POLL_LOCAL_CLOSE       0x0020
-#  define AFD_POLL_ACCEPT            0x0080
-#  define AFD_POLL_CONNECT_FAIL      0x0100
+#define AFD_POLL_RECEIVE_BIT            0
+#define AFD_POLL_RECEIVE                (1 << AFD_POLL_RECEIVE_BIT)
+#define AFD_POLL_RECEIVE_EXPEDITED_BIT  1
+#define AFD_POLL_RECEIVE_EXPEDITED      (1 << AFD_POLL_RECEIVE_EXPEDITED_BIT)
+#define AFD_POLL_SEND_BIT               2
+#define AFD_POLL_SEND                   (1 << AFD_POLL_SEND_BIT)
+#define AFD_POLL_DISCONNECT_BIT         3
+#define AFD_POLL_DISCONNECT             (1 << AFD_POLL_DISCONNECT_BIT)
+#define AFD_POLL_ABORT_BIT              4
+#define AFD_POLL_ABORT                  (1 << AFD_POLL_ABORT_BIT)
+#define AFD_POLL_LOCAL_CLOSE_BIT        5
+#define AFD_POLL_LOCAL_CLOSE            (1 << AFD_POLL_LOCAL_CLOSE_BIT)
+#define AFD_POLL_CONNECT_BIT            6
+#define AFD_POLL_CONNECT                (1 << AFD_POLL_CONNECT_BIT)
+#define AFD_POLL_ACCEPT_BIT             7
+#define AFD_POLL_ACCEPT                 (1 << AFD_POLL_ACCEPT_BIT)
+#define AFD_POLL_CONNECT_FAIL_BIT       8
+#define AFD_POLL_CONNECT_FAIL           (1 << AFD_POLL_CONNECT_FAIL_BIT)
+#define AFD_POLL_QOS_BIT                9
+#define AFD_POLL_QOS                    (1 << AFD_POLL_QOS_BIT)
+#define AFD_POLL_GROUP_QOS_BIT          10
+#define AFD_POLL_GROUP_QOS              (1 << AFD_POLL_GROUP_QOS_BIT)
+
+#define AFD_NUM_POLL_EVENTS             11
+#define AFD_POLL_ALL                    ((1 << AFD_NUM_POLL_EVENTS) - 1)
 
 typedef struct _AFD_POLL_HANDLE_INFO {
   HANDLE   Handle;

--- a/src/lib/ares_event_win32.h
+++ b/src/lib/ares_event_win32.h
@@ -67,34 +67,53 @@ typedef VOID(NTAPI *PIO_APC_ROUTINE)(PVOID            ApcContext,
 #  define STATUS_CANCELLED ((NTSTATUS)0xC0000120L)
 #  define STATUS_NOT_FOUND ((NTSTATUS)0xC0000225L)
 
+typedef struct _UNICODE_STRING {
+  USHORT  Length;
+  USHORT  MaximumLength;
+  LPCWSTR Buffer;
+} UNICODE_STRING, *PUNICODE_STRING;
+
+typedef struct _OBJECT_ATTRIBUTES {
+  ULONG           Length;
+  HANDLE          RootDirectory;
+  PUNICODE_STRING ObjectName;
+  ULONG           Attributes;
+  PVOID           SecurityDescriptor;
+  PVOID           SecurityQualityOfService;
+} OBJECT_ATTRIBUTES, *POBJECT_ATTRIBUTES;
+
+#  ifndef FILE_OPEN
+#    define FILE_OPEN 0x00000001UL
+#  endif
+
 /* Not sure what headers might have these */
 #  define IOCTL_AFD_POLL 0x00012024
 
-#define AFD_POLL_RECEIVE_BIT            0
-#define AFD_POLL_RECEIVE                (1 << AFD_POLL_RECEIVE_BIT)
-#define AFD_POLL_RECEIVE_EXPEDITED_BIT  1
-#define AFD_POLL_RECEIVE_EXPEDITED      (1 << AFD_POLL_RECEIVE_EXPEDITED_BIT)
-#define AFD_POLL_SEND_BIT               2
-#define AFD_POLL_SEND                   (1 << AFD_POLL_SEND_BIT)
-#define AFD_POLL_DISCONNECT_BIT         3
-#define AFD_POLL_DISCONNECT             (1 << AFD_POLL_DISCONNECT_BIT)
-#define AFD_POLL_ABORT_BIT              4
-#define AFD_POLL_ABORT                  (1 << AFD_POLL_ABORT_BIT)
-#define AFD_POLL_LOCAL_CLOSE_BIT        5
-#define AFD_POLL_LOCAL_CLOSE            (1 << AFD_POLL_LOCAL_CLOSE_BIT)
-#define AFD_POLL_CONNECT_BIT            6
-#define AFD_POLL_CONNECT                (1 << AFD_POLL_CONNECT_BIT)
-#define AFD_POLL_ACCEPT_BIT             7
-#define AFD_POLL_ACCEPT                 (1 << AFD_POLL_ACCEPT_BIT)
-#define AFD_POLL_CONNECT_FAIL_BIT       8
-#define AFD_POLL_CONNECT_FAIL           (1 << AFD_POLL_CONNECT_FAIL_BIT)
-#define AFD_POLL_QOS_BIT                9
-#define AFD_POLL_QOS                    (1 << AFD_POLL_QOS_BIT)
-#define AFD_POLL_GROUP_QOS_BIT          10
-#define AFD_POLL_GROUP_QOS              (1 << AFD_POLL_GROUP_QOS_BIT)
+#  define AFD_POLL_RECEIVE_BIT           0
+#  define AFD_POLL_RECEIVE               (1 << AFD_POLL_RECEIVE_BIT)
+#  define AFD_POLL_RECEIVE_EXPEDITED_BIT 1
+#  define AFD_POLL_RECEIVE_EXPEDITED     (1 << AFD_POLL_RECEIVE_EXPEDITED_BIT)
+#  define AFD_POLL_SEND_BIT              2
+#  define AFD_POLL_SEND                  (1 << AFD_POLL_SEND_BIT)
+#  define AFD_POLL_DISCONNECT_BIT        3
+#  define AFD_POLL_DISCONNECT            (1 << AFD_POLL_DISCONNECT_BIT)
+#  define AFD_POLL_ABORT_BIT             4
+#  define AFD_POLL_ABORT                 (1 << AFD_POLL_ABORT_BIT)
+#  define AFD_POLL_LOCAL_CLOSE_BIT       5
+#  define AFD_POLL_LOCAL_CLOSE           (1 << AFD_POLL_LOCAL_CLOSE_BIT)
+#  define AFD_POLL_CONNECT_BIT           6
+#  define AFD_POLL_CONNECT               (1 << AFD_POLL_CONNECT_BIT)
+#  define AFD_POLL_ACCEPT_BIT            7
+#  define AFD_POLL_ACCEPT                (1 << AFD_POLL_ACCEPT_BIT)
+#  define AFD_POLL_CONNECT_FAIL_BIT      8
+#  define AFD_POLL_CONNECT_FAIL          (1 << AFD_POLL_CONNECT_FAIL_BIT)
+#  define AFD_POLL_QOS_BIT               9
+#  define AFD_POLL_QOS                   (1 << AFD_POLL_QOS_BIT)
+#  define AFD_POLL_GROUP_QOS_BIT         10
+#  define AFD_POLL_GROUP_QOS             (1 << AFD_POLL_GROUP_QOS_BIT)
 
-#define AFD_NUM_POLL_EVENTS             11
-#define AFD_POLL_ALL                    ((1 << AFD_NUM_POLL_EVENTS) - 1)
+#  define AFD_NUM_POLL_EVENTS 11
+#  define AFD_POLL_ALL        ((1 << AFD_NUM_POLL_EVENTS) - 1)
 
 typedef struct _AFD_POLL_HANDLE_INFO {
   HANDLE   Handle;
@@ -117,6 +136,12 @@ typedef NTSTATUS(NTAPI *NtDeviceIoControlFile_t)(
   HANDLE FileHandle, HANDLE Event, PIO_APC_ROUTINE ApcRoutine, PVOID ApcContext,
   PIO_STATUS_BLOCK IoStatusBlock, ULONG IoControlCode, PVOID InputBuffer,
   ULONG InputBufferLength, PVOID OutputBuffer, ULONG OutputBufferLength);
+
+typedef NTSTATUS(NTAPI *NtCreateFile_t)(
+  PHANDLE FileHandle, ACCESS_MASK DesiredAccess,
+  POBJECT_ATTRIBUTES ObjectAttributes, PIO_STATUS_BLOCK IoStatusBlock,
+  PLARGE_INTEGER AllocationSize, ULONG FileAttributes, ULONG ShareAccess,
+  ULONG CreateDisposition, ULONG CreateOptions, PVOID EaBuffer, ULONG EaLength);
 
 /* On UWP/Windows Store, these definitions aren't there for some reason */
 #  ifndef SIO_BSP_HANDLE_POLL

--- a/src/lib/ares_sysconfig_win.c
+++ b/src/lib/ares_sysconfig_win.c
@@ -345,9 +345,6 @@ static ares_bool_t get_DNS_Windows(char **outptr)
     goto done;
   }
 
-  /* NOTE: misaligned_assign() is used to work around UBSAN issues on 32bit
-   *       windows. */
-
   for (ipaaEntry = ipaa; ipaaEntry; ipaaEntry = ipaaEntry->Next) {
     if (ipaaEntry->OperStatus != IfOperStatusUp) {
       continue;

--- a/test/ares-test-mock-et.cc
+++ b/test/ares-test-mock-et.cc
@@ -817,9 +817,9 @@ TEST_P(MockEventThreadTest, BulkCancel) {
     for (size_t i = 0; i<BULKCANCEL_CNT; i++) {
       EXPECT_TRUE(result[i].done_);
       EXPECT_TRUE(result[i].status_ == ARES_ECANCELLED || result[i].status_ == ARES_SUCCESS);
-      if (result[i].status_ == ARES_SUCCESS)
+      if (result[i].done_ && result[i].status_ == ARES_SUCCESS)
         success_cnt++;
-      if (result[i].status_ == ARES_ECANCELLED)
+      if (result[i].done_ && result[i].status_ == ARES_ECANCELLED)
         cancel_cnt++;
     }
     if (verbose) std::cerr << "success: " << success_cnt << ", cancel: " << cancel_cnt << std::endl;

--- a/test/ares-test-mock-et.cc
+++ b/test/ares-test-mock-et.cc
@@ -103,8 +103,8 @@ static int sock_cb_count = 0;
 static int SocketConnectCallback(ares_socket_t fd, int type, void *data) {
   int rc = *(int*)data;
   (void)type;
-  if (verbose) std::cerr << "SocketConnectCallback(" << fd << ") invoked" << std::endl;
   sock_cb_count++;
+  if (verbose) std::cerr << "SocketConnectCallback(fd: " << fd << ", cnt: " << sock_cb_count << ") invoked" << std::endl;
   return rc;
 }
 
@@ -214,6 +214,55 @@ TEST_P(MockUDPEventThreadMaxQueriesTest, GetHostByNameParallelLookups) {
     EXPECT_EQ("{'www.google.com' aliases=[] addrs=[2.3.4.5]}", ss.str());
   }
 }
+
+class MockUDPEventThreadSingleQueryPerConnTest
+    : public MockEventThreadOptsTest,
+      public ::testing::WithParamInterface<std::tuple<ares_evsys_t,int>> {
+ public:
+  MockUDPEventThreadSingleQueryPerConnTest()
+    : MockEventThreadOptsTest(1, std::get<0>(GetParam()), std::get<1>(GetParam()), false,
+                          FillOptions(&opts_),
+                          ARES_OPT_UDP_MAX_QUERIES) {}
+  static struct ares_options* FillOptions(struct ares_options * opts) {
+    memset(opts, 0, sizeof(struct ares_options));
+    opts->udp_max_queries = 1;
+    return opts;
+  }
+ private:
+  struct ares_options opts_;
+};
+
+#define LOTSOFCONNECTIONS_CNT 64
+TEST_P(MockUDPEventThreadSingleQueryPerConnTest, LotsOfConnections) {
+  DNSPacket rsp;
+  rsp.set_response().set_aa()
+    .add_question(new DNSQuestion("www.google.com", T_A))
+    .add_answer(new DNSARR("www.google.com", 100, {2, 3, 4, 5}));
+  ON_CALL(server_, OnRequest("www.google.com", T_A))
+    .WillByDefault(SetReply(&server_, &rsp));
+
+  // Get notified of new sockets so we can validate how many are created
+  int rc = ARES_SUCCESS;
+  ares_set_socket_callback(channel_, SocketConnectCallback, &rc);
+  sock_cb_count = 0;
+
+  HostResult result[LOTSOFCONNECTIONS_CNT];
+  for (size_t i=0; i<LOTSOFCONNECTIONS_CNT; i++) {
+    ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback, &result[i]);
+  }
+
+  Process();
+
+  EXPECT_EQ(LOTSOFCONNECTIONS_CNT, sock_cb_count);
+
+  for (size_t i=0; i<LOTSOFCONNECTIONS_CNT; i++) {
+    std::stringstream ss;
+    EXPECT_TRUE(result[i].done_);
+    ss << result[i].host_;
+    EXPECT_EQ("{'www.google.com' aliases=[] addrs=[2.3.4.5]}", ss.str());
+  }
+}
+
 
 class CacheQueriesEventThreadTest
     : public MockEventThreadOptsTest,
@@ -1490,6 +1539,9 @@ INSTANTIATE_TEST_SUITE_P(AddressFamilies, MockEDNSEventThreadTest, ::testing::Va
 INSTANTIATE_TEST_SUITE_P(TransportModes, NoRotateMultiMockEventThreadTest, ::testing::ValuesIn(ares::test::evsys_families_modes), ares::test::PrintEvsysFamilyMode);
 
 INSTANTIATE_TEST_SUITE_P(TransportModes, ServerFailoverOptsMockEventThreadTest, ::testing::ValuesIn(ares::test::evsys_families_modes), ares::test::PrintEvsysFamilyMode);
+
+INSTANTIATE_TEST_SUITE_P(AddressFamilies, MockUDPEventThreadSingleQueryPerConnTest, ::testing::ValuesIn(ares::test::evsys_families), ares::test::PrintEvsysFamily);
+
 
 }  // namespace test
 }  // namespace ares

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -865,6 +865,8 @@ void MockEventThreadOptsTest::Process(unsigned int cancel_ms) {
   }
 
   while (ares_queue_active_queries(channel_)) {
+    //if (verbose) std::cerr << "pending queries: " << ares_queue_active_queries(channel_) << std::endl;
+
     int nfds = 0;
     fd_set readers;
 
@@ -912,6 +914,8 @@ void MockEventThreadOptsTest::Process(unsigned int cancel_ms) {
       }
     }
   }
+
+  //if (verbose) std::cerr << "pending queries at process end: " << ares_queue_active_queries(channel_) << std::endl;
 }
 
 std::ostream& operator<<(std::ostream& os, const HostResult& result) {


### PR DESCRIPTION
We've had reports of user-after-free type crashes in Windows cleanup code for the Event Thread.  In evaluating the code, it appeared there were some memory leaks on per-connection handles that may have remained open during shutdown, while trying to resolve that it became apparent the methodology chosen may not have been the right one for interfacing with the Windows AFD system as stability issues were seen during this debugging process.

Since this system is completely undocumented, there was no clear resolution path other than to switch to the *other* methodology which involves directly opening `\Device\Afd`, rather than spawning a "peer socket" to use to queue AFD operations.

The original methodology chosen more closely resembled what is employed by [libuv](https://github.com/libuv/libuv) and given its widespread use was the reason it was used.  The new methodology more closely resembles [wepoll](https://github.com/piscisaureus/wepoll).

Its not clear if there are any scalability or performance advantages or disadvantages for either method.  They both seem like different ways to do the same thing, but this current way does seem more stable.

Fixes #798 
Fix By: Brad House (@bradh352)