### PR TITLE
Add DNS cookie support (RFC7873 + RFC9018)

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TEST_FILTER: "--gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*"
+  TEST_FILTER: "-4 --gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*:*LiveGetLocalhostByAddr*"
   CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCMAKE_INSTALL_PREFIX=C:/projects/build-cares/test_install -DCARES_STATIC_PIC=ON -G Ninja"
   CONFIG_OPTS: "--disable-shared"
   MAKE: make

--- a/docs/ares_dns_rr.3
+++ b/docs/ares_dns_rr.3
@@ -96,6 +96,10 @@ ares_status_t ares_dns_rr_set_opt(ares_dns_rr_t       *dns_rr,
                                   const unsigned char *val,
                                   size_t               val_len);
 
+ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t       *dns_rr,
+                                       ares_dns_rr_key_t    key,
+                                       unsigned short       opt);
+
 const struct in_addr *ares_dns_rr_get_addr(const ares_dns_rr_t *dns_rr,
                                            ares_dns_rr_key_t key);
 
@@ -553,7 +557,7 @@ parameter, and the index to remove is provided in the
 parameter.
 
 The \fIares_dns_rr_set_opt(3)\fP function is used to set option/parameter keys and
-values for the resource record when the datatype if \fIARES_DATATYPE_OPT\fP.  The
+values for the resource record when the datatype is \fIARES_DATATYPE_OPT\fP.  The
 resource record to be modified is provided in the
 .IR dns_rr
 parameter.  They key/parameter is provided in the
@@ -567,6 +571,18 @@ enumerations.  The value for the option is always provided in binary form in
 .IR val
 with length provided in
 .IR val_len.
+
+The \fIares_dns_rr_del_opt_byid(3)\fP function is used to delete option/parameter
+keys and values for the resource record when the datatype is
+\fIARES_DATATYPE_OPT\fP.  The resource record to be modified is provided in the
+.IR dns_rr
+parameter.  They key/parameter is provided in the
+.IR key
+parameter.  The option/parameter value specific to the resource record is provided
+in the
+.IR opt
+parameter.  This function returns \fIARES_SUCCESS\fP if the record is successfully
+removed, or \fIARES_ENOTFOUND\fP if the record could not be found.
 
 The \fIares_dns_rr_get_addr(3)\fP function is used to retrieve the IPv4 address
 from the resource record when the datatype is \fIARES_DATATYPE_INADDR\fP.  The

--- a/docs/ares_dns_rr_del_opt_byid.3
+++ b/docs/ares_dns_rr_del_opt_byid.3
@@ -1,0 +1,3 @@
+.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" SPDX-License-Identifier: MIT
+.so man3/ares_dns_rr.3

--- a/include/ares_dns_record.h
+++ b/include/ares_dns_record.h
@@ -918,6 +918,17 @@ CARES_EXTERN ares_status_t ares_dns_rr_set_opt(ares_dns_rr_t       *dns_rr,
                                                const unsigned char *val,
                                                size_t               val_len);
 
+/*! Delete the option for the RR by id
+ *
+ *  \param[in] dns_rr   Pointer to resource record
+ *  \param[in] key      DNS Resource Record Key
+ *  \param[in] opt      Option record key id.
+ *  \return ARES_SUCCESS if removed, ARES_ENOTFOUND if not found
+ */
+CARES_EXTERN ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t *dns_rr,
+                                                    ares_dns_rr_key_t key,
+                                                    unsigned short opt);
+
 /*! Retrieve a pointer to the ipv4 address.  Can only be used on keys with
  *  datatype ARES_DATATYPE_INADDR.
  *

--- a/include/ares_dns_record.h
+++ b/include/ares_dns_record.h
@@ -925,9 +925,9 @@ CARES_EXTERN ares_status_t ares_dns_rr_set_opt(ares_dns_rr_t       *dns_rr,
  *  \param[in] opt      Option record key id.
  *  \return ARES_SUCCESS if removed, ARES_ENOTFOUND if not found
  */
-CARES_EXTERN ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t *dns_rr,
+CARES_EXTERN ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t    *dns_rr,
                                                     ares_dns_rr_key_t key,
-                                                    unsigned short opt);
+                                                    unsigned short    opt);
 
 /*! Retrieve a pointer to the ipv4 address.  Can only be used on keys with
  *  datatype ARES_DATATYPE_INADDR.

--- a/src/lib/Makefile.inc
+++ b/src/lib/Makefile.inc
@@ -10,6 +10,7 @@ CSOURCES = ares__addrinfo2hostent.c	\
   ares__sortaddrinfo.c			\
   ares_android.c			\
   ares_cancel.c				\
+  ares_cookie.c				\
   ares_data.c				\
   ares_destroy.c			\
   ares_dns_mapping.c			\

--- a/src/lib/ares__close_sockets.c
+++ b/src/lib/ares__close_sockets.c
@@ -37,7 +37,7 @@ static void ares__requeue_queries(struct server_connection *conn,
   ares__tvnow(&now);
 
   while ((query = ares__llist_first_val(conn->queries_to_conn)) != NULL) {
-    ares__requeue_query(query, &now, requeue_status);
+    ares__requeue_query(query, &now, requeue_status, ARES_TRUE);
   }
 }
 

--- a/src/lib/ares__socket.c
+++ b/src/lib/ares__socket.c
@@ -292,6 +292,8 @@ static ares_status_t ares_conn_set_self_ip(struct server_connection *conn)
 
   ares_socklen_t len = sizeof(from);
 
+  memset(&from, 0, sizeof(from));
+
   int            rv = getsockname(conn->fd, &from.sa, &len);
   if (rv != 0) {
     return ARES_ECONNREFUSED;

--- a/src/lib/ares__socket.c
+++ b/src/lib/ares__socket.c
@@ -282,15 +282,15 @@ ares_bool_t ares_sockaddr_to_ares_addr(struct ares_addr *ares_addr,
 
 static ares_status_t ares_conn_set_self_ip(struct server_connection *conn)
 {
-  struct sockaddr addr;
-  ares_socklen_t  len = sizeof(addr);
+  struct sockaddr_storage addr;
+  ares_socklen_t          len = sizeof(addr);
 
-  int rv = getsockname(conn->fd, &addr, &len);
+  int rv = getsockname(conn->fd, (struct sockaddr *)&addr, &len);
   if (rv != 0) {
     return ARES_ECONNREFUSED;
   }
 
-  if (!ares_sockaddr_to_ares_addr(&conn->self_ip, NULL, &addr)) {
+  if (!ares_sockaddr_to_ares_addr(&conn->self_ip, NULL, (struct sockaddr *)&addr)) {
     return ARES_ECONNREFUSED;
   }
 

--- a/src/lib/ares__socket.c
+++ b/src/lib/ares__socket.c
@@ -242,8 +242,8 @@ static int configure_socket(ares_socket_t s, struct server_state *server)
   return 0;
 }
 
-ares_bool_t ares_sockaddr_to_ares_addr(struct ares_addr *ares_addr,
-                                       unsigned short   *port,
+ares_bool_t ares_sockaddr_to_ares_addr(struct ares_addr      *ares_addr,
+                                       unsigned short        *port,
                                        const struct sockaddr *sockaddr)
 {
   if (sockaddr->sa_family == AF_INET) {
@@ -289,9 +289,10 @@ static ares_status_t ares_conn_set_self_ip(struct server_connection *conn)
     struct sockaddr_in  sa4;
     struct sockaddr_in6 sa6;
   } from;
+
   ares_socklen_t len = sizeof(from);
 
-  int rv = getsockname(conn->fd, &from.sa, &len);
+  int            rv = getsockname(conn->fd, &from.sa, &len);
   if (rv != 0) {
     return ARES_ECONNREFUSED;
   }

--- a/src/lib/ares__socket.c
+++ b/src/lib/ares__socket.c
@@ -289,12 +289,12 @@ static ares_status_t ares_conn_set_self_ip(struct server_connection *conn)
     struct sockaddr_in  sa4;
     struct sockaddr_in6 sa6;
   } from;
-
+  int            rv;
   ares_socklen_t len = sizeof(from);
 
   memset(&from, 0, sizeof(from));
 
-  int            rv = getsockname(conn->fd, &from.sa, &len);
+  rv = getsockname(conn->fd, &from.sa, &len);
   if (rv != 0) {
     return ARES_ECONNREFUSED;
   }

--- a/src/lib/ares_cookie.c
+++ b/src/lib/ares_cookie.c
@@ -72,7 +72,7 @@ static ares_bool_t timeval_expired(const ares_timeval_t *tv,
   ares_timeval_t tvdiff;
   ares__timeval_diff(&tvdiff, tv, now);
 
-  tvdiff_ms = tv->sec * 1000 + tv->usec / 1000;
+  tvdiff_ms = tvdiff.sec * 1000 + tvdiff.usec / 1000;
   if (tvdiff_ms >= (ares_int64_t)millsecs) {
     return ARES_TRUE;
   }
@@ -265,8 +265,11 @@ ares_status_t ares_cookie_validate(struct query             *query,
 
     /* Resend the request, hopefully it will work the next time as we should
      * have recorded a server cookie */
