### PR TITLE
gitignore: ignore .dirstamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ c-ares-config-version.cmake
 Makefile.inc.cmake
 cmake_install.cmake
 aminclude_static.am
+src/lib/*/.dirstamp


### PR DESCRIPTION
Generated by Automake.