### PR TITLE
adig: read arguments from adigrc

### DIFF
--- a/docs/adig.1
+++ b/docs/adig.1
@@ -19,7 +19,7 @@ information, where \fINAME\fR is a valid DNS name (e.g. www.example.com,
 .PP
 This utility comes with the \fBc\-ares\fR asynchronous resolver library.
 .PP
-It is possible to specify default arguments for \fBadig\fR via \fB${HOME}/.adigrc\fR.
+It is possible to specify default arguments for \fBadig\fR via \fB${XDG_CONFIG_HOME}/adigrc\fR.
 .SH OPTIONS
 .TP
 \fB\-c\fR class
@@ -62,7 +62,7 @@ Connect to the specified UDP port of DNS server.
 
 .SH FILES
 
-${HOME}/.adigrc
+${XDG_CONFIG_HOME}/adigrc
 
 .SH "REPORTING BUGS"
 Report bugs to the c-ares mailing list:

--- a/docs/adig.1
+++ b/docs/adig.1
@@ -18,6 +18,8 @@ information, where \fINAME\fR is a valid DNS name (e.g. www.example.com,
 1.2.3.10.in-addr.arpa).
 .PP
 This utility comes with the \fBc\-ares\fR asynchronous resolver library.
+.PP
+It is possible to specify default arguments for \fBadig\fR via \fB${HOME}/.adigrc\fR.
 .SH OPTIONS
 .TP
 \fB\-c\fR class
@@ -57,6 +59,10 @@ Connect to the specified TCP port of DNS server.
 .TP
 \fB\-U\fR port
 Connect to the specified UDP port of DNS server.
+
+.SH FILES
+
+${HOME}/.adigrc
 
 .SH "REPORTING BUGS"
 Report bugs to the c-ares mailing list:

--- a/src/tools/adig.c
+++ b/src/tools/adig.c
@@ -46,6 +46,10 @@
 #include "ares_dns.h"
 #include "ares_str.h"
 
+#if defined(_WIN32)
+#  define strtok_r strtok_s
+#endif
+
 #include "ares_getopt.h"
 
 typedef struct {

--- a/src/tools/adig.c
+++ b/src/tools/adig.c
@@ -268,11 +268,16 @@ static ares_bool_t read_cmdline(int argc, const char * const *argv,
 
 static ares_bool_t read_rcfile(adig_config_t *config)
 {
-  char          configdir[128];
-  char         *configdir_xdg;
-  unsigned int  cdlen  = 0;
-  unsigned int  cdsize = sizeof(configdir);
-  char         *homedir;
+  char         configdir[128];
+  unsigned int cdlen  = 0;
+  unsigned int cdsize = sizeof(configdir);
+
+#if !defined(WIN32)
+#  if !defined(__APPLE__)
+  char *configdir_xdg;
+#  endif
+  char *homedir;
+#endif
 
   char          rcfile[128];
   unsigned int  rclen;

--- a/src/tools/adig.c
+++ b/src/tools/adig.c
@@ -328,7 +328,6 @@ static ares_bool_t read_rcfile(adig_config_t *config)
   if (ares__buf_load_file(rcfile, rcbuf) == ARES_SUCCESS) {
     rcstatus = ares__buf_split_str(rcbuf, (const unsigned char *)"\n ", 2,
                                    ARES_BUF_SPLIT_TRIM, 0, &rcargv, &rcargc);
-    ares__buf_destroy(rcbuf);
 
     if (rcstatus == ARES_SUCCESS) {
       read_cmdline((int)rcargc, (const char * const *)rcargv, config,
@@ -342,12 +341,14 @@ static ares_bool_t read_rcfile(adig_config_t *config)
     ares_free_array(rcargv, rcargc, ares_free);
 
     if (rcstatus != ARES_SUCCESS) {
+      ares__buf_destroy(rcbuf);
       return ARES_FALSE;
     }
 
   } else {
     DEBUGF(fprintf(stderr, "read_cmdline() failed to load rcfile"));
   }
+  ares__buf_destroy(rcbuf);
 
   return ARES_TRUE;
 }


### PR DESCRIPTION
This allows for default arguments to be provided through a user configuration file, useful for avoiding repetitive passing of flags on the command line when using adig frequently. The syntax within $XDG_CONFIG_HOME/adigrc resembles the one from dig's ~/.digrc, meaning any command line arguments can be provided, separated either by line breaks or whitespaces.