-    return ares__requeue_query(query, now, ARES_SUCCESS,
-                               ARES_FALSE /* Don't increment try count */);
+    ares__requeue_query(query, now, ARES_SUCCESS,
+                        ARES_FALSE /* Don't increment try count */);
+
+    /* Parent needs to drop this response */
+    return ARES_EBADRESP;
   }
 
   /* We've got a response with a server cookie, and we've done all the

--- a/src/lib/ares_cookie.c
+++ b/src/lib/ares_cookie.c
@@ -26,21 +26,17 @@
 
 #include "ares_private.h"
 
-ares_status_t ares_dns_cookie_set(ares_dns_record_t *dnsrec,
-                                  const unsigned char *cookie, size_t len)
-{
-  ares_dns_rr_t *rr  = ares_dns_get_opt_rr(dnsrec);
+/* 1 day */
+#define COOKIE_CLIENT_TIMEOUT_MS (86400 * 1000)
 
-  if (rr == NULL) {
-    return ARES_EFORMERR;
-  }
+/* 5 minutes */
+#define COOKIE_UNSUPPORTED_TIMEOUT_MS (300 * 1000)
 
-  return ares_dns_rr_set_opt(rr, ARES_RR_OPT_OPTIONS, ARES_OPT_PARAM_COOKIE,
-                             cookie, len);
-}
+/* 2 minutes */
+#define COOKIE_REGRESSION_TIMEOUT_MS (120 * 1000)
 
