### PR TITLE
CI: Migrate latest linux testing from Cirrus-CI to GitHub Actions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,21 +8,6 @@ env:
 
 task:
   matrix:
-    - name: "Debian amd64"
-      env:
-        DIST: "DEBIAN"
-        LC_ALL: "C"
-        SCAN_BUILD: "scan-build"
-        MAKE: "make"
-        BUILD_ASAN: "yes"
-        BUILD_UBSAN: "yes"
-        BUILD_VALGRIND: "yes"
-        BUILD_COVERAGE: "yes"
-        BUILD_ANALYZE: "yes"
-        TEST_DEBUGGER: "gdb"
-        TEST_SYMBOL_VISIBILITY: "yes"
-      container:
-        image: debian:latest
     - name: "Alpine amd64"
       env:
         DIST: "ALPINE"
@@ -87,16 +72,6 @@ task:
     - name: "CMAKE"
       env:
         BUILD_TYPE: "cmake"
-    - name: "CMAKE no threads"
-      only_if: $DIST == 'DEBIAN'
-      env:
-        BUILD_TYPE: "cmake"
-        CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_THREADS=OFF -G Ninja"
-    - name: "CMAKE HIDE SYMBOLS"
-      only_if: $TEST_SYMBOL_VISIBILITY == 'yes'
-      env:
-        BUILD_TYPE: "cmake"
-        CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=OFF -DCARES_SYMBOL_HIDING=ON -G Ninja"
     - name: "AUTOTOOLS"
       env:
         BUILD_TYPE: "autotools"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,23 +1,23 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
-name: Ubuntu
+name: Ubuntu (latest)
 on:
   push:
   pull_request:
 
 concurrency:
-  group: ${{ github.ref }}-ubuntu
+  group: ${{ github.ref }}-ubuntu-latest
   cancel-in-progress: true
 
 env:
-  TEST_FILTER: "-v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*"
+  TEST_FILTER: "--gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*"
   CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -G Ninja"
   MAKE: make
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: "Ubuntu"
+    name: "Ubuntu (latest)"
     steps:
       - name: Install packages
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -88,7 +88,7 @@ jobs:
         env:
           BUILD_TYPE: "valgrind"
           TEST_WRAP: "valgrind --leak-check=full"
-          TEST_FILTER: "-4 --gtest_filter=-*Container*:-*LiveSearchANY*"
+          TEST_FILTER: "--gtest_filter=-*Container*:*LiveSearchANY*:*LiveSearchTXT*"
           CMAKE_TEST_FLAGS: "-DCARES_BUILD_TESTS=ON"
           TEST_DEBUGGER: none
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,106 @@
+# Copyright (C) The c-ares project and its contributors
+# SPDX-License-Identifier: MIT
+name: Ubuntu
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.ref }}-ubuntu
+  cancel-in-progress: true
+
+env:
+  TEST_FILTER: "-v --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*"
+  CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -G Ninja"
+  MAKE: make
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: "Ubuntu"
+    steps:
+      - name: Install packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: cmake ninja-build autoconf automake libtool g++ libgmock-dev pkg-config clang clang-tools lldb gdb valgrind
+          version: 1.0
+      - name: Checkout c-ares
+        uses: actions/checkout@v4
+      - name: "CMake: build and test c-ares"
+        env:
+          BUILD_TYPE: CMAKE
+          CMAKE_TEST_FLAGS: "-DCARES_BUILD_TESTS=ON"
+          TEST_DEBUGGER: gdb
+        run: |
+          ./ci/build.sh
+          ./ci/test.sh
+      - name: "Autotools: build and test c-ares"
+        env:
+          BUILD_TYPE: autotools
+          TEST_DEBUGGER: gdb
+        run: |
+          ./ci/build.sh
+          ./ci/test.sh
+          ./ci/distcheck.sh
+      - name: "CMake: (no threads) build and test c-ares"
+        env:
+          BUILD_TYPE: CMAKE
+          CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_THREADS=OFF -G Ninja"
+          CMAKE_TEST_FLAGS: "-DCARES_BUILD_TESTS=ON"
+          TEST_DEBUGGER: gdb
+        run: |
+          ./ci/build.sh
+          ./ci/test.sh
+      - name: "CMake: (hide symbols) build and test c-ares"
+        env:
+          BUILD_TYPE: CMAKE
+          CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=OFF -DCARES_SYMBOL_HIDING=ON -G Ninja"
+          CMAKE_TEST_FLAGS: "-DCARES_BUILD_TESTS=ON"
+          TEST_DEBUGGER: gdb
+        run: |
+          ./ci/build.sh
+          ./ci/test.sh
+      - name: "CMake: UBSAN: build and test c-ares"
+        env:
+          BUILD_TYPE: "ubsan"
+          CC: "clang"
+          CMAKE_TEST_FLAGS: "-DCARES_BUILD_TESTS=ON"
+          CFLAGS: "-fsanitize=undefined -fno-sanitize-recover"
+          CXXFLAGS: "-fsanitize=undefined -fno-sanitize-recover"
+          LDFLAGS: "-fsanitize=undefined"
+          TEST_DEBUGGER: "none"
+        run: |
+          ./ci/build.sh
+          ./ci/test.sh
+      - name: "CMake: ASAN: build and test c-ares"
+        env:
+          BUILD_TYPE: "asan"
+          CC: "clang"
+          CMAKE_TEST_FLAGS: "-DCARES_BUILD_TESTS=ON"
+          CFLAGS: "-fsanitize=address"
+          CXXFLAGS: "-fsanitize=address"
+          LDFLAGS: "-fsanitize=address"
+          TEST_DEBUGGER: "none"
+        run: |
+          ./ci/build.sh
+          ./ci/test.sh
+      - name: "Valgrind: build and test c-ares"
+        env:
+          BUILD_TYPE: "valgrind"
+          TEST_WRAP: "valgrind --leak-check=full"
+          TEST_FILTER: "-4 --gtest_filter=-*Container*:-*LiveSearchANY*"
+          CMAKE_TEST_FLAGS: "-DCARES_BUILD_TESTS=ON"
+          TEST_DEBUGGER: none
+        run: |
+          ./ci/build.sh
+          ./ci/test.sh
+      - name: "CMake: Static Analyzer: build c-ares"
+        env:
+          BUILD_TYPE: "analyze"
+          CC: "clang"
+          SCAN_WRAP: "scan-build -v --status-bugs"
+          CMAKE_TEST_FLAGS: "-DCARES_BUILD_TESTS=OFF"
+          TEST_DEBUGGER: "lldb"
+        run: |
+          ./ci/build.sh
+          ./ci/test.sh


### PR DESCRIPTION
Cirrus CI compute credits run out too fast.  Lets migrate more tasks to GitHub Actions.

Fix By: Brad House (@bradh352)