### PR TITLE
ares__buf: include ares__llist

### DIFF
--- a/src/lib/include/ares__buf.h
+++ b/src/lib/include/ares__buf.h
@@ -27,6 +27,7 @@
 #define __ARES__BUF_H
 
 #include "ares.h"
+#include "ares__llist.h"
 
 /*! \addtogroup ares__buf Safe Data Builder and buffer
  *


### PR DESCRIPTION
Needed by ares__buf_split().