### PR TITLE
MSVC: Force different PDB names for different targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -708,15 +708,6 @@ IF (CARES_COVERAGE)
 	)
 ENDIF()
 
-IF (MSVC)
-	# AppVeyor reports issues like "fatal error C1041: cannot open program database" randomly.
-	# The /FS flag is supposed to correct this on highly parallel builds like performed when
-	# using Ninja, but it looks like CMake already adds this.  Maybe appending it at the
-	# end will work as maybe some prior flag is counteracting its effectiveness.
-	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /FS")
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FS")
-ENDIF ()
-
 # TRANSFORM_MAKEFILE_INC
 #
 # This function consumes the "Makefile.inc" autotools file, and converts it into
@@ -763,9 +754,6 @@ IF (CARES_BUILD_TESTS OR CARES_BUILD_CONTAINER_TESTS)
 	ADD_SUBDIRECTORY (test)
 ENDIF ()
 
-
-
-
 # Export targets
 IF (CARES_INSTALL)
 	SET (CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
@@ -788,7 +776,6 @@ IF (CARES_INSTALL)
 	CONFIGURE_FILE("libcares.pc.cmake" "libcares.pc" @ONLY)
 	INSTALL (FILES "${CMAKE_CURRENT_BINARY_DIR}/libcares.pc" COMPONENT Devel DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 ENDIF ()
-
 
 # Legacy chain-building variables (provided for compatibility with old code).
 # Don't use these, external code should be updated to refer to the aliases directly (e.g., Cares::cares).

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -26,6 +26,11 @@ IF (CARES_BUILD_TOOLS)
 
 	TARGET_COMPILE_DEFINITIONS (ahost PRIVATE HAVE_CONFIG_H=1 CARES_NO_DEPRECATED)
 	TARGET_LINK_LIBRARIES (ahost PRIVATE ${PROJECT_NAME})
+
+	# Avoid "fatal error C1041: cannot open program database" due to multiple
+	# targets trying to use the same PDB.  /FS does NOT resolve this issue.
+	SET_TARGET_PROPERTIES(ahost PROPERTIES COMPILE_PDB_NAME ahost.pdb)
+
 	IF (CARES_INSTALL)
 		INSTALL (TARGETS ahost COMPONENT Tools ${TARGETS_INST_DEST})
 	ENDIF ()
@@ -55,6 +60,11 @@ IF (CARES_BUILD_TOOLS)
 
 	TARGET_COMPILE_DEFINITIONS (adig PRIVATE HAVE_CONFIG_H=1 CARES_NO_DEPRECATED)
 	TARGET_LINK_LIBRARIES (adig PRIVATE ${PROJECT_NAME})
+
+	# Avoid "fatal error C1041: cannot open program database" due to multiple
+	# targets trying to use the same PDB.  /FS does NOT resolve this issue.
+	SET_TARGET_PROPERTIES(adig PROPERTIES COMPILE_PDB_NAME adig.pdb)
+
 	IF (CARES_INSTALL)
 		INSTALL (TARGETS adig COMPONENT Tools ${TARGETS_INST_DEST})
 	ENDIF ()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,22 +55,40 @@ target_compile_definitions(arestest PRIVATE CARES_NO_DEPRECATED)
 IF (CARES_BUILD_CONTAINER_TESTS)
   target_compile_definitions(arestest PRIVATE HAVE_USER_NAMESPACE HAVE_UTS_NAMESPACE)
 ENDIF ()
+# Avoid "fatal error C1041: cannot open program database" due to multiple
+# targets trying to use the same PDB.  /FS does NOT resolve this issue.
+set_target_properties(arestest PROPERTIES COMPILE_PDB_NAME arestest.pdb)
 
 add_executable(aresfuzz ${FUZZSOURCES})
 target_compile_definitions(aresfuzz PRIVATE CARES_NO_DEPRECATED)
 target_link_libraries(aresfuzz PRIVATE caresinternal)
+# Avoid "fatal error C1041: cannot open program database" due to multiple
+# targets trying to use the same PDB.  /FS does NOT resolve this issue.
+set_target_properties(aresfuzz PROPERTIES COMPILE_PDB_NAME aresfuzz.pdb)
 
 add_executable(aresfuzzname ${FUZZNAMESOURCES})
 target_compile_definitions(aresfuzzname PRIVATE CARES_NO_DEPRECATED)
 target_link_libraries(aresfuzzname PRIVATE caresinternal)
+# Avoid "fatal error C1041: cannot open program database" due to multiple
+# targets trying to use the same PDB.  /FS does NOT resolve this issue.
+set_target_properties(aresfuzzname PROPERTIES COMPILE_PDB_NAME aresfuzzname.pdb)
 
 add_executable(dnsdump ${DUMPSOURCES})
 target_compile_definitions(dnsdump PRIVATE CARES_NO_DEPRECATED)
 target_link_libraries(dnsdump PRIVATE caresinternal)
+# Avoid "fatal error C1041: cannot open program database" due to multiple
+# targets trying to use the same PDB.  /FS does NOT resolve this issue.
+set_target_properties(dnsdump PROPERTIES COMPILE_PDB_NAME dnsdump.pdb)
 
 add_executable(ares_queryloop ${LOOPSOURCES})
 target_compile_definitions(ares_queryloop PRIVATE CARES_NO_DEPRECATED)
 target_link_libraries(ares_queryloop PRIVATE caresinternal)
+# Avoid "fatal error C1041: cannot open program database" due to multiple
+# targets trying to use the same PDB.  /FS does NOT resolve this issue.
+set_target_properties(ares_queryloop PROPERTIES COMPILE_PDB_NAME ares_queryloop.pdb)
+
+
+
 
 # register tests
 


### PR DESCRIPTION
During compiling using MSVC and Ninja, its not uncommon to see errors such as:
```
C:\projects\c-ares\test\ares_queryloop.c: fatal error C1041: cannot open program database 'C:\projects\c-ares\build\bin\vc140.pdb'; if multiple CL.EXE write to the same .PDB file, please use /FS
```

We see this as build failures in our AppVeyor runs.

The suggestion of using `/FS` is misleading as it already exists in the compiler flags (and previous attempts to append them again were wrong).  The real issue I believe is that different output targets are being compiled in parallel, but trying to use the same pdb file, but clearly shouldn't be since they're different targets.

This CMake issue may be related:
https://gitlab.kitware.com/cmake/cmake/-/issues/20188

Authored-By: Brad House (@bradh352)