-const unsigned char *ares_dns_cookie_fetch(const ares_dns_record_t *dnsrec,
-                                           size_t *len)
+static const unsigned char *ares_dns_cookie_fetch(const ares_dns_record_t *dnsrec,
+                                                  size_t *len)
 {
   const ares_dns_rr_t *rr  = ares_dns_get_opt_rr_const(dnsrec);
   const unsigned char *val = NULL;
@@ -58,14 +54,151 @@ const unsigned char *ares_dns_cookie_fetch(const ares_dns_record_t *dnsrec,
   return val;
 }
 
-void ares_dns_cookie_delete(ares_dns_record_t *dnsrec)
+static ares_bool_t timeval_is_set(const ares_timeval_t *tv)
 {
-  ares_dns_rr_t *rr  = ares_dns_get_opt_rr(dnsrec);
-
-  if (rr == NULL) {
-    return;
-  }
-
-  ares_dns_rr_del_opt_byid(rr, ARES_RR_OPT_OPTIONS, ARES_OPT_PARAM_COOKIE);
+  if (tv->sec != 0 && tv->usec != 0)
+    return ARES_TRUE;
+  return ARES_FALSE;
 }
 
+static ares_bool_t timeval_expired(const ares_timeval_t *tv,
+                                   const ares_timeval_t *now,
+                                   unsigned long millsecs)
+{
+  ares_int64_t   tvdiff_ms;
+  ares_timeval_t tvdiff;
+  ares__timeval_diff(&tvdiff, tv, now);
+
+  tvdiff_ms = tv->sec * 1000 + tv->usec / 1000;
+  if (tvdiff_ms >= (ares_int64_t)millsecs) {
+    return ARES_TRUE;
+  }
+  return ARES_FALSE;
+}
+
+static void ares_cookie_clear(ares_cookie_t *cookie)
+{
+  memset(cookie, 0, sizeof(*cookie));
+  cookie->state = ARES_COOKIE_INITIAL;
+}
+
+static void ares_cookie_generate(ares_cookie_t *cookie,
+                                 struct server_connection *conn,
+                                 const ares_timeval_t *now)
+{
+  ares_channel_t      *channel = conn->server->channel;
+
+  ares__rand_bytes(channel->rand_state, cookie->client, sizeof(cookie->client));
+  memcpy(&cookie->client_ts, now, sizeof(cookie->client_ts));
+  memcpy(&cookie->client_ip, &conn->self_ip, sizeof(cookie->client_ip));
+}
+
+static void ares_cookie_clear_server(ares_cookie_t *cookie)
+{
+  memset(cookie->server, 0, sizeof(cookie->server));
+  cookie->server_len = 0;
+}
+
+static ares_bool_t ares_addr_equal(const struct ares_addr *addr1,
+                                   const struct ares_addr *addr2)
+{
+  if (addr1->family != addr2->family) {
+    return ARES_FALSE;
+  }
+
+  switch (addr1->family) {
+    case AF_INET:
+      if (memcmp(&addr1->addr.addr4, &addr2->addr.addr4,
+          sizeof(addr1->addr.addr4)) == 0) {
+        return ARES_TRUE;
+      }
+      break;
+    case AF_INET6:
+      if (memcmp(&addr1->addr.addr6, &addr2->addr.addr6,
+          sizeof(addr1->addr.addr6)) == 0) {
+        return ARES_TRUE;
+      }
+      break;
+    default:
+      break; /* LCOV_EXCL_LINE */
+  }
+
+  return ARES_FALSE;
+}
+
+ares_status_t ares_cookie_apply(ares_dns_record_t        *dnsrec,
+                                struct server_connection *conn,
+                                const ares_timeval_t     *now)
+{
+  struct server_state *server  = conn->server;
+  ares_cookie_t       *cookie  = &server->cookie;
+  ares_dns_rr_t       *rr      = ares_dns_get_opt_rr(dnsrec);
+  unsigned char        c[40];
+  size_t               c_len;
+
+  /* If there is no OPT record, then EDNS isn't supported, and therefore
+   * cookies can't be supported */
+  if (rr == NULL) {
+    return ARES_SUCCESS;
+  }
+
+  /* No cookies on TCP, make sure we remove one if one is present */
+  if (conn->is_tcp) {
+    ares_dns_rr_del_opt_byid(rr, ARES_RR_OPT_OPTIONS, ARES_OPT_PARAM_COOKIE);
+    return ARES_SUCCESS;
+  }
+
+  /* Look for regression */
+  if (cookie->state == ARES_COOKIE_SUPPORTED    &&
+      timeval_is_set(&cookie->unsupported_ts)   &&
+      timeval_expired(&cookie->unsupported_ts, now,
+        COOKIE_REGRESSION_TIMEOUT_MS)) {
+    ares_cookie_clear(cookie);
+  }
+
+  /* Handle unsupported state */
+  if (cookie->state == ARES_COOKIE_UNSUPPORTED) {
+    /* If timer hasn't expired, just delete any possible cookie and return */
+    if (!timeval_expired(&cookie->unsupported_ts, now,
+        COOKIE_REGRESSION_TIMEOUT_MS)) {
+      ares_dns_rr_del_opt_byid(rr, ARES_RR_OPT_OPTIONS, ARES_OPT_PARAM_COOKIE);
+      return ARES_SUCCESS;
+    }
+
+    /* We want to try to "learn" again */
+    ares_cookie_clear(cookie);
+  }
+
+  /* Generate a new cookie */
+  if (cookie->state == ARES_COOKIE_INITIAL) {
+    ares_cookie_generate(cookie, conn, now);
+    cookie->state = ARES_COOKIE_GENERATED;
+  }
+
+  /* Regenerate the cookie and clear the server cookie if the client ip has
+   * changed */
+  if ((cookie->state == ARES_COOKIE_GENERATED ||
+      cookie->state == ARES_COOKIE_SUPPORTED) &&
+      !ares_addr_equal(&conn->self_ip, &cookie->client_ip)) {
+    ares_cookie_clear_server(cookie);
+    ares_cookie_generate(cookie, conn, now);
+  }
+
+  /* If the client cookie has reached its maximum time, refresh it */
+  if (cookie->state == ARES_COOKIE_SUPPORTED &&
+      timeval_expired(&cookie->client_ts, now, COOKIE_CLIENT_TIMEOUT_MS)) {
+    ares_cookie_clear_server(cookie);
+    ares_cookie_generate(cookie, conn, now);
+  }
+
+  /* Generate the full cookie which is the client cookie concatenated with the
+   * server cookie (if there is one) and apply it. */
+  memcpy(c, cookie->client, sizeof(cookie->client));
+  if (cookie->server_len) {
+    memcpy(c + sizeof(cookie->client), cookie->server, cookie->server_len);
+  }
+  c_len = sizeof(cookie->client) + cookie->server_len;
+
+  return ares_dns_rr_set_opt(rr, ARES_RR_OPT_OPTIONS, ARES_OPT_PARAM_COOKIE,
+                             c, c_len);
+}

--- a/src/lib/ares_cookie.c
+++ b/src/lib/ares_cookie.c
@@ -1,0 +1,71 @@
+/* MIT License
+ *
+ * Copyright (c) 2024 Brad House
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "ares_private.h"
+
+ares_status_t ares_dns_cookie_set(ares_dns_record_t *dnsrec,
+                                  const unsigned char *cookie, size_t len)
+{
+  ares_dns_rr_t *rr  = ares_dns_get_opt_rr(dnsrec);
+
+  if (rr == NULL) {
+    return ARES_EFORMERR;
+  }
+
+  return ares_dns_rr_set_opt(rr, ARES_RR_OPT_OPTIONS, ARES_OPT_PARAM_COOKIE,
+                             cookie, len);
+}
+
+const unsigned char *ares_dns_cookie_fetch(const ares_dns_record_t *dnsrec,
+                                           size_t *len)
+{
+  const ares_dns_rr_t *rr  = ares_dns_get_opt_rr_const(dnsrec);
+  const unsigned char *val = NULL;
+  *len = 0;
+
+  if (rr == NULL) {
+    return NULL;
+  }
+
+  if (!ares_dns_rr_get_opt_byid(rr, ARES_RR_OPT_OPTIONS, ARES_OPT_PARAM_COOKIE,
+                                &val, len)) {
+    return NULL;
+  }
+
+  return val;
+}
+
+void ares_dns_cookie_delete(ares_dns_record_t *dnsrec)
+{
+  ares_dns_rr_t *rr  = ares_dns_get_opt_rr(dnsrec);
+
+  if (rr == NULL) {
+    return;
+  }
+
+  ares_dns_rr_del_opt_byid(rr, ARES_RR_OPT_OPTIONS, ARES_OPT_PARAM_COOKIE);
+}
+

--- a/src/lib/ares_cookie.c
+++ b/src/lib/ares_cookie.c
@@ -59,10 +59,10 @@
  * ### Constants:
  *  - `COOKIE_CLIENT_TIMEOUT`: 86400s (1 day)
  *     - How often to regenerate the per-server client cookie, even if our
- * source ip address hasn't changed.
+ *       source ip address hasn't changed.
  *  - `COOKIE_UNSUPPORTED_TIMEOUT`: 300s (5 minutes)
  *     - If a server responds without a cookie in the reply, this is how long to
- * wait before attempting to send a client cookie again.
+ *       wait before attempting to send a client cookie again.
  *  - `COOKIE_REGRESSION_TIMEOUT`: 120s (2 minutes)
  *     - If a server was once known to return cookies, and all of a sudden stops
  *       returning cookies (but the reply is otherwise valid), this is how long

--- a/src/lib/ares_cookie.c
+++ b/src/lib/ares_cookie.c
@@ -239,7 +239,7 @@ ares_status_t ares_cookie_validate(struct query             *query,
     return ARES_EBADRESP;
   }
 
-  if (resp_cookie_len > 8) {
+  if (resp_cookie && resp_cookie_len > 8) {
     /* Make sure we record that we successfully received a cookie response */
     cookie->state = ARES_COOKIE_SUPPORTED;
     memset(&cookie->unsupported_ts, 0, sizeof(cookie->unsupported_ts));

--- a/src/lib/ares_dns_private.h
+++ b/src/lib/ares_dns_private.h
@@ -38,23 +38,23 @@ ares_bool_t ares_dns_class_isvalid(ares_dns_class_t    qclass,
                                    ares_dns_rec_type_t type,
                                    ares_bool_t         is_query);
 ares_bool_t ares_dns_section_isvalid(ares_dns_section_t sect);
-ares_status_t ares_dns_rr_set_str_own(ares_dns_rr_t    *dns_rr,
-                                      ares_dns_rr_key_t key, char *val);
-ares_status_t ares_dns_rr_set_bin_own(ares_dns_rr_t    *dns_rr,
-                                      ares_dns_rr_key_t key, unsigned char *val,
-                                      size_t len);
-ares_status_t ares_dns_rr_set_abin_own(ares_dns_rr_t           *dns_rr,
-                                       ares_dns_rr_key_t        key,
-                                       ares__dns_multistring_t *strs);
-ares_status_t ares_dns_rr_set_opt_own(ares_dns_rr_t    *dns_rr,
-                                      ares_dns_rr_key_t key, unsigned short opt,
-                                      unsigned char *val, size_t val_len);
-ares_status_t ares_dns_record_rr_prealloc(ares_dns_record_t *dnsrec,
-                                          ares_dns_section_t sect, size_t cnt);
-ares_dns_rr_t *ares_dns_get_opt_rr(ares_dns_record_t *rec);
+ares_status_t        ares_dns_rr_set_str_own(ares_dns_rr_t    *dns_rr,
+                                             ares_dns_rr_key_t key, char *val);
+ares_status_t        ares_dns_rr_set_bin_own(ares_dns_rr_t    *dns_rr,
+                                             ares_dns_rr_key_t key, unsigned char *val,
+                                             size_t len);
+ares_status_t        ares_dns_rr_set_abin_own(ares_dns_rr_t           *dns_rr,
+                                              ares_dns_rr_key_t        key,
+                                              ares__dns_multistring_t *strs);
+ares_status_t        ares_dns_rr_set_opt_own(ares_dns_rr_t    *dns_rr,
+                                             ares_dns_rr_key_t key, unsigned short opt,
+                                             unsigned char *val, size_t val_len);
+ares_status_t        ares_dns_record_rr_prealloc(ares_dns_record_t *dnsrec,
+                                                 ares_dns_section_t sect, size_t cnt);
+ares_dns_rr_t       *ares_dns_get_opt_rr(ares_dns_record_t *rec);
 const ares_dns_rr_t *ares_dns_get_opt_rr_const(const ares_dns_record_t *rec);
-void          ares_dns_record_write_ttl_decrement(ares_dns_record_t *dnsrec,
-                                                  unsigned int       ttl_decrement);
+void ares_dns_record_write_ttl_decrement(ares_dns_record_t *dnsrec,
+                                         unsigned int       ttl_decrement);
 
 /*! Create a DNS record object for a query. The arguments are the same as
  *  those for ares_create_query().

--- a/src/lib/ares_dns_private.h
+++ b/src/lib/ares_dns_private.h
@@ -51,7 +51,8 @@ ares_status_t ares_dns_rr_set_opt_own(ares_dns_rr_t    *dns_rr,
                                       unsigned char *val, size_t val_len);
 ares_status_t ares_dns_record_rr_prealloc(ares_dns_record_t *dnsrec,
                                           ares_dns_section_t sect, size_t cnt);
-ares_bool_t   ares_dns_has_opt_rr(const ares_dns_record_t *rec);
+ares_dns_rr_t *ares_dns_get_opt_rr(ares_dns_record_t *rec);
+const ares_dns_rr_t *ares_dns_get_opt_rr_const(const ares_dns_record_t *rec);
 void          ares_dns_record_write_ttl_decrement(ares_dns_record_t *dnsrec,
                                                   unsigned int       ttl_decrement);
 

--- a/src/lib/ares_dns_record.c
+++ b/src/lib/ares_dns_record.c
@@ -1466,7 +1466,7 @@ ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t *dns_rr,
 {
   ares__dns_options_t **options;
   size_t                idx;
-
+  size_t                cnt_after;
 
   if (ares_dns_rr_key_datatype(key) != ARES_DATATYPE_OPT) {
     return ARES_EFORMERR;
@@ -1475,6 +1475,11 @@ ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t *dns_rr,
   options = ares_dns_rr_data_ptr(dns_rr, key, NULL);
   if (options == NULL) {
     return ARES_EFORMERR;
+  }
+
+  /* No options */
+  if (*options == NULL) {
+    return ARES_SUCCESS;
   }
 
   for (idx = 0; idx < (*options)->cnt; idx++) {
@@ -1488,9 +1493,10 @@ ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t *dns_rr,
     return ARES_ENOTFOUND;
   }
 
-  if (idx != (*options)->cnt - 1) {
+  cnt_after = (*options)->cnt - idx - 1;
+  if (cnt_after) {
     memmove(&(*options)->optval[idx], &(*options)->optval[idx+1],
-      sizeof(*(*options)->optval) * ((*options)->cnt - idx - 1));
+      sizeof(*(*options)->optval) * cnt_after);
   }
 
   (*options)->cnt--;

--- a/src/lib/ares_dns_record.c
+++ b/src/lib/ares_dns_record.c
@@ -1460,9 +1460,9 @@ ares_status_t ares_dns_rr_set_opt(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
   return status;
 }
 
-ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t *dns_rr,
+ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t    *dns_rr,
                                        ares_dns_rr_key_t key,
-                                       unsigned short opt)
+                                       unsigned short    opt)
 {
   ares__dns_options_t **options;
   size_t                idx;
@@ -1497,8 +1497,8 @@ ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t *dns_rr,
 
   cnt_after = (*options)->cnt - idx - 1;
   if (cnt_after) {
-    memmove(&(*options)->optval[idx], &(*options)->optval[idx+1],
-      sizeof(*(*options)->optval) * cnt_after);
+    memmove(&(*options)->optval[idx], &(*options)->optval[idx + 1],
+            sizeof(*(*options)->optval) * cnt_after);
   }
 
   (*options)->cnt--;
@@ -1581,8 +1581,7 @@ ares_dns_rr_t *ares_dns_get_opt_rr(ares_dns_record_t *rec)
 {
   size_t i;
   for (i = 0; i < ares_dns_record_rr_cnt(rec, ARES_SECTION_ADDITIONAL); i++) {
-    ares_dns_rr_t *rr =
-      ares_dns_record_rr_get(rec, ARES_SECTION_ADDITIONAL, i);
+    ares_dns_rr_t *rr = ares_dns_record_rr_get(rec, ARES_SECTION_ADDITIONAL, i);
 
     if (ares_dns_rr_get_type(rr) == ARES_REC_TYPE_OPT) {
       return rr;

--- a/src/lib/ares_dns_record.c
+++ b/src/lib/ares_dns_record.c
@@ -1460,6 +1460,43 @@ ares_status_t ares_dns_rr_set_opt(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
   return status;
 }
 
+ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t *dns_rr,
+                                       ares_dns_rr_key_t key,
+                                       unsigned short opt)
+{
+  ares__dns_options_t **options;
+  size_t                idx;
+
+
+  if (ares_dns_rr_key_datatype(key) != ARES_DATATYPE_OPT) {
+    return ARES_EFORMERR;
+  }
+
+  options = ares_dns_rr_data_ptr(dns_rr, key, NULL);
+  if (options == NULL) {
+    return ARES_EFORMERR;
+  }
+
+  for (idx = 0; idx < (*options)->cnt; idx++) {
+    if ((*options)->optval[idx].opt == opt) {
+      break;
+    }
+  }
+
+  /* No matching option */
+  if (idx == (*options)->cnt) {
+    return ARES_ENOTFOUND;
+  }
+
+  if (idx != (*options)->cnt - 1) {
+    memmove(&(*options)->optval[idx], &(*options)->optval[idx+1],
+      sizeof(*(*options)->optval) * ((*options)->cnt - idx - 1));
+  }
+
+  (*options)->cnt--;
+  return ARES_SUCCESS;
+}
+
 char *ares_dns_addr_to_ptr(const struct ares_addr *addr)
 {
   ares__buf_t               *buf     = NULL;
@@ -1532,8 +1569,21 @@ fail:
   return NULL;
 }
 
-/* search for an OPT RR in the response */
-ares_bool_t ares_dns_has_opt_rr(const ares_dns_record_t *rec)
+ares_dns_rr_t *ares_dns_get_opt_rr(ares_dns_record_t *rec)
+{
+  size_t i;
+  for (i = 0; i < ares_dns_record_rr_cnt(rec, ARES_SECTION_ADDITIONAL); i++) {
+    ares_dns_rr_t *rr =
+      ares_dns_record_rr_get(rec, ARES_SECTION_ADDITIONAL, i);
+
+    if (ares_dns_rr_get_type(rr) == ARES_REC_TYPE_OPT) {
+      return rr;
+    }
+  }
+  return NULL;
+}
+
+const ares_dns_rr_t *ares_dns_get_opt_rr_const(const ares_dns_record_t *rec)
 {
   size_t i;
   for (i = 0; i < ares_dns_record_rr_cnt(rec, ARES_SECTION_ADDITIONAL); i++) {
@@ -1541,10 +1591,10 @@ ares_bool_t ares_dns_has_opt_rr(const ares_dns_record_t *rec)
       ares_dns_record_rr_get_const(rec, ARES_SECTION_ADDITIONAL, i);
 
     if (ares_dns_rr_get_type(rr) == ARES_REC_TYPE_OPT) {
-      return ARES_TRUE;
+      return rr;
     }
   }
-  return ARES_FALSE;
+  return NULL;
 }
 
 /* Construct a DNS record for a name with given class and type. Used internally

--- a/src/lib/ares_dns_record.c
+++ b/src/lib/ares_dns_record.c
@@ -1493,6 +1493,8 @@ ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t *dns_rr,
     return ARES_ENOTFOUND;
   }
 
+  ares_free((*options)->optval[idx].val);
+
   cnt_after = (*options)->cnt - idx - 1;
   if (cnt_after) {
     memmove(&(*options)->optval[idx], &(*options)->optval[idx+1],

--- a/src/lib/ares_dns_write.c
+++ b/src/lib/ares_dns_write.c
@@ -91,7 +91,7 @@ static ares_status_t ares_dns_write_header(const ares_dns_record_t *dnsrec,
   }
 
   /* RCODE */
-  if (dnsrec->rcode > 15 && !ares_dns_has_opt_rr(dnsrec)) {
+  if (dnsrec->rcode > 15 && ares_dns_get_opt_rr_const(dnsrec) == NULL) {
     /* Must have OPT RR in order to write extended error codes */
     rcode = ARES_RCODE_SERVFAIL;
   } else {

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -220,19 +220,19 @@ typedef struct {
   /*! starts at INITIAL, transitions as needed. */
   ares_cookie_state_t state;
   /*! randomly-generate client cookie */
-  unsigned char    client[8];
+  unsigned char       client[8];
   /*! timestamp client cookie was generated, used for rotation purposes */
-  ares_timeval_t   client_ts;
+  ares_timeval_t      client_ts;
   /*! IP address last used for client to connect to server.  If this changes
    *  The client cookie gets invalidated */
-  struct ares_addr client_ip;
+  struct ares_addr    client_ip;
   /*! Server Cookie last received, 8-32 bytes in length */
-  unsigned char    server[32];
+  unsigned char       server[32];
   /*! Length of server cookie on file. */
-  size_t           server_len;
+  size_t              server_len;
   /*! Timestamp of last attempt to use cookies, but it was determined that the
    *  server didn't support them */
-  ares_timeval_t   unsupported_ts;
+  ares_timeval_t      unsupported_ts;
 } ares_cookie_t;
 
 struct server_state {
@@ -300,7 +300,7 @@ struct query {
   size_t        cookie_try_count; /* Attempt count for cookie resends */
   ares_bool_t   using_tcp;
   ares_status_t error_status;
-  size_t        timeouts; /* number of timeouts we saw for this request */
+  size_t        timeouts;   /* number of timeouts we saw for this request */
   ares_bool_t   no_retries; /* do not perform any additional retries, this is
                              * set when a query is to be canceled */
 };
@@ -589,9 +589,9 @@ ares_status_t ares__addrinfo_localhost(const char *name, unsigned short port,
 ares_status_t ares__open_connection(ares_channel_t      *channel,
                                     struct server_state *server,
                                     ares_bool_t          is_tcp);
-ares_bool_t ares_sockaddr_to_ares_addr(struct ares_addr *ares_addr,
-                                       unsigned short   *port,
-                                       const struct sockaddr *sockaddr);
+ares_bool_t   ares_sockaddr_to_ares_addr(struct ares_addr      *ares_addr,
+                                         unsigned short        *port,
+                                         const struct sockaddr *sockaddr);
 ares_socket_t ares__open_socket(ares_channel_t *channel, int af, int type,
                                 int protocol);
 ares_ssize_t  ares__socket_write(ares_channel_t *channel, ares_socket_t s,

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -755,6 +755,16 @@ size_t        ares_metrics_server_timeout(const struct server_state *server,
 ares_status_t ares_cookie_apply(ares_dns_record_t        *dnsrec,
                                 struct server_connection *conn,
                                 const ares_timeval_t     *now);
+typedef enum {
+  ARES_COOKIE_SUCCESS = 0,
+  ARES_COOKIE_DROP    = 1,
+  ARES_COOKIE_RESEND  = 2
+} ares_cookie_response_t;
+
+ares_cookie_response_t ares_cookie_validate(const ares_dns_record_t  *dnsreq,
+                                            const ares_dns_record_t  *dnsresp,
+                                            struct server_connection *conn,
+                                            const ares_timeval_t     *now);
 
 ares_status_t ares__channel_threading_init(ares_channel_t *channel);
 void          ares__channel_threading_destroy(ares_channel_t *channel);

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -297,6 +297,7 @@ struct query {
 
   /* Query status */
   size_t        try_count; /* Number of times we tried this query already. */
+  size_t        cookie_try_count; /* Attempt count for cookie resends */
   ares_bool_t   using_tcp;
   ares_status_t error_status;
   size_t        timeouts; /* number of timeouts we saw for this request */
@@ -445,7 +446,8 @@ ares_bool_t   ares__timedout(const ares_timeval_t *now,
 ares_status_t ares__send_query(struct query *query, const ares_timeval_t *now);
 ares_status_t ares__requeue_query(struct query         *query,
                                   const ares_timeval_t *now,
-                                  ares_status_t         status);
+                                  ares_status_t         status,
+                                  ares_bool_t           inc_try_count);
 
 /*! Retrieve a list of names to use for searching.  The first successful
  *  query in the list wins.  This function also uses the HOSTSALIASES file
@@ -755,16 +757,10 @@ size_t        ares_metrics_server_timeout(const struct server_state *server,
 ares_status_t ares_cookie_apply(ares_dns_record_t        *dnsrec,
                                 struct server_connection *conn,
                                 const ares_timeval_t     *now);
-typedef enum {
-  ARES_COOKIE_SUCCESS = 0,
-  ARES_COOKIE_DROP    = 1,
-  ARES_COOKIE_RESEND  = 2
-} ares_cookie_response_t;
-
-ares_cookie_response_t ares_cookie_validate(const ares_dns_record_t  *dnsreq,
-                                            const ares_dns_record_t  *dnsresp,
-                                            struct server_connection *conn,
-                                            const ares_timeval_t     *now);
+ares_status_t ares_cookie_validate(struct query             *query,
+                                   const ares_dns_record_t  *dnsresp,
+                                   struct server_connection *conn,
+                                   const ares_timeval_t     *now);
 
 ares_status_t ares__channel_threading_init(ares_channel_t *channel);
 void          ares__channel_threading_destroy(ares_channel_t *channel);

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -662,13 +662,13 @@ static ares_status_t process_answer(ares_channel_t      *channel,
                                     struct server_connection *conn,
                                     ares_bool_t tcp, const ares_timeval_t *now)
 {
-  struct query          *query;
+  struct query        *query;
   /* Cache these as once ares__send_query() gets called, it may end up
    * invalidating the connection all-together */
-  struct server_state   *server  = conn->server;
-  ares_dns_record_t     *rdnsrec = NULL;
-  ares_status_t          status;
-  ares_bool_t            is_cached = ARES_FALSE;
+  struct server_state *server  = conn->server;
+  ares_dns_record_t   *rdnsrec = NULL;
+  ares_status_t        status;
+  ares_bool_t          is_cached = ARES_FALSE;
 
   /* Parse the response */
   status = ares_dns_parse(abuf, alen, 0, &rdnsrec);
@@ -954,7 +954,8 @@ static ares_status_t ares__append_tcpbuf(struct server_connection *conn,
     goto done;
   }
 
-  status = ares__buf_append_be16(conn->server->tcp_send, (unsigned short)qbuf_len);
+  status =
+    ares__buf_append_be16(conn->server->tcp_send, (unsigned short)qbuf_len);
   if (status != ARES_SUCCESS) {
     goto done; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -984,7 +985,8 @@ static ares_status_t ares__write_udpbuf(struct server_connection *conn,
     goto done;
   }
 
-  if (ares__socket_write(conn->server->channel, conn->fd, qbuf, qbuf_len) == -1) {
+  if (ares__socket_write(conn->server->channel, conn->fd, qbuf, qbuf_len) ==
+      -1) {
     if (try_again(SOCKERRNO)) {
       status = ARES_ESERVFAIL;
     } else {

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -708,7 +708,8 @@ static ares_status_t process_answer(ares_channel_t      *channel,
    * protocol extension is not understood by the responder. We must retry the
    * query without EDNS enabled. */
   if (ares_dns_record_get_rcode(rdnsrec) == ARES_RCODE_FORMERR &&
-      ares_dns_has_opt_rr(query->query) && !ares_dns_has_opt_rr(rdnsrec)) {
+      ares_dns_get_opt_rr_const(query->query) != NULL &&
+      ares_dns_get_opt_rr_const(rdnsrec) == NULL) {
     status = rewrite_without_edns(query);
     if (status != ARES_SUCCESS) {
       end_query(channel, server, query, status, NULL);

--- a/src/lib/ares_sysconfig_mac.c
+++ b/src/lib/ares_sysconfig_mac.c
@@ -274,25 +274,7 @@ static ares_status_t read_resolver(const dns_resolver_t *resolver,
     /* UBSAN alignment workaround to fetch memory address */
     memcpy(&sockaddr, resolver->nameserver + i, sizeof(sockaddr));
 
-    if (sockaddr->sa_family == AF_INET) {
-      /* NOTE: memcpy sockaddr_in due to alignment issues found by UBSAN due to
-       *       dnsinfo packing */
-      struct sockaddr_in addr_in;
-      memcpy(&addr_in, sockaddr, sizeof(addr_in));
-
-      addr.family = AF_INET;
-      memcpy(&addr.addr.addr4, &(addr_in.sin_addr), sizeof(addr.addr.addr4));
-      addrport = ntohs(addr_in.sin_port);
-    } else if (sockaddr->sa_family == AF_INET6) {
-      /* NOTE: memcpy sockaddr_in6 due to alignment issues found by UBSAN due to
-       *       dnsinfo packing */
-      struct sockaddr_in6 addr_in6;
-      memcpy(&addr_in6, sockaddr, sizeof(addr_in6));
-
-      addr.family = AF_INET6;
-      memcpy(&addr.addr.addr6, &(addr_in6.sin6_addr), sizeof(addr.addr.addr6));
-      addrport = ntohs(addr_in6.sin6_port);
-    } else {
+    if (!ares_sockaddr_to_ares_addr(&addr, &addrport, sockaddr)) {
       continue;
     }
 

--- a/src/lib/event/ares_event_thread.c
+++ b/src/lib/event/ares_event_thread.c
@@ -143,13 +143,13 @@ ares_status_t ares_event_update(ares_event_t **event, ares_event_thread_t *e,
     ev = ares_malloc_zero(sizeof(*ev));
     if (ev == NULL) {
       status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
-      goto done; /* LCOV_EXCL_LINE: OutOfMemory */
+      goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
     if (ares__llist_insert_last(e->ev_updates, ev) == NULL) {
-      ares_free(ev); /* LCOV_EXCL_LINE: OutOfMemory */
+      ares_free(ev);        /* LCOV_EXCL_LINE: OutOfMemory */
       status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
-      goto done; /* LCOV_EXCL_LINE: OutOfMemory */
+      goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
 

--- a/src/tools/adig.c
+++ b/src/tools/adig.c
@@ -754,18 +754,31 @@ static void print_section(ares_dns_record_t *dnsrec, ares_dns_section_t section)
 
 static void print_opt_psuedosection(ares_dns_record_t *dnsrec)
 {
-  const ares_dns_rr_t *rr = has_opt(dnsrec, ARES_SECTION_ADDITIONAL);
+  const ares_dns_rr_t *rr         = has_opt(dnsrec, ARES_SECTION_ADDITIONAL);
+  const unsigned char *cookie     = NULL;
+  size_t               cookie_len = 0;
+
   if (rr == NULL) {
     return;
   }
 
+  if (!ares_dns_rr_get_opt_byid(rr, ARES_RR_OPT_OPTIONS, ARES_OPT_PARAM_COOKIE,
+                                &cookie, &cookie_len)) {
+    cookie = NULL;
+  }
+
+
   printf(";; OPT PSEUDOSECTION:\n");
-  printf("; EDNS: version: %u, flags: %u; udp: %u\t",
+  printf("; EDNS: version: %u, flags: %u; udp: %u\n",
          (unsigned int)ares_dns_rr_get_u8(rr, ARES_RR_OPT_VERSION),
          (unsigned int)ares_dns_rr_get_u16(rr, ARES_RR_OPT_FLAGS),
          (unsigned int)ares_dns_rr_get_u16(rr, ARES_RR_OPT_UDP_SIZE));
 
-  printf("\n");
+  if (cookie) {
+    printf("; COOKIE: ");
+    print_opt_bin(cookie, cookie_len);
+    printf(" (good)\n");
+  }
 }
 
 static void callback(void *arg, int status, int timeouts, unsigned char *abuf,

--- a/test/ares-test-misc.cc
+++ b/test/ares-test-misc.cc
@@ -519,7 +519,7 @@ TEST_F(LibraryTest, CreateEDNSQuery) {
   std::string actual = PacketToString(data);
   DNSPacket pkt;
   pkt.set_qid(0x1234).add_question(new DNSQuestion("example.com", T_A))
-    .add_additional(new DNSOptRR(0, 0, 0, 1280, { } /* No server cookie */));
+    .add_additional(new DNSOptRR(0, 0, 0, 1280, { }, { } /* No server cookie */));
   std::string expected = PacketToString(pkt.data());
   EXPECT_EQ(expected, actual);
 }

--- a/test/ares-test-misc.cc
+++ b/test/ares-test-misc.cc
@@ -519,7 +519,7 @@ TEST_F(LibraryTest, CreateEDNSQuery) {
   std::string actual = PacketToString(data);
   DNSPacket pkt;
   pkt.set_qid(0x1234).add_question(new DNSQuestion("example.com", T_A))
-    .add_additional(new DNSOptRR(0, 1280));
+    .add_additional(new DNSOptRR(0, 1280, { } /* No server cookie */));
   std::string expected = PacketToString(pkt.data());
   EXPECT_EQ(expected, actual);
 }

--- a/test/ares-test-misc.cc
+++ b/test/ares-test-misc.cc
@@ -519,7 +519,7 @@ TEST_F(LibraryTest, CreateEDNSQuery) {
   std::string actual = PacketToString(data);
   DNSPacket pkt;
   pkt.set_qid(0x1234).add_question(new DNSQuestion("example.com", T_A))
-    .add_additional(new DNSOptRR(0, 1280, { } /* No server cookie */));
+    .add_additional(new DNSOptRR(0, 0, 0, 1280, { } /* No server cookie */));
   std::string expected = PacketToString(pkt.data());
   EXPECT_EQ(expected, actual);
 }

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -1005,7 +1005,9 @@ TEST_P(MockChannelTest, SearchHighNdots) {
 
 // Test that performing an EDNS search with an OPT RR options value works. The
 // options value should be included on the requests to the mock server.
-TEST_P(MockEDNSChannelTest, SearchOptVal) {
+// We are going to do this only via TCP since this won't include the dynamically
+// generated DNS cookie that would otherwise mess with this result.
+TEST_P(MockTCPChannelTest, SearchOptVal) {
   /* Define the OPT RR options code and value to use. */
   unsigned short opt_opt = 3;
   unsigned char opt_val[] = { 'c', '-', 'a', 'r', 'e', 's' };

--- a/test/ares-test-parse-ptr.cc
+++ b/test/ares-test-parse-ptr.cc
@@ -73,8 +73,8 @@ TEST_F(LibraryTest, ParsePtrReplyCname) {
 struct DNSMalformedCnameRR : public DNSCnameRR {
   DNSMalformedCnameRR(const std::string& name, int ttl, const std::string& other)
     : DNSCnameRR(name, ttl, other) {}
-  std::vector<byte> data() const {
-    std::vector<byte> data = DNSRR::data();
+  std::vector<byte> data(const ares_dns_record_t *dnsrec) const {
+    std::vector<byte> data = DNSRR::data(dnsrec);
     std::vector<byte> encname = EncodeString(other_);
     encname[0] = encname[0] + 63;  // invalid label length
     int len = (int)encname.size();

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -1033,6 +1033,44 @@ void HostCallback(void *data, int status, int timeouts,
   if (verbose) std::cerr << "HostCallback(" << *result << ")" << std::endl;
 }
 
+std::ostream& operator<<(std::ostream& os, const AresDnsRecord& dnsrec) {
+  os << "{'";
+  /* XXX: Todo */
+  os << '}';
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const QueryResult& result) {
+  os << '{';
+  if (result.done_) {
+    os << StatusToString(result.status_);
+      if (result.dnsrec_.dnsrec_ != nullptr) {
+        os << " " << result.dnsrec_;
+      } else {
+        os << ", (no dnsrec)";
+      }
+  } else {
+    os << "(incomplete)";
+  }
+  os << '}';
+  return os;
+}
+
+void QueryCallback(void *data, ares_status_t status, size_t timeouts,
+                   const ares_dns_record_t *dnsrec) {
+  EXPECT_NE(nullptr, data);
+  if (data == nullptr)
+    return;
+
+  QueryResult* result = reinterpret_cast<QueryResult*>(data);
+  result->done_ = true;
+  result->status_ = status;
+  result->timeouts_ = timeouts;
+  if (dnsrec)
+    result->dnsrec_ = AresDnsRecord(dnsrec);
+  if (verbose) std::cerr << "QueryCallback(" << *result << ")" << std::endl;
+}
+
 std::ostream& operator<<(std::ostream& os, const AddrInfoResult& result) {
   os << '{';
   if (result.done_ && result.ai_) {

--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -496,6 +496,48 @@ struct HostResult {
 
 std::ostream &operator<<(std::ostream &os, const HostResult &result);
 
+
+// C++ wrapper for ares_dns_record_t.
+struct AresDnsRecord {
+  AresDnsRecord() : dnsrec_(nullptr)
+  {
+  }
+
+  ~AresDnsRecord()
+  {
+    ares_dns_record_destroy(dnsrec_);
+  }
+
+  AresDnsRecord(const ares_dns_record_t *dnsrec) : dnsrec_(nullptr)
+  {
+    if (dnsrec == NULL)
+      return;
+    dnsrec_ = ares_dns_record_duplicate(dnsrec);
+  }
+
+  ares_dns_record_t *dnsrec_;
+};
+
+std::ostream &operator<<(std::ostream &os, const AresDnsRecord &result);
+
+// Structure that describes the result of an ares_host_callback invocation.
+struct QueryResult {
+  QueryResult() : done_(false), status_(ARES_SUCCESS), timeouts_(0)
+  {
+  }
+
+  // Whether the callback has been invoked.
+  bool    done_;
+  // Explicitly provided result information.
+  ares_status_t status_;
+  size_t        timeouts_;
+  // Contents of the ares_dns_record_t structure if provided
+  AresDnsRecord dnsrec_;
+};
+
+std::ostream &operator<<(std::ostream &os, const QueryResult &result);
+
+
 // Structure that describes the result of an ares_callback invocation.
 struct SearchResult {
   // Whether the callback has been invoked.

--- a/test/dns-proto.cc
+++ b/test/dns-proto.cc
@@ -674,7 +674,14 @@ std::vector<byte> DNSOptRR::data(const ares_dns_record_t *dnsrec) const {
 
     if (ares_dns_rr_get_opt_byid(rr, ARES_RR_OPT_OPTIONS, ARES_OPT_PARAM_COOKIE,
                                   &val, &len)) {
-      cookie.insert(cookie.end(), val, val+8);
+      /* If client cookie was provided to test framework, we are overwriting
+       * the one received from the client.  This is likely to test failure
+       * scenarios */
+      if (client_cookie_.size()) {
+        cookie.insert(cookie.end(), client_cookie_.begin(), client_cookie_.end());
+      } else {
+        cookie.insert(cookie.end(), val, val+8);
+      }
       cookie.insert(cookie.end(), server_cookie_.begin(), server_cookie_.end());
     }
   }

--- a/test/dns-proto.cc
+++ b/test/dns-proto.cc
@@ -548,7 +548,7 @@ std::vector<byte> EncodeString(const std::string &name) {
   return data;
 }
 
-std::vector<byte> DNSQuestion::data(const char *request_name) const {
+std::vector<byte> DNSQuestion::data(const char *request_name, const ares_dns_record_t *dnsrec) const {
   std::vector<byte> data;
   std::vector<byte> encname;
   if (request_name != nullptr && strcasecmp(request_name, name_.c_str()) == 0) {
@@ -562,14 +562,14 @@ std::vector<byte> DNSQuestion::data(const char *request_name) const {
   return data;
 }
 
-std::vector<byte> DNSRR::data() const {
-  std::vector<byte> data = DNSQuestion::data();
+std::vector<byte> DNSRR::data(const ares_dns_record_t *dnsrec) const {
+  std::vector<byte> data = DNSQuestion::data(dnsrec);
   PushInt32(&data, ttl_);
   return data;
 }
 
-std::vector<byte> DNSSingleNameRR::data() const {
-  std::vector<byte> data = DNSRR::data();
+std::vector<byte> DNSSingleNameRR::data(const ares_dns_record_t *dnsrec) const {
+  std::vector<byte> data = DNSRR::data(dnsrec);
   std::vector<byte> encname = EncodeString(other_);
   int len = (int)encname.size();
   PushInt16(&data, len);
@@ -577,8 +577,8 @@ std::vector<byte> DNSSingleNameRR::data() const {
   return data;
 }
 
-std::vector<byte> DNSTxtRR::data() const {
-  std::vector<byte> data = DNSRR::data();
+std::vector<byte> DNSTxtRR::data(const ares_dns_record_t *dnsrec) const {
+  std::vector<byte> data = DNSRR::data(dnsrec);
   int len = 0;
   for (const std::string& txt : txt_) {
     len += (1 + (int)txt.size());
@@ -591,8 +591,8 @@ std::vector<byte> DNSTxtRR::data() const {
   return data;
 }
 
-std::vector<byte> DNSMxRR::data() const {
-  std::vector<byte> data = DNSRR::data();
+std::vector<byte> DNSMxRR::data(const ares_dns_record_t *dnsrec) const {
+  std::vector<byte> data = DNSRR::data(dnsrec);
   std::vector<byte> encname = EncodeString(other_);
   int len = 2 + (int)encname.size();
   PushInt16(&data, len);
@@ -601,8 +601,8 @@ std::vector<byte> DNSMxRR::data() const {
   return data;
 }
 
-std::vector<byte> DNSSrvRR::data() const {
-  std::vector<byte> data = DNSRR::data();
+std::vector<byte> DNSSrvRR::data(const ares_dns_record_t *dnsrec) const {
+  std::vector<byte> data = DNSRR::data(dnsrec);
   std::vector<byte> encname = EncodeString(target_);
   int len = 6 + (int)encname.size();
   PushInt16(&data, len);
@@ -613,8 +613,8 @@ std::vector<byte> DNSSrvRR::data() const {
   return data;
 }
 
-std::vector<byte> DNSUriRR::data() const {
-  std::vector<byte> data = DNSRR::data();
+std::vector<byte> DNSUriRR::data(const ares_dns_record_t *dnsrec) const {
+  std::vector<byte> data = DNSRR::data(dnsrec);
   int len = 4 + (int)target_.size();
   PushInt16(&data, len);
   PushInt16(&data, prio_);
@@ -623,16 +623,16 @@ std::vector<byte> DNSUriRR::data() const {
   return data;
 }
 
-std::vector<byte> DNSAddressRR::data() const {
-  std::vector<byte> data = DNSRR::data();
+std::vector<byte> DNSAddressRR::data(const ares_dns_record_t *dnsrec) const {
+  std::vector<byte> data = DNSRR::data(dnsrec);
   int len = (int)addr_.size();
   PushInt16(&data, len);
   data.insert(data.end(), addr_.begin(), addr_.end());
   return data;
 }
 
-std::vector<byte> DNSSoaRR::data() const {
-  std::vector<byte> data = DNSRR::data();
+std::vector<byte> DNSSoaRR::data(const ares_dns_record_t *dnsrec) const {
+  std::vector<byte> data = DNSRR::data(dnsrec);
   std::vector<byte> encname1 = EncodeString(nsname_);
   std::vector<byte> encname2 = EncodeString(rname_);
   int len = (int)encname1.size() + (int)encname2.size() + 5*4;
@@ -647,8 +647,22 @@ std::vector<byte> DNSSoaRR::data() const {
   return data;
 }
 
-std::vector<byte> DNSOptRR::data() const {
-  std::vector<byte> data = DNSRR::data();
+static const ares_dns_rr_t *fetch_rr(const ares_dns_record_t *rec)
+{
+  size_t i;
+  for (i = 0; i < ares_dns_record_rr_cnt(rec, ARES_SECTION_ADDITIONAL); i++) {
+    const ares_dns_rr_t *rr =
+      ares_dns_record_rr_get_const(rec, ARES_SECTION_ADDITIONAL, i);
+
+    if (ares_dns_rr_get_type(rr) == ARES_REC_TYPE_OPT) {
+      return rr;
+    }
+  }
+  return NULL;
+}
+
+std::vector<byte> DNSOptRR::data(const ares_dns_record_t *dnsrec) const {
+  std::vector<byte> data = DNSRR::data(dnsrec);
   int len = 0;
   for (const DNSOption& opt : opts_) {
     len += (4 + (int)opt.data_.size());
@@ -659,11 +673,33 @@ std::vector<byte> DNSOptRR::data() const {
     PushInt16(&data, (int)opt.data_.size());
     data.insert(data.end(), opt.data_.begin(), opt.data_.end());
   }
+
+  /* See if we should be applying a server cookie */
+  if (server_cookie_.size()) {
+    const ares_dns_rr_t *rr  = fetch_rr(dnsrec);
+    const unsigned char *val = NULL;
+    size_t               len = 0;
+
+    if (rr == NULL) {
+      goto done;
+    }
+
+    if (!ares_dns_rr_get_opt_byid(rr, ARES_RR_OPT_OPTIONS, ARES_OPT_PARAM_COOKIE,
+                                  &val, &len)) {
+      goto done;
+    }
+
+    PushInt16(&data, 10);
+    PushInt16(&data, (int)server_cookie_.size() + 8);
+    data.insert(data.end(), server_cookie_.begin(), server_cookie_.end());
+  }
+
+done:
   return data;
 }
 
-std::vector<byte> DNSNaptrRR::data() const {
-  std::vector<byte> data = DNSRR::data();
+std::vector<byte> DNSNaptrRR::data(const ares_dns_record_t *dnsrec) const {
+  std::vector<byte> data = DNSRR::data(dnsrec);
   std::vector<byte> encname = EncodeString(replacement_);
   int len = (4 + 1 + (int)flags_.size() + 1 + (int)service_.size() + 1 + (int)regexp_.size() + (int)encname.size());
   PushInt16(&data, len);
@@ -679,7 +715,7 @@ std::vector<byte> DNSNaptrRR::data() const {
   return data;
 }
 
-std::vector<byte> DNSPacket::data(const char *request_name) const {
+std::vector<byte> DNSPacket::data(const char *request_name, const ares_dns_record_t *dnsrec) const {
   std::vector<byte> data;
   PushInt16(&data, qid_);
   byte b = 0x00;
@@ -707,19 +743,19 @@ std::vector<byte> DNSPacket::data(const char *request_name) const {
   PushInt16(&data, count);
 
   for (const std::unique_ptr<DNSQuestion>& question : questions_) {
-    std::vector<byte> qdata = question->data(request_name);
+    std::vector<byte> qdata = question->data(request_name, dnsrec);
     data.insert(data.end(), qdata.begin(), qdata.end());
   }
   for (const std::unique_ptr<DNSRR>& rr : answers_) {
-    std::vector<byte> rrdata = rr->data();
+    std::vector<byte> rrdata = rr->data(dnsrec);
     data.insert(data.end(), rrdata.begin(), rrdata.end());
   }
   for (const std::unique_ptr<DNSRR>& rr : auths_) {
-    std::vector<byte> rrdata = rr->data();
+    std::vector<byte> rrdata = rr->data(dnsrec);
     data.insert(data.end(), rrdata.begin(), rrdata.end());
   }
   for (const std::unique_ptr<DNSRR>& rr : adds_) {
-    std::vector<byte> rrdata = rr->data();
+    std::vector<byte> rrdata = rr->data(dnsrec);
     data.insert(data.end(), rrdata.begin(), rrdata.end());
   }
   return data;

--- a/test/dns-proto.cc
+++ b/test/dns-proto.cc
@@ -687,7 +687,7 @@ std::vector<byte> DNSOptRR::data(const ares_dns_record_t *dnsrec) const {
   }
 
   if (cookie.size()) {
-    len += 4 + cookie.size();
+    len += 4 + (int)cookie.size();
   }
   for (const DNSOption& opt : opts_) {
     len += (4 + (int)opt.data_.size());

--- a/test/dns-proto.h
+++ b/test/dns-proto.h
@@ -288,14 +288,16 @@ struct DNSOption {
 };
 
 struct DNSOptRR : public DNSRR {
-  DNSOptRR(unsigned char extrcode, unsigned char version, unsigned short flags, int udpsize, std::vector<byte> server_cookie)
+  DNSOptRR(unsigned char extrcode, unsigned char version, unsigned short flags, int udpsize, std::vector<byte> client_cookie, std::vector<byte> server_cookie)
     : DNSRR("", T_OPT, static_cast<int>(udpsize), ((int)extrcode) << 24 | ((int)version) << 16 | ((int)flags)/* ttl */)
   {
+    client_cookie_ = client_cookie;
     server_cookie_ = server_cookie;
   }
 
   virtual std::vector<byte> data(const ares_dns_record_t *dnsrec) const;
   std::vector<DNSOption>    opts_;
+  std::vector<byte>         client_cookie_;
   std::vector<byte>         server_cookie_;
 };
 

--- a/test/dns-proto.h
+++ b/test/dns-proto.h
@@ -53,6 +53,8 @@ std::string           RRTypeToString(int rrtype);
 std::string           ClassToString(int qclass);
 std::string           AddressToString(const void *addr, int len);
 
+const ares_dns_rr_t *fetch_rr_opt(const ares_dns_record_t *rec);
+
 // Convert DNS protocol data to strings.
 // Note that these functions are not defensive; they assume
 // a validly formatted input, and so should not be used on

--- a/test/dns-proto.h
+++ b/test/dns-proto.h
@@ -288,8 +288,8 @@ struct DNSOption {
 };
 
 struct DNSOptRR : public DNSRR {
-  DNSOptRR(int extrcode, int udpsize, std::vector<byte> server_cookie)
-    : DNSRR("", T_OPT, static_cast<int>(udpsize), extrcode)
+  DNSOptRR(unsigned char extrcode, unsigned char version, unsigned short flags, int udpsize, std::vector<byte> server_cookie)
+    : DNSRR("", T_OPT, static_cast<int>(udpsize), ((int)extrcode) << 24 | ((int)version) << 16 | ((int)flags)/* ttl */)
   {
     server_cookie_ = server_cookie;
   }


### PR DESCRIPTION
DNS cookies are a simple form of learned mutual authentication supported by most DNS server implementations these days and can help prevent DNS Cache Poisoning attacks for clients and DNS amplification attacks for servers.

Fixes #620
Fix By: Brad House (@bradh352)