### PR TITLE
struct areas_options: reduce padding

### DIFF
--- a/include/ares.h
+++ b/include/ares.h
@@ -377,8 +377,8 @@ struct ares_options {
   unsigned short tcp_port; /* host byte order */
   int            socket_send_buffer_size;
   int            socket_receive_buffer_size;
-  struct in_addr    *servers;
   int                nservers;
+  struct in_addr    *servers;
   char             **domains;
   int                ndomains;
   char              *lookups;


### PR DESCRIPTION
Moved nservers parameter to reduce padding.

Before:
```
struct ares_options {
        int                        flags;                /*     0     4 */
        int                        timeout;              /*     4     4 */
        int                        tries;                /*     8     4 */
        int                        ndots;                /*    12     4 */
        short unsigned int         udp_port;             /*    16     2 */
        short unsigned int         tcp_port;             /*    18     2 */
        int                        socket_send_buffer_size; /*    20     4 */
        int                        socket_receive_buffer_size; /*    24     4 */

        /* XXX 4 bytes hole, try to pack */

        struct in_addr *           servers;              /*    32     8 */
        int                        nservers;             /*    40     4 */

        /* XXX 4 bytes hole, try to pack */

        char * *                   domains;              /*    48     8 */
        int                        ndomains;             /*    56     4 */

        /* XXX 4 bytes hole, try to pack */

        /* --- cacheline 1 boundary (64 bytes) --- */
        char *                     lookups;              /*    64     8 */
        ares_sock_state_cb         sock_state_cb;        /*    72     8 */
        void *                     sock_state_cb_data;   /*    80     8 */
        struct apattern *          sortlist;             /*    88     8 */
        int                        nsort;                /*    96     4 */
        int                        ednspsz;              /*   100     4 */
        char *                     resolvconf_path;      /*   104     8 */
        char *                     hosts_path;           /*   112     8 */
        int                        udp_max_queries;      /*   120     4 */
        int                        maxtimeout;           /*   124     4 */
        /* --- cacheline 2 boundary (128 bytes) --- */
        unsigned int               qcache_max_ttl;       /*   128     4 */
        ares_evsys_t               evsys;                /*   132     4 */

        /* size: 136, cachelines: 3, members: 24 */
        /* sum members: 124, holes: 3, sum holes: 12 */
        /* last cacheline: 8 bytes */
```
After:
```
struct ares_options {
        int                        flags;                /*     0     4 */
        int                        timeout;              /*     4     4 */
        int                        tries;                /*     8     4 */
        int                        ndots;                /*    12     4 */
        short unsigned int         udp_port;             /*    16     2 */
        short unsigned int         tcp_port;             /*    18     2 */
        int                        socket_send_buffer_size; /*    20     4 */
        int                        socket_receive_buffer_size; /*    24     4 */
        int                        nservers;             /*    28     4 */
        struct in_addr *           servers;              /*    32     8 */
        char * *                   domains;              /*    40     8 */
        int                        ndomains;             /*    48     4 */

        /* XXX 4 bytes hole, try to pack */

        char *                     lookups;              /*    56     8 */
        /* --- cacheline 1 boundary (64 bytes) --- */
        ares_sock_state_cb         sock_state_cb;        /*    64     8 */
        void *                     sock_state_cb_data;   /*    72     8 */
        struct apattern *          sortlist;             /*    80     8 */
        int                        nsort;                /*    88     4 */
        int                        ednspsz;              /*    92     4 */
        char *                     resolvconf_path;      /*    96     8 */
        char *                     hosts_path;           /*   104     8 */
        int                        udp_max_queries;      /*   112     4 */
        int                        maxtimeout;           /*   116     4 */
        unsigned int               qcache_max_ttl;       /*   120     4 */
        ares_evsys_t               evsys;                /*   124     4 */

        /* size: 128, cachelines: 2, members: 24 */
        /* sum members: 124, holes: 1, sum holes: 4 */
```