### PR TITLE
fix: potential `WIN32_LEAN_AND_MEAN` redefinition

### DIFF
--- a/include/ares_build.h.dist
+++ b/include/ares_build.h.dist
@@ -165,9 +165,6 @@
 #  define CARES_TYPEOF_ARES_SOCKLEN_T int
 
 #elif defined(_WIN32)
-#  ifndef WIN32_LEAN_AND_MEAN
-#    define WIN32_LEAN_AND_MEAN
-#  endif
 #  define CARES_TYPEOF_ARES_SOCKLEN_T int
 #  define CARES_HAVE_WINDOWS_H          1
 #  define CARES_HAVE_SYS_TYPES_H        1

--- a/include/ares_build.h.dist
+++ b/include/ares_build.h.dist
@@ -165,7 +165,9 @@
 #  define CARES_TYPEOF_ARES_SOCKLEN_T int
 
 #elif defined(_WIN32)
-#  define WIN32_LEAN_AND_MEAN
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
 #  define CARES_TYPEOF_ARES_SOCKLEN_T int
 #  define CARES_HAVE_WINDOWS_H          1
 #  define CARES_HAVE_SYS_TYPES_H        1


### PR DESCRIPTION
Refs https://github.com/c-ares/c-ares/commit/94b69fbd45b99dcc2f766d63f0c6692561dea89d

We should ensure `WIN32_LEAN_AND_MEAN` isn't already defined before defining it in `ares_build.h`.
The above commit, included in Node.js upgrade to c-ares v1.32.2, causes compilation failures like the following:

```
../../third_party/electron_node/deps/cares/include\ares_build.h(168,11): err
or: 'WIN32_LEAN_AND_MEAN' macro redefined [-Werror,-Wmacro-redefined]
      168 | #  define WIN32_LEAN_AND_MEAN
          |           ^
    <command line>(25,9): note: previous definition is here
       25 | #define WIN32_LEAN_AND_MEAN 1
          |         ^
    1 error generated.
    [287 processes, 49437/51449 @ 48.5/s : 1018.562s] CC obj/third_party/electro
n_node/deps/cares/cares/ares__socket.obj
    FAILED: obj/third_party/electron_node/deps/cares/cares/ares__socket.obj
```

Other areas of c-ares (see [`ares_setup.h`](https://github.com/codebytere/c-ares/blob/d4ecf95be5d41a70c5de1d7b7a145d3f2bd7b905/src/lib/ares_setup.h#L78) already do this.