### PR TITLE
Remove `ares__` prefix, just use `ares_`

### DIFF
--- a/src/lib/Makefile.inc
+++ b/src/lib/Makefile.inc
@@ -1,13 +1,13 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 
-CSOURCES = ares__addrinfo2hostent.c	\
-  ares__addrinfo_localhost.c		\
-  ares__close_sockets.c			\
-  ares__hosts_file.c			\
-  ares__parse_into_addrinfo.c		\
-  ares__socket.c			\
-  ares__sortaddrinfo.c			\
+CSOURCES = ares_addrinfo2hostent.c	\
+  ares_addrinfo_localhost.c		\
+  ares_close_sockets.c			\
+  ares_hosts_file.c			\
+  ares_parse_into_addrinfo.c		\
+  ares_socket.c			\
+  ares_sortaddrinfo.c			\
   ares_android.c			\
   ares_cancel.c				\
   ares_cookie.c				\
@@ -42,14 +42,14 @@ CSOURCES = ares__addrinfo2hostent.c	\
   inet_net_pton.c			\
   inet_ntop.c				\
   windows_port.c			\
-  dsa/ares__array.c			\
-  dsa/ares__htable.c			\
-  dsa/ares__htable_asvp.c		\
-  dsa/ares__htable_strvp.c		\
-  dsa/ares__htable_szvp.c		\
-  dsa/ares__htable_vpvp.c		\
-  dsa/ares__llist.c			\
-  dsa/ares__slist.c			\
+  dsa/ares_array.c			\
+  dsa/ares_htable.c			\
+  dsa/ares_htable_asvp.c		\
+  dsa/ares_htable_strvp.c		\
+  dsa/ares_htable_szvp.c		\
+  dsa/ares_htable_vpvp.c		\
+  dsa/ares_llist.c			\
+  dsa/ares_slist.c			\
   event/ares_event_configchg.c		\
   event/ares_event_epoll.c		\
   event/ares_event_kqueue.c		\
@@ -80,12 +80,12 @@ CSOURCES = ares__addrinfo2hostent.c	\
   record/ares_dns_parse.c		\
   record/ares_dns_record.c		\
   record/ares_dns_write.c		\
-  str/ares__buf.c			\
+  str/ares_buf.c			\
   str/ares_str.c			\
   str/ares_strsplit.c			\
-  util/ares__iface_ips.c		\
-  util/ares__threads.c			\
-  util/ares__timeval.c			\
+  util/ares_iface_ips.c		\
+  util/ares_threads.c			\
+  util/ares_timeval.c			\
   util/ares_math.c			\
   util/ares_rand.c
 
@@ -98,23 +98,23 @@ HHEADERS = ares_android.h			\
   ares_platform.h			\
   ares_private.h			\
   ares_setup.h				\
-  dsa/ares__htable.h			\
-  dsa/ares__slist.h			\
+  dsa/ares_htable.h			\
+  dsa/ares_slist.h			\
   event/ares_event.h			\
   event/ares_event_win32.h		\
-  include/ares__array.h			\
-  include/ares__buf.h			\
-  include/ares__htable_asvp.h		\
-  include/ares__htable_strvp.h		\
-  include/ares__htable_szvp.h		\
-  include/ares__htable_vpvp.h		\
-  include/ares__llist.h			\
+  include/ares_array.h			\
+  include/ares_buf.h			\
+  include/ares_htable_asvp.h		\
+  include/ares_htable_strvp.h		\
+  include/ares_htable_szvp.h		\
+  include/ares_htable_vpvp.h		\
+  include/ares_llist.h			\
   include/ares_str.h			\
   record/ares_dns_multistring.h		\
   record/ares_dns_private.h		\
   str/ares_strsplit.h			\
-  util/ares__iface_ips.h		\
-  util/ares__threads.h			\
+  util/ares_iface_ips.h		\
+  util/ares_threads.h			\
   util/ares_math.h			\
   util/ares_rand.h			\
   util/ares_time.h			\

--- a/src/lib/ares_addrinfo2hostent.c
+++ b/src/lib/ares_addrinfo2hostent.c
@@ -49,7 +49,7 @@
 
 
 ares_status_t ares_addrinfo2hostent(const struct ares_addrinfo *ai, int family,
-                                     struct hostent **host)
+                                    struct hostent **host)
 {
   struct ares_addrinfo_node  *next;
   struct ares_addrinfo_cname *next_cname;
@@ -197,10 +197,10 @@ enomem:
 }
 
 ares_status_t ares_addrinfo2addrttl(const struct ares_addrinfo *ai, int family,
-                                     size_t                req_naddrttls,
-                                     struct ares_addrttl  *addrttls,
-                                     struct ares_addr6ttl *addr6ttls,
-                                     size_t               *naddrttls)
+                                    size_t                req_naddrttls,
+                                    struct ares_addrttl  *addrttls,
+                                    struct ares_addr6ttl *addr6ttls,
+                                    size_t               *naddrttls)
 {
   struct ares_addrinfo_node  *next;
   struct ares_addrinfo_cname *next_cname;

--- a/src/lib/ares_addrinfo2hostent.c
+++ b/src/lib/ares_addrinfo2hostent.c
@@ -48,7 +48,7 @@
 #endif
 
 
-ares_status_t ares__addrinfo2hostent(const struct ares_addrinfo *ai, int family,
+ares_status_t ares_addrinfo2hostent(const struct ares_addrinfo *ai, int family,
                                      struct hostent **host)
 {
   struct ares_addrinfo_node  *next;
@@ -196,7 +196,7 @@ enomem:
   /* LCOV_EXCL_STOP */
 }
 
-ares_status_t ares__addrinfo2addrttl(const struct ares_addrinfo *ai, int family,
+ares_status_t ares_addrinfo2addrttl(const struct ares_addrinfo *ai, int family,
                                      size_t                req_naddrttls,
                                      struct ares_addrttl  *addrttls,
                                      struct ares_addr6ttl *addr6ttls,

--- a/src/lib/ares_addrinfo_localhost.c
+++ b/src/lib/ares_addrinfo_localhost.c
@@ -55,7 +55,7 @@ ares_status_t ares_append_ai_node(int aftype, unsigned short port,
 {
   struct ares_addrinfo_node *node;
 
-  node = ares__append_addrinfo_node(nodes);
+  node = ares_append_addrinfo_node(nodes);
   if (!node) {
     return ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -102,7 +102,7 @@ ares_status_t ares_append_ai_node(int aftype, unsigned short port,
 }
 
 static ares_status_t
-  ares__default_loopback_addrs(int aftype, unsigned short port,
+  ares_default_loopback_addrs(int aftype, unsigned short port,
                                struct ares_addrinfo_node **nodes)
 {
   ares_status_t status = ARES_SUCCESS;
@@ -129,7 +129,7 @@ static ares_status_t
 }
 
 static ares_status_t
-  ares__system_loopback_addrs(int aftype, unsigned short port,
+  ares_system_loopback_addrs(int aftype, unsigned short port,
                               struct ares_addrinfo_node **nodes)
 {
 #if defined(USE_WINSOCK) && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600 && \
@@ -176,7 +176,7 @@ fail:
   FreeMibTable(table);
 
   if (status != ARES_SUCCESS) {
-    ares__freeaddrinfo_nodes(*nodes);
+    ares_freeaddrinfo_nodes(*nodes);
     *nodes = NULL;
   }
 
@@ -191,7 +191,7 @@ fail:
 #endif
 }
 
-ares_status_t ares__addrinfo_localhost(const char *name, unsigned short port,
+ares_status_t ares_addrinfo_localhost(const char *name, unsigned short port,
                                        const struct ares_addrinfo_hints *hints,
                                        struct ares_addrinfo             *ai)
 {
@@ -213,19 +213,19 @@ ares_status_t ares__addrinfo_localhost(const char *name, unsigned short port,
     goto enomem; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  status = ares__system_loopback_addrs(hints->ai_family, port, &nodes);
+  status = ares_system_loopback_addrs(hints->ai_family, port, &nodes);
 
   if (status == ARES_ENOTFOUND) {
-    status = ares__default_loopback_addrs(hints->ai_family, port, &nodes);
+    status = ares_default_loopback_addrs(hints->ai_family, port, &nodes);
   }
 
-  ares__addrinfo_cat_nodes(&ai->nodes, nodes);
+  ares_addrinfo_cat_nodes(&ai->nodes, nodes);
 
   return status;
 
 /* LCOV_EXCL_START: OutOfMemory */
 enomem:
-  ares__freeaddrinfo_nodes(nodes);
+  ares_freeaddrinfo_nodes(nodes);
   ares_free(ai->name);
   ai->name = NULL;
   return ARES_ENOMEM;

--- a/src/lib/ares_addrinfo_localhost.c
+++ b/src/lib/ares_addrinfo_localhost.c
@@ -103,7 +103,7 @@ ares_status_t ares_append_ai_node(int aftype, unsigned short port,
 
 static ares_status_t
   ares_default_loopback_addrs(int aftype, unsigned short port,
-                               struct ares_addrinfo_node **nodes)
+                              struct ares_addrinfo_node **nodes)
 {
   ares_status_t status = ARES_SUCCESS;
 
@@ -130,7 +130,7 @@ static ares_status_t
 
 static ares_status_t
   ares_system_loopback_addrs(int aftype, unsigned short port,
-                              struct ares_addrinfo_node **nodes)
+                             struct ares_addrinfo_node **nodes)
 {
 #if defined(USE_WINSOCK) && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600 && \
   !defined(__WATCOMC__)
@@ -192,8 +192,8 @@ fail:
 }
 
 ares_status_t ares_addrinfo_localhost(const char *name, unsigned short port,
-                                       const struct ares_addrinfo_hints *hints,
-                                       struct ares_addrinfo             *ai)
+                                      const struct ares_addrinfo_hints *hints,
+                                      struct ares_addrinfo             *ai)
 {
   struct ares_addrinfo_node *nodes = NULL;
   ares_status_t              status;

--- a/src/lib/ares_cancel.c
+++ b/src/lib/ares_cancel.c
@@ -48,7 +48,7 @@ void ares_cancel(ares_channel_t *channel)
      * queries being cancelled will not be cancelled themselves.
      */
     ares_llist_t      *list_copy = channel->all_queries;
-    channel->all_queries          = ares_llist_create(NULL);
+    channel->all_queries         = ares_llist_create(NULL);
 
     /* Out of memory, this function doesn't return a result code though so we
      * can't report to caller */

--- a/src/lib/ares_cancel.c
+++ b/src/lib/ares_cancel.c
@@ -37,18 +37,18 @@ void ares_cancel(ares_channel_t *channel)
     return;
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
 
-  if (ares__llist_len(channel->all_queries) > 0) {
-    ares__llist_node_t *node = NULL;
-    ares__llist_node_t *next = NULL;
+  if (ares_llist_len(channel->all_queries) > 0) {
+    ares_llist_node_t *node = NULL;
+    ares_llist_node_t *next = NULL;
 
     /* Swap list heads, so that only those queries which were present on entry
      * into this function are cancelled. New queries added by callbacks of
      * queries being cancelled will not be cancelled themselves.
      */
-    ares__llist_t      *list_copy = channel->all_queries;
-    channel->all_queries          = ares__llist_create(NULL);
+    ares_llist_t      *list_copy = channel->all_queries;
+    channel->all_queries          = ares_llist_create(NULL);
 
     /* Out of memory, this function doesn't return a result code though so we
      * can't report to caller */
@@ -57,31 +57,31 @@ void ares_cancel(ares_channel_t *channel)
       goto done;                        /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
-    node = ares__llist_node_first(list_copy);
+    node = ares_llist_node_first(list_copy);
     while (node != NULL) {
       ares_query_t *query;
 
       /* Cache next since this node is being deleted */
-      next = ares__llist_node_next(node);
+      next = ares_llist_node_next(node);
 
-      query                   = ares__llist_node_claim(node);
+      query                   = ares_llist_node_claim(node);
       query->node_all_queries = NULL;
 
       /* NOTE: its possible this may enqueue new queries */
       query->callback(query->arg, ARES_ECANCELLED, 0, NULL);
-      ares__free_query(query);
+      ares_free_query(query);
 
       node = next;
     }
 
-    ares__llist_destroy(list_copy);
+    ares_llist_destroy(list_copy);
   }
 
   /* See if the connections should be cleaned up */
-  ares__check_cleanup_conns(channel);
+  ares_check_cleanup_conns(channel);
 
   ares_queue_notify_empty(channel);
 
 done:
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 }

--- a/src/lib/ares_close_sockets.c
+++ b/src/lib/ares_close_sockets.c
@@ -29,7 +29,7 @@
 #include <assert.h>
 
 static void ares_requeue_queries(ares_conn_t  *conn,
-                                  ares_status_t requeue_status)
+                                 ares_status_t requeue_status)
 {
   ares_query_t  *query;
   ares_timeval_t now;
@@ -91,16 +91,16 @@ void ares_check_cleanup_conns(const ares_channel_t *channel)
   /* Iterate across each server */
   for (snode = ares_slist_node_first(channel->servers); snode != NULL;
        snode = ares_slist_node_next(snode)) {
-    ares_server_t      *server = ares_slist_node_val(snode);
+    ares_server_t     *server = ares_slist_node_val(snode);
     ares_llist_node_t *cnode;
 
     /* Iterate across each connection */
     cnode = ares_llist_node_first(server->connections);
     while (cnode != NULL) {
       ares_llist_node_t *next       = ares_llist_node_next(cnode);
-      ares_conn_t        *conn       = ares_llist_node_val(cnode);
-      ares_bool_t         do_cleanup = ARES_FALSE;
-      cnode                          = next;
+      ares_conn_t       *conn       = ares_llist_node_val(cnode);
+      ares_bool_t        do_cleanup = ARES_FALSE;
+      cnode                         = next;
 
       /* Has connections, not eligible */
       if (ares_llist_len(conn->queries_to_conn)) {

--- a/src/lib/ares_close_sockets.c
+++ b/src/lib/ares_close_sockets.c
@@ -28,82 +28,82 @@
 #include "ares_private.h"
 #include <assert.h>
 
-static void ares__requeue_queries(ares_conn_t  *conn,
+static void ares_requeue_queries(ares_conn_t  *conn,
                                   ares_status_t requeue_status)
 {
   ares_query_t  *query;
   ares_timeval_t now;
 
-  ares__tvnow(&now);
+  ares_tvnow(&now);
 
-  while ((query = ares__llist_first_val(conn->queries_to_conn)) != NULL) {
-    ares__requeue_query(query, &now, requeue_status, ARES_TRUE, NULL);
+  while ((query = ares_llist_first_val(conn->queries_to_conn)) != NULL) {
+    ares_requeue_query(query, &now, requeue_status, ARES_TRUE, NULL);
   }
 }
 
-void ares__close_connection(ares_conn_t *conn, ares_status_t requeue_status)
+void ares_close_connection(ares_conn_t *conn, ares_status_t requeue_status)
 {
   ares_server_t  *server  = conn->server;
   ares_channel_t *channel = server->channel;
 
   /* Unlink */
-  ares__llist_node_claim(
-    ares__htable_asvp_get_direct(channel->connnode_by_socket, conn->fd));
-  ares__htable_asvp_remove(channel->connnode_by_socket, conn->fd);
+  ares_llist_node_claim(
+    ares_htable_asvp_get_direct(channel->connnode_by_socket, conn->fd));
+  ares_htable_asvp_remove(channel->connnode_by_socket, conn->fd);
 
   if (conn->flags & ARES_CONN_FLAG_TCP) {
     server->tcp_conn = NULL;
   }
 
-  ares__buf_destroy(conn->in_buf);
-  ares__buf_destroy(conn->out_buf);
+  ares_buf_destroy(conn->in_buf);
+  ares_buf_destroy(conn->out_buf);
 
   /* Requeue queries to other connections */
-  ares__requeue_queries(conn, requeue_status);
+  ares_requeue_queries(conn, requeue_status);
 
-  ares__llist_destroy(conn->queries_to_conn);
+  ares_llist_destroy(conn->queries_to_conn);
 
-  ares__conn_sock_state_cb_update(conn, ARES_CONN_STATE_NONE);
+  ares_conn_sock_state_cb_update(conn, ARES_CONN_STATE_NONE);
 
-  ares__close_socket(channel, conn->fd);
+  ares_close_socket(channel, conn->fd);
 
   ares_free(conn);
 }
 
-void ares__close_sockets(ares_server_t *server)
+void ares_close_sockets(ares_server_t *server)
 {
-  ares__llist_node_t *node;
+  ares_llist_node_t *node;
 
-  while ((node = ares__llist_node_first(server->connections)) != NULL) {
-    ares_conn_t *conn = ares__llist_node_val(node);
-    ares__close_connection(conn, ARES_SUCCESS);
+  while ((node = ares_llist_node_first(server->connections)) != NULL) {
+    ares_conn_t *conn = ares_llist_node_val(node);
+    ares_close_connection(conn, ARES_SUCCESS);
   }
 }
 
-void ares__check_cleanup_conns(const ares_channel_t *channel)
+void ares_check_cleanup_conns(const ares_channel_t *channel)
 {
-  ares__slist_node_t *snode;
+  ares_slist_node_t *snode;
 
   if (channel == NULL) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
   /* Iterate across each server */
-  for (snode = ares__slist_node_first(channel->servers); snode != NULL;
-       snode = ares__slist_node_next(snode)) {
-    ares_server_t      *server = ares__slist_node_val(snode);
-    ares__llist_node_t *cnode;
+  for (snode = ares_slist_node_first(channel->servers); snode != NULL;
+       snode = ares_slist_node_next(snode)) {
+    ares_server_t      *server = ares_slist_node_val(snode);
+    ares_llist_node_t *cnode;
 
     /* Iterate across each connection */
-    cnode = ares__llist_node_first(server->connections);
+    cnode = ares_llist_node_first(server->connections);
     while (cnode != NULL) {
-      ares__llist_node_t *next       = ares__llist_node_next(cnode);
-      ares_conn_t        *conn       = ares__llist_node_val(cnode);
+      ares_llist_node_t *next       = ares_llist_node_next(cnode);
+      ares_conn_t        *conn       = ares_llist_node_val(cnode);
       ares_bool_t         do_cleanup = ARES_FALSE;
       cnode                          = next;
 
       /* Has connections, not eligible */
-      if (ares__llist_len(conn->queries_to_conn)) {
+      if (ares_llist_len(conn->queries_to_conn)) {
         continue;
       }
 
@@ -131,7 +131,7 @@ void ares__check_cleanup_conns(const ares_channel_t *channel)
       }
 
       /* Clean it up */
-      ares__close_connection(conn, ARES_SUCCESS);
+      ares_close_connection(conn, ARES_SUCCESS);
     }
   }
 }

--- a/src/lib/ares_conn.h
+++ b/src/lib/ares_conn.h
@@ -63,19 +63,19 @@ struct ares_conn {
    *  stream in TCP format (big endian 16bit length prefix followed by DNS
    *  wire-format message).  For TCP this can be sent as-is, UDP this must
    *  be sent per-packet (stripping the length prefix) */
-  ares_buf_t            *out_buf;
+  ares_buf_t             *out_buf;
 
   /*! Inbound buffered data that is not yet parsed.  Exists as one contiguous
    *  stream in TCP format (big endian 16bit length prefix followed by DNS
    *  wire-format message).  TCP may have partial data and this needs to be
    *  handled gracefully, but UDP will always have a full message */
-  ares_buf_t            *in_buf;
+  ares_buf_t             *in_buf;
 
   /* total number of queries run on this connection since it was established */
   size_t                  total_queries;
 
   /* list of outstanding queries to this connection */
-  ares_llist_t          *queries_to_conn;
+  ares_llist_t           *queries_to_conn;
 };
 
 /*! Various buckets for grouping history */
@@ -144,7 +144,7 @@ struct ares_server {
   size_t                consec_failures; /* Consecutive query failure count
                                           * can be hard errors or timeouts
                                           */
-  ares_llist_t        *connections;
+  ares_llist_t         *connections;
   ares_conn_t          *tcp_conn;
 
   /* The next time when we will retry this server if it has hit failures */
@@ -166,8 +166,8 @@ void ares_check_cleanup_conns(const ares_channel_t *channel);
 
 void ares_destroy_servers_state(ares_channel_t *channel);
 ares_status_t ares_open_connection(ares_conn_t   **conn_out,
-                                    ares_channel_t *channel,
-                                    ares_server_t *server, ares_bool_t is_tcp);
+                                   ares_channel_t *channel,
+                                   ares_server_t *server, ares_bool_t is_tcp);
 ares_bool_t   ares_sockaddr_to_ares_addr(struct ares_addr      *ares_addr,
                                          unsigned short        *port,
                                          const struct sockaddr *sockaddr);
@@ -194,29 +194,28 @@ typedef enum {
 } ares_conn_err_t;
 
 ares_conn_err_t ares_open_socket(ares_socket_t *sock, ares_channel_t *channel,
-                                  int af, int type, int protocol);
+                                 int af, int type, int protocol);
 ares_bool_t     ares_socket_try_again(int errnum);
-ares_conn_err_t ares_conn_write(ares_conn_t *conn, const void *data,
-                                 size_t len, size_t *written);
+ares_conn_err_t ares_conn_write(ares_conn_t *conn, const void *data, size_t len,
+                                size_t *written);
 ares_status_t   ares_conn_flush(ares_conn_t *conn);
 ares_conn_err_t ares_conn_read(ares_conn_t *conn, void *data, size_t len,
-                                size_t *read_bytes);
+                               size_t *read_bytes);
 void            ares_conn_sock_state_cb_update(ares_conn_t            *conn,
-                                                ares_conn_state_flags_t flags);
+                                               ares_conn_state_flags_t flags);
 ares_conn_err_t ares_socket_recv(ares_channel_t *channel, ares_socket_t s,
-                                  ares_bool_t is_tcp, void *data,
-                                  size_t data_len, size_t *read_bytes);
+                                 ares_bool_t is_tcp, void *data,
+                                 size_t data_len, size_t *read_bytes);
 ares_conn_err_t ares_socket_recvfrom(ares_channel_t *channel, ares_socket_t s,
-                                      ares_bool_t is_tcp, void *data,
-                                      size_t data_len, int flags,
-                                      struct sockaddr *from,
-                                      ares_socklen_t  *from_len,
-                                      size_t          *read_bytes);
+                                     ares_bool_t is_tcp, void *data,
+                                     size_t data_len, int flags,
+                                     struct sockaddr *from,
+                                     ares_socklen_t  *from_len,
+                                     size_t          *read_bytes);
 void            ares_close_socket(ares_channel_t *channel, ares_socket_t s);
-ares_status_t   ares_connect_socket(ares_channel_t        *channel,
-                                     ares_socket_t          sockfd,
-                                     const struct sockaddr *addr,
-                                     ares_socklen_t         addrlen);
-void            ares_destroy_server(ares_server_t *server);
+ares_status_t ares_connect_socket(ares_channel_t *channel, ares_socket_t sockfd,
+                                  const struct sockaddr *addr,
+                                  ares_socklen_t         addrlen);
+void          ares_destroy_server(ares_server_t *server);
 
 #endif

--- a/src/lib/ares_conn.h
+++ b/src/lib/ares_conn.h
@@ -63,19 +63,19 @@ struct ares_conn {
    *  stream in TCP format (big endian 16bit length prefix followed by DNS
    *  wire-format message).  For TCP this can be sent as-is, UDP this must
    *  be sent per-packet (stripping the length prefix) */
-  ares__buf_t            *out_buf;
+  ares_buf_t            *out_buf;
 
   /*! Inbound buffered data that is not yet parsed.  Exists as one contiguous
    *  stream in TCP format (big endian 16bit length prefix followed by DNS
    *  wire-format message).  TCP may have partial data and this needs to be
    *  handled gracefully, but UDP will always have a full message */
-  ares__buf_t            *in_buf;
+  ares_buf_t            *in_buf;
 
   /* total number of queries run on this connection since it was established */
   size_t                  total_queries;
 
   /* list of outstanding queries to this connection */
-  ares__llist_t          *queries_to_conn;
+  ares_llist_t          *queries_to_conn;
 };
 
 /*! Various buckets for grouping history */
@@ -144,7 +144,7 @@ struct ares_server {
   size_t                consec_failures; /* Consecutive query failure count
                                           * can be hard errors or timeouts
                                           */
-  ares__llist_t        *connections;
+  ares_llist_t        *connections;
   ares_conn_t          *tcp_conn;
 
   /* The next time when we will retry this server if it has hit failures */
@@ -160,12 +160,12 @@ struct ares_server {
   ares_channel_t       *channel;
 };
 
-void ares__close_connection(ares_conn_t *conn, ares_status_t requeue_status);
-void ares__close_sockets(ares_server_t *server);
-void ares__check_cleanup_conns(const ares_channel_t *channel);
+void ares_close_connection(ares_conn_t *conn, ares_status_t requeue_status);
+void ares_close_sockets(ares_server_t *server);
+void ares_check_cleanup_conns(const ares_channel_t *channel);
 
-void ares__destroy_servers_state(ares_channel_t *channel);
-ares_status_t ares__open_connection(ares_conn_t   **conn_out,
+void ares_destroy_servers_state(ares_channel_t *channel);
+ares_status_t ares_open_connection(ares_conn_t   **conn_out,
                                     ares_channel_t *channel,
                                     ares_server_t *server, ares_bool_t is_tcp);
 ares_bool_t   ares_sockaddr_to_ares_addr(struct ares_addr      *ares_addr,
@@ -193,30 +193,30 @@ typedef enum {
   ARES_CONN_ERR_FAILURE      = 99  /*!< Generic failure */
 } ares_conn_err_t;
 
-ares_conn_err_t ares__open_socket(ares_socket_t *sock, ares_channel_t *channel,
+ares_conn_err_t ares_open_socket(ares_socket_t *sock, ares_channel_t *channel,
                                   int af, int type, int protocol);
-ares_bool_t     ares__socket_try_again(int errnum);
-ares_conn_err_t ares__conn_write(ares_conn_t *conn, const void *data,
+ares_bool_t     ares_socket_try_again(int errnum);
+ares_conn_err_t ares_conn_write(ares_conn_t *conn, const void *data,
                                  size_t len, size_t *written);
-ares_status_t   ares__conn_flush(ares_conn_t *conn);
-ares_conn_err_t ares__conn_read(ares_conn_t *conn, void *data, size_t len,
+ares_status_t   ares_conn_flush(ares_conn_t *conn);
+ares_conn_err_t ares_conn_read(ares_conn_t *conn, void *data, size_t len,
                                 size_t *read_bytes);
-void            ares__conn_sock_state_cb_update(ares_conn_t            *conn,
+void            ares_conn_sock_state_cb_update(ares_conn_t            *conn,
                                                 ares_conn_state_flags_t flags);
-ares_conn_err_t ares__socket_recv(ares_channel_t *channel, ares_socket_t s,
+ares_conn_err_t ares_socket_recv(ares_channel_t *channel, ares_socket_t s,
                                   ares_bool_t is_tcp, void *data,
                                   size_t data_len, size_t *read_bytes);
-ares_conn_err_t ares__socket_recvfrom(ares_channel_t *channel, ares_socket_t s,
+ares_conn_err_t ares_socket_recvfrom(ares_channel_t *channel, ares_socket_t s,
                                       ares_bool_t is_tcp, void *data,
                                       size_t data_len, int flags,
                                       struct sockaddr *from,
                                       ares_socklen_t  *from_len,
                                       size_t          *read_bytes);
-void            ares__close_socket(ares_channel_t *channel, ares_socket_t s);
-ares_status_t   ares__connect_socket(ares_channel_t        *channel,
+void            ares_close_socket(ares_channel_t *channel, ares_socket_t s);
+ares_status_t   ares_connect_socket(ares_channel_t        *channel,
                                      ares_socket_t          sockfd,
                                      const struct sockaddr *addr,
                                      ares_socklen_t         addrlen);
-void            ares__destroy_server(ares_server_t *server);
+void            ares_destroy_server(ares_server_t *server);
 
 #endif

--- a/src/lib/ares_cookie.c
+++ b/src/lib/ares_cookie.c
@@ -229,7 +229,7 @@ static ares_bool_t timeval_expired(const ares_timeval_t *tv,
 {
   ares_int64_t   tvdiff_ms;
   ares_timeval_t tvdiff;
-  ares__timeval_diff(&tvdiff, tv, now);
+  ares_timeval_diff(&tvdiff, tv, now);
 
   tvdiff_ms = tvdiff.sec * 1000 + tvdiff.usec / 1000;
   if (tvdiff_ms >= (ares_int64_t)millsecs) {
@@ -249,7 +249,7 @@ static void ares_cookie_generate(ares_cookie_t *cookie, ares_conn_t *conn,
 {
   ares_channel_t *channel = conn->server->channel;
 
-  ares__rand_bytes(channel->rand_state, cookie->client, sizeof(cookie->client));
+  ares_rand_bytes(channel->rand_state, cookie->client, sizeof(cookie->client));
   memcpy(&cookie->client_ts, now, sizeof(cookie->client_ts));
   memcpy(&cookie->client_ip, &conn->self_ip, sizeof(cookie->client_ip));
 }
@@ -426,7 +426,7 @@ ares_status_t ares_cookie_validate(ares_query_t            *query,
 
     /* Resend the request, hopefully it will work the next time as we should
      * have recorded a server cookie */
-    ares__requeue_query(query, now, ARES_SUCCESS,
+    ares_requeue_query(query, now, ARES_SUCCESS,
                         ARES_FALSE /* Don't increment try count */, NULL);
 
     /* Parent needs to drop this response */

--- a/src/lib/ares_cookie.c
+++ b/src/lib/ares_cookie.c
@@ -427,7 +427,7 @@ ares_status_t ares_cookie_validate(ares_query_t            *query,
     /* Resend the request, hopefully it will work the next time as we should
      * have recorded a server cookie */
     ares_requeue_query(query, now, ARES_SUCCESS,
-                        ARES_FALSE /* Don't increment try count */, NULL);
+                       ARES_FALSE /* Don't increment try count */, NULL);
 
     /* Parent needs to drop this response */
     return ARES_EBADRESP;

--- a/src/lib/ares_destroy.c
+++ b/src/lib/ares_destroy.c
@@ -32,16 +32,16 @@
 void ares_destroy(ares_channel_t *channel)
 {
   size_t              i;
-  ares__llist_node_t *node = NULL;
+  ares_llist_node_t *node = NULL;
 
   if (channel == NULL) {
     return;
   }
 
   /* Mark as being shutdown */
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
   channel->sys_up = ARES_FALSE;
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 
   /* Disable configuration change monitoring.  We can't hold a lock because
    * some cleanup routines, such as on Windows, are synchronous operations.
@@ -61,23 +61,23 @@ void ares_destroy(ares_channel_t *channel)
    * holding a lock as the thread may take locks. */
   if (channel->reinit_thread != NULL) {
     void *rv;
-    ares__thread_join(channel->reinit_thread, &rv);
+    ares_thread_join(channel->reinit_thread, &rv);
     channel->reinit_thread = NULL;
   }
 
   /* Lock because callbacks will be triggered, and any system-generated
    * callbacks need to hold a channel lock. */
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
 
   /* Destroy all queries */
-  node = ares__llist_node_first(channel->all_queries);
+  node = ares_llist_node_first(channel->all_queries);
   while (node != NULL) {
-    ares__llist_node_t *next  = ares__llist_node_next(node);
-    ares_query_t       *query = ares__llist_node_claim(node);
+    ares_llist_node_t *next  = ares_llist_node_next(node);
+    ares_query_t       *query = ares_llist_node_claim(node);
 
     query->node_all_queries = NULL;
     query->callback(query->arg, ARES_EDESTRUCTION, 0, NULL);
-    ares__free_query(query);
+    ares_free_query(query);
 
     node = next;
   }
@@ -88,19 +88,19 @@ void ares_destroy(ares_channel_t *channel)
   /* Freeing the query should remove it from all the lists in which it sits,
    * so all query lists should be empty now.
    */
-  assert(ares__llist_len(channel->all_queries) == 0);
-  assert(ares__htable_szvp_num_keys(channel->queries_by_qid) == 0);
-  assert(ares__slist_len(channel->queries_by_timeout) == 0);
+  assert(ares_llist_len(channel->all_queries) == 0);
+  assert(ares_htable_szvp_num_keys(channel->queries_by_qid) == 0);
+  assert(ares_slist_len(channel->queries_by_timeout) == 0);
 #endif
 
-  ares__destroy_servers_state(channel);
+  ares_destroy_servers_state(channel);
 
 #ifndef NDEBUG
-  assert(ares__htable_asvp_num_keys(channel->connnode_by_socket) == 0);
+  assert(ares_htable_asvp_num_keys(channel->connnode_by_socket) == 0);
 #endif
 
   /* No more callbacks will be triggered after this point, unlock */
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 
   /* Shut down the event thread */
   if (channel->optmask & ARES_OPT_EVENT_THREAD) {
@@ -114,46 +114,46 @@ void ares_destroy(ares_channel_t *channel)
     ares_free(channel->domains);
   }
 
-  ares__llist_destroy(channel->all_queries);
-  ares__slist_destroy(channel->queries_by_timeout);
-  ares__htable_szvp_destroy(channel->queries_by_qid);
-  ares__htable_asvp_destroy(channel->connnode_by_socket);
+  ares_llist_destroy(channel->all_queries);
+  ares_slist_destroy(channel->queries_by_timeout);
+  ares_htable_szvp_destroy(channel->queries_by_qid);
+  ares_htable_asvp_destroy(channel->connnode_by_socket);
 
   ares_free(channel->sortlist);
   ares_free(channel->lookups);
   ares_free(channel->resolvconf_path);
   ares_free(channel->hosts_path);
-  ares__destroy_rand_state(channel->rand_state);
+  ares_destroy_rand_state(channel->rand_state);
 
-  ares__hosts_file_destroy(channel->hf);
+  ares_hosts_file_destroy(channel->hf);
 
-  ares__qcache_destroy(channel->qcache);
+  ares_qcache_destroy(channel->qcache);
 
-  ares__channel_threading_destroy(channel);
+  ares_channel_threading_destroy(channel);
 
   ares_free(channel);
 }
 
-void ares__destroy_server(ares_server_t *server)
+void ares_destroy_server(ares_server_t *server)
 {
   if (server == NULL) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  ares__close_sockets(server);
-  ares__llist_destroy(server->connections);
+  ares_close_sockets(server);
+  ares_llist_destroy(server->connections);
   ares_free(server);
 }
 
-void ares__destroy_servers_state(ares_channel_t *channel)
+void ares_destroy_servers_state(ares_channel_t *channel)
 {
-  ares__slist_node_t *node;
+  ares_slist_node_t *node;
 
-  while ((node = ares__slist_node_first(channel->servers)) != NULL) {
-    ares_server_t *server = ares__slist_node_claim(node);
-    ares__destroy_server(server);
+  while ((node = ares_slist_node_first(channel->servers)) != NULL) {
+    ares_server_t *server = ares_slist_node_claim(node);
+    ares_destroy_server(server);
   }
 
-  ares__slist_destroy(channel->servers);
+  ares_slist_destroy(channel->servers);
   channel->servers = NULL;
 }

--- a/src/lib/ares_destroy.c
+++ b/src/lib/ares_destroy.c
@@ -31,7 +31,7 @@
 
 void ares_destroy(ares_channel_t *channel)
 {
-  size_t              i;
+  size_t             i;
   ares_llist_node_t *node = NULL;
 
   if (channel == NULL) {
@@ -73,7 +73,7 @@ void ares_destroy(ares_channel_t *channel)
   node = ares_llist_node_first(channel->all_queries);
   while (node != NULL) {
     ares_llist_node_t *next  = ares_llist_node_next(node);
-    ares_query_t       *query = ares_llist_node_claim(node);
+    ares_query_t      *query = ares_llist_node_claim(node);
 
     query->node_all_queries = NULL;
     query->callback(query->arg, ARES_EDESTRUCTION, 0, NULL);

--- a/src/lib/ares_freeaddrinfo.c
+++ b/src/lib/ares_freeaddrinfo.c
@@ -31,7 +31,7 @@
 #  include <netdb.h>
 #endif
 
-void ares__freeaddrinfo_cnames(struct ares_addrinfo_cname *head)
+void ares_freeaddrinfo_cnames(struct ares_addrinfo_cname *head)
 {
   struct ares_addrinfo_cname *current;
   while (head) {
@@ -43,7 +43,7 @@ void ares__freeaddrinfo_cnames(struct ares_addrinfo_cname *head)
   }
 }
 
-void ares__freeaddrinfo_nodes(struct ares_addrinfo_node *head)
+void ares_freeaddrinfo_nodes(struct ares_addrinfo_node *head)
 {
   struct ares_addrinfo_node *current;
   while (head) {
@@ -59,8 +59,8 @@ void ares_freeaddrinfo(struct ares_addrinfo *ai)
   if (ai == NULL) {
     return;
   }
-  ares__freeaddrinfo_cnames(ai->cnames);
-  ares__freeaddrinfo_nodes(ai->nodes);
+  ares_freeaddrinfo_cnames(ai->cnames);
+  ares_freeaddrinfo_nodes(ai->nodes);
 
   ares_free(ai->name);
   ares_free(ai);

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -124,7 +124,7 @@ struct ares_addrinfo_cname *
 }
 
 void ares_addrinfo_cat_cnames(struct ares_addrinfo_cname **head,
-                               struct ares_addrinfo_cname  *tail)
+                              struct ares_addrinfo_cname  *tail)
 {
   struct ares_addrinfo_cname *last = *head;
   if (!last) {
@@ -164,7 +164,7 @@ struct ares_addrinfo_node *
 }
 
 void ares_addrinfo_cat_nodes(struct ares_addrinfo_node **head,
-                              struct ares_addrinfo_node  *tail)
+                             struct ares_addrinfo_node  *tail)
 {
   struct ares_addrinfo_node *last = *head;
   if (!last) {
@@ -426,7 +426,7 @@ done:
   if (status != ARES_SUCCESS && status != ARES_ENOMEM &&
       ares_is_localhost(hquery->name)) {
     return ares_addrinfo_localhost(hquery->name, hquery->port, &hquery->hints,
-                                    hquery->ai);
+                                   hquery->ai);
   }
 
   return status;

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -101,7 +101,7 @@ static const struct ares_addrinfo_hints default_hints = {
 static ares_bool_t next_dns_lookup(struct host_query *hquery);
 
 struct ares_addrinfo_cname *
-  ares__append_addrinfo_cname(struct ares_addrinfo_cname **head)
+  ares_append_addrinfo_cname(struct ares_addrinfo_cname **head)
 {
   struct ares_addrinfo_cname *tail = ares_malloc_zero(sizeof(*tail));
   struct ares_addrinfo_cname *last = *head;
@@ -123,7 +123,7 @@ struct ares_addrinfo_cname *
   return tail;
 }
 
-void ares__addrinfo_cat_cnames(struct ares_addrinfo_cname **head,
+void ares_addrinfo_cat_cnames(struct ares_addrinfo_cname **head,
                                struct ares_addrinfo_cname  *tail)
 {
   struct ares_addrinfo_cname *last = *head;
@@ -141,7 +141,7 @@ void ares__addrinfo_cat_cnames(struct ares_addrinfo_cname **head,
 
 /* Allocate new addrinfo and append to the tail. */
 struct ares_addrinfo_node *
-  ares__append_addrinfo_node(struct ares_addrinfo_node **head)
+  ares_append_addrinfo_node(struct ares_addrinfo_node **head)
 {
   struct ares_addrinfo_node *tail = ares_malloc_zero(sizeof(*tail));
   struct ares_addrinfo_node *last = *head;
@@ -163,7 +163,7 @@ struct ares_addrinfo_node *
   return tail;
 }
 
-void ares__addrinfo_cat_nodes(struct ares_addrinfo_node **head,
+void ares_addrinfo_cat_nodes(struct ares_addrinfo_node **head,
                               struct ares_addrinfo_node  *tail)
 {
   struct ares_addrinfo_node *last = *head;
@@ -252,7 +252,7 @@ static ares_bool_t fake_addrinfo(const char *name, unsigned short port,
     ares_bool_t valid   = ARES_TRUE;
     const char *p;
     for (p = name; *p; p++) {
-      if (!ares__isdigit(*p) && *p != '.') {
+      if (!ares_isdigit(*p) && *p != '.') {
         valid = ARES_FALSE;
         break;
       } else if (*p == '.') {
@@ -297,7 +297,7 @@ static ares_bool_t fake_addrinfo(const char *name, unsigned short port,
   }
 
   if (hints->ai_flags & ARES_AI_CANONNAME) {
-    cname = ares__append_addrinfo_cname(&ai->cnames);
+    cname = ares_append_addrinfo_cname(&ai->cnames);
     if (!cname) {
       /* LCOV_EXCL_START: OutOfMemory */
       ares_freeaddrinfo(ai);
@@ -327,7 +327,7 @@ static void hquery_free(struct host_query *hquery, ares_bool_t cleanup_ai)
   if (cleanup_ai) {
     ares_freeaddrinfo(hquery->ai);
   }
-  ares__strsplit_free(hquery->names, hquery->names_cnt);
+  ares_strsplit_free(hquery->names, hquery->names_cnt);
   ares_free(hquery->name);
   ares_free(hquery->lookups);
   ares_free(hquery);
@@ -341,7 +341,7 @@ static void end_hquery(struct host_query *hquery, ares_status_t status)
   if (status == ARES_SUCCESS) {
     if (!(hquery->hints.ai_flags & ARES_AI_NOSORT) && hquery->ai->nodes) {
       sentinel.ai_next = hquery->ai->nodes;
-      ares__sortaddrinfo(hquery->channel, &sentinel);
+      ares_sortaddrinfo(hquery->channel, &sentinel);
       hquery->ai->nodes = sentinel.ai_next;
     }
     next = hquery->ai->nodes;
@@ -361,7 +361,7 @@ static void end_hquery(struct host_query *hquery, ares_status_t status)
   hquery_free(hquery, ARES_FALSE);
 }
 
-ares_bool_t ares__is_localhost(const char *name)
+ares_bool_t ares_is_localhost(const char *name)
 {
   /* RFC6761 6.3 says : The domain "localhost." and any names falling within
    * ".localhost." */
@@ -394,11 +394,11 @@ static ares_status_t file_lookup(struct host_query *hquery)
   ares_status_t             status;
 
   /* Per RFC 7686, reject queries for ".onion" domain names with NXDOMAIN. */
-  if (ares__is_onion_domain(hquery->name)) {
+  if (ares_is_onion_domain(hquery->name)) {
     return ARES_ENOTFOUND;
   }
 
-  status = ares__hosts_search_host(
+  status = ares_hosts_search_host(
     hquery->channel,
     (hquery->hints.ai_flags & ARES_AI_ENVHOSTS) ? ARES_TRUE : ARES_FALSE,
     hquery->name, &entry);
@@ -407,7 +407,7 @@ static ares_status_t file_lookup(struct host_query *hquery)
     goto done;
   }
 
-  status = ares__hosts_entry_to_addrinfo(
+  status = ares_hosts_entry_to_addrinfo(
     entry, hquery->name, hquery->hints.ai_family, hquery->port,
     (hquery->hints.ai_flags & ARES_AI_CANONNAME) ? ARES_TRUE : ARES_FALSE,
     hquery->ai);
@@ -424,8 +424,8 @@ done:
    * We will also ignore ALL errors when trying to resolve localhost, such
    * as permissions errors reading /etc/hosts or a malformed /etc/hosts */
   if (status != ARES_SUCCESS && status != ARES_ENOMEM &&
-      ares__is_localhost(hquery->name)) {
-    return ares__addrinfo_localhost(hquery->name, hquery->port, &hquery->hints,
+      ares_is_localhost(hquery->name)) {
+    return ares_addrinfo_localhost(hquery->name, hquery->port, &hquery->hints,
                                     hquery->ai);
   }
 
@@ -440,7 +440,7 @@ static void next_lookup(struct host_query *hquery, ares_status_t status)
        * queries for localhost names to their configured caching DNS
        * server(s)."
        * Otherwise, DNS lookup. */
-      if (!ares__is_localhost(hquery->name) && next_dns_lookup(hquery)) {
+      if (!ares_is_localhost(hquery->name) && next_dns_lookup(hquery)) {
         break;
       }
 
@@ -477,7 +477,7 @@ static void terminate_retries(const struct host_query *hquery,
     return;
   }
 
-  query = ares__htable_szvp_get_direct(channel->queries_by_qid, term_qid);
+  query = ares_htable_szvp_get_direct(channel->queries_by_qid, term_qid);
   if (query == NULL) {
     return;
   }
@@ -498,7 +498,7 @@ static void host_callback(void *arg, ares_status_t status, size_t timeouts,
       addinfostatus = ARES_EBADRESP; /* LCOV_EXCL_LINE: DefensiveCoding */
     } else {
       addinfostatus =
-        ares__parse_into_addrinfo(dnsrec, ARES_TRUE, hquery->port, hquery->ai);
+        ares_parse_into_addrinfo(dnsrec, ARES_TRUE, hquery->port, hquery->ai);
     }
     if (addinfostatus == ARES_SUCCESS) {
       terminate_retries(hquery, ares_dns_record_get_id(dnsrec));
@@ -530,7 +530,7 @@ static void host_callback(void *arg, ares_status_t status, size_t timeouts,
       }
       next_lookup(hquery, hquery->nodata_cnt ? ARES_ENODATA : status);
     } else if ((status == ARES_ESERVFAIL || status == ARES_EREFUSED) &&
-               ares__name_label_cnt(hquery->names[hquery->next_name_idx - 1]) ==
+               ares_name_label_cnt(hquery->names[hquery->next_name_idx - 1]) ==
                  1) {
       /* Issue #852, systemd-resolved may return SERVFAIL or REFUSED on a
        * single label domain name. */
@@ -567,7 +567,7 @@ static void ares_getaddrinfo_int(ares_channel_t *channel, const char *name,
     return;
   }
 
-  if (ares__is_onion_domain(name)) {
+  if (ares_is_onion_domain(name)) {
     callback(arg, ARES_ENOTFOUND, 0, NULL);
     return;
   }
@@ -630,7 +630,7 @@ static void ares_getaddrinfo_int(ares_channel_t *channel, const char *name,
   }
 
   status =
-    ares__search_name_list(channel, name, &hquery->names, &hquery->names_cnt);
+    ares_search_name_list(channel, name, &hquery->names, &hquery->names_cnt);
   if (status != ARES_SUCCESS) {
     hquery_free(hquery, ARES_TRUE);
     callback(arg, (int)status, 0, NULL);
@@ -659,9 +659,9 @@ void ares_getaddrinfo(ares_channel_t *channel, const char *name,
   if (channel == NULL) {
     return;
   }
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
   ares_getaddrinfo_int(channel, name, service, hints, callback, arg);
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 }
 
 static ares_bool_t next_dns_lookup(struct host_query *hquery)

--- a/src/lib/ares_gethostbyaddr.c
+++ b/src/lib/ares_gethostbyaddr.c
@@ -112,9 +112,9 @@ void ares_gethostbyaddr(ares_channel_t *channel, const void *addr, int addrlen,
   if (channel == NULL) {
     return;
   }
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
   ares_gethostbyaddr_nolock(channel, addr, addrlen, family, callback, arg);
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 }
 
 static void next_lookup(struct addr_query *aquery)
@@ -216,12 +216,12 @@ static ares_status_t file_lookup(ares_channel_t         *channel,
     return ARES_ENOTFOUND;
   }
 
-  status = ares__hosts_search_ipaddr(channel, ARES_FALSE, ipaddr, &entry);
+  status = ares_hosts_search_ipaddr(channel, ARES_FALSE, ipaddr, &entry);
   if (status != ARES_SUCCESS) {
     return status;
   }
 
-  status = ares__hosts_entry_to_hostent(entry, addr->family, host);
+  status = ares_hosts_entry_to_hostent(entry, addr->family, host);
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }

--- a/src/lib/ares_gethostbyname.c
+++ b/src/lib/ares_gethostbyname.c
@@ -239,7 +239,7 @@ static size_t get6_address_index(const struct ares_in6_addr *addr,
 }
 
 static ares_status_t ares_hostent_localhost(const char *name, int family,
-                                             struct hostent **host_out)
+                                            struct hostent **host_out)
 {
   ares_status_t              status;
   struct ares_addrinfo      *ai = NULL;

--- a/src/lib/ares_gethostbyname.c
+++ b/src/lib/ares_gethostbyname.c
@@ -68,7 +68,7 @@ static void ares_gethostbyname_callback(void *arg, int status, int timeouts,
   struct host_query *ghbn_arg = arg;
 
   if (status == ARES_SUCCESS) {
-    status = (int)ares__addrinfo2hostent(result, AF_UNSPEC, &hostent);
+    status = (int)ares_addrinfo2hostent(result, AF_UNSPEC, &hostent);
   }
 
   /* addrinfo2hostent will only return ENODATA if there are no addresses _and_
@@ -175,7 +175,7 @@ static size_t get_address_index(const struct in_addr  *addr,
       continue;
     }
 
-    if (ares__subnet_match(&aaddr, &sortlist[i].addr, sortlist[i].mask)) {
+    if (ares_subnet_match(&aaddr, &sortlist[i].addr, sortlist[i].mask)) {
       break;
     }
   }
@@ -231,14 +231,14 @@ static size_t get6_address_index(const struct ares_in6_addr *addr,
       continue;
     }
 
-    if (ares__subnet_match(&aaddr, &sortlist[i].addr, sortlist[i].mask)) {
+    if (ares_subnet_match(&aaddr, &sortlist[i].addr, sortlist[i].mask)) {
       break;
     }
   }
   return i;
 }
 
-static ares_status_t ares__hostent_localhost(const char *name, int family,
+static ares_status_t ares_hostent_localhost(const char *name, int family,
                                              struct hostent **host_out)
 {
   ares_status_t              status;
@@ -254,12 +254,12 @@ static ares_status_t ares__hostent_localhost(const char *name, int family,
     goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  status = ares__addrinfo_localhost(name, 0, &hints, ai);
+  status = ares_addrinfo_localhost(name, 0, &hints, ai);
   if (status != ARES_SUCCESS) {
     goto done; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  status = ares__addrinfo2hostent(ai, family, host_out);
+  status = ares_addrinfo2hostent(ai, family, host_out);
   if (status != ARES_SUCCESS) {
     goto done; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -289,16 +289,16 @@ static ares_status_t ares_gethostbyname_file_int(ares_channel_t *channel,
   }
 
   /* Per RFC 7686, reject queries for ".onion" domain names with NXDOMAIN. */
-  if (ares__is_onion_domain(name)) {
+  if (ares_is_onion_domain(name)) {
     return ARES_ENOTFOUND;
   }
 
-  status = ares__hosts_search_host(channel, ARES_FALSE, name, &entry);
+  status = ares_hosts_search_host(channel, ARES_FALSE, name, &entry);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  status = ares__hosts_entry_to_hostent(entry, family, host);
+  status = ares_hosts_entry_to_hostent(entry, family, host);
   if (status != ARES_SUCCESS) {
     goto done; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -310,8 +310,8 @@ done:
    * We will also ignore ALL errors when trying to resolve localhost, such
    * as permissions errors reading /etc/hosts or a malformed /etc/hosts */
   if (status != ARES_SUCCESS && status != ARES_ENOMEM &&
-      ares__is_localhost(name)) {
-    return ares__hostent_localhost(name, family, host);
+      ares_is_localhost(name)) {
+    return ares_hostent_localhost(name, family, host);
   }
 
   return status;
@@ -325,8 +325,8 @@ int ares_gethostbyname_file(ares_channel_t *channel, const char *name,
     return ARES_ENOTFOUND;
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
   status = ares_gethostbyname_file_int(channel, name, family, host);
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
   return (int)status;
 }

--- a/src/lib/ares_getnameinfo.c
+++ b/src/lib/ares_getnameinfo.c
@@ -193,9 +193,9 @@ void ares_getnameinfo(ares_channel_t *channel, const struct sockaddr *sa,
     return;
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
   ares_getnameinfo_int(channel, sa, salen, flags_int, callback, arg);
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 }
 
 static void nameinfo_callback(void *arg, int status, int timeouts,
@@ -410,8 +410,8 @@ static char *ares_striendstr(const char *s1, const char *s2)
   c1       = c1_begin;
   c2       = s2;
   while (c2 < s2 + s2_len) {
-    lo1 = ares__tolower((unsigned char)*c1);
-    lo2 = ares__tolower((unsigned char)*c2);
+    lo1 = ares_tolower((unsigned char)*c1);
+    lo2 = ares_tolower((unsigned char)*c2);
     if (lo1 != lo2) {
       return NULL;
     } else {
@@ -423,7 +423,7 @@ static char *ares_striendstr(const char *s1, const char *s2)
   return (char *)((size_t)c1_begin);
 }
 
-ares_bool_t ares__is_onion_domain(const char *name)
+ares_bool_t ares_is_onion_domain(const char *name)
 {
   if (ares_striendstr(name, ".onion")) {
     return ARES_TRUE;

--- a/src/lib/ares_hosts_file.c
+++ b/src/lib/ares_hosts_file.c
@@ -84,16 +84,16 @@ struct ares_hosts_file {
   char                 *filename;
   /*! iphash is the owner of the 'entry' object as there is only ever a single
    *  match to the object. */
-  ares__htable_strvp_t *iphash;
+  ares_htable_strvp_t *iphash;
   /*! hosthash does not own the entry so won't free on destruction */
-  ares__htable_strvp_t *hosthash;
+  ares_htable_strvp_t *hosthash;
 };
 
 struct ares_hosts_entry {
   size_t         refcnt; /*! If the entry is stored multiple times in the
                           *  ip address hash, we have to reference count it */
-  ares__llist_t *ips;
-  ares__llist_t *hosts;
+  ares_llist_t *ips;
+  ares_llist_t *hosts;
 };
 
 const void *ares_dns_pton(const char *ipaddr, struct ares_addr *addr,
@@ -132,7 +132,7 @@ const void *ares_dns_pton(const char *ipaddr, struct ares_addr *addr,
   return ptr;
 }
 
-static ares_bool_t ares__normalize_ipaddr(const char *ipaddr, char *out,
+static ares_bool_t ares_normalize_ipaddr(const char *ipaddr, char *out,
                                           size_t out_len)
 {
   struct ares_addr data;
@@ -154,7 +154,7 @@ static ares_bool_t ares__normalize_ipaddr(const char *ipaddr, char *out,
   return ARES_TRUE;
 }
 
-static void ares__hosts_entry_destroy(ares_hosts_entry_t *entry)
+static void ares_hosts_entry_destroy(ares_hosts_entry_t *entry)
 {
   if (entry == NULL) {
     return;
@@ -169,29 +169,29 @@ static void ares__hosts_entry_destroy(ares_hosts_entry_t *entry)
     return;
   }
 
-  ares__llist_destroy(entry->hosts);
-  ares__llist_destroy(entry->ips);
+  ares_llist_destroy(entry->hosts);
+  ares_llist_destroy(entry->ips);
   ares_free(entry);
 }
 
-static void ares__hosts_entry_destroy_cb(void *entry)
+static void ares_hosts_entry_destroy_cb(void *entry)
 {
-  ares__hosts_entry_destroy(entry);
+  ares_hosts_entry_destroy(entry);
 }
 
-void ares__hosts_file_destroy(ares_hosts_file_t *hf)
+void ares_hosts_file_destroy(ares_hosts_file_t *hf)
 {
   if (hf == NULL) {
     return;
   }
 
   ares_free(hf->filename);
-  ares__htable_strvp_destroy(hf->hosthash);
-  ares__htable_strvp_destroy(hf->iphash);
+  ares_htable_strvp_destroy(hf->hosthash);
+  ares_htable_strvp_destroy(hf->iphash);
   ares_free(hf);
 }
 
-static ares_hosts_file_t *ares__hosts_file_create(const char *filename)
+static ares_hosts_file_t *ares_hosts_file_create(const char *filename)
 {
   ares_hosts_file_t *hf = ares_malloc_zero(sizeof(*hf));
   if (hf == NULL) {
@@ -205,12 +205,12 @@ static ares_hosts_file_t *ares__hosts_file_create(const char *filename)
     goto fail;
   }
 
-  hf->iphash = ares__htable_strvp_create(ares__hosts_entry_destroy_cb);
+  hf->iphash = ares_htable_strvp_create(ares_hosts_entry_destroy_cb);
   if (hf->iphash == NULL) {
     goto fail;
   }
 
-  hf->hosthash = ares__htable_strvp_create(NULL);
+  hf->hosthash = ares_htable_strvp_create(NULL);
   if (hf->hosthash == NULL) {
     goto fail;
   }
@@ -218,7 +218,7 @@ static ares_hosts_file_t *ares__hosts_file_create(const char *filename)
   return hf;
 
 fail:
-  ares__hosts_file_destroy(hf);
+  ares_hosts_file_destroy(hf);
   return NULL;
 }
 
@@ -228,63 +228,63 @@ typedef enum {
   ARES_MATCH_HOST   = 2
 } ares_hosts_file_match_t;
 
-static ares_status_t ares__hosts_file_merge_entry(
+static ares_status_t ares_hosts_file_merge_entry(
   const ares_hosts_file_t *hf, ares_hosts_entry_t *existing,
   ares_hosts_entry_t *entry, ares_hosts_file_match_t matchtype)
 {
-  ares__llist_node_t *node;
+  ares_llist_node_t *node;
 
   /* If we matched on IP address, we know there can only be 1, so there's no
    * reason to do anything */
   if (matchtype != ARES_MATCH_IPADDR) {
-    while ((node = ares__llist_node_first(entry->ips)) != NULL) {
-      const char *ipaddr = ares__llist_node_val(node);
+    while ((node = ares_llist_node_first(entry->ips)) != NULL) {
+      const char *ipaddr = ares_llist_node_val(node);
 
-      if (ares__htable_strvp_get_direct(hf->iphash, ipaddr) != NULL) {
-        ares__llist_node_destroy(node);
+      if (ares_htable_strvp_get_direct(hf->iphash, ipaddr) != NULL) {
+        ares_llist_node_destroy(node);
         continue;
       }
 
-      ares__llist_node_mvparent_last(node, existing->ips);
+      ares_llist_node_mvparent_last(node, existing->ips);
     }
   }
 
 
-  while ((node = ares__llist_node_first(entry->hosts)) != NULL) {
-    const char *hostname = ares__llist_node_val(node);
+  while ((node = ares_llist_node_first(entry->hosts)) != NULL) {
+    const char *hostname = ares_llist_node_val(node);
 
-    if (ares__htable_strvp_get_direct(hf->hosthash, hostname) != NULL) {
-      ares__llist_node_destroy(node);
+    if (ares_htable_strvp_get_direct(hf->hosthash, hostname) != NULL) {
+      ares_llist_node_destroy(node);
       continue;
     }
 
-    ares__llist_node_mvparent_last(node, existing->hosts);
+    ares_llist_node_mvparent_last(node, existing->hosts);
   }
 
-  ares__hosts_entry_destroy(entry);
+  ares_hosts_entry_destroy(entry);
   return ARES_SUCCESS;
 }
 
 static ares_hosts_file_match_t
-  ares__hosts_file_match(const ares_hosts_file_t *hf, ares_hosts_entry_t *entry,
+  ares_hosts_file_match(const ares_hosts_file_t *hf, ares_hosts_entry_t *entry,
                          ares_hosts_entry_t **match)
 {
-  ares__llist_node_t *node;
+  ares_llist_node_t *node;
   *match = NULL;
 
-  for (node = ares__llist_node_first(entry->ips); node != NULL;
-       node = ares__llist_node_next(node)) {
-    const char *ipaddr = ares__llist_node_val(node);
-    *match             = ares__htable_strvp_get_direct(hf->iphash, ipaddr);
+  for (node = ares_llist_node_first(entry->ips); node != NULL;
+       node = ares_llist_node_next(node)) {
+    const char *ipaddr = ares_llist_node_val(node);
+    *match             = ares_htable_strvp_get_direct(hf->iphash, ipaddr);
     if (*match != NULL) {
       return ARES_MATCH_IPADDR;
     }
   }
 
-  for (node = ares__llist_node_first(entry->hosts); node != NULL;
-       node = ares__llist_node_next(node)) {
-    const char *host = ares__llist_node_val(node);
-    *match           = ares__htable_strvp_get_direct(hf->hosthash, host);
+  for (node = ares_llist_node_first(entry->hosts); node != NULL;
+       node = ares_llist_node_next(node)) {
+    const char *host = ares_llist_node_val(node);
+    *match           = ares_htable_strvp_get_direct(hf->hosthash, host);
     if (*match != NULL) {
       return ARES_MATCH_HOST;
     }
@@ -294,26 +294,26 @@ static ares_hosts_file_match_t
 }
 
 /*! entry is invalidated upon calling this function, always, even on error */
-static ares_status_t ares__hosts_file_add(ares_hosts_file_t  *hosts,
+static ares_status_t ares_hosts_file_add(ares_hosts_file_t  *hosts,
                                           ares_hosts_entry_t *entry)
 {
   ares_hosts_entry_t     *match  = NULL;
   ares_status_t           status = ARES_SUCCESS;
-  ares__llist_node_t     *node;
+  ares_llist_node_t     *node;
   ares_hosts_file_match_t matchtype;
   size_t                  num_hostnames;
 
   /* Record the number of hostnames in this entry file.  If we merge into an
    * existing record, these will be *appended* to the entry, so we'll count
    * backwards when adding to the hosts hashtable */
-  num_hostnames = ares__llist_len(entry->hosts);
+  num_hostnames = ares_llist_len(entry->hosts);
 
-  matchtype = ares__hosts_file_match(hosts, entry, &match);
+  matchtype = ares_hosts_file_match(hosts, entry, &match);
 
   if (matchtype != ARES_MATCH_NONE) {
-    status = ares__hosts_file_merge_entry(hosts, match, entry, matchtype);
+    status = ares_hosts_file_merge_entry(hosts, match, entry, matchtype);
     if (status != ARES_SUCCESS) {
-      ares__hosts_entry_destroy(entry); /* LCOV_EXCL_LINE: DefensiveCoding */
+      ares_hosts_entry_destroy(entry); /* LCOV_EXCL_LINE: DefensiveCoding */
       return status;                    /* LCOV_EXCL_LINE: DefensiveCoding */
     }
     /* entry was invalidated above by merging */
@@ -321,11 +321,11 @@ static ares_status_t ares__hosts_file_add(ares_hosts_file_t  *hosts,
   }
 
   if (matchtype != ARES_MATCH_IPADDR) {
-    const char *ipaddr = ares__llist_last_val(entry->ips);
+    const char *ipaddr = ares_llist_last_val(entry->ips);
 
-    if (!ares__htable_strvp_get(hosts->iphash, ipaddr, NULL)) {
-      if (!ares__htable_strvp_insert(hosts->iphash, ipaddr, entry)) {
-        ares__hosts_entry_destroy(entry);
+    if (!ares_htable_strvp_get(hosts->iphash, ipaddr, NULL)) {
+      if (!ares_htable_strvp_insert(hosts->iphash, ipaddr, entry)) {
+        ares_hosts_entry_destroy(entry);
         return ARES_ENOMEM;
       }
       entry->refcnt++;
@@ -334,9 +334,9 @@ static ares_status_t ares__hosts_file_add(ares_hosts_file_t  *hosts,
 
   /* Go backwards, on a merge, hostnames are appended.  Breakout once we've
    * consumed all the hosts that we appended */
-  for (node = ares__llist_node_last(entry->hosts); node != NULL;
-       node = ares__llist_node_prev(node)) {
-    const char *val = ares__llist_node_val(node);
+  for (node = ares_llist_node_last(entry->hosts); node != NULL;
+       node = ares_llist_node_prev(node)) {
+    const char *val = ares_llist_node_val(node);
 
     if (num_hostnames == 0) {
       break;
@@ -346,11 +346,11 @@ static ares_status_t ares__hosts_file_add(ares_hosts_file_t  *hosts,
 
     /* first hostname match wins.  If we detect a duplicate hostname for another
      * ip it will automatically be added to the same entry */
-    if (ares__htable_strvp_get(hosts->hosthash, val, NULL)) {
+    if (ares_htable_strvp_get(hosts->hosthash, val, NULL)) {
       continue;
     }
 
-    if (!ares__htable_strvp_insert(hosts->hosthash, val, entry)) {
+    if (!ares_htable_strvp_insert(hosts->hosthash, val, entry)) {
       return ARES_ENOMEM;
     }
   }
@@ -358,14 +358,14 @@ static ares_status_t ares__hosts_file_add(ares_hosts_file_t  *hosts,
   return ARES_SUCCESS;
 }
 
-static ares_bool_t ares__hosts_entry_isdup(ares_hosts_entry_t *entry,
+static ares_bool_t ares_hosts_entry_isdup(ares_hosts_entry_t *entry,
                                            const char         *host)
 {
-  ares__llist_node_t *node;
+  ares_llist_node_t *node;
 
-  for (node = ares__llist_node_first(entry->ips); node != NULL;
-       node = ares__llist_node_next(node)) {
-    const char *myhost = ares__llist_node_val(node);
+  for (node = ares_llist_node_first(entry->ips); node != NULL;
+       node = ares_llist_node_next(node)) {
+    const char *myhost = ares_llist_node_val(node);
     if (ares_strcaseeq(myhost, host)) {
       return ARES_TRUE;
     }
@@ -374,44 +374,44 @@ static ares_bool_t ares__hosts_entry_isdup(ares_hosts_entry_t *entry,
   return ARES_FALSE;
 }
 
-static ares_status_t ares__parse_hosts_hostnames(ares__buf_t        *buf,
+static ares_status_t ares_parse_hosts_hostnames(ares_buf_t        *buf,
                                                  ares_hosts_entry_t *entry)
 {
-  entry->hosts = ares__llist_create(ares_free);
+  entry->hosts = ares_llist_create(ares_free);
   if (entry->hosts == NULL) {
     return ARES_ENOMEM;
   }
 
   /* Parse hostnames and aliases */
-  while (ares__buf_len(buf)) {
+  while (ares_buf_len(buf)) {
     char          hostname[256];
     char         *temp;
     ares_status_t status;
     unsigned char comment = '#';
 
-    ares__buf_consume_whitespace(buf, ARES_FALSE);
+    ares_buf_consume_whitespace(buf, ARES_FALSE);
 
-    if (ares__buf_len(buf) == 0) {
+    if (ares_buf_len(buf) == 0) {
       break;
     }
 
     /* See if it is a comment, if so stop processing */
-    if (ares__buf_begins_with(buf, &comment, 1)) {
+    if (ares_buf_begins_with(buf, &comment, 1)) {
       break;
     }
 
-    ares__buf_tag(buf);
+    ares_buf_tag(buf);
 
     /* Must be at end of line */
-    if (ares__buf_consume_nonwhitespace(buf) == 0) {
+    if (ares_buf_consume_nonwhitespace(buf) == 0) {
       break;
     }
 
-    status = ares__buf_tag_fetch_string(buf, hostname, sizeof(hostname));
+    status = ares_buf_tag_fetch_string(buf, hostname, sizeof(hostname));
     if (status != ARES_SUCCESS) {
       /* Bad entry, just ignore as long as its not the first.  If its the first,
        * it must be valid */
-      if (ares__llist_len(entry->hosts) == 0) {
+      if (ares_llist_len(entry->hosts) == 0) {
         return ARES_EBADSTR;
       }
 
@@ -419,12 +419,12 @@ static ares_status_t ares__parse_hosts_hostnames(ares__buf_t        *buf,
     }
 
     /* Validate it is a valid hostname characterset */
-    if (!ares__is_hostname(hostname)) {
+    if (!ares_is_hostname(hostname)) {
       continue;
     }
 
     /* Don't add a duplicate to the same entry */
-    if (ares__hosts_entry_isdup(entry, hostname)) {
+    if (ares_hosts_entry_isdup(entry, hostname)) {
       continue;
     }
 
@@ -434,21 +434,21 @@ static ares_status_t ares__parse_hosts_hostnames(ares__buf_t        *buf,
       return ARES_ENOMEM;
     }
 
-    if (ares__llist_insert_last(entry->hosts, temp) == NULL) {
+    if (ares_llist_insert_last(entry->hosts, temp) == NULL) {
       ares_free(temp);
       return ARES_ENOMEM;
     }
   }
 
   /* Must have at least 1 entry */
-  if (ares__llist_len(entry->hosts) == 0) {
+  if (ares_llist_len(entry->hosts) == 0) {
     return ARES_EBADSTR;
   }
 
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares__parse_hosts_ipaddr(ares__buf_t         *buf,
+static ares_status_t ares_parse_hosts_ipaddr(ares_buf_t         *buf,
                                               ares_hosts_entry_t **entry_out)
 {
   char                addr[INET6_ADDRSTRLEN];
@@ -458,15 +458,15 @@ static ares_status_t ares__parse_hosts_ipaddr(ares__buf_t         *buf,
 
   *entry_out = NULL;
 
-  ares__buf_tag(buf);
-  ares__buf_consume_nonwhitespace(buf);
-  status = ares__buf_tag_fetch_string(buf, addr, sizeof(addr));
+  ares_buf_tag(buf);
+  ares_buf_consume_nonwhitespace(buf);
+  status = ares_buf_tag_fetch_string(buf, addr, sizeof(addr));
   if (status != ARES_SUCCESS) {
     return status;
   }
 
   /* Validate and normalize the ip address format */
-  if (!ares__normalize_ipaddr(addr, addr, sizeof(addr))) {
+  if (!ares_normalize_ipaddr(addr, addr, sizeof(addr))) {
     return ARES_EBADSTR;
   }
 
@@ -475,21 +475,21 @@ static ares_status_t ares__parse_hosts_ipaddr(ares__buf_t         *buf,
     return ARES_ENOMEM;
   }
 
-  entry->ips = ares__llist_create(ares_free);
+  entry->ips = ares_llist_create(ares_free);
   if (entry->ips == NULL) {
-    ares__hosts_entry_destroy(entry);
+    ares_hosts_entry_destroy(entry);
     return ARES_ENOMEM;
   }
 
   temp = ares_strdup(addr);
   if (temp == NULL) {
-    ares__hosts_entry_destroy(entry);
+    ares_hosts_entry_destroy(entry);
     return ARES_ENOMEM;
   }
 
-  if (ares__llist_insert_first(entry->ips, temp) == NULL) {
+  if (ares_llist_insert_first(entry->ips, temp) == NULL) {
     ares_free(temp);
-    ares__hosts_entry_destroy(entry);
+    ares_hosts_entry_destroy(entry);
     return ARES_ENOMEM;
   }
 
@@ -498,99 +498,99 @@ static ares_status_t ares__parse_hosts_ipaddr(ares__buf_t         *buf,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares__parse_hosts(const char         *filename,
+static ares_status_t ares_parse_hosts(const char         *filename,
                                        ares_hosts_file_t **out)
 {
-  ares__buf_t        *buf    = NULL;
+  ares_buf_t        *buf    = NULL;
   ares_status_t       status = ARES_EBADRESP;
   ares_hosts_file_t  *hf     = NULL;
   ares_hosts_entry_t *entry  = NULL;
 
   *out = NULL;
 
-  buf = ares__buf_create();
+  buf = ares_buf_create();
   if (buf == NULL) {
     status = ARES_ENOMEM;
     goto done;
   }
 
-  status = ares__buf_load_file(filename, buf);
+  status = ares_buf_load_file(filename, buf);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  hf = ares__hosts_file_create(filename);
+  hf = ares_hosts_file_create(filename);
   if (hf == NULL) {
     status = ARES_ENOMEM;
     goto done;
   }
 
-  while (ares__buf_len(buf)) {
+  while (ares_buf_len(buf)) {
     unsigned char comment = '#';
 
     /* -- Start of new line here -- */
 
     /* Consume any leading whitespace */
-    ares__buf_consume_whitespace(buf, ARES_FALSE);
+    ares_buf_consume_whitespace(buf, ARES_FALSE);
 
-    if (ares__buf_len(buf) == 0) {
+    if (ares_buf_len(buf) == 0) {
       break;
     }
 
     /* See if it is a comment, if so, consume remaining line */
-    if (ares__buf_begins_with(buf, &comment, 1)) {
-      ares__buf_consume_line(buf, ARES_TRUE);
+    if (ares_buf_begins_with(buf, &comment, 1)) {
+      ares_buf_consume_line(buf, ARES_TRUE);
       continue;
     }
 
     /* Pull off ip address */
-    status = ares__parse_hosts_ipaddr(buf, &entry);
+    status = ares_parse_hosts_ipaddr(buf, &entry);
     if (status == ARES_ENOMEM) {
       goto done;
     }
     if (status != ARES_SUCCESS) {
       /* Bad line, consume and go onto next */
-      ares__buf_consume_line(buf, ARES_TRUE);
+      ares_buf_consume_line(buf, ARES_TRUE);
       continue;
     }
 
     /* Parse of the hostnames */
-    status = ares__parse_hosts_hostnames(buf, entry);
+    status = ares_parse_hosts_hostnames(buf, entry);
     if (status == ARES_ENOMEM) {
       goto done;
     } else if (status != ARES_SUCCESS) {
       /* Bad line, consume and go onto next */
-      ares__hosts_entry_destroy(entry);
+      ares_hosts_entry_destroy(entry);
       entry = NULL;
-      ares__buf_consume_line(buf, ARES_TRUE);
+      ares_buf_consume_line(buf, ARES_TRUE);
       continue;
     }
 
     /* Append the successful entry to the hosts file */
-    status = ares__hosts_file_add(hf, entry);
+    status = ares_hosts_file_add(hf, entry);
     entry  = NULL; /* is always invalidated by this function, even on error */
     if (status != ARES_SUCCESS) {
       goto done;
     }
 
     /* Go to next line */
-    ares__buf_consume_line(buf, ARES_TRUE);
+    ares_buf_consume_line(buf, ARES_TRUE);
   }
 
   status = ARES_SUCCESS;
 
 done:
-  ares__hosts_entry_destroy(entry);
-  ares__buf_destroy(buf);
+  ares_hosts_entry_destroy(entry);
+  ares_buf_destroy(buf);
   if (status != ARES_SUCCESS) {
-    ares__hosts_file_destroy(hf);
+    ares_hosts_file_destroy(hf);
   } else {
     *out = hf;
   }
   return status;
 }
 
-static ares_bool_t ares__hosts_expired(const char              *filename,
+static ares_bool_t ares_hosts_expired(const char              *filename,
                                        const ares_hosts_file_t *hf)
 {
   time_t mod_ts = 0;
@@ -631,7 +631,7 @@ static ares_bool_t ares__hosts_expired(const char              *filename,
   return ARES_FALSE;
 }
 
-static ares_status_t ares__hosts_path(const ares_channel_t *channel,
+static ares_status_t ares_hosts_path(const ares_channel_t *channel,
                                       ares_bool_t use_env, char **path)
 {
   char *path_hosts = NULL;
@@ -688,31 +688,31 @@ static ares_status_t ares__hosts_path(const ares_channel_t *channel,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares__hosts_update(ares_channel_t *channel,
+static ares_status_t ares_hosts_update(ares_channel_t *channel,
                                         ares_bool_t     use_env)
 {
   ares_status_t status;
   char         *filename = NULL;
 
-  status = ares__hosts_path(channel, use_env, &filename);
+  status = ares_hosts_path(channel, use_env, &filename);
   if (status != ARES_SUCCESS) {
     return status;
   }
 
-  if (!ares__hosts_expired(filename, channel->hf)) {
+  if (!ares_hosts_expired(filename, channel->hf)) {
     ares_free(filename);
     return ARES_SUCCESS;
   }
 
-  ares__hosts_file_destroy(channel->hf);
+  ares_hosts_file_destroy(channel->hf);
   channel->hf = NULL;
 
-  status = ares__parse_hosts(filename, &channel->hf);
+  status = ares_parse_hosts(filename, &channel->hf);
   ares_free(filename);
   return status;
 }
 
-ares_status_t ares__hosts_search_ipaddr(ares_channel_t *channel,
+ares_status_t ares_hosts_search_ipaddr(ares_channel_t *channel,
                                         ares_bool_t use_env, const char *ipaddr,
                                         const ares_hosts_entry_t **entry)
 {
@@ -721,7 +721,7 @@ ares_status_t ares__hosts_search_ipaddr(ares_channel_t *channel,
 
   *entry = NULL;
 
-  status = ares__hosts_update(channel, use_env);
+  status = ares_hosts_update(channel, use_env);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -730,11 +730,11 @@ ares_status_t ares__hosts_search_ipaddr(ares_channel_t *channel,
     return ARES_ENOTFOUND; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  if (!ares__normalize_ipaddr(ipaddr, addr, sizeof(addr))) {
+  if (!ares_normalize_ipaddr(ipaddr, addr, sizeof(addr))) {
     return ARES_EBADNAME;
   }
 
-  *entry = ares__htable_strvp_get_direct(channel->hf->iphash, addr);
+  *entry = ares_htable_strvp_get_direct(channel->hf->iphash, addr);
   if (*entry == NULL) {
     return ARES_ENOTFOUND;
   }
@@ -742,7 +742,7 @@ ares_status_t ares__hosts_search_ipaddr(ares_channel_t *channel,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__hosts_search_host(ares_channel_t *channel,
+ares_status_t ares_hosts_search_host(ares_channel_t *channel,
                                       ares_bool_t use_env, const char *host,
                                       const ares_hosts_entry_t **entry)
 {
@@ -750,7 +750,7 @@ ares_status_t ares__hosts_search_host(ares_channel_t *channel,
 
   *entry = NULL;
 
-  status = ares__hosts_update(channel, use_env);
+  status = ares_hosts_update(channel, use_env);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -759,7 +759,7 @@ ares_status_t ares__hosts_search_host(ares_channel_t *channel,
     return ARES_ENOTFOUND; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  *entry = ares__htable_strvp_get_direct(channel->hf->hosthash, host);
+  *entry = ares_htable_strvp_get_direct(channel->hf->hosthash, host);
   if (*entry == NULL) {
     return ARES_ENOTFOUND;
   }
@@ -768,23 +768,23 @@ ares_status_t ares__hosts_search_host(ares_channel_t *channel,
 }
 
 static ares_status_t
-  ares__hosts_ai_append_cnames(const ares_hosts_entry_t    *entry,
+  ares_hosts_ai_append_cnames(const ares_hosts_entry_t    *entry,
                                struct ares_addrinfo_cname **cnames_out)
 {
   struct ares_addrinfo_cname *cname  = NULL;
   struct ares_addrinfo_cname *cnames = NULL;
   const char                 *primaryhost;
-  ares__llist_node_t         *node;
+  ares_llist_node_t         *node;
   ares_status_t               status;
   size_t                      cnt = 0;
 
-  node        = ares__llist_node_first(entry->hosts);
-  primaryhost = ares__llist_node_val(node);
+  node        = ares_llist_node_first(entry->hosts);
+  primaryhost = ares_llist_node_val(node);
   /* Skip to next node to start with aliases */
-  node = ares__llist_node_next(node);
+  node = ares_llist_node_next(node);
 
   while (node != NULL) {
-    const char *host = ares__llist_node_val(node);
+    const char *host = ares_llist_node_val(node);
 
     /* Cap at 100 entries. , some people use
      * https://github.com/StevenBlack/hosts and we don't need 200k+ aliases */
@@ -793,7 +793,7 @@ static ares_status_t
       break; /* LCOV_EXCL_LINE: DefensiveCoding */
     }
 
-    cname = ares__append_addrinfo_cname(&cnames);
+    cname = ares_append_addrinfo_cname(&cnames);
     if (cname == NULL) {
       status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
       goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
@@ -811,12 +811,12 @@ static ares_status_t
       goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
-    node = ares__llist_node_next(node);
+    node = ares_llist_node_next(node);
   }
 
   /* No entries, add only primary */
   if (cnames == NULL) {
-    cname = ares__append_addrinfo_cname(&cnames);
+    cname = ares_append_addrinfo_cname(&cnames);
     if (cname == NULL) {
       status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
       goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
@@ -832,7 +832,7 @@ static ares_status_t
 
 done:
   if (status != ARES_SUCCESS) {
-    ares__freeaddrinfo_cnames(cnames); /* LCOV_EXCL_LINE: DefensiveCoding */
+    ares_freeaddrinfo_cnames(cnames); /* LCOV_EXCL_LINE: DefensiveCoding */
     return status;                     /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
@@ -840,7 +840,7 @@ done:
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__hosts_entry_to_addrinfo(const ares_hosts_entry_t *entry,
+ares_status_t ares_hosts_entry_to_addrinfo(const ares_hosts_entry_t *entry,
                                             const char *name, int family,
                                             unsigned short        port,
                                             ares_bool_t           want_cnames,
@@ -849,7 +849,7 @@ ares_status_t ares__hosts_entry_to_addrinfo(const ares_hosts_entry_t *entry,
   ares_status_t               status;
   struct ares_addrinfo_cname *cnames  = NULL;
   struct ares_addrinfo_node  *ainodes = NULL;
-  ares__llist_node_t         *node;
+  ares_llist_node_t         *node;
 
   switch (family) {
     case AF_INET:
@@ -868,12 +868,12 @@ ares_status_t ares__hosts_entry_to_addrinfo(const ares_hosts_entry_t *entry,
     }
   }
 
-  for (node = ares__llist_node_first(entry->ips); node != NULL;
-       node = ares__llist_node_next(node)) {
+  for (node = ares_llist_node_first(entry->ips); node != NULL;
+       node = ares_llist_node_next(node)) {
     struct ares_addr addr;
     const void      *ptr     = NULL;
     size_t           ptr_len = 0;
-    const char      *ipaddr  = ares__llist_node_val(node);
+    const char      *ipaddr  = ares_llist_node_val(node);
 
     memset(&addr, 0, sizeof(addr));
     addr.family = family;
@@ -890,7 +890,7 @@ ares_status_t ares__hosts_entry_to_addrinfo(const ares_hosts_entry_t *entry,
   }
 
   if (want_cnames) {
-    status = ares__hosts_ai_append_cnames(entry, &cnames);
+    status = ares_hosts_ai_append_cnames(entry, &cnames);
     if (status != ARES_SUCCESS) {
       goto done; /* LCOV_EXCL_LINE: DefensiveCoding */
     }
@@ -901,20 +901,20 @@ ares_status_t ares__hosts_entry_to_addrinfo(const ares_hosts_entry_t *entry,
 done:
   if (status != ARES_SUCCESS) {
     /* LCOV_EXCL_START: defensive coding */
-    ares__freeaddrinfo_cnames(cnames);
-    ares__freeaddrinfo_nodes(ainodes);
+    ares_freeaddrinfo_cnames(cnames);
+    ares_freeaddrinfo_nodes(ainodes);
     ares_free(ai->name);
     ai->name = NULL;
     return status;
     /* LCOV_EXCL_STOP */
   }
-  ares__addrinfo_cat_cnames(&ai->cnames, cnames);
-  ares__addrinfo_cat_nodes(&ai->nodes, ainodes);
+  ares_addrinfo_cat_cnames(&ai->cnames, cnames);
+  ares_addrinfo_cat_nodes(&ai->nodes, ainodes);
 
   return status;
 }
 
-ares_status_t ares__hosts_entry_to_hostent(const ares_hosts_entry_t *entry,
+ares_status_t ares_hosts_entry_to_hostent(const ares_hosts_entry_t *entry,
                                            int family, struct hostent **hostent)
 {
   ares_status_t         status;
@@ -926,12 +926,12 @@ ares_status_t ares__hosts_entry_to_hostent(const ares_hosts_entry_t *entry,
     return ARES_ENOMEM;
   }
 
-  status = ares__hosts_entry_to_addrinfo(entry, NULL, family, 0, ARES_TRUE, ai);
+  status = ares_hosts_entry_to_addrinfo(entry, NULL, family, 0, ARES_TRUE, ai);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  status = ares__addrinfo2hostent(ai, family, hostent);
+  status = ares_addrinfo2hostent(ai, family, hostent);
   if (status != ARES_SUCCESS) {
     goto done;
   }

--- a/src/lib/ares_hosts_file.c
+++ b/src/lib/ares_hosts_file.c
@@ -78,10 +78,10 @@
  */
 
 struct ares_hosts_file {
-  time_t                ts;
+  time_t               ts;
   /*! cache the filename so we know if the filename changes it automatically
    *  invalidates the cache */
-  char                 *filename;
+  char                *filename;
   /*! iphash is the owner of the 'entry' object as there is only ever a single
    *  match to the object. */
   ares_htable_strvp_t *iphash;
@@ -90,8 +90,8 @@ struct ares_hosts_file {
 };
 
 struct ares_hosts_entry {
-  size_t         refcnt; /*! If the entry is stored multiple times in the
-                          *  ip address hash, we have to reference count it */
+  size_t        refcnt; /*! If the entry is stored multiple times in the
+                         *  ip address hash, we have to reference count it */
   ares_llist_t *ips;
   ares_llist_t *hosts;
 };
@@ -133,7 +133,7 @@ const void *ares_dns_pton(const char *ipaddr, struct ares_addr *addr,
 }
 
 static ares_bool_t ares_normalize_ipaddr(const char *ipaddr, char *out,
-                                          size_t out_len)
+                                         size_t out_len)
 {
   struct ares_addr data;
   const void      *addr;
@@ -267,7 +267,7 @@ static ares_status_t ares_hosts_file_merge_entry(
 
 static ares_hosts_file_match_t
   ares_hosts_file_match(const ares_hosts_file_t *hf, ares_hosts_entry_t *entry,
-                         ares_hosts_entry_t **match)
+                        ares_hosts_entry_t **match)
 {
   ares_llist_node_t *node;
   *match = NULL;
@@ -295,11 +295,11 @@ static ares_hosts_file_match_t
 
 /*! entry is invalidated upon calling this function, always, even on error */
 static ares_status_t ares_hosts_file_add(ares_hosts_file_t  *hosts,
-                                          ares_hosts_entry_t *entry)
+                                         ares_hosts_entry_t *entry)
 {
   ares_hosts_entry_t     *match  = NULL;
   ares_status_t           status = ARES_SUCCESS;
-  ares_llist_node_t     *node;
+  ares_llist_node_t      *node;
   ares_hosts_file_match_t matchtype;
   size_t                  num_hostnames;
 
@@ -314,7 +314,7 @@ static ares_status_t ares_hosts_file_add(ares_hosts_file_t  *hosts,
     status = ares_hosts_file_merge_entry(hosts, match, entry, matchtype);
     if (status != ARES_SUCCESS) {
       ares_hosts_entry_destroy(entry); /* LCOV_EXCL_LINE: DefensiveCoding */
-      return status;                    /* LCOV_EXCL_LINE: DefensiveCoding */
+      return status;                   /* LCOV_EXCL_LINE: DefensiveCoding */
     }
     /* entry was invalidated above by merging */
     entry = match;
@@ -359,7 +359,7 @@ static ares_status_t ares_hosts_file_add(ares_hosts_file_t  *hosts,
 }
 
 static ares_bool_t ares_hosts_entry_isdup(ares_hosts_entry_t *entry,
-                                           const char         *host)
+                                          const char         *host)
 {
   ares_llist_node_t *node;
 
@@ -374,8 +374,8 @@ static ares_bool_t ares_hosts_entry_isdup(ares_hosts_entry_t *entry,
   return ARES_FALSE;
 }
 
-static ares_status_t ares_parse_hosts_hostnames(ares_buf_t        *buf,
-                                                 ares_hosts_entry_t *entry)
+static ares_status_t ares_parse_hosts_hostnames(ares_buf_t         *buf,
+                                                ares_hosts_entry_t *entry)
 {
   entry->hosts = ares_llist_create(ares_free);
   if (entry->hosts == NULL) {
@@ -448,8 +448,8 @@ static ares_status_t ares_parse_hosts_hostnames(ares_buf_t        *buf,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_parse_hosts_ipaddr(ares_buf_t         *buf,
-                                              ares_hosts_entry_t **entry_out)
+static ares_status_t ares_parse_hosts_ipaddr(ares_buf_t          *buf,
+                                             ares_hosts_entry_t **entry_out)
 {
   char                addr[INET6_ADDRSTRLEN];
   char               *temp;
@@ -499,9 +499,9 @@ static ares_status_t ares_parse_hosts_ipaddr(ares_buf_t         *buf,
 }
 
 static ares_status_t ares_parse_hosts(const char         *filename,
-                                       ares_hosts_file_t **out)
+                                      ares_hosts_file_t **out)
 {
-  ares_buf_t        *buf    = NULL;
+  ares_buf_t         *buf    = NULL;
   ares_status_t       status = ARES_EBADRESP;
   ares_hosts_file_t  *hf     = NULL;
   ares_hosts_entry_t *entry  = NULL;
@@ -591,7 +591,7 @@ done:
 }
 
 static ares_bool_t ares_hosts_expired(const char              *filename,
-                                       const ares_hosts_file_t *hf)
+                                      const ares_hosts_file_t *hf)
 {
   time_t mod_ts = 0;
 
@@ -632,7 +632,7 @@ static ares_bool_t ares_hosts_expired(const char              *filename,
 }
 
 static ares_status_t ares_hosts_path(const ares_channel_t *channel,
-                                      ares_bool_t use_env, char **path)
+                                     ares_bool_t use_env, char **path)
 {
   char *path_hosts = NULL;
 
@@ -689,7 +689,7 @@ static ares_status_t ares_hosts_path(const ares_channel_t *channel,
 }
 
 static ares_status_t ares_hosts_update(ares_channel_t *channel,
-                                        ares_bool_t     use_env)
+                                       ares_bool_t     use_env)
 {
   ares_status_t status;
   char         *filename = NULL;
@@ -713,8 +713,8 @@ static ares_status_t ares_hosts_update(ares_channel_t *channel,
 }
 
 ares_status_t ares_hosts_search_ipaddr(ares_channel_t *channel,
-                                        ares_bool_t use_env, const char *ipaddr,
-                                        const ares_hosts_entry_t **entry)
+                                       ares_bool_t use_env, const char *ipaddr,
+                                       const ares_hosts_entry_t **entry)
 {
   ares_status_t status;
   char          addr[INET6_ADDRSTRLEN];
@@ -743,8 +743,8 @@ ares_status_t ares_hosts_search_ipaddr(ares_channel_t *channel,
 }
 
 ares_status_t ares_hosts_search_host(ares_channel_t *channel,
-                                      ares_bool_t use_env, const char *host,
-                                      const ares_hosts_entry_t **entry)
+                                     ares_bool_t use_env, const char *host,
+                                     const ares_hosts_entry_t **entry)
 {
   ares_status_t status;
 
@@ -769,12 +769,12 @@ ares_status_t ares_hosts_search_host(ares_channel_t *channel,
 
 static ares_status_t
   ares_hosts_ai_append_cnames(const ares_hosts_entry_t    *entry,
-                               struct ares_addrinfo_cname **cnames_out)
+                              struct ares_addrinfo_cname **cnames_out)
 {
   struct ares_addrinfo_cname *cname  = NULL;
   struct ares_addrinfo_cname *cnames = NULL;
   const char                 *primaryhost;
-  ares_llist_node_t         *node;
+  ares_llist_node_t          *node;
   ares_status_t               status;
   size_t                      cnt = 0;
 
@@ -833,7 +833,7 @@ static ares_status_t
 done:
   if (status != ARES_SUCCESS) {
     ares_freeaddrinfo_cnames(cnames); /* LCOV_EXCL_LINE: DefensiveCoding */
-    return status;                     /* LCOV_EXCL_LINE: DefensiveCoding */
+    return status;                    /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
   *cnames_out = cnames;
@@ -841,15 +841,15 @@ done:
 }
 
 ares_status_t ares_hosts_entry_to_addrinfo(const ares_hosts_entry_t *entry,
-                                            const char *name, int family,
-                                            unsigned short        port,
-                                            ares_bool_t           want_cnames,
-                                            struct ares_addrinfo *ai)
+                                           const char *name, int family,
+                                           unsigned short        port,
+                                           ares_bool_t           want_cnames,
+                                           struct ares_addrinfo *ai)
 {
   ares_status_t               status;
   struct ares_addrinfo_cname *cnames  = NULL;
   struct ares_addrinfo_node  *ainodes = NULL;
-  ares_llist_node_t         *node;
+  ares_llist_node_t          *node;
 
   switch (family) {
     case AF_INET:
@@ -915,7 +915,7 @@ done:
 }
 
 ares_status_t ares_hosts_entry_to_hostent(const ares_hosts_entry_t *entry,
-                                           int family, struct hostent **hostent)
+                                          int family, struct hostent **hostent)
 {
   ares_status_t         status;
   struct ares_addrinfo *ai = ares_malloc_zero(sizeof(*ai));

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -117,7 +117,7 @@ static void server_destroy_cb(void *data)
   if (data == NULL) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
-  ares__destroy_server(data);
+  ares_destroy_server(data);
 }
 
 static ares_status_t init_by_defaults(ares_channel_t *channel)
@@ -128,7 +128,7 @@ static ares_status_t init_by_defaults(ares_channel_t *channel)
   const char *dot;
 #endif
   struct ares_addr addr;
-  ares__llist_t   *sconfig = NULL;
+  ares_llist_t   *sconfig = NULL;
 
   /* Enable EDNS by default */
   if (!(channel->optmask & ARES_OPT_FLAGS)) {
@@ -146,7 +146,7 @@ static ares_status_t init_by_defaults(ares_channel_t *channel)
     channel->tries = DEFAULT_TRIES;
   }
 
-  if (ares__slist_len(channel->servers) == 0) {
+  if (ares_slist_len(channel->servers) == 0) {
     /* Add a default local named server to the channel unless configured not
      * to (in which case return an error).
      */
@@ -158,13 +158,13 @@ static ares_status_t init_by_defaults(ares_channel_t *channel)
     addr.family            = AF_INET;
     addr.addr.addr4.s_addr = htonl(INADDR_LOOPBACK);
 
-    rc = ares__sconfig_append(&sconfig, &addr, 0, 0, NULL);
+    rc = ares_sconfig_append(&sconfig, &addr, 0, 0, NULL);
     if (rc != ARES_SUCCESS) {
       goto error; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
-    rc = ares__servers_update(channel, sconfig, ARES_FALSE);
-    ares__llist_destroy(sconfig);
+    rc = ares_servers_update(channel, sconfig, ARES_FALSE);
+    ares_llist_destroy(sconfig);
 
     if (rc != ARES_SUCCESS) {
       goto error;
@@ -258,13 +258,13 @@ int ares_init_options(ares_channel_t           **channelptr,
   /* One option where zero is valid, so set default value here */
   channel->ndots = 1;
 
-  status = ares__channel_threading_init(channel);
+  status = ares_channel_threading_init(channel);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
   /* Generate random key */
-  channel->rand_state = ares__init_rand_state();
+  channel->rand_state = ares_init_rand_state();
   if (channel->rand_state == NULL) {
     status = ARES_ENOMEM;
     DEBUGF(fprintf(stderr, "Error: init_id_key failed: %s\n",
@@ -274,33 +274,33 @@ int ares_init_options(ares_channel_t           **channelptr,
 
   /* Initialize Server List */
   channel->servers =
-    ares__slist_create(channel->rand_state, server_sort_cb, server_destroy_cb);
+    ares_slist_create(channel->rand_state, server_sort_cb, server_destroy_cb);
   if (channel->servers == NULL) {
     status = ARES_ENOMEM;
     goto done;
   }
 
   /* Initialize our lists of queries */
-  channel->all_queries = ares__llist_create(NULL);
+  channel->all_queries = ares_llist_create(NULL);
   if (channel->all_queries == NULL) {
     status = ARES_ENOMEM;
     goto done;
   }
 
-  channel->queries_by_qid = ares__htable_szvp_create(NULL);
+  channel->queries_by_qid = ares_htable_szvp_create(NULL);
   if (channel->queries_by_qid == NULL) {
     status = ARES_ENOMEM;
     goto done;
   }
 
   channel->queries_by_timeout =
-    ares__slist_create(channel->rand_state, ares_query_timeout_cmp_cb, NULL);
+    ares_slist_create(channel->rand_state, ares_query_timeout_cmp_cb, NULL);
   if (channel->queries_by_timeout == NULL) {
     status = ARES_ENOMEM;
     goto done;
   }
 
-  channel->connnode_by_socket = ares__htable_asvp_create(NULL);
+  channel->connnode_by_socket = ares_htable_asvp_create(NULL);
   if (channel->connnode_by_socket == NULL) {
     status = ARES_ENOMEM;
     goto done;
@@ -310,7 +310,7 @@ int ares_init_options(ares_channel_t           **channelptr,
    * precedence to lowest.
    */
 
-  status = ares__init_by_options(channel, options, optmask);
+  status = ares_init_by_options(channel, options, optmask);
   if (status != ARES_SUCCESS) {
     DEBUGF(fprintf(stderr, "Error: init_by_options failed: %s\n",
                    ares_strerror(status)));
@@ -322,14 +322,14 @@ int ares_init_options(ares_channel_t           **channelptr,
   /* Go ahead and let it initialize the query cache even if the ttl is 0 and
    * completely unused.  This reduces the number of different code paths that
    * might be followed even if there is a minor performance hit. */
-  status = ares__qcache_create(channel->rand_state, channel->qcache_max_ttl,
+  status = ares_qcache_create(channel->rand_state, channel->qcache_max_ttl,
                                &channel->qcache);
   if (status != ARES_SUCCESS) {
     goto done; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   if (status == ARES_SUCCESS) {
-    status = ares__init_by_sysconfig(channel);
+    status = ares_init_by_sysconfig(channel);
     if (status != ARES_SUCCESS) {
       DEBUGF(fprintf(stderr, "Error: init_by_sysconfig failed: %s\n",
                      ares_strerror(status)));
@@ -381,23 +381,23 @@ static void *ares_reinit_thread(void *arg)
   ares_channel_t *channel = arg;
   ares_status_t   status;
 
-  /* ares__init_by_sysconfig() will lock when applying the config, but not
+  /* ares_init_by_sysconfig() will lock when applying the config, but not
    * when retrieving. */
-  status = ares__init_by_sysconfig(channel);
+  status = ares_init_by_sysconfig(channel);
   if (status != ARES_SUCCESS) {
     DEBUGF(fprintf(stderr, "Error: init_by_sysconfig failed: %s\n",
                    ares_strerror(status)));
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
 
   /* Flush cached queries on reinit */
   if (status == ARES_SUCCESS && channel->qcache) {
-    ares__qcache_flush(channel->qcache);
+    ares_qcache_flush(channel->qcache);
   }
 
   channel->reinit_pending = ARES_FALSE;
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 
   return NULL;
 }
@@ -410,34 +410,34 @@ ares_status_t ares_reinit(ares_channel_t *channel)
     return ARES_EFORMERR;
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
 
   /* If a reinit is already in process, lets not do it again. Or if we are
    * shutting down, skip. */
   if (!channel->sys_up || channel->reinit_pending) {
-    ares__channel_unlock(channel);
+    ares_channel_unlock(channel);
     return ARES_SUCCESS;
   }
   channel->reinit_pending = ARES_TRUE;
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 
   if (ares_threadsafety()) {
     /* clean up the prior reinit process's thread.  We know the thread isn't
      * running since reinit_pending was false */
     if (channel->reinit_thread != NULL) {
       void *rv;
-      ares__thread_join(channel->reinit_thread, &rv);
+      ares_thread_join(channel->reinit_thread, &rv);
       channel->reinit_thread = NULL;
     }
 
     /* Spawn a new thread */
     status =
-      ares__thread_create(&channel->reinit_thread, ares_reinit_thread, channel);
+      ares_thread_create(&channel->reinit_thread, ares_reinit_thread, channel);
     if (status != ARES_SUCCESS) {
       /* LCOV_EXCL_START: UntestablePath */
-      ares__channel_lock(channel);
+      ares_channel_lock(channel);
       channel->reinit_pending = ARES_FALSE;
-      ares__channel_unlock(channel);
+      ares_channel_unlock(channel);
       /* LCOV_EXCL_STOP */
     }
   } else {
@@ -480,7 +480,7 @@ int ares_dup(ares_channel_t **dest, const ares_channel_t *src)
     goto done;
   }
 
-  ares__channel_lock(src);
+  ares_channel_lock(src);
   /* Now clone the options that ares_save_options() doesn't support, but are
    * user-provided */
   (*dest)->sock_create_cb       = src->sock_create_cb;
@@ -496,7 +496,7 @@ int ares_dup(ares_channel_t **dest, const ares_channel_t *src)
               sizeof((*dest)->local_dev_name));
   (*dest)->local_ip4 = src->local_ip4;
   memcpy((*dest)->local_ip6, src->local_ip6, sizeof(src->local_ip6));
-  ares__channel_unlock(src);
+  ares_channel_unlock(src);
 
   /* Servers are a bit unique as ares_init_options() only allows ipv4 servers
    * and not a port per server, but there are other user specified ways, that
@@ -540,9 +540,9 @@ void ares_set_local_ip4(ares_channel_t *channel, unsigned int local_ip)
   if (channel == NULL) {
     return;
   }
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
   channel->local_ip4 = local_ip;
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 }
 
 /* local_ip6 should be 16 bytes in length */
@@ -551,9 +551,9 @@ void ares_set_local_ip6(ares_channel_t *channel, const unsigned char *local_ip6)
   if (channel == NULL) {
     return;
   }
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
   memcpy(&channel->local_ip6, local_ip6, sizeof(channel->local_ip6));
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 }
 
 /* local_dev_name should be null terminated. */
@@ -563,11 +563,11 @@ void ares_set_local_dev(ares_channel_t *channel, const char *local_dev_name)
     return;
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
   ares_strcpy(channel->local_dev_name, local_dev_name,
               sizeof(channel->local_dev_name));
   channel->local_dev_name[sizeof(channel->local_dev_name) - 1] = 0;
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 }
 
 int ares_set_sortlist(ares_channel_t *channel, const char *sortstr)
@@ -579,9 +579,9 @@ int ares_set_sortlist(ares_channel_t *channel, const char *sortstr)
   if (!channel) {
     return ARES_ENODATA;
   }
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
 
-  status = ares__parse_sortlist(&sortlist, &nsort, sortstr);
+  status = ares_parse_sortlist(&sortlist, &nsort, sortstr);
   if (status == ARES_SUCCESS && sortlist) {
     if (channel->sortlist) {
       ares_free(channel->sortlist);
@@ -592,6 +592,6 @@ int ares_set_sortlist(ares_channel_t *channel, const char *sortstr)
     /* Save sortlist as if it was passed in as an option */
     channel->optmask |= ARES_OPT_SORTLIST;
   }
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
   return (int)status;
 }

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -128,7 +128,7 @@ static ares_status_t init_by_defaults(ares_channel_t *channel)
   const char *dot;
 #endif
   struct ares_addr addr;
-  ares_llist_t   *sconfig = NULL;
+  ares_llist_t    *sconfig = NULL;
 
   /* Enable EDNS by default */
   if (!(channel->optmask & ARES_OPT_FLAGS)) {
@@ -323,7 +323,7 @@ int ares_init_options(ares_channel_t           **channelptr,
    * completely unused.  This reduces the number of different code paths that
    * might be followed even if there is a minor performance hit. */
   status = ares_qcache_create(channel->rand_state, channel->qcache_max_ttl,
-                               &channel->qcache);
+                              &channel->qcache);
   if (status != ARES_SUCCESS) {
     goto done; /* LCOV_EXCL_LINE: OutOfMemory */
   }

--- a/src/lib/ares_metrics.c
+++ b/src/lib/ares_metrics.c
@@ -162,14 +162,14 @@ void ares_metrics_record(const ares_query_t *query, ares_server_t *server,
     return;
   }
 
-  ares__tvnow(&now);
+  ares_tvnow(&now);
 
   rcode = ares_dns_record_get_rcode(dnsrec);
   if (rcode != ARES_RCODE_NOERROR && rcode != ARES_RCODE_NXDOMAIN) {
     return;
   }
 
-  ares__timeval_diff(&tvdiff, &query->ts, &now);
+  ares_timeval_diff(&tvdiff, &query->ts, &now);
   query_ms = (unsigned int)((tvdiff.sec * 1000) + (tvdiff.usec / 1000));
   if (query_ms == 0) {
     query_ms = 1;

--- a/src/lib/ares_options.c
+++ b/src/lib/ares_options.c
@@ -55,7 +55,7 @@ static struct in_addr *ares_save_opt_servers(const ares_channel_t *channel,
                                              int                  *nservers)
 {
   ares_slist_node_t *snode;
-  struct in_addr     *out =
+  struct in_addr    *out =
     ares_malloc_zero(ares_slist_len(channel->servers) * sizeof(*out));
 
   *nservers = 0;
@@ -239,11 +239,11 @@ int ares_save_options(const ares_channel_t *channel,
 }
 
 static ares_status_t ares_init_options_servers(ares_channel_t       *channel,
-                                                const struct in_addr *servers,
-                                                size_t                nservers)
+                                               const struct in_addr *servers,
+                                               size_t                nservers)
 {
   ares_llist_t *slist = NULL;
-  ares_status_t  status;
+  ares_status_t status;
 
   status = ares_in_addr_to_sconfig_llist(servers, nservers, &slist);
   if (status != ARES_SUCCESS) {
@@ -258,8 +258,8 @@ static ares_status_t ares_init_options_servers(ares_channel_t       *channel,
 }
 
 ares_status_t ares_init_by_options(ares_channel_t            *channel,
-                                    const struct ares_options *options,
-                                    int                        optmask)
+                                   const struct ares_options *options,
+                                   int                        optmask)
 {
   size_t i;
 
@@ -473,7 +473,7 @@ ares_status_t ares_init_by_options(ares_channel_t            *channel,
     } else {
       ares_status_t status;
       status = ares_init_options_servers(channel, options->servers,
-                                          (size_t)options->nservers);
+                                         (size_t)options->nservers);
       if (status != ARES_SUCCESS) {
         return status; /* LCOV_EXCL_LINE: OutOfMemory */
       }

--- a/src/lib/ares_options.c
+++ b/src/lib/ares_options.c
@@ -54,9 +54,9 @@ void ares_destroy_options(struct ares_options *options)
 static struct in_addr *ares_save_opt_servers(const ares_channel_t *channel,
                                              int                  *nservers)
 {
-  ares__slist_node_t *snode;
+  ares_slist_node_t *snode;
   struct in_addr     *out =
-    ares_malloc_zero(ares__slist_len(channel->servers) * sizeof(*out));
+    ares_malloc_zero(ares_slist_len(channel->servers) * sizeof(*out));
 
   *nservers = 0;
 
@@ -64,9 +64,9 @@ static struct in_addr *ares_save_opt_servers(const ares_channel_t *channel,
     return NULL;
   }
 
-  for (snode = ares__slist_node_first(channel->servers); snode != NULL;
-       snode = ares__slist_node_next(snode)) {
-    const ares_server_t *server = ares__slist_node_val(snode);
+  for (snode = ares_slist_node_first(channel->servers); snode != NULL;
+       snode = ares_slist_node_next(snode)) {
+    const ares_server_t *server = ares_slist_node_val(snode);
 
     if (server->addr.family != AF_INET) {
       continue;
@@ -111,7 +111,7 @@ int ares_save_options(const ares_channel_t *channel,
   }
 
   /* We convert ARES_OPT_TIMEOUT to ARES_OPT_TIMEOUTMS in
-   * ares__init_by_options() */
+   * ares_init_by_options() */
   if (channel->optmask & ARES_OPT_TIMEOUTMS) {
     options->timeout = (int)channel->timeout;
   }
@@ -238,11 +238,11 @@ int ares_save_options(const ares_channel_t *channel,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares__init_options_servers(ares_channel_t       *channel,
+static ares_status_t ares_init_options_servers(ares_channel_t       *channel,
                                                 const struct in_addr *servers,
                                                 size_t                nservers)
 {
-  ares__llist_t *slist = NULL;
+  ares_llist_t *slist = NULL;
   ares_status_t  status;
 
   status = ares_in_addr_to_sconfig_llist(servers, nservers, &slist);
@@ -250,14 +250,14 @@ static ares_status_t ares__init_options_servers(ares_channel_t       *channel,
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  status = ares__servers_update(channel, slist, ARES_TRUE);
+  status = ares_servers_update(channel, slist, ARES_TRUE);
 
-  ares__llist_destroy(slist);
+  ares_llist_destroy(slist);
 
   return status;
 }
 
-ares_status_t ares__init_by_options(ares_channel_t            *channel,
+ares_status_t ares_init_by_options(ares_channel_t            *channel,
                                     const struct ares_options *options,
                                     int                        optmask)
 {
@@ -472,7 +472,7 @@ ares_status_t ares__init_by_options(ares_channel_t            *channel,
       optmask &= ~(ARES_OPT_SERVERS);
     } else {
       ares_status_t status;
-      status = ares__init_options_servers(channel, options->servers,
+      status = ares_init_options_servers(channel, options->servers,
                                           (size_t)options->nservers);
       if (status != ARES_SUCCESS) {
         return status; /* LCOV_EXCL_LINE: OutOfMemory */

--- a/src/lib/ares_parse_into_addrinfo.c
+++ b/src/lib/ares_parse_into_addrinfo.c
@@ -46,9 +46,9 @@
 
 
 ares_status_t ares_parse_into_addrinfo(const ares_dns_record_t *dnsrec,
-                                        ares_bool_t    cname_only_is_enodata,
-                                        unsigned short port,
-                                        struct ares_addrinfo *ai)
+                                       ares_bool_t    cname_only_is_enodata,
+                                       unsigned short port,
+                                       struct ares_addrinfo *ai)
 {
   ares_status_t               status;
   size_t                      i;

--- a/src/lib/ares_parse_into_addrinfo.c
+++ b/src/lib/ares_parse_into_addrinfo.c
@@ -45,7 +45,7 @@
 #endif
 
 
-ares_status_t ares__parse_into_addrinfo(const ares_dns_record_t *dnsrec,
+ares_status_t ares_parse_into_addrinfo(const ares_dns_record_t *dnsrec,
                                         ares_bool_t    cname_only_is_enodata,
                                         unsigned short port,
                                         struct ares_addrinfo *ai)
@@ -103,7 +103,7 @@ ares_status_t ares__parse_into_addrinfo(const ares_dns_record_t *dnsrec,
        * SA: Seems wrong as it introduces order dependency. */
       hostname = ares_dns_rr_get_str(rr, ARES_RR_CNAME_CNAME);
 
-      cname = ares__append_addrinfo_cname(&cnames);
+      cname = ares_append_addrinfo_cname(&cnames);
       if (cname == NULL) {
         status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
         goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
@@ -157,18 +157,18 @@ ares_status_t ares__parse_into_addrinfo(const ares_dns_record_t *dnsrec,
   }
 
   if (got_a || got_aaaa) {
-    ares__addrinfo_cat_nodes(&ai->nodes, nodes);
+    ares_addrinfo_cat_nodes(&ai->nodes, nodes);
     nodes = NULL;
   }
 
   if (got_cname) {
-    ares__addrinfo_cat_cnames(&ai->cnames, cnames);
+    ares_addrinfo_cat_cnames(&ai->cnames, cnames);
     cnames = NULL;
   }
 
 done:
-  ares__freeaddrinfo_cnames(cnames);
-  ares__freeaddrinfo_nodes(nodes);
+  ares_freeaddrinfo_cnames(cnames);
+  ares_freeaddrinfo_nodes(nodes);
 
   /* compatibility */
   if (status == ARES_EBADNAME) {

--- a/src/lib/ares_platform.c
+++ b/src/lib/ares_platform.c
@@ -35,7 +35,7 @@
 #  define V_PLATFORM_WIN32_NT      2
 #  define V_PLATFORM_WIN32_CE      3
 
-win_platform ares__getplatform(void)
+win_platform ares_getplatform(void)
 {
   OSVERSIONINFOEX OsvEx;
 

--- a/src/lib/ares_platform.h
+++ b/src/lib/ares_platform.h
@@ -37,7 +37,7 @@ typedef enum {
   WIN_CE
 } win_platform;
 
-win_platform ares__getplatform(void);
+win_platform ares_getplatform(void);
 
 #endif
 

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -156,9 +156,9 @@ struct ares_query {
    * Node object for each list entry the query belongs to in order to
    * make removal operations O(1).
    */
-  ares_slist_node_t  *node_queries_by_timeout;
-  ares_llist_node_t  *node_queries_to_conn;
-  ares_llist_node_t  *node_all_queries;
+  ares_slist_node_t   *node_queries_by_timeout;
+  ares_llist_node_t   *node_queries_to_conn;
+  ares_llist_node_t   *node_all_queries;
 
   /* connection handle query is associated with */
   ares_conn_t         *conn;
@@ -192,32 +192,32 @@ typedef struct ares_hosts_file ares_hosts_file_t;
 
 struct ares_channeldata {
   /* Configuration data */
-  unsigned int          flags;
-  size_t                timeout; /* in milliseconds */
-  size_t                tries;
-  size_t                ndots;
-  size_t                maxtimeout;              /* in milliseconds */
-  ares_bool_t           rotate;
-  unsigned short        udp_port;                /* stored in network order */
-  unsigned short        tcp_port;                /* stored in network order */
-  int                   socket_send_buffer_size; /* setsockopt takes int */
-  int                   socket_receive_buffer_size; /* setsockopt takes int */
-  char                **domains;
-  size_t                ndomains;
-  struct apattern      *sortlist;
-  size_t                nsort;
-  char                 *lookups;
-  size_t                ednspsz;
-  unsigned int          qcache_max_ttl;
-  ares_evsys_t          evsys;
-  unsigned int          optmask;
+  unsigned int         flags;
+  size_t               timeout; /* in milliseconds */
+  size_t               tries;
+  size_t               ndots;
+  size_t               maxtimeout;                 /* in milliseconds */
+  ares_bool_t          rotate;
+  unsigned short       udp_port;                   /* stored in network order */
+  unsigned short       tcp_port;                   /* stored in network order */
+  int                  socket_send_buffer_size;    /* setsockopt takes int */
+  int                  socket_receive_buffer_size; /* setsockopt takes int */
+  char               **domains;
+  size_t               ndomains;
+  struct apattern     *sortlist;
+  size_t               nsort;
+  char                *lookups;
+  size_t               ednspsz;
+  unsigned int         qcache_max_ttl;
+  ares_evsys_t         evsys;
+  unsigned int         optmask;
 
   /* For binding to local devices and/or IP addresses.  Leave
    * them null/zero for no binding.
    */
-  char                  local_dev_name[32];
-  unsigned int          local_ip4;
-  unsigned char         local_ip6[16];
+  char                 local_dev_name[32];
+  unsigned int         local_ip4;
+  unsigned char        local_ip6[16];
 
   /* Thread safety lock */
   ares_thread_mutex_t *lock;
@@ -231,7 +231,7 @@ struct ares_channeldata {
 
   /* random state to use when generating new ids and generating retry penalties
    */
-  ares_rand_state      *rand_state;
+  ares_rand_state     *rand_state;
 
   /* All active queries in a single list */
   ares_llist_t        *all_queries;
@@ -247,8 +247,8 @@ struct ares_channeldata {
    * scan all connections) */
   ares_htable_asvp_t  *connnode_by_socket;
 
-  ares_sock_state_cb    sock_state_cb;
-  void                 *sock_state_cb_data;
+  ares_sock_state_cb   sock_state_cb;
+  void                *sock_state_cb_data;
 
   ares_sock_create_callback           sock_create_cb;
   void                               *sock_create_cb_data;
@@ -276,7 +276,7 @@ struct ares_channeldata {
   ares_hosts_file_t                  *hf;
 
   /* Query Cache */
-  ares_qcache_t                     *qcache;
+  ares_qcache_t                      *qcache;
 
   /* Fields controlling server failover behavior.
    * The retry chance is the probability (1/N) by which we will retry a failed
@@ -297,7 +297,7 @@ struct ares_channeldata {
    * reading may block.  The thread handle is provided for waiting on thread
    * exit. */
   ares_bool_t                         reinit_pending;
-  ares_thread_t                     *reinit_thread;
+  ares_thread_t                      *reinit_thread;
 
   /* Whether the system is up or not.  This is mainly to prevent deadlocks
    * and access violations during the cleanup process.  Some things like
@@ -311,11 +311,10 @@ ares_bool_t   ares_is_onion_domain(const char *name);
 
 /* Returns one of the normal ares status codes like ARES_SUCCESS */
 ares_status_t ares_send_query(ares_query_t *query, const ares_timeval_t *now);
-ares_status_t ares_requeue_query(ares_query_t            *query,
-                                  const ares_timeval_t    *now,
-                                  ares_status_t            status,
-                                  ares_bool_t              inc_try_count,
-                                  const ares_dns_record_t *dnsrec);
+ares_status_t ares_requeue_query(ares_query_t *query, const ares_timeval_t *now,
+                                 ares_status_t            status,
+                                 ares_bool_t              inc_try_count,
+                                 const ares_dns_record_t *dnsrec);
 
 /*! Count the number of labels (dots+1) in a domain */
 size_t        ares_name_label_cnt(const char *name);
@@ -332,8 +331,8 @@ size_t        ares_name_label_cnt(const char *name);
  *  \return ARES_SUCCESS on success, otherwise one of the other error codes.
  */
 ares_status_t ares_search_name_list(const ares_channel_t *channel,
-                                     const char *name, char ***names,
-                                     size_t *names_len);
+                                    const char *name, char ***names,
+                                    size_t *names_len);
 
 /*! Function to create callback arg for converting from ares_callback_dnsrec
  *  to ares_calback */
@@ -344,26 +343,26 @@ void         *ares_dnsrec_convert_arg(ares_callback callback, void *arg);
  *  the inner callback.
  */
 void ares_dnsrec_convert_cb(void *arg, ares_status_t status, size_t timeouts,
-                             const ares_dns_record_t *dnsrec);
+                            const ares_dns_record_t *dnsrec);
 
 void ares_free_query(ares_query_t *query);
 
 unsigned short ares_generate_new_id(ares_rand_state *state);
 ares_status_t  ares_expand_name_validated(const unsigned char *encoded,
-                                           const unsigned char *abuf,
-                                           size_t alen, char **s, size_t *enclen,
-                                           ares_bool_t is_hostname);
+                                          const unsigned char *abuf, size_t alen,
+                                          char **s, size_t *enclen,
+                                          ares_bool_t is_hostname);
 ares_status_t  ares_expand_string_ex(const unsigned char *encoded,
                                      const unsigned char *abuf, size_t alen,
                                      unsigned char **s, size_t *enclen);
 ares_status_t  ares_init_servers_state(ares_channel_t *channel);
 ares_status_t  ares_init_by_options(ares_channel_t            *channel,
-                                     const struct ares_options *options,
-                                     int                        optmask);
+                                    const struct ares_options *options,
+                                    int                        optmask);
 ares_status_t  ares_init_by_sysconfig(ares_channel_t *channel);
 
 typedef struct {
-  ares_llist_t   *sconfig;
+  ares_llist_t    *sconfig;
   struct apattern *sortlist;
   size_t           nsortlist;
   char           **domains;
@@ -377,12 +376,12 @@ typedef struct {
 } ares_sysconfig_t;
 
 ares_status_t ares_sysconfig_set_options(ares_sysconfig_t *sysconfig,
-                                          const char       *str);
+                                         const char       *str);
 
 ares_status_t ares_init_by_environment(ares_sysconfig_t *sysconfig);
 
 ares_status_t ares_init_sysconfig_files(const ares_channel_t *channel,
-                                         ares_sysconfig_t     *sysconfig);
+                                        ares_sysconfig_t     *sysconfig);
 #ifdef __APPLE__
 ares_status_t ares_init_sysconfig_macos(ares_sysconfig_t *sysconfig);
 #endif
@@ -391,17 +390,17 @@ ares_status_t ares_init_sysconfig_windows(ares_sysconfig_t *sysconfig);
 #endif
 
 ares_status_t ares_parse_sortlist(struct apattern **sortlist, size_t *nsort,
-                                   const char *str);
+                                  const char *str);
 
 /* Returns ARES_SUCCESS if alias found, alias is set.  Returns ARES_ENOTFOUND
  * if not alias found.  Returns other errors on critical failure like
  * ARES_ENOMEM */
 ares_status_t ares_lookup_hostaliases(const ares_channel_t *channel,
-                                       const char *name, char **alias);
+                                      const char *name, char **alias);
 
 ares_status_t ares_cat_domain(const char *name, const char *domain, char **s);
 ares_status_t ares_sortaddrinfo(ares_channel_t            *channel,
-                                 struct ares_addrinfo_node *ai_node);
+                                struct ares_addrinfo_node *ai_node);
 
 void          ares_freeaddrinfo_nodes(struct ares_addrinfo_node *ai_node);
 ares_bool_t   ares_is_localhost(const char *name);
@@ -409,11 +408,11 @@ ares_bool_t   ares_is_localhost(const char *name);
 struct ares_addrinfo_node    *
   ares_append_addrinfo_node(struct ares_addrinfo_node **ai_node);
 void ares_addrinfo_cat_nodes(struct ares_addrinfo_node **head,
-                              struct ares_addrinfo_node  *tail);
+                             struct ares_addrinfo_node  *tail);
 
 void ares_freeaddrinfo_cnames(struct ares_addrinfo_cname *ai_cname);
 
-struct ares_addrinfo_cname *
+struct ares_addrinfo_cname             *
   ares_append_addrinfo_cname(struct ares_addrinfo_cname **ai_cname);
 
 ares_status_t ares_append_ai_node(int aftype, unsigned short port,
@@ -421,62 +420,61 @@ ares_status_t ares_append_ai_node(int aftype, unsigned short port,
                                   struct ares_addrinfo_node **nodes);
 
 void          ares_addrinfo_cat_cnames(struct ares_addrinfo_cname **head,
-                                        struct ares_addrinfo_cname  *tail);
+                                       struct ares_addrinfo_cname  *tail);
 
 ares_status_t ares_parse_into_addrinfo(const ares_dns_record_t *dnsrec,
-                                        ares_bool_t    cname_only_is_enodata,
-                                        unsigned short port,
-                                        struct ares_addrinfo *ai);
+                                       ares_bool_t    cname_only_is_enodata,
+                                       unsigned short port,
+                                       struct ares_addrinfo *ai);
 ares_status_t ares_parse_ptr_reply_dnsrec(const ares_dns_record_t *dnsrec,
                                           const void *addr, int addrlen,
                                           int family, struct hostent **host);
 
 ares_status_t ares_addrinfo2hostent(const struct ares_addrinfo *ai, int family,
-                                     struct hostent **host);
+                                    struct hostent **host);
 ares_status_t ares_addrinfo2addrttl(const struct ares_addrinfo *ai, int family,
-                                     size_t                req_naddrttls,
-                                     struct ares_addrttl  *addrttls,
-                                     struct ares_addr6ttl *addr6ttls,
-                                     size_t               *naddrttls);
+                                    size_t                req_naddrttls,
+                                    struct ares_addrttl  *addrttls,
+                                    struct ares_addr6ttl *addr6ttls,
+                                    size_t               *naddrttls);
 ares_status_t ares_addrinfo_localhost(const char *name, unsigned short port,
-                                       const struct ares_addrinfo_hints *hints,
-                                       struct ares_addrinfo             *ai);
+                                      const struct ares_addrinfo_hints *hints,
+                                      struct ares_addrinfo             *ai);
 
 ares_status_t ares_servers_update(ares_channel_t *channel,
-                                   ares_llist_t  *server_list,
-                                   ares_bool_t     user_specified);
-ares_status_t ares_sconfig_append(ares_llist_t         **sconfig,
-                                   const struct ares_addr *addr,
-                                   unsigned short          udp_port,
-                                   unsigned short          tcp_port,
-                                   const char             *ll_iface);
+                                  ares_llist_t   *server_list,
+                                  ares_bool_t     user_specified);
+ares_status_t ares_sconfig_append(ares_llist_t          **sconfig,
+                                  const struct ares_addr *addr,
+                                  unsigned short          udp_port,
+                                  unsigned short          tcp_port,
+                                  const char             *ll_iface);
 ares_status_t ares_sconfig_append_fromstr(ares_llist_t **sconfig,
-                                           const char     *str,
-                                           ares_bool_t     ignore_invalid);
+                                          const char    *str,
+                                          ares_bool_t    ignore_invalid);
 ares_status_t ares_in_addr_to_sconfig_llist(const struct in_addr *servers,
                                             size_t                nservers,
-                                            ares_llist_t       **llist);
+                                            ares_llist_t        **llist);
 ares_status_t ares_get_server_addr(const ares_server_t *server,
-                                   ares_buf_t         *buf);
+                                   ares_buf_t          *buf);
 
 struct ares_hosts_entry;
 typedef struct ares_hosts_entry ares_hosts_entry_t;
 
 void                            ares_hosts_file_destroy(ares_hosts_file_t *hf);
 ares_status_t ares_hosts_search_ipaddr(ares_channel_t *channel,
-                                        ares_bool_t use_env, const char *ipaddr,
-                                        const ares_hosts_entry_t **entry);
+                                       ares_bool_t use_env, const char *ipaddr,
+                                       const ares_hosts_entry_t **entry);
 ares_status_t ares_hosts_search_host(ares_channel_t *channel,
-                                      ares_bool_t use_env, const char *host,
-                                      const ares_hosts_entry_t **entry);
+                                     ares_bool_t use_env, const char *host,
+                                     const ares_hosts_entry_t **entry);
 ares_status_t ares_hosts_entry_to_hostent(const ares_hosts_entry_t *entry,
-                                           int                       family,
-                                           struct hostent          **hostent);
+                                          int family, struct hostent **hostent);
 ares_status_t ares_hosts_entry_to_addrinfo(const ares_hosts_entry_t *entry,
-                                            const char *name, int family,
-                                            unsigned short        port,
-                                            ares_bool_t           want_cnames,
-                                            struct ares_addrinfo *ai);
+                                           const char *name, int family,
+                                           unsigned short        port,
+                                           ares_bool_t           want_cnames,
+                                           struct ares_addrinfo *ai);
 
 /* Same as ares_query_dnsrec() except does not take a channel lock.  Use this
  * if a channel lock is already held */
@@ -514,7 +512,7 @@ void ares_gethostbyaddr_nolock(ares_channel_t *channel, const void *addr,
  *  \return ARES_SUCCESS on success
  */
 ares_status_t ares_dns_name_parse(ares_buf_t *buf, char **name,
-                                   ares_bool_t is_hostname);
+                                  ares_bool_t is_hostname);
 
 /*! Write the DNS name to the buffer in the DNS domain-name syntax as a
  *  series of labels.  The maximum domain name length is 255 characters with
@@ -534,8 +532,8 @@ ares_status_t ares_dns_name_parse(ares_buf_t *buf, char **name,
  *          bad.
  */
 ares_status_t ares_dns_name_write(ares_buf_t *buf, ares_llist_t **list,
-                                   ares_bool_t validate_hostname,
-                                   const char *name);
+                                  ares_bool_t validate_hostname,
+                                  const char *name);
 
 /*! Check if the queue is empty, if so, wake any waiters.  This is only
  *  effective if built with threading support.
@@ -546,19 +544,19 @@ ares_status_t ares_dns_name_write(ares_buf_t *buf, ares_llist_t **list,
  */
 void          ares_queue_notify_empty(ares_channel_t *channel);
 
-#define ARES_CONFIG_CHECK(x)                                               \
+#define ARES_CONFIG_CHECK(x)                                              \
   (x && x->lookups && ares_slist_len(x->servers) > 0 && x->timeout > 0 && \
    x->tries > 0)
 
 ares_bool_t   ares_subnet_match(const struct ares_addr *addr,
-                                 const struct ares_addr *subnet,
-                                 unsigned char           netmask);
+                                const struct ares_addr *subnet,
+                                unsigned char           netmask);
 ares_bool_t   ares_addr_is_linklocal(const struct ares_addr *addr);
 
 void          ares_qcache_destroy(ares_qcache_t *cache);
 ares_status_t ares_qcache_create(ares_rand_state *rand_state,
-                                  unsigned int     max_ttl,
-                                  ares_qcache_t **cache_out);
+                                 unsigned int     max_ttl,
+                                 ares_qcache_t  **cache_out);
 void          ares_qcache_flush(ares_qcache_t *cache);
 ares_status_t ares_qcache_insert(ares_channel_t       *channel,
                                  const ares_timeval_t *now,

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -79,7 +79,7 @@ static void invoke_server_state_cb(const ares_server_t *server,
                                    ares_bool_t success, int flags)
 {
   const ares_channel_t *channel = server->channel;
-  ares_buf_t          *buf;
+  ares_buf_t           *buf;
   ares_status_t         status;
   char                 *server_string;
 
@@ -95,7 +95,7 @@ static void invoke_server_state_cb(const ares_server_t *server,
   status = ares_get_server_addr(server, buf);
   if (status != ARES_SUCCESS) {
     ares_buf_destroy(buf); /* LCOV_EXCL_LINE: OutOfMemory */
-    return;                 /* LCOV_EXCL_LINE: OutOfMemory */
+    return;                /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   server_string = ares_buf_finish_str(buf, NULL);
@@ -112,7 +112,7 @@ static void invoke_server_state_cb(const ares_server_t *server,
 static void server_increment_failures(ares_server_t *server,
                                       ares_bool_t    used_tcp)
 {
-  ares_slist_node_t   *node;
+  ares_slist_node_t    *node;
   const ares_channel_t *channel = server->channel;
   ares_timeval_t        next_retry_time;
 
@@ -135,7 +135,7 @@ static void server_increment_failures(ares_server_t *server,
 
 static void server_set_good(ares_server_t *server, ares_bool_t used_tcp)
 {
-  ares_slist_node_t   *node;
+  ares_slist_node_t    *node;
   const ares_channel_t *channel = server->channel;
 
   node = ares_slist_node_find(channel->servers, server);
@@ -158,7 +158,7 @@ static void server_set_good(ares_server_t *server, ares_bool_t used_tcp)
 
 /* return true if now is exactly check time or later */
 ares_bool_t ares_timedout(const ares_timeval_t *now,
-                           const ares_timeval_t *check)
+                          const ares_timeval_t *check)
 {
   ares_int64_t secs = (now->sec - check->sec);
 
@@ -244,7 +244,7 @@ static ares_socket_t *channel_socket_list(const ares_channel_t *channel,
 
   for (snode = ares_slist_node_first(channel->servers); snode != NULL;
        snode = ares_slist_node_next(snode)) {
-    ares_server_t      *server = ares_slist_node_val(snode);
+    ares_server_t     *server = ares_slist_node_val(snode);
     ares_llist_node_t *node;
 
     for (node = ares_llist_node_first(server->connections); node != NULL;
@@ -260,7 +260,7 @@ static ares_socket_t *channel_socket_list(const ares_channel_t *channel,
       status = ares_array_insert_last((void **)&sptr, arr);
       if (status != ARES_SUCCESS) {
         ares_array_destroy(arr); /* LCOV_EXCL_LINE: OutOfMemory */
-        return NULL;              /* LCOV_EXCL_LINE: OutOfMemory */
+        return NULL;             /* LCOV_EXCL_LINE: OutOfMemory */
       }
       *sptr = conn->fd;
     }
@@ -290,9 +290,9 @@ static void ares_notify_write(ares_conn_t *conn)
 static void process_write(const ares_channel_t *channel, fd_set *write_fds,
                           ares_socket_t write_fd)
 {
-  size_t              i;
-  ares_socket_t      *socketlist  = NULL;
-  size_t              num_sockets = 0;
+  size_t             i;
+  ares_socket_t     *socketlist  = NULL;
+  size_t             num_sockets = 0;
   ares_llist_node_t *node        = NULL;
 
   if (!write_fds && write_fd == ARES_SOCKET_BAD) {
@@ -518,9 +518,9 @@ static void read_conn(ares_conn_t *conn, const ares_timeval_t *now)
 static void process_read(const ares_channel_t *channel, fd_set *read_fds,
                          ares_socket_t read_fd, const ares_timeval_t *now)
 {
-  size_t              i;
-  ares_socket_t      *socketlist  = NULL;
-  size_t              num_sockets = 0;
+  size_t             i;
+  ares_socket_t     *socketlist  = NULL;
+  size_t             num_sockets = 0;
   ares_llist_node_t *node        = NULL;
 
   if (!read_fds && (read_fd == ARES_SOCKET_BAD)) {
@@ -655,7 +655,7 @@ static ares_status_t process_answer(ares_channel_t      *channel,
    * hashed/bucketed by query id, so this lookup should be quick.
    */
   query = ares_htable_szvp_get_direct(channel->queries_by_qid,
-                                       ares_dns_record_get_id(rdnsrec));
+                                      ares_dns_record_get_id(rdnsrec));
   if (!query) {
     /* We may have stopped listening for this query, that's ok */
     status = ARES_SUCCESS;
@@ -782,14 +782,13 @@ static void handle_conn_error(ares_conn_t *conn, ares_bool_t critical_failure,
   ares_close_connection(conn, failure_status);
 }
 
-ares_status_t ares_requeue_query(ares_query_t            *query,
-                                  const ares_timeval_t    *now,
-                                  ares_status_t            status,
-                                  ares_bool_t              inc_try_count,
-                                  const ares_dns_record_t *dnsrec)
+ares_status_t ares_requeue_query(ares_query_t *query, const ares_timeval_t *now,
+                                 ares_status_t            status,
+                                 ares_bool_t              inc_try_count,
+                                 const ares_dns_record_t *dnsrec)
 {
-  ares_channel_t *channel = query->channel;
-  size_t max_tries        = ares_slist_len(channel->servers) * channel->tries;
+  ares_channel_t *channel   = query->channel;
+  size_t          max_tries = ares_slist_len(channel->servers) * channel->tries;
 
   ares_query_remove_from_conn(query);
 
@@ -819,11 +818,11 @@ ares_status_t ares_requeue_query(ares_query_t            *query,
  * the list */
 static ares_server_t *ares_random_server(ares_channel_t *channel)
 {
-  unsigned char       c;
-  size_t              cnt;
-  size_t              idx;
+  unsigned char      c;
+  size_t             cnt;
+  size_t             idx;
   ares_slist_node_t *node;
-  size_t              num_servers = ares_slist_len(channel->servers);
+  size_t             num_servers = ares_slist_len(channel->servers);
 
   /* Silence coverity, not possible */
   if (num_servers == 0) {
@@ -892,7 +891,7 @@ static ares_server_t *ares_failover_server(ares_channel_t *channel)
   ares_rand_bytes(channel->rand_state, (unsigned char *)&r, sizeof(r));
   if (r % channel->server_retry_chance == 0) {
     /* Select a suitable failed server to retry. */
-    ares_timeval_t      now;
+    ares_timeval_t     now;
     ares_slist_node_t *node;
 
     ares_tvnow(&now);
@@ -911,8 +910,8 @@ static ares_server_t *ares_failover_server(ares_channel_t *channel)
 }
 
 static size_t ares_calc_query_timeout(const ares_query_t   *query,
-                                       const ares_server_t  *server,
-                                       const ares_timeval_t *now)
+                                      const ares_server_t  *server,
+                                      const ares_timeval_t *now)
 {
   const ares_channel_t *channel  = query->channel;
   size_t                timeout  = ares_metrics_server_timeout(server, now);
@@ -963,11 +962,11 @@ static size_t ares_calc_query_timeout(const ares_query_t   *query,
 }
 
 static ares_conn_t *ares_fetch_connection(const ares_channel_t *channel,
-                                           ares_server_t        *server,
-                                           const ares_query_t   *query)
+                                          ares_server_t        *server,
+                                          const ares_query_t   *query)
 {
   ares_llist_node_t *node;
-  ares_conn_t        *conn;
+  ares_conn_t       *conn;
 
   if (query->using_tcp) {
     return server->tcp_conn;
@@ -995,8 +994,8 @@ static ares_conn_t *ares_fetch_connection(const ares_channel_t *channel,
 }
 
 static ares_status_t ares_conn_query_write(ares_conn_t          *conn,
-                                            ares_query_t         *query,
-                                            const ares_timeval_t *now)
+                                           ares_query_t         *query,
+                                           const ares_timeval_t *now)
 {
   ares_server_t  *server  = conn->server;
   ares_channel_t *channel = server->channel;

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -64,11 +64,11 @@ static void        end_query(ares_channel_t *channel, ares_server_t *server,
                              ares_query_t *query, ares_status_t status,
                              const ares_dns_record_t *dnsrec);
 
-static void        ares__query_remove_from_conn(ares_query_t *query)
+static void        ares_query_remove_from_conn(ares_query_t *query)
 {
   /* If its not part of a connection, it can't be tracked for timeouts either */
-  ares__slist_node_destroy(query->node_queries_by_timeout);
-  ares__llist_node_destroy(query->node_queries_to_conn);
+  ares_slist_node_destroy(query->node_queries_by_timeout);
+  ares_llist_node_destroy(query->node_queries_to_conn);
   query->node_queries_by_timeout = NULL;
   query->node_queries_to_conn    = NULL;
   query->conn                    = NULL;
@@ -79,7 +79,7 @@ static void invoke_server_state_cb(const ares_server_t *server,
                                    ares_bool_t success, int flags)
 {
   const ares_channel_t *channel = server->channel;
-  ares__buf_t          *buf;
+  ares_buf_t          *buf;
   ares_status_t         status;
   char                 *server_string;
 
@@ -87,18 +87,18 @@ static void invoke_server_state_cb(const ares_server_t *server,
     return;
   }
 
-  buf = ares__buf_create();
+  buf = ares_buf_create();
   if (buf == NULL) {
     return; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   status = ares_get_server_addr(server, buf);
   if (status != ARES_SUCCESS) {
-    ares__buf_destroy(buf); /* LCOV_EXCL_LINE: OutOfMemory */
+    ares_buf_destroy(buf); /* LCOV_EXCL_LINE: OutOfMemory */
     return;                 /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  server_string = ares__buf_finish_str(buf, NULL);
+  server_string = ares_buf_finish_str(buf, NULL);
   buf           = NULL;
   if (server_string == NULL) {
     return; /* LCOV_EXCL_LINE: OutOfMemory */
@@ -112,19 +112,19 @@ static void invoke_server_state_cb(const ares_server_t *server,
 static void server_increment_failures(ares_server_t *server,
                                       ares_bool_t    used_tcp)
 {
-  ares__slist_node_t   *node;
+  ares_slist_node_t   *node;
   const ares_channel_t *channel = server->channel;
   ares_timeval_t        next_retry_time;
 
-  node = ares__slist_node_find(channel->servers, server);
+  node = ares_slist_node_find(channel->servers, server);
   if (node == NULL) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
   server->consec_failures++;
-  ares__slist_node_reinsert(node);
+  ares_slist_node_reinsert(node);
 
-  ares__tvnow(&next_retry_time);
+  ares_tvnow(&next_retry_time);
   timeadd(&next_retry_time, channel->server_retry_delay);
   server->next_retry_time = next_retry_time;
 
@@ -135,17 +135,17 @@ static void server_increment_failures(ares_server_t *server,
 
 static void server_set_good(ares_server_t *server, ares_bool_t used_tcp)
 {
-  ares__slist_node_t   *node;
+  ares_slist_node_t   *node;
   const ares_channel_t *channel = server->channel;
 
-  node = ares__slist_node_find(channel->servers, server);
+  node = ares_slist_node_find(channel->servers, server);
   if (node == NULL) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
   if (server->consec_failures > 0) {
     server->consec_failures = 0;
-    ares__slist_node_reinsert(node);
+    ares_slist_node_reinsert(node);
   }
 
   server->next_retry_time.sec  = 0;
@@ -157,7 +157,7 @@ static void server_set_good(ares_server_t *server, ares_bool_t used_tcp)
 }
 
 /* return true if now is exactly check time or later */
-ares_bool_t ares__timedout(const ares_timeval_t *now,
+ares_bool_t ares_timedout(const ares_timeval_t *now,
                            const ares_timeval_t *check)
 {
   ares_int64_t secs = (now->sec - check->sec);
@@ -200,15 +200,15 @@ static void processfds(ares_channel_t *channel, fd_set *read_fds,
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  ares__channel_lock(channel);
-  ares__tvnow(&now);
+  ares_channel_lock(channel);
+  ares_tvnow(&now);
   process_read(channel, read_fds, read_fd, &now);
   process_timeouts(channel, &now);
   process_write(channel, write_fds, write_fd);
 
   /* See if any connections should be cleaned up */
-  ares__check_cleanup_conns(channel);
-  ares__channel_unlock(channel);
+  ares_check_cleanup_conns(channel);
+  ares_channel_unlock(channel);
 }
 
 /* Something interesting happened on the wire, or there was a timeout.
@@ -233,8 +233,8 @@ void ares_process_fd(ares_channel_t *channel,
 static ares_socket_t *channel_socket_list(const ares_channel_t *channel,
                                           size_t               *num)
 {
-  ares__slist_node_t *snode;
-  ares__array_t      *arr = ares__array_create(sizeof(ares_socket_t), NULL);
+  ares_slist_node_t *snode;
+  ares_array_t      *arr = ares_array_create(sizeof(ares_socket_t), NULL);
 
   *num = 0;
 
@@ -242,14 +242,14 @@ static ares_socket_t *channel_socket_list(const ares_channel_t *channel,
     return NULL; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  for (snode = ares__slist_node_first(channel->servers); snode != NULL;
-       snode = ares__slist_node_next(snode)) {
-    ares_server_t      *server = ares__slist_node_val(snode);
-    ares__llist_node_t *node;
+  for (snode = ares_slist_node_first(channel->servers); snode != NULL;
+       snode = ares_slist_node_next(snode)) {
+    ares_server_t      *server = ares_slist_node_val(snode);
+    ares_llist_node_t *node;
 
-    for (node = ares__llist_node_first(server->connections); node != NULL;
-         node = ares__llist_node_next(node)) {
-      const ares_conn_t *conn = ares__llist_node_val(node);
+    for (node = ares_llist_node_first(server->connections); node != NULL;
+         node = ares_llist_node_next(node)) {
+      const ares_conn_t *conn = ares_llist_node_val(node);
       ares_socket_t     *sptr;
       ares_status_t      status;
 
@@ -257,16 +257,16 @@ static ares_socket_t *channel_socket_list(const ares_channel_t *channel,
         continue;
       }
 
-      status = ares__array_insert_last((void **)&sptr, arr);
+      status = ares_array_insert_last((void **)&sptr, arr);
       if (status != ARES_SUCCESS) {
-        ares__array_destroy(arr); /* LCOV_EXCL_LINE: OutOfMemory */
+        ares_array_destroy(arr); /* LCOV_EXCL_LINE: OutOfMemory */
         return NULL;              /* LCOV_EXCL_LINE: OutOfMemory */
       }
       *sptr = conn->fd;
     }
   }
 
-  return ares__array_finish(arr, num);
+  return ares_array_finish(arr, num);
 }
 
 /* If any TCP sockets select true for writing, write out queued data
@@ -281,7 +281,7 @@ static void ares_notify_write(ares_conn_t *conn)
     conn->state_flags |= ARES_CONN_STATE_CONNECTED;
   }
 
-  status = ares__conn_flush(conn);
+  status = ares_conn_flush(conn);
   if (status != ARES_SUCCESS) {
     handle_conn_error(conn, ARES_TRUE, status);
   }
@@ -293,7 +293,7 @@ static void process_write(const ares_channel_t *channel, fd_set *write_fds,
   size_t              i;
   ares_socket_t      *socketlist  = NULL;
   size_t              num_sockets = 0;
-  ares__llist_node_t *node        = NULL;
+  ares_llist_node_t *node        = NULL;
 
   if (!write_fds && write_fd == ARES_SOCKET_BAD) {
     /* no possible action */
@@ -302,12 +302,12 @@ static void process_write(const ares_channel_t *channel, fd_set *write_fds,
 
   /* Single socket specified */
   if (!write_fds) {
-    node = ares__htable_asvp_get_direct(channel->connnode_by_socket, write_fd);
+    node = ares_htable_asvp_get_direct(channel->connnode_by_socket, write_fd);
     if (node == NULL) {
       return;
     }
 
-    ares_notify_write(ares__llist_node_val(node));
+    ares_notify_write(ares_llist_node_val(node));
     return;
   }
 
@@ -329,12 +329,12 @@ static void process_write(const ares_channel_t *channel, fd_set *write_fds,
     FD_CLR(socketlist[i], write_fds);
 
     node =
-      ares__htable_asvp_get_direct(channel->connnode_by_socket, socketlist[i]);
+      ares_htable_asvp_get_direct(channel->connnode_by_socket, socketlist[i]);
     if (node == NULL) {
       return;
     }
 
-    ares_notify_write(ares__llist_node_val(node));
+    ares_notify_write(ares_llist_node_val(node));
   }
 
   ares_free(socketlist);
@@ -342,27 +342,27 @@ static void process_write(const ares_channel_t *channel, fd_set *write_fds,
 
 void ares_process_pending_write(ares_channel_t *channel)
 {
-  ares__slist_node_t *node;
+  ares_slist_node_t *node;
 
   if (channel == NULL) {
     return;
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
   if (!channel->notify_pending_write) {
-    ares__channel_unlock(channel);
+    ares_channel_unlock(channel);
     return;
   }
 
-  /* Set as untriggerd before calling into ares__conn_flush(), this is
-   * because its possible ares__conn_flush() might cause additional data to
+  /* Set as untriggerd before calling into ares_conn_flush(), this is
+   * because its possible ares_conn_flush() might cause additional data to
    * be enqueued if there is some form of exception so it will need to recurse.
    */
   channel->notify_pending_write = ARES_FALSE;
 
-  for (node = ares__slist_node_first(channel->servers); node != NULL;
-       node = ares__slist_node_next(node)) {
-    ares_server_t *server = ares__slist_node_val(node);
+  for (node = ares_slist_node_first(channel->servers); node != NULL;
+       node = ares_slist_node_next(node)) {
+    ares_server_t *server = ares_slist_node_val(node);
     ares_conn_t   *conn   = server->tcp_conn;
     ares_status_t  status;
 
@@ -371,13 +371,13 @@ void ares_process_pending_write(ares_channel_t *channel)
     }
 
     /* Enqueue any pending data if there is any */
-    status = ares__conn_flush(conn);
+    status = ares_conn_flush(conn);
     if (status != ARES_SUCCESS) {
       handle_conn_error(conn, ARES_TRUE, status);
     }
   }
 
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 }
 
 static ares_status_t read_conn_packets(ares_conn_t *conn)
@@ -390,18 +390,18 @@ static ares_status_t read_conn_packets(ares_conn_t *conn)
     size_t         count;
     size_t         len = 65535;
     unsigned char *ptr;
-    size_t         start_len = ares__buf_len(conn->in_buf);
+    size_t         start_len = ares_buf_len(conn->in_buf);
 
     /* If UDP, lets write out a placeholder for the length indicator */
     if (!(conn->flags & ARES_CONN_FLAG_TCP) &&
-        ares__buf_append_be16(conn->in_buf, 0) != ARES_SUCCESS) {
+        ares_buf_append_be16(conn->in_buf, 0) != ARES_SUCCESS) {
       handle_conn_error(conn, ARES_FALSE /* not critical to connection */,
                         ARES_SUCCESS);
       return ARES_ENOMEM;
     }
 
     /* Get a buffer of sufficient size */
-    ptr = ares__buf_append_start(conn->in_buf, &len);
+    ptr = ares_buf_append_start(conn->in_buf, &len);
 
     if (ptr == NULL) {
       handle_conn_error(conn, ARES_FALSE /* not critical to connection */,
@@ -410,18 +410,18 @@ static ares_status_t read_conn_packets(ares_conn_t *conn)
     }
 
     /* Read from socket */
-    err = ares__conn_read(conn, ptr, len, &count);
+    err = ares_conn_read(conn, ptr, len, &count);
 
     if (err != ARES_CONN_ERR_SUCCESS) {
-      ares__buf_append_finish(conn->in_buf, 0);
+      ares_buf_append_finish(conn->in_buf, 0);
       if (!(conn->flags & ARES_CONN_FLAG_TCP)) {
-        ares__buf_set_length(conn->in_buf, start_len);
+        ares_buf_set_length(conn->in_buf, start_len);
       }
       break;
     }
 
     /* Record amount of data read */
-    ares__buf_append_finish(conn->in_buf, count);
+    ares_buf_append_finish(conn->in_buf, count);
 
     /* Only loop if we're not overwriting socket functions, and are using UDP
      * or are using TCP and read the maximum buffer size */
@@ -436,10 +436,10 @@ static ares_status_t read_conn_packets(ares_conn_t *conn)
 
     /* If UDP, overwrite length */
     if (!(conn->flags & ARES_CONN_FLAG_TCP)) {
-      len = ares__buf_len(conn->in_buf);
-      ares__buf_set_length(conn->in_buf, start_len);
-      ares__buf_append_be16(conn->in_buf, (unsigned short)count);
-      ares__buf_set_length(conn->in_buf, len);
+      len = ares_buf_len(conn->in_buf);
+      ares_buf_set_length(conn->in_buf, start_len);
+      ares_buf_append_be16(conn->in_buf, (unsigned short)count);
+      ares_buf_set_length(conn->in_buf, len);
     }
     /* Try to read again only if *we* set up the socket, otherwise it may be
      * a blocking socket and would cause recvfrom to hang. */
@@ -465,24 +465,24 @@ static void read_answers(ares_conn_t *conn, const ares_timeval_t *now)
     ares_status_t        status;
 
     /* Tag so we can roll back */
-    ares__buf_tag(conn->in_buf);
+    ares_buf_tag(conn->in_buf);
 
     /* Read length indicator */
-    if (ares__buf_fetch_be16(conn->in_buf, &dns_len) != ARES_SUCCESS) {
-      ares__buf_tag_rollback(conn->in_buf);
+    if (ares_buf_fetch_be16(conn->in_buf, &dns_len) != ARES_SUCCESS) {
+      ares_buf_tag_rollback(conn->in_buf);
       break;
     }
 
     /* Not enough data for a full response yet */
-    if (ares__buf_consume(conn->in_buf, dns_len) != ARES_SUCCESS) {
-      ares__buf_tag_rollback(conn->in_buf);
+    if (ares_buf_consume(conn->in_buf, dns_len) != ARES_SUCCESS) {
+      ares_buf_tag_rollback(conn->in_buf);
       break;
     }
 
     /* Can't fail except for misuse */
-    data = ares__buf_tag_fetch(conn->in_buf, &data_len);
+    data = ares_buf_tag_fetch(conn->in_buf, &data_len);
     if (data == NULL || data_len < 2) {
-      ares__buf_tag_clear(conn->in_buf);
+      ares_buf_tag_clear(conn->in_buf);
       break;
     }
 
@@ -498,7 +498,7 @@ static void read_answers(ares_conn_t *conn, const ares_timeval_t *now)
     }
 
     /* Since we processed the answer, clear the tag so space can be reclaimed */
-    ares__buf_tag_clear(conn->in_buf);
+    ares_buf_tag_clear(conn->in_buf);
   }
 }
 
@@ -521,7 +521,7 @@ static void process_read(const ares_channel_t *channel, fd_set *read_fds,
   size_t              i;
   ares_socket_t      *socketlist  = NULL;
   size_t              num_sockets = 0;
-  ares__llist_node_t *node        = NULL;
+  ares_llist_node_t *node        = NULL;
 
   if (!read_fds && (read_fd == ARES_SOCKET_BAD)) {
     /* no possible action */
@@ -530,12 +530,12 @@ static void process_read(const ares_channel_t *channel, fd_set *read_fds,
 
   /* Single socket specified */
   if (!read_fds) {
-    node = ares__htable_asvp_get_direct(channel->connnode_by_socket, read_fd);
+    node = ares_htable_asvp_get_direct(channel->connnode_by_socket, read_fd);
     if (node == NULL) {
       return;
     }
 
-    read_conn(ares__llist_node_val(node), now);
+    read_conn(ares_llist_node_val(node), now);
 
     return;
   }
@@ -558,12 +558,12 @@ static void process_read(const ares_channel_t *channel, fd_set *read_fds,
     FD_CLR(socketlist[i], read_fds);
 
     node =
-      ares__htable_asvp_get_direct(channel->connnode_by_socket, socketlist[i]);
+      ares_htable_asvp_get_direct(channel->connnode_by_socket, socketlist[i]);
     if (node == NULL) {
       return;
     }
 
-    read_conn(ares__llist_node_val(node), now);
+    read_conn(ares_llist_node_val(node), now);
   }
 
   ares_free(socketlist);
@@ -572,18 +572,18 @@ static void process_read(const ares_channel_t *channel, fd_set *read_fds,
 /* If any queries have timed out, note the timeout and move them on. */
 static void process_timeouts(ares_channel_t *channel, const ares_timeval_t *now)
 {
-  ares__slist_node_t *node;
+  ares_slist_node_t *node;
 
   /* Just keep popping off the first as this list will re-sort as things come
    * and go.  We don't want to try to rely on 'next' as some operation might
    * cause a cleanup of that pointer and would become invalid */
-  while ((node = ares__slist_node_first(channel->queries_by_timeout)) != NULL) {
-    ares_query_t *query = ares__slist_node_val(node);
+  while ((node = ares_slist_node_first(channel->queries_by_timeout)) != NULL) {
+    ares_query_t *query = ares_slist_node_val(node);
     ares_conn_t  *conn;
 
     /* Since this is sorted, as soon as we hit a query that isn't timed out,
      * break */
-    if (!ares__timedout(now, &query->timeout)) {
+    if (!ares_timedout(now, &query->timeout)) {
       break;
     }
 
@@ -591,7 +591,7 @@ static void process_timeouts(ares_channel_t *channel, const ares_timeval_t *now)
 
     conn = query->conn;
     server_increment_failures(conn->server, query->using_tcp);
-    ares__requeue_query(query, now, ARES_ETIMEOUT, ARES_TRUE, NULL);
+    ares_requeue_query(query, now, ARES_ETIMEOUT, ARES_TRUE, NULL);
   }
 }
 
@@ -631,7 +631,7 @@ static ares_status_t process_answer(ares_channel_t      *channel,
                                     const ares_timeval_t *now)
 {
   ares_query_t      *query;
-  /* Cache these as once ares__send_query() gets called, it may end up
+  /* Cache these as once ares_send_query() gets called, it may end up
    * invalidating the connection all-together */
   ares_server_t     *server  = conn->server;
   ares_dns_record_t *rdnsrec = NULL;
@@ -654,7 +654,7 @@ static ares_status_t process_answer(ares_channel_t      *channel,
   /* Find the query corresponding to this packet. The queries are
    * hashed/bucketed by query id, so this lookup should be quick.
    */
-  query = ares__htable_szvp_get_direct(channel->queries_by_qid,
+  query = ares_htable_szvp_get_direct(channel->queries_by_qid,
                                        ares_dns_record_get_id(rdnsrec));
   if (!query) {
     /* We may have stopped listening for this query, that's ok */
@@ -682,7 +682,7 @@ static ares_status_t process_answer(ares_channel_t      *channel,
    * remove it from the connection's queue so we can possibly invalidate the
    * connection. Delay cleaning up the connection though as we may enqueue
    * something new.  */
-  ares__llist_node_destroy(query->node_queries_to_conn);
+  ares_llist_node_destroy(query->node_queries_to_conn);
   query->node_queries_to_conn = NULL;
 
   /* If we use EDNS and server answers with FORMERR without an OPT RR, the
@@ -697,7 +697,7 @@ static ares_status_t process_answer(ares_channel_t      *channel,
       goto cleanup;
     }
 
-    ares__send_query(query, now);
+    ares_send_query(query, now);
     status = ARES_SUCCESS;
     goto cleanup;
   }
@@ -710,7 +710,7 @@ static ares_status_t process_answer(ares_channel_t      *channel,
       !(conn->flags & ARES_CONN_FLAG_TCP) &&
       !(channel->flags & ARES_FLAG_IGNTC)) {
     query->using_tcp = ARES_TRUE;
-    ares__send_query(query, now);
+    ares_send_query(query, now);
     status = ARES_SUCCESS; /* Switched to TCP is ok */
     goto cleanup;
   }
@@ -737,7 +737,7 @@ static ares_status_t process_answer(ares_channel_t      *channel,
       }
 
       server_increment_failures(server, query->using_tcp);
-      ares__requeue_query(query, now, status, ARES_TRUE, rdnsrec);
+      ares_requeue_query(query, now, status, ARES_TRUE, rdnsrec);
 
       /* Should any of these cause a connection termination?
        * Maybe SERVER_FAILURE? */
@@ -779,19 +779,19 @@ static void handle_conn_error(ares_conn_t *conn, ares_bool_t critical_failure,
   }
 
   /* This will requeue any connections automatically */
-  ares__close_connection(conn, failure_status);
+  ares_close_connection(conn, failure_status);
 }
 
-ares_status_t ares__requeue_query(ares_query_t            *query,
+ares_status_t ares_requeue_query(ares_query_t            *query,
                                   const ares_timeval_t    *now,
                                   ares_status_t            status,
                                   ares_bool_t              inc_try_count,
                                   const ares_dns_record_t *dnsrec)
 {
   ares_channel_t *channel = query->channel;
-  size_t max_tries        = ares__slist_len(channel->servers) * channel->tries;
+  size_t max_tries        = ares_slist_len(channel->servers) * channel->tries;
 
-  ares__query_remove_from_conn(query);
+  ares_query_remove_from_conn(query);
 
   if (status != ARES_SUCCESS) {
     query->error_status = status;
@@ -802,7 +802,7 @@ ares_status_t ares__requeue_query(ares_query_t            *query,
   }
 
   if (query->try_count < max_tries && !query->no_retries) {
-    return ares__send_query(query, now);
+    return ares_send_query(query, now);
   }
 
   /* If we are here, all attempts to perform query failed. */
@@ -817,29 +817,29 @@ ares_status_t ares__requeue_query(ares_query_t            *query,
 /* Pick a random server from the list, we first get a random number in the
  * range of the number of servers, then scan until we find that server in
  * the list */
-static ares_server_t *ares__random_server(ares_channel_t *channel)
+static ares_server_t *ares_random_server(ares_channel_t *channel)
 {
   unsigned char       c;
   size_t              cnt;
   size_t              idx;
-  ares__slist_node_t *node;
-  size_t              num_servers = ares__slist_len(channel->servers);
+  ares_slist_node_t *node;
+  size_t              num_servers = ares_slist_len(channel->servers);
 
   /* Silence coverity, not possible */
   if (num_servers == 0) {
     return NULL;
   }
 
-  ares__rand_bytes(channel->rand_state, &c, 1);
+  ares_rand_bytes(channel->rand_state, &c, 1);
 
   cnt = c;
   idx = cnt % num_servers;
 
   cnt = 0;
-  for (node = ares__slist_node_first(channel->servers); node != NULL;
-       node = ares__slist_node_next(node)) {
+  for (node = ares_slist_node_first(channel->servers); node != NULL;
+       node = ares_slist_node_next(node)) {
     if (cnt == idx) {
-      return ares__slist_node_val(node);
+      return ares_slist_node_val(node);
     }
 
     cnt++;
@@ -861,10 +861,10 @@ static ares_server_t *ares__random_server(ares_channel_t *channel)
  * To resolve this, with some probability we select a failed server to retry
  * instead.
  */
-static ares_server_t *ares__failover_server(ares_channel_t *channel)
+static ares_server_t *ares_failover_server(ares_channel_t *channel)
 {
-  ares_server_t       *first_server = ares__slist_first_val(channel->servers);
-  const ares_server_t *last_server  = ares__slist_last_val(channel->servers);
+  ares_server_t       *first_server = ares_slist_first_val(channel->servers);
+  const ares_server_t *last_server  = ares_slist_last_val(channel->servers);
   unsigned short       r;
 
   /* Defensive code against no servers being available on the channel. */
@@ -889,18 +889,18 @@ static ares_server_t *ares__failover_server(ares_channel_t *channel)
    * precision of 1/2^B where B is the number of bits in the random value.
    * We use an unsigned short for the random value for increased precision.
    */
-  ares__rand_bytes(channel->rand_state, (unsigned char *)&r, sizeof(r));
+  ares_rand_bytes(channel->rand_state, (unsigned char *)&r, sizeof(r));
   if (r % channel->server_retry_chance == 0) {
     /* Select a suitable failed server to retry. */
     ares_timeval_t      now;
-    ares__slist_node_t *node;
+    ares_slist_node_t *node;
 
-    ares__tvnow(&now);
-    for (node = ares__slist_node_first(channel->servers); node != NULL;
-         node = ares__slist_node_next(node)) {
-      ares_server_t *node_val = ares__slist_node_val(node);
+    ares_tvnow(&now);
+    for (node = ares_slist_node_first(channel->servers); node != NULL;
+         node = ares_slist_node_next(node)) {
+      ares_server_t *node_val = ares_slist_node_val(node);
       if (node_val != NULL && node_val->consec_failures > 0 &&
-          ares__timedout(&now, &node_val->next_retry_time)) {
+          ares_timedout(&now, &node_val->next_retry_time)) {
         return node_val;
       }
     }
@@ -910,7 +910,7 @@ static ares_server_t *ares__failover_server(ares_channel_t *channel)
   return first_server;
 }
 
-static size_t ares__calc_query_timeout(const ares_query_t   *query,
+static size_t ares_calc_query_timeout(const ares_query_t   *query,
                                        const ares_server_t  *server,
                                        const ares_timeval_t *now)
 {
@@ -918,7 +918,7 @@ static size_t ares__calc_query_timeout(const ares_query_t   *query,
   size_t                timeout  = ares_metrics_server_timeout(server, now);
   size_t                timeplus = timeout;
   size_t                rounds;
-  size_t                num_servers = ares__slist_len(channel->servers);
+  size_t                num_servers = ares_slist_len(channel->servers);
 
   if (num_servers == 0) {
     return 0; /* LCOV_EXCL_LINE: DefensiveCoding */
@@ -948,7 +948,7 @@ static size_t ares__calc_query_timeout(const ares_query_t   *query,
     unsigned short r;
     float          delta_multiplier;
 
-    ares__rand_bytes(channel->rand_state, (unsigned char *)&r, sizeof(r));
+    ares_rand_bytes(channel->rand_state, (unsigned char *)&r, sizeof(r));
     delta_multiplier  = ((float)r / USHRT_MAX) * 0.5f;
     timeplus         -= (size_t)((float)timeplus * delta_multiplier);
   }
@@ -962,11 +962,11 @@ static size_t ares__calc_query_timeout(const ares_query_t   *query,
   return timeplus;
 }
 
-static ares_conn_t *ares__fetch_connection(const ares_channel_t *channel,
+static ares_conn_t *ares_fetch_connection(const ares_channel_t *channel,
                                            ares_server_t        *server,
                                            const ares_query_t   *query)
 {
-  ares__llist_node_t *node;
+  ares_llist_node_t *node;
   ares_conn_t        *conn;
 
   if (query->using_tcp) {
@@ -974,12 +974,12 @@ static ares_conn_t *ares__fetch_connection(const ares_channel_t *channel,
   }
 
   /* Fetch existing UDP connection */
-  node = ares__llist_node_first(server->connections);
+  node = ares_llist_node_first(server->connections);
   if (node == NULL) {
     return NULL;
   }
 
-  conn = ares__llist_node_val(node);
+  conn = ares_llist_node_val(node);
   /* Not UDP, skip */
   if (conn->flags & ARES_CONN_FLAG_TCP) {
     return NULL;
@@ -994,7 +994,7 @@ static ares_conn_t *ares__fetch_connection(const ares_channel_t *channel,
   return conn;
 }
 
-static ares_status_t ares__conn_query_write(ares_conn_t          *conn,
+static ares_status_t ares_conn_query_write(ares_conn_t          *conn,
                                             ares_query_t         *query,
                                             const ares_timeval_t *now)
 {
@@ -1033,10 +1033,10 @@ static ares_status_t ares__conn_query_write(ares_conn_t          *conn,
 
   /* Unfortunately we need to write right away and can't aggregate multiple
    * queries into a single write. */
-  return ares__conn_flush(conn);
+  return ares_conn_flush(conn);
 }
 
-ares_status_t ares__send_query(ares_query_t *query, const ares_timeval_t *now)
+ares_status_t ares_send_query(ares_query_t *query, const ares_timeval_t *now)
 {
   ares_channel_t *channel = query->channel;
   ares_server_t  *server;
@@ -1047,10 +1047,10 @@ ares_status_t ares__send_query(ares_query_t *query, const ares_timeval_t *now)
   /* Choose the server to send the query to */
   if (channel->rotate) {
     /* Pull random server */
-    server = ares__random_server(channel);
+    server = ares_random_server(channel);
   } else {
     /* Pull server with failover behavior */
-    server = ares__failover_server(channel);
+    server = ares_failover_server(channel);
   }
 
   if (server == NULL) {
@@ -1058,9 +1058,9 @@ ares_status_t ares__send_query(ares_query_t *query, const ares_timeval_t *now)
     return ARES_ENOSERVER;
   }
 
-  conn = ares__fetch_connection(channel, server, query);
+  conn = ares_fetch_connection(channel, server, query);
   if (conn == NULL) {
-    status = ares__open_connection(&conn, channel, server, query->using_tcp);
+    status = ares_open_connection(&conn, channel, server, query->using_tcp);
     switch (status) {
       /* Good result, continue on */
       case ARES_SUCCESS:
@@ -1071,7 +1071,7 @@ ares_status_t ares__send_query(ares_query_t *query, const ares_timeval_t *now)
       case ARES_ECONNREFUSED:
       case ARES_EBADFAMILY:
         server_increment_failures(server, query->using_tcp);
-        return ares__requeue_query(query, now, status, ARES_TRUE, NULL);
+        return ares_requeue_query(query, now, status, ARES_TRUE, NULL);
 
       /* Anything else is not retryable, likely ENOMEM */
       default:
@@ -1081,7 +1081,7 @@ ares_status_t ares__send_query(ares_query_t *query, const ares_timeval_t *now)
   }
 
   /* Write the query */
-  status = ares__conn_query_write(conn, query, now);
+  status = ares_conn_query_write(conn, query, now);
   switch (status) {
     /* Good result, continue on */
     case ARES_SUCCESS:
@@ -1097,7 +1097,7 @@ ares_status_t ares__send_query(ares_query_t *query, const ares_timeval_t *now)
     case ARES_ECONNREFUSED:
     case ARES_EBADFAMILY:
       handle_conn_error(conn, ARES_TRUE, status);
-      status = ares__requeue_query(query, now, status, ARES_TRUE, NULL);
+      status = ares_requeue_query(query, now, status, ARES_TRUE, NULL);
       if (status == ARES_ETIMEOUT) {
         status = ARES_ECONNREFUSED;
       }
@@ -1105,20 +1105,20 @@ ares_status_t ares__send_query(ares_query_t *query, const ares_timeval_t *now)
 
     default:
       server_increment_failures(server, query->using_tcp);
-      status = ares__requeue_query(query, now, status, ARES_TRUE, NULL);
+      status = ares_requeue_query(query, now, status, ARES_TRUE, NULL);
       return status;
   }
 
-  timeplus = ares__calc_query_timeout(query, server, now);
+  timeplus = ares_calc_query_timeout(query, server, now);
   /* Keep track of queries bucketed by timeout, so we can process
    * timeout events quickly.
    */
-  ares__slist_node_destroy(query->node_queries_by_timeout);
+  ares_slist_node_destroy(query->node_queries_by_timeout);
   query->ts      = *now;
   query->timeout = *now;
   timeadd(&query->timeout, timeplus);
   query->node_queries_by_timeout =
-    ares__slist_insert(channel->queries_by_timeout, query);
+    ares_slist_insert(channel->queries_by_timeout, query);
   if (!query->node_queries_by_timeout) {
     /* LCOV_EXCL_START: OutOfMemory */
     end_query(channel, server, query, ARES_ENOMEM, NULL);
@@ -1128,9 +1128,9 @@ ares_status_t ares__send_query(ares_query_t *query, const ares_timeval_t *now)
 
   /* Keep track of queries bucketed by connection, so we can process errors
    * quickly. */
-  ares__llist_node_destroy(query->node_queries_to_conn);
+  ares_llist_node_destroy(query->node_queries_to_conn);
   query->node_queries_to_conn =
-    ares__llist_insert_last(conn->queries_to_conn, query);
+    ares_llist_insert_last(conn->queries_to_conn, query);
 
   if (query->node_queries_to_conn == NULL) {
     /* LCOV_EXCL_START: OutOfMemory */
@@ -1208,9 +1208,9 @@ done:
 static void ares_detach_query(ares_query_t *query)
 {
   /* Remove the query from all the lists in which it is linked */
-  ares__query_remove_from_conn(query);
-  ares__htable_szvp_remove(query->channel->queries_by_qid, query->qid);
-  ares__llist_node_destroy(query->node_all_queries);
+  ares_query_remove_from_conn(query);
+  ares_htable_szvp_remove(query->channel->queries_by_qid, query->qid);
+  ares_llist_node_destroy(query->node_all_queries);
   query->node_all_queries = NULL;
 }
 
@@ -1222,7 +1222,7 @@ static void end_query(ares_channel_t *channel, ares_server_t *server,
 
   /* Invoke the callback. */
   query->callback(query->arg, status, query->timeouts, dnsrec);
-  ares__free_query(query);
+  ares_free_query(query);
 
   /* Check and notify if no other queries are enqueued on the channel.  This
    * must come after the callback and freeing the query for 2 reasons.
@@ -1232,7 +1232,7 @@ static void end_query(ares_channel_t *channel, ares_server_t *server,
   ares_queue_notify_empty(channel);
 }
 
-void ares__free_query(ares_query_t *query)
+void ares_free_query(ares_query_t *query)
 {
   ares_detach_query(query);
   /* Zero out some important stuff, to help catch bugs */

--- a/src/lib/ares_qcache.c
+++ b/src/lib/ares_qcache.c
@@ -28,7 +28,7 @@
 struct ares_qcache {
   ares_htable_strvp_t *cache;
   ares_slist_t        *expire;
-  unsigned int          max_ttl;
+  unsigned int         max_ttl;
 };
 
 typedef struct {
@@ -40,7 +40,7 @@ typedef struct {
 
 static char *ares_qcache_calc_key(const ares_dns_record_t *dnsrec)
 {
-  ares_buf_t     *buf = ares_buf_create();
+  ares_buf_t      *buf = ares_buf_create();
   size_t           i;
   ares_status_t    status;
   ares_dns_flags_t flags;
@@ -138,8 +138,7 @@ fail:
   /* LCOV_EXCL_STOP */
 }
 
-static void ares_qcache_expire(ares_qcache_t       *cache,
-                                const ares_timeval_t *now)
+static void ares_qcache_expire(ares_qcache_t *cache, const ares_timeval_t *now)
 {
   ares_slist_node_t *node;
 
@@ -205,10 +204,10 @@ static void ares_qcache_entry_destroy_cb(void *arg)
 }
 
 ares_status_t ares_qcache_create(ares_rand_state *rand_state,
-                                  unsigned int     max_ttl,
-                                  ares_qcache_t **cache_out)
+                                 unsigned int     max_ttl,
+                                 ares_qcache_t  **cache_out)
 {
-  ares_status_t   status = ARES_SUCCESS;
+  ares_status_t  status = ARES_SUCCESS;
   ares_qcache_t *cache;
 
   cache = ares_malloc_zero(sizeof(*cache));
@@ -224,7 +223,7 @@ ares_status_t ares_qcache_create(ares_rand_state *rand_state,
   }
 
   cache->expire = ares_slist_create(rand_state, ares_qcache_entry_sort_cb,
-                                     ares_qcache_entry_destroy_cb);
+                                    ares_qcache_entry_destroy_cb);
   if (cache->expire == NULL) {
     status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
     goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
@@ -302,15 +301,15 @@ static unsigned int ares_qcache_soa_minimum(ares_dns_record_t *dnsrec)
 }
 
 /* On success, takes ownership of dnsrec */
-static ares_status_t ares_qcache_insert_int(ares_qcache_t          *qcache,
+static ares_status_t ares_qcache_insert_int(ares_qcache_t           *qcache,
                                             ares_dns_record_t       *qresp,
                                             const ares_dns_record_t *qreq,
                                             const ares_timeval_t    *now)
 {
   ares_qcache_entry_t *entry;
-  unsigned int          ttl;
-  ares_dns_rcode_t      rcode = ares_dns_record_get_rcode(qresp);
-  ares_dns_flags_t      flags = ares_dns_record_get_flags(qresp);
+  unsigned int         ttl;
+  ares_dns_rcode_t     rcode = ares_dns_record_get_rcode(qresp);
+  ares_dns_flags_t     flags = ares_dns_record_get_flags(qresp);
 
   if (qcache == NULL || qresp == NULL) {
     return ARES_EFORMERR;
@@ -386,9 +385,9 @@ ares_status_t ares_qcache_fetch(ares_channel_t           *channel,
                                 const ares_dns_record_t  *dnsrec,
                                 const ares_dns_record_t **dnsrec_resp)
 {
-  char                 *key = NULL;
+  char                *key = NULL;
   ares_qcache_entry_t *entry;
-  ares_status_t         status = ARES_SUCCESS;
+  ares_status_t        status = ARES_SUCCESS;
 
   if (channel == NULL || dnsrec == NULL || dnsrec_resp == NULL) {
     return ARES_EFORMERR;

--- a/src/lib/ares_qcache.c
+++ b/src/lib/ares_qcache.c
@@ -25,9 +25,9 @@
  */
 #include "ares_private.h"
 
-struct ares__qcache {
-  ares__htable_strvp_t *cache;
-  ares__slist_t        *expire;
+struct ares_qcache {
+  ares_htable_strvp_t *cache;
+  ares_slist_t        *expire;
   unsigned int          max_ttl;
 };
 
@@ -36,11 +36,11 @@ typedef struct {
   ares_dns_record_t *dnsrec;
   time_t             expire_ts;
   time_t             insert_ts;
-} ares__qcache_entry_t;
+} ares_qcache_entry_t;
 
-static char *ares__qcache_calc_key(const ares_dns_record_t *dnsrec)
+static char *ares_qcache_calc_key(const ares_dns_record_t *dnsrec)
 {
-  ares__buf_t     *buf = ares__buf_create();
+  ares_buf_t     *buf = ares_buf_create();
   size_t           i;
   ares_status_t    status;
   ares_dns_flags_t flags;
@@ -51,13 +51,13 @@ static char *ares__qcache_calc_key(const ares_dns_record_t *dnsrec)
 
   /* Format is OPCODE|FLAGS[|QTYPE1|QCLASS1|QNAME1]... */
 
-  status = ares__buf_append_str(
+  status = ares_buf_append_str(
     buf, ares_dns_opcode_tostr(ares_dns_record_get_opcode(dnsrec)));
   if (status != ARES_SUCCESS) {
     goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  status = ares__buf_append_byte(buf, '|');
+  status = ares_buf_append_byte(buf, '|');
   if (status != ARES_SUCCESS) {
     goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -65,13 +65,13 @@ static char *ares__qcache_calc_key(const ares_dns_record_t *dnsrec)
   flags = ares_dns_record_get_flags(dnsrec);
   /* Only care about RD and CD */
   if (flags & ARES_FLAG_RD) {
-    status = ares__buf_append_str(buf, "rd");
+    status = ares_buf_append_str(buf, "rd");
     if (status != ARES_SUCCESS) {
       goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
   if (flags & ARES_FLAG_CD) {
-    status = ares__buf_append_str(buf, "cd");
+    status = ares_buf_append_str(buf, "cd");
     if (status != ARES_SUCCESS) {
       goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -88,27 +88,27 @@ static char *ares__qcache_calc_key(const ares_dns_record_t *dnsrec)
       goto fail; /* LCOV_EXCL_LINE: DefensiveCoding */
     }
 
-    status = ares__buf_append_byte(buf, '|');
+    status = ares_buf_append_byte(buf, '|');
     if (status != ARES_SUCCESS) {
       goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
-    status = ares__buf_append_str(buf, ares_dns_rec_type_tostr(qtype));
+    status = ares_buf_append_str(buf, ares_dns_rec_type_tostr(qtype));
     if (status != ARES_SUCCESS) {
       goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
-    status = ares__buf_append_byte(buf, '|');
+    status = ares_buf_append_byte(buf, '|');
     if (status != ARES_SUCCESS) {
       goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
-    status = ares__buf_append_str(buf, ares_dns_class_tostr(qclass));
+    status = ares_buf_append_str(buf, ares_dns_class_tostr(qclass));
     if (status != ARES_SUCCESS) {
       goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
-    status = ares__buf_append_byte(buf, '|');
+    status = ares_buf_append_byte(buf, '|');
     if (status != ARES_SUCCESS) {
       goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -122,64 +122,64 @@ static char *ares__qcache_calc_key(const ares_dns_record_t *dnsrec)
     }
 
     if (name_len > 0) {
-      status = ares__buf_append(buf, (const unsigned char *)name, name_len);
+      status = ares_buf_append(buf, (const unsigned char *)name, name_len);
       if (status != ARES_SUCCESS) {
         goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
       }
     }
   }
 
-  return ares__buf_finish_str(buf, NULL);
+  return ares_buf_finish_str(buf, NULL);
 
 /* LCOV_EXCL_START: OutOfMemory */
 fail:
-  ares__buf_destroy(buf);
+  ares_buf_destroy(buf);
   return NULL;
   /* LCOV_EXCL_STOP */
 }
 
-static void ares__qcache_expire(ares__qcache_t       *cache,
+static void ares_qcache_expire(ares_qcache_t       *cache,
                                 const ares_timeval_t *now)
 {
-  ares__slist_node_t *node;
+  ares_slist_node_t *node;
 
   if (cache == NULL) {
     return;
   }
 
-  while ((node = ares__slist_node_first(cache->expire)) != NULL) {
-    const ares__qcache_entry_t *entry = ares__slist_node_val(node);
+  while ((node = ares_slist_node_first(cache->expire)) != NULL) {
+    const ares_qcache_entry_t *entry = ares_slist_node_val(node);
 
     /* If now is NULL, we're flushing everything, so don't break */
     if (now != NULL && entry->expire_ts > now->sec) {
       break;
     }
 
-    ares__htable_strvp_remove(cache->cache, entry->key);
-    ares__slist_node_destroy(node);
+    ares_htable_strvp_remove(cache->cache, entry->key);
+    ares_slist_node_destroy(node);
   }
 }
 
-void ares__qcache_flush(ares__qcache_t *cache)
+void ares_qcache_flush(ares_qcache_t *cache)
 {
-  ares__qcache_expire(cache, NULL /* flush all */);
+  ares_qcache_expire(cache, NULL /* flush all */);
 }
 
-void ares__qcache_destroy(ares__qcache_t *cache)
+void ares_qcache_destroy(ares_qcache_t *cache)
 {
   if (cache == NULL) {
     return;
   }
 
-  ares__htable_strvp_destroy(cache->cache);
-  ares__slist_destroy(cache->expire);
+  ares_htable_strvp_destroy(cache->cache);
+  ares_slist_destroy(cache->expire);
   ares_free(cache);
 }
 
-static int ares__qcache_entry_sort_cb(const void *arg1, const void *arg2)
+static int ares_qcache_entry_sort_cb(const void *arg1, const void *arg2)
 {
-  const ares__qcache_entry_t *entry1 = arg1;
-  const ares__qcache_entry_t *entry2 = arg2;
+  const ares_qcache_entry_t *entry1 = arg1;
+  const ares_qcache_entry_t *entry2 = arg2;
 
   if (entry1->expire_ts > entry2->expire_ts) {
     return 1;
@@ -192,9 +192,9 @@ static int ares__qcache_entry_sort_cb(const void *arg1, const void *arg2)
   return 0;
 }
 
-static void ares__qcache_entry_destroy_cb(void *arg)
+static void ares_qcache_entry_destroy_cb(void *arg)
 {
-  ares__qcache_entry_t *entry = arg;
+  ares_qcache_entry_t *entry = arg;
   if (entry == NULL) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
@@ -204,12 +204,12 @@ static void ares__qcache_entry_destroy_cb(void *arg)
   ares_free(entry);
 }
 
-ares_status_t ares__qcache_create(ares_rand_state *rand_state,
+ares_status_t ares_qcache_create(ares_rand_state *rand_state,
                                   unsigned int     max_ttl,
-                                  ares__qcache_t **cache_out)
+                                  ares_qcache_t **cache_out)
 {
   ares_status_t   status = ARES_SUCCESS;
-  ares__qcache_t *cache;
+  ares_qcache_t *cache;
 
   cache = ares_malloc_zero(sizeof(*cache));
   if (cache == NULL) {
@@ -217,14 +217,14 @@ ares_status_t ares__qcache_create(ares_rand_state *rand_state,
     goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  cache->cache = ares__htable_strvp_create(NULL);
+  cache->cache = ares_htable_strvp_create(NULL);
   if (cache->cache == NULL) {
     status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
     goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  cache->expire = ares__slist_create(rand_state, ares__qcache_entry_sort_cb,
-                                     ares__qcache_entry_destroy_cb);
+  cache->expire = ares_slist_create(rand_state, ares_qcache_entry_sort_cb,
+                                     ares_qcache_entry_destroy_cb);
   if (cache->expire == NULL) {
     status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
     goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
@@ -235,7 +235,7 @@ ares_status_t ares__qcache_create(ares_rand_state *rand_state,
 done:
   if (status != ARES_SUCCESS) {
     *cache_out = NULL;
-    ares__qcache_destroy(cache);
+    ares_qcache_destroy(cache);
     return status;
   }
 
@@ -243,7 +243,7 @@ done:
   return status;
 }
 
-static unsigned int ares__qcache_calc_minttl(ares_dns_record_t *dnsrec)
+static unsigned int ares_qcache_calc_minttl(ares_dns_record_t *dnsrec)
 {
   unsigned int minttl = 0xFFFFFFFF;
   size_t       sect;
@@ -272,7 +272,7 @@ static unsigned int ares__qcache_calc_minttl(ares_dns_record_t *dnsrec)
   return minttl;
 }
 
-static unsigned int ares__qcache_soa_minimum(ares_dns_record_t *dnsrec)
+static unsigned int ares_qcache_soa_minimum(ares_dns_record_t *dnsrec)
 {
   size_t i;
 
@@ -302,12 +302,12 @@ static unsigned int ares__qcache_soa_minimum(ares_dns_record_t *dnsrec)
 }
 
 /* On success, takes ownership of dnsrec */
-static ares_status_t ares__qcache_insert(ares__qcache_t          *qcache,
-                                         ares_dns_record_t       *qresp,
-                                         const ares_dns_record_t *qreq,
-                                         const ares_timeval_t    *now)
+static ares_status_t ares_qcache_insert_int(ares_qcache_t          *qcache,
+                                            ares_dns_record_t       *qresp,
+                                            const ares_dns_record_t *qreq,
+                                            const ares_timeval_t    *now)
 {
-  ares__qcache_entry_t *entry;
+  ares_qcache_entry_t *entry;
   unsigned int          ttl;
   ares_dns_rcode_t      rcode = ares_dns_record_get_rcode(qresp);
   ares_dns_flags_t      flags = ares_dns_record_get_flags(qresp);
@@ -328,9 +328,9 @@ static ares_status_t ares__qcache_insert(ares__qcache_t          *qcache,
 
   /* Look at SOA for NXDOMAIN for minimum */
   if (rcode == ARES_RCODE_NXDOMAIN) {
-    ttl = ares__qcache_soa_minimum(qresp);
+    ttl = ares_qcache_soa_minimum(qresp);
   } else {
-    ttl = ares__qcache_calc_minttl(qresp);
+    ttl = ares_qcache_calc_minttl(qresp);
   }
 
   if (ttl > qcache->max_ttl) {
@@ -355,16 +355,16 @@ static ares_status_t ares__qcache_insert(ares__qcache_t          *qcache,
    * request had, so we have to re-parse the request in order to generate the
    * key for caching, but we'll only do this once we know for sure we really
    * want to cache it */
-  entry->key = ares__qcache_calc_key(qreq);
+  entry->key = ares_qcache_calc_key(qreq);
   if (entry->key == NULL) {
     goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  if (!ares__htable_strvp_insert(qcache->cache, entry->key, entry)) {
+  if (!ares_htable_strvp_insert(qcache->cache, entry->key, entry)) {
     goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  if (ares__slist_insert(qcache->expire, entry) == NULL) {
+  if (ares_slist_insert(qcache->expire, entry) == NULL) {
     goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
@@ -373,7 +373,7 @@ static ares_status_t ares__qcache_insert(ares__qcache_t          *qcache,
 /* LCOV_EXCL_START: OutOfMemory */
 fail:
   if (entry != NULL && entry->key != NULL) {
-    ares__htable_strvp_remove(qcache->cache, entry->key);
+    ares_htable_strvp_remove(qcache->cache, entry->key);
     ares_free(entry->key);
     ares_free(entry);
   }
@@ -387,7 +387,7 @@ ares_status_t ares_qcache_fetch(ares_channel_t           *channel,
                                 const ares_dns_record_t **dnsrec_resp)
 {
   char                 *key = NULL;
-  ares__qcache_entry_t *entry;
+  ares_qcache_entry_t *entry;
   ares_status_t         status = ARES_SUCCESS;
 
   if (channel == NULL || dnsrec == NULL || dnsrec_resp == NULL) {
@@ -398,15 +398,15 @@ ares_status_t ares_qcache_fetch(ares_channel_t           *channel,
     return ARES_ENOTFOUND;
   }
 
-  ares__qcache_expire(channel->qcache, now);
+  ares_qcache_expire(channel->qcache, now);
 
-  key = ares__qcache_calc_key(dnsrec);
+  key = ares_qcache_calc_key(dnsrec);
   if (key == NULL) {
     status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
     goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  entry = ares__htable_strvp_get_direct(channel->qcache->cache, key);
+  entry = ares_htable_strvp_get_direct(channel->qcache->cache, key);
   if (entry == NULL) {
     status = ARES_ENOTFOUND;
     goto done;
@@ -427,5 +427,5 @@ ares_status_t ares_qcache_insert(ares_channel_t       *channel,
                                  const ares_query_t   *query,
                                  ares_dns_record_t    *dnsrec)
 {
-  return ares__qcache_insert(channel->qcache, dnsrec, query->query, now);
+  return ares_qcache_insert_int(channel->qcache, dnsrec, query->query, now);
 }

--- a/src/lib/ares_query.c
+++ b/src/lib/ares_query.c
@@ -123,9 +123,9 @@ ares_status_t ares_query_dnsrec(ares_channel_t *channel, const char *name,
     return ARES_EFORMERR;
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
   status = ares_query_nolock(channel, name, dnsclass, type, callback, arg, qid);
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
   return status;
 }
 
@@ -138,13 +138,13 @@ void ares_query(ares_channel_t *channel, const char *name, int dnsclass,
     return;
   }
 
-  carg = ares__dnsrec_convert_arg(callback, arg);
+  carg = ares_dnsrec_convert_arg(callback, arg);
   if (carg == NULL) {
     callback(arg, ARES_ENOMEM, 0, NULL, 0); /* LCOV_EXCL_LINE: OutOfMemory */
     return;                                 /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   ares_query_dnsrec(channel, name, (ares_dns_class_t)dnsclass,
-                    (ares_dns_rec_type_t)type, ares__dnsrec_convert_cb, carg,
+                    (ares_dns_rec_type_t)type, ares_dnsrec_convert_cb, carg,
                     NULL);
 }

--- a/src/lib/ares_search.c
+++ b/src/lib/ares_search.c
@@ -55,7 +55,7 @@ static void squery_free(struct search_query *squery)
   if (squery == NULL) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
-  ares__strsplit_free(squery->names, squery->names_cnt);
+  ares_strsplit_free(squery->names, squery->names_cnt);
   ares_dns_record_destroy(squery->dnsrec);
   ares_free(squery);
 }
@@ -129,7 +129,7 @@ static void search_callback(void *arg, ares_status_t status, size_t timeouts,
     case ARES_EREFUSED:
       /* Issue #852, systemd-resolved may return SERVFAIL or REFUSED on a
        * single label domain name. */
-      if (ares__name_label_cnt(squery->names[squery->next_name_idx - 1]) != 1) {
+      if (ares_name_label_cnt(squery->names[squery->next_name_idx - 1]) != 1) {
         end_squery(squery, mystatus, dnsrec);
         return;
       }
@@ -168,7 +168,7 @@ static void search_callback(void *arg, ares_status_t status, size_t timeouts,
 
 /* Determine if the domain should be looked up as-is, or if it is eligible
  * for search by appending domains */
-static ares_bool_t ares__search_eligible(const ares_channel_t *channel,
+static ares_bool_t ares_search_eligible(const ares_channel_t *channel,
                                          const char           *name)
 {
   size_t len = ares_strlen(name);
@@ -185,7 +185,7 @@ static ares_bool_t ares__search_eligible(const ares_channel_t *channel,
   return ARES_TRUE;
 }
 
-size_t ares__name_label_cnt(const char *name)
+size_t ares_name_label_cnt(const char *name)
 {
   const char *p;
   size_t      ndots = 0;
@@ -204,7 +204,7 @@ size_t ares__name_label_cnt(const char *name)
   return ndots + 1;
 }
 
-ares_status_t ares__search_name_list(const ares_channel_t *channel,
+ares_status_t ares_search_name_list(const ares_channel_t *channel,
                                      const char *name, char ***names,
                                      size_t *names_len)
 {
@@ -217,7 +217,7 @@ ares_status_t ares__search_name_list(const ares_channel_t *channel,
   size_t        i;
 
   /* Perform HOSTALIASES resolution */
-  status = ares__lookup_hostaliases(channel, name, &alias);
+  status = ares_lookup_hostaliases(channel, name, &alias);
   if (status == ARES_SUCCESS) {
     /* If hostalias succeeds, there is no searching, it is used as-is */
     list_len = 1;
@@ -234,7 +234,7 @@ ares_status_t ares__search_name_list(const ares_channel_t *channel,
   }
 
   /* See if searching is eligible at all, if not, look up as-is only */
-  if (!ares__search_eligible(channel, name)) {
+  if (!ares_search_eligible(channel, name)) {
     list_len = 1;
     list     = ares_malloc_zero(sizeof(*list) * list_len);
     if (list == NULL) {
@@ -251,7 +251,7 @@ ares_status_t ares__search_name_list(const ares_channel_t *channel,
   }
 
   /* Count the number of dots in name, 1 less than label count */
-  ndots = ares__name_label_cnt(name);
+  ndots = ares_name_label_cnt(name);
   if (ndots > 0) {
     ndots--;
   }
@@ -265,7 +265,7 @@ ares_status_t ares__search_name_list(const ares_channel_t *channel,
   }
 
   /* Set status here, its possible there are no search domains at all, so
-   * status may be ARES_ENOTFOUND from ares__lookup_hostaliases(). */
+   * status may be ARES_ENOTFOUND from ares_lookup_hostaliases(). */
   status = ARES_SUCCESS;
 
   /* Try as-is first */
@@ -280,7 +280,7 @@ ares_status_t ares__search_name_list(const ares_channel_t *channel,
 
   /* Append each search suffix to the name */
   for (i = 0; i < channel->ndomains; i++) {
-    status = ares__cat_domain(name, channel->domains[i], &list[idx]);
+    status = ares_cat_domain(name, channel->domains[i], &list[idx]);
     if (status != ARES_SUCCESS) {
       goto done;
     }
@@ -303,7 +303,7 @@ done:
     *names     = list;
     *names_len = list_len;
   } else {
-    ares__strsplit_free(list, list_len);
+    ares_strsplit_free(list, list_len);
   }
 
   ares_free(alias);
@@ -333,7 +333,7 @@ static ares_status_t ares_search_int(ares_channel_t          *channel,
   }
 
   /* Per RFC 7686, reject queries for ".onion" domain names with NXDOMAIN. */
-  if (ares__is_onion_domain(name)) {
+  if (ares_is_onion_domain(name)) {
     status = ARES_ENOTFOUND;
     goto fail;
   }
@@ -362,7 +362,7 @@ static ares_status_t ares_search_int(ares_channel_t          *channel,
   squery->ever_got_nodata = ARES_FALSE;
 
   status =
-    ares__search_name_list(channel, name, &squery->names, &squery->names_cnt);
+    ares_search_name_list(channel, name, &squery->names, &squery->names_cnt);
   if (status != ARES_SUCCESS) {
     goto fail;
   }
@@ -382,7 +382,7 @@ fail:
   return status;
 }
 
-/* Callback argument structure passed to ares__dnsrec_convert_cb(). */
+/* Callback argument structure passed to ares_dnsrec_convert_cb(). */
 typedef struct {
   ares_callback callback;
   void         *arg;
@@ -390,7 +390,7 @@ typedef struct {
 
 /*! Function to create callback arg for converting from ares_callback_dnsrec
  *  to ares_calback */
-void *ares__dnsrec_convert_arg(ares_callback callback, void *arg)
+void *ares_dnsrec_convert_arg(ares_callback callback, void *arg)
 {
   dnsrec_convert_arg_t *carg = ares_malloc_zero(sizeof(*carg));
   if (carg == NULL) {
@@ -405,7 +405,7 @@ void *ares__dnsrec_convert_arg(ares_callback callback, void *arg)
  *  the ares_callback prototype, by writing the result and passing that to
  *  the inner callback.
  */
-void ares__dnsrec_convert_cb(void *arg, ares_status_t status, size_t timeouts,
+void ares_dnsrec_convert_cb(void *arg, ares_status_t status, size_t timeouts,
                              const ares_dns_record_t *dnsrec)
 {
   dnsrec_convert_arg_t *carg = arg;
@@ -441,11 +441,11 @@ void ares_search(ares_channel_t *channel, const char *name, int dnsclass,
   }
 
   /* For now, ares_search_int() uses the ares_callback prototype. We need to
-   * wrap the callback passed to this function in ares__dnsrec_convert_cb, to
+   * wrap the callback passed to this function in ares_dnsrec_convert_cb, to
    * convert from ares_callback_dnsrec to ares_callback. Allocate the convert
    * arg structure here.
    */
-  carg = ares__dnsrec_convert_arg(callback, arg);
+  carg = ares_dnsrec_convert_arg(callback, arg);
   if (carg == NULL) {
     callback(arg, ARES_ENOMEM, 0, NULL, 0);
     return;
@@ -462,9 +462,9 @@ void ares_search(ares_channel_t *channel, const char *name, int dnsclass,
     return;
   }
 
-  ares__channel_lock(channel);
-  ares_search_int(channel, dnsrec, ares__dnsrec_convert_cb, carg);
-  ares__channel_unlock(channel);
+  ares_channel_lock(channel);
+  ares_search_int(channel, dnsrec, ares_dnsrec_convert_cb, carg);
+  ares_channel_unlock(channel);
 
   ares_dns_record_destroy(dnsrec);
 }
@@ -480,15 +480,15 @@ ares_status_t ares_search_dnsrec(ares_channel_t          *channel,
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
   status = ares_search_int(channel, dnsrec, callback, arg);
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 
   return status;
 }
 
 /* Concatenate two domains. */
-ares_status_t ares__cat_domain(const char *name, const char *domain, char **s)
+ares_status_t ares_cat_domain(const char *name, const char *domain, char **s)
 {
   size_t nlen = ares_strlen(name);
   size_t dlen = ares_strlen(domain);
@@ -509,14 +509,14 @@ ares_status_t ares__cat_domain(const char *name, const char *domain, char **s)
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__lookup_hostaliases(const ares_channel_t *channel,
+ares_status_t ares_lookup_hostaliases(const ares_channel_t *channel,
                                        const char *name, char **alias)
 {
   ares_status_t       status      = ARES_SUCCESS;
   const char         *hostaliases = NULL;
-  ares__buf_t        *buf         = NULL;
-  ares__llist_t      *lines       = NULL;
-  ares__llist_node_t *node;
+  ares_buf_t        *buf         = NULL;
+  ares_llist_t      *lines       = NULL;
+  ares_llist_node_t *node;
 
   if (channel == NULL || name == NULL || alias == NULL) {
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
@@ -540,13 +540,13 @@ ares_status_t ares__lookup_hostaliases(const ares_channel_t *channel,
     goto done;
   }
 
-  buf = ares__buf_create();
+  buf = ares_buf_create();
   if (buf == NULL) {
     status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
     goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  status = ares__buf_load_file(hostaliases, buf);
+  status = ares_buf_load_file(hostaliases, buf);
   if (status != ARES_SUCCESS) {
     goto done;
   }
@@ -559,22 +559,22 @@ ares_status_t ares__lookup_hostaliases(const ares_channel_t *channel,
    * curl    www.curl.se
    */
 
-  status = ares__buf_split(buf, (const unsigned char *)"\n", 1,
+  status = ares_buf_split(buf, (const unsigned char *)"\n", 1,
                            ARES_BUF_SPLIT_TRIM, 0, &lines);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  for (node = ares__llist_node_first(lines); node != NULL;
-       node = ares__llist_node_next(node)) {
-    ares__buf_t *line         = ares__llist_node_val(node);
+  for (node = ares_llist_node_first(lines); node != NULL;
+       node = ares_llist_node_next(node)) {
+    ares_buf_t *line         = ares_llist_node_val(node);
     char         hostname[64] = "";
     char         fqdn[256]    = "";
 
     /* Pull off hostname */
-    ares__buf_tag(line);
-    ares__buf_consume_nonwhitespace(line);
-    if (ares__buf_tag_fetch_string(line, hostname, sizeof(hostname)) !=
+    ares_buf_tag(line);
+    ares_buf_consume_nonwhitespace(line);
+    if (ares_buf_tag_fetch_string(line, hostname, sizeof(hostname)) !=
         ARES_SUCCESS) {
       continue;
     }
@@ -585,18 +585,18 @@ ares_status_t ares__lookup_hostaliases(const ares_channel_t *channel,
     }
 
     /* consume whitespace */
-    ares__buf_consume_whitespace(line, ARES_TRUE);
+    ares_buf_consume_whitespace(line, ARES_TRUE);
 
     /* pull off fqdn */
-    ares__buf_tag(line);
-    ares__buf_consume_nonwhitespace(line);
-    if (ares__buf_tag_fetch_string(line, fqdn, sizeof(fqdn)) != ARES_SUCCESS ||
+    ares_buf_tag(line);
+    ares_buf_consume_nonwhitespace(line);
+    if (ares_buf_tag_fetch_string(line, fqdn, sizeof(fqdn)) != ARES_SUCCESS ||
         ares_strlen(fqdn) == 0) {
       continue;
     }
 
     /* Validate characterset */
-    if (!ares__is_hostname(fqdn)) {
+    if (!ares_is_hostname(fqdn)) {
       continue;
     }
 
@@ -614,8 +614,8 @@ ares_status_t ares__lookup_hostaliases(const ares_channel_t *channel,
   status = ARES_ENOTFOUND;
 
 done:
-  ares__buf_destroy(buf);
-  ares__llist_destroy(lines);
+  ares_buf_destroy(buf);
+  ares_llist_destroy(lines);
 
   return status;
 }

--- a/src/lib/ares_search.c
+++ b/src/lib/ares_search.c
@@ -169,7 +169,7 @@ static void search_callback(void *arg, ares_status_t status, size_t timeouts,
 /* Determine if the domain should be looked up as-is, or if it is eligible
  * for search by appending domains */
 static ares_bool_t ares_search_eligible(const ares_channel_t *channel,
-                                         const char           *name)
+                                        const char           *name)
 {
   size_t len = ares_strlen(name);
 
@@ -205,8 +205,8 @@ size_t ares_name_label_cnt(const char *name)
 }
 
 ares_status_t ares_search_name_list(const ares_channel_t *channel,
-                                     const char *name, char ***names,
-                                     size_t *names_len)
+                                    const char *name, char ***names,
+                                    size_t *names_len)
 {
   ares_status_t status;
   char        **list     = NULL;
@@ -406,7 +406,7 @@ void *ares_dnsrec_convert_arg(ares_callback callback, void *arg)
  *  the inner callback.
  */
 void ares_dnsrec_convert_cb(void *arg, ares_status_t status, size_t timeouts,
-                             const ares_dns_record_t *dnsrec)
+                            const ares_dns_record_t *dnsrec)
 {
   dnsrec_convert_arg_t *carg = arg;
   unsigned char        *abuf = NULL;
@@ -510,10 +510,10 @@ ares_status_t ares_cat_domain(const char *name, const char *domain, char **s)
 }
 
 ares_status_t ares_lookup_hostaliases(const ares_channel_t *channel,
-                                       const char *name, char **alias)
+                                      const char *name, char **alias)
 {
-  ares_status_t       status      = ARES_SUCCESS;
-  const char         *hostaliases = NULL;
+  ares_status_t      status      = ARES_SUCCESS;
+  const char        *hostaliases = NULL;
   ares_buf_t        *buf         = NULL;
   ares_llist_t      *lines       = NULL;
   ares_llist_node_t *node;
@@ -560,7 +560,7 @@ ares_status_t ares_lookup_hostaliases(const ares_channel_t *channel,
    */
 
   status = ares_buf_split(buf, (const unsigned char *)"\n", 1,
-                           ARES_BUF_SPLIT_TRIM, 0, &lines);
+                          ARES_BUF_SPLIT_TRIM, 0, &lines);
   if (status != ARES_SUCCESS) {
     goto done;
   }
@@ -568,8 +568,8 @@ ares_status_t ares_lookup_hostaliases(const ares_channel_t *channel,
   for (node = ares_llist_node_first(lines); node != NULL;
        node = ares_llist_node_next(node)) {
     ares_buf_t *line         = ares_llist_node_val(node);
-    char         hostname[64] = "";
-    char         fqdn[256]    = "";
+    char        hostname[64] = "";
+    char        fqdn[256]    = "";
 
     /* Pull off hostname */
     ares_buf_tag(line);

--- a/src/lib/ares_send.c
+++ b/src/lib/ares_send.c
@@ -37,8 +37,8 @@ static unsigned short generate_unique_qid(ares_channel_t *channel)
   unsigned short id;
 
   do {
-    id = ares__generate_new_id(channel->rand_state);
-  } while (ares__htable_szvp_get(channel->queries_by_qid, id, NULL));
+    id = ares_generate_new_id(channel->rand_state);
+  } while (ares_htable_szvp_get(channel->queries_by_qid, id, NULL));
 
   return id;
 }
@@ -77,14 +77,14 @@ static ares_status_t ares_apply_dns0x20(ares_channel_t    *channel,
    * is 1 bit per byte */
   total_bits     = ((len + 7) / 8) * 8;
   remaining_bits = total_bits;
-  ares__rand_bytes(channel->rand_state, randdata, total_bits / 8);
+  ares_rand_bytes(channel->rand_state, randdata, total_bits / 8);
 
   /* Randomly apply 0x20 to name */
   for (i = 0; i < len; i++) {
     size_t bit;
 
     /* Only apply 0x20 to alpha characters */
-    if (!ares__isalpha(name[i])) {
+    if (!ares_isalpha(name[i])) {
       dns0x20name[i] = name[i];
       continue;
     }
@@ -116,9 +116,9 @@ ares_status_t ares_send_nolock(ares_channel_t          *channel,
   unsigned short           id          = generate_unique_qid(channel);
   const ares_dns_record_t *dnsrec_resp = NULL;
 
-  ares__tvnow(&now);
+  ares_tvnow(&now);
 
-  if (ares__slist_len(channel->servers) == 0) {
+  if (ares_slist_len(channel->servers) == 0) {
     callback(arg, ARES_ENOSERVER, 0, NULL);
     return ARES_ENOSERVER;
   }
@@ -162,7 +162,7 @@ ares_status_t ares_send_nolock(ares_channel_t          *channel,
     if (status != ARES_SUCCESS) {
       /* LCOV_EXCL_START: OutOfMemory */
       callback(arg, status, 0, NULL);
-      ares__free_query(query);
+      ares_free_query(query);
       return status;
       /* LCOV_EXCL_STOP */
     }
@@ -185,11 +185,11 @@ ares_status_t ares_send_nolock(ares_channel_t          *channel,
 
   /* Chain the query into the list of all queries. */
   query->node_all_queries =
-    ares__llist_insert_last(channel->all_queries, query);
+    ares_llist_insert_last(channel->all_queries, query);
   if (query->node_all_queries == NULL) {
     /* LCOV_EXCL_START: OutOfMemory */
     callback(arg, ARES_ENOMEM, 0, NULL);
-    ares__free_query(query);
+    ares_free_query(query);
     return ARES_ENOMEM;
     /* LCOV_EXCL_STOP */
   }
@@ -197,17 +197,17 @@ ares_status_t ares_send_nolock(ares_channel_t          *channel,
   /* Keep track of queries bucketed by qid, so we can process DNS
    * responses quickly.
    */
-  if (!ares__htable_szvp_insert(channel->queries_by_qid, query->qid, query)) {
+  if (!ares_htable_szvp_insert(channel->queries_by_qid, query->qid, query)) {
     /* LCOV_EXCL_START: OutOfMemory */
     callback(arg, ARES_ENOMEM, 0, NULL);
-    ares__free_query(query);
+    ares_free_query(query);
     return ARES_ENOMEM;
     /* LCOV_EXCL_STOP */
   }
 
   /* Perform the first query action. */
 
-  status = ares__send_query(query, &now);
+  status = ares_send_query(query, &now);
   if (status == ARES_SUCCESS && qid) {
     *qid = id;
   }
@@ -225,11 +225,11 @@ ares_status_t ares_send_dnsrec(ares_channel_t          *channel,
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
 
   status = ares_send_nolock(channel, dnsrec, callback, arg, qid);
 
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 
   return status;
 }
@@ -257,7 +257,7 @@ void ares_send(ares_channel_t *channel, const unsigned char *qbuf, int qlen,
     return;
   }
 
-  carg = ares__dnsrec_convert_arg(callback, arg);
+  carg = ares_dnsrec_convert_arg(callback, arg);
   if (carg == NULL) {
     /* LCOV_EXCL_START: OutOfMemory */
     status = ARES_ENOMEM;
@@ -267,7 +267,7 @@ void ares_send(ares_channel_t *channel, const unsigned char *qbuf, int qlen,
     /* LCOV_EXCL_STOP */
   }
 
-  ares_send_dnsrec(channel, dnsrec, ares__dnsrec_convert_cb, carg, NULL);
+  ares_send_dnsrec(channel, dnsrec, ares_dnsrec_convert_cb, carg, NULL);
 
   ares_dns_record_destroy(dnsrec);
 }
@@ -280,11 +280,11 @@ size_t ares_queue_active_queries(const ares_channel_t *channel)
     return 0;
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
 
-  len = ares__llist_len(channel->all_queries);
+  len = ares_llist_len(channel->all_queries);
 
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 
   return len;
 }

--- a/src/lib/ares_send.c
+++ b/src/lib/ares_send.c
@@ -184,8 +184,7 @@ ares_status_t ares_send_nolock(ares_channel_t          *channel,
   query->node_queries_to_conn    = NULL;
 
   /* Chain the query into the list of all queries. */
-  query->node_all_queries =
-    ares_llist_insert_last(channel->all_queries, query);
+  query->node_all_queries = ares_llist_insert_last(channel->all_queries, query);
   if (query->node_all_queries == NULL) {
     /* LCOV_EXCL_START: OutOfMemory */
     callback(arg, ARES_ENOMEM, 0, NULL);

--- a/src/lib/ares_socket.c
+++ b/src/lib/ares_socket.c
@@ -248,7 +248,7 @@ static ares_bool_t same_address(const struct sockaddr  *sa,
 }
 
 void ares_conn_sock_state_cb_update(ares_conn_t            *conn,
-                                     ares_conn_state_flags_t flags)
+                                    ares_conn_state_flags_t flags)
 {
   ares_channel_t *channel = conn->server->channel;
 
@@ -264,8 +264,8 @@ void ares_conn_sock_state_cb_update(ares_conn_t            *conn,
 }
 
 ares_conn_err_t ares_socket_recv(ares_channel_t *channel, ares_socket_t s,
-                                  ares_bool_t is_tcp, void *data,
-                                  size_t data_len, size_t *read_bytes)
+                                 ares_bool_t is_tcp, void *data,
+                                 size_t data_len, size_t *read_bytes)
 {
   ares_ssize_t rv;
 
@@ -298,11 +298,11 @@ ares_conn_err_t ares_socket_recv(ares_channel_t *channel, ares_socket_t s,
 }
 
 ares_conn_err_t ares_socket_recvfrom(ares_channel_t *channel, ares_socket_t s,
-                                      ares_bool_t is_tcp, void *data,
-                                      size_t data_len, int flags,
-                                      struct sockaddr *from,
-                                      ares_socklen_t  *from_len,
-                                      size_t          *read_bytes)
+                                     ares_bool_t is_tcp, void *data,
+                                     size_t data_len, int flags,
+                                     struct sockaddr *from,
+                                     ares_socklen_t  *from_len,
+                                     size_t          *read_bytes)
 {
   ares_ssize_t rv;
 
@@ -337,7 +337,7 @@ ares_conn_err_t ares_socket_recvfrom(ares_channel_t *channel, ares_socket_t s,
 }
 
 ares_conn_err_t ares_conn_read(ares_conn_t *conn, void *data, size_t len,
-                                size_t *read_bytes)
+                               size_t *read_bytes)
 {
   ares_channel_t *channel = conn->server->channel;
   ares_conn_err_t err;
@@ -350,7 +350,7 @@ ares_conn_err_t ares_conn_read(ares_conn_t *conn, void *data, size_t len,
 
     err =
       ares_socket_recvfrom(channel, conn->fd, ARES_FALSE, data, len, 0,
-                            (struct sockaddr *)&sa_storage, &salen, read_bytes);
+                           (struct sockaddr *)&sa_storage, &salen, read_bytes);
 
 #ifdef HAVE_RECVFROM
     if (err == ARES_CONN_ERR_SUCCESS &&
@@ -359,8 +359,7 @@ ares_conn_err_t ares_conn_read(ares_conn_t *conn, void *data, size_t len,
     }
 #endif
   } else {
-    err =
-      ares_socket_recv(channel, conn->fd, ARES_TRUE, data, len, read_bytes);
+    err = ares_socket_recv(channel, conn->fd, ARES_TRUE, data, len, read_bytes);
   }
 
   /* Toggle connected state if needed */
@@ -378,8 +377,8 @@ ares_conn_err_t ares_conn_read(ares_conn_t *conn, void *data, size_t len,
  *   ares_conn_set_sockaddr(conn, sa, &salen);
  */
 static ares_status_t ares_conn_set_sockaddr(const ares_conn_t *conn,
-                                             struct sockaddr   *sa,
-                                             ares_socklen_t    *salen)
+                                            struct sockaddr   *sa,
+                                            ares_socklen_t    *salen)
 {
   const ares_server_t *server = conn->server;
   unsigned short       port =
@@ -455,8 +454,8 @@ static ares_status_t ares_conn_set_self_ip(ares_conn_t *conn, ares_bool_t early)
   return ARES_SUCCESS;
 }
 
-ares_conn_err_t ares_conn_write(ares_conn_t *conn, const void *data,
-                                 size_t len, size_t *written)
+ares_conn_err_t ares_conn_write(ares_conn_t *conn, const void *data, size_t len,
+                                size_t *written)
 {
   ares_channel_t *channel = conn->server->channel;
   int             flags   = 0;
@@ -543,7 +542,7 @@ done:
   } else if (err == ARES_CONN_ERR_WOULDBLOCK) {
     /* Need to wait on more buffer space to write */
     ares_conn_sock_state_cb_update(conn, ARES_CONN_STATE_READ |
-                                            ARES_CONN_STATE_WRITE);
+                                           ARES_CONN_STATE_WRITE);
   }
 
   return err;
@@ -862,7 +861,7 @@ ares_bool_t ares_sockaddr_to_ares_addr(struct ares_addr      *ares_addr,
 }
 
 static ares_status_t ares_conn_connect(ares_conn_t *conn, struct sockaddr *sa,
-                                        ares_socklen_t salen)
+                                       ares_socklen_t salen)
 {
   /* Normal non TCPFastOpen style connect */
   if (!(conn->flags & ARES_CONN_FLAG_TFO)) {
@@ -909,15 +908,15 @@ static ares_status_t ares_conn_connect(ares_conn_t *conn, struct sockaddr *sa,
 }
 
 ares_status_t ares_open_connection(ares_conn_t   **conn_out,
-                                    ares_channel_t *channel,
-                                    ares_server_t *server, ares_bool_t is_tcp)
+                                   ares_channel_t *channel,
+                                   ares_server_t *server, ares_bool_t is_tcp)
 {
   ares_status_t           status;
   struct sockaddr_storage sa_storage;
   ares_socklen_t          salen = sizeof(sa_storage);
   struct sockaddr        *sa    = (struct sockaddr *)&sa_storage;
   ares_conn_t            *conn;
-  ares_llist_node_t     *node  = NULL;
+  ares_llist_node_t      *node  = NULL;
   int                     stype = is_tcp ? SOCK_STREAM : SOCK_DGRAM;
   ares_conn_state_flags_t state_flags;
 
@@ -1064,7 +1063,7 @@ done:
 }
 
 ares_conn_err_t ares_open_socket(ares_socket_t *sock, ares_channel_t *channel,
-                                  int af, int type, int protocol)
+                                 int af, int type, int protocol)
 {
   ares_socket_t s;
 
@@ -1086,10 +1085,9 @@ ares_conn_err_t ares_open_socket(ares_socket_t *sock, ares_channel_t *channel,
   return ARES_CONN_ERR_SUCCESS;
 }
 
-ares_status_t ares_connect_socket(ares_channel_t        *channel,
-                                   ares_socket_t          sockfd,
-                                   const struct sockaddr *addr,
-                                   ares_socklen_t         addrlen)
+ares_status_t ares_connect_socket(ares_channel_t *channel, ares_socket_t sockfd,
+                                  const struct sockaddr *addr,
+                                  ares_socklen_t         addrlen)
 {
   int             rv;
   ares_conn_err_t err;

--- a/src/lib/ares_socket.c
+++ b/src/lib/ares_socket.c
@@ -175,7 +175,7 @@ struct iovec {
 };
 #endif
 
-static ares_conn_err_t ares__socket_deref_error(int err)
+static ares_conn_err_t ares_socket_deref_error(int err)
 {
   switch (err) {
 #if defined(EWOULDBLOCK)
@@ -247,7 +247,7 @@ static ares_bool_t same_address(const struct sockaddr  *sa,
   return ARES_FALSE; /* different */
 }
 
-void ares__conn_sock_state_cb_update(ares_conn_t            *conn,
+void ares_conn_sock_state_cb_update(ares_conn_t            *conn,
                                      ares_conn_state_flags_t flags)
 {
   ares_channel_t *channel = conn->server->channel;
@@ -263,7 +263,7 @@ void ares__conn_sock_state_cb_update(ares_conn_t            *conn,
   conn->state_flags |= flags;
 }
 
-ares_conn_err_t ares__socket_recv(ares_channel_t *channel, ares_socket_t s,
+ares_conn_err_t ares_socket_recv(ares_channel_t *channel, ares_socket_t s,
                                   ares_bool_t is_tcp, void *data,
                                   size_t data_len, size_t *read_bytes)
 {
@@ -294,10 +294,10 @@ ares_conn_err_t ares__socket_recv(ares_channel_t *channel, ares_socket_t s,
   }
 
   /* If we're here, rv<0 */
-  return ares__socket_deref_error(SOCKERRNO);
+  return ares_socket_deref_error(SOCKERRNO);
 }
 
-ares_conn_err_t ares__socket_recvfrom(ares_channel_t *channel, ares_socket_t s,
+ares_conn_err_t ares_socket_recvfrom(ares_channel_t *channel, ares_socket_t s,
                                       ares_bool_t is_tcp, void *data,
                                       size_t data_len, int flags,
                                       struct sockaddr *from,
@@ -314,7 +314,7 @@ ares_conn_err_t ares__socket_recvfrom(ares_channel_t *channel, ares_socket_t s,
     rv = (ares_ssize_t)recvfrom(s, data, (RECVFROM_TYPE_ARG3)data_len, flags,
                                 from, from_len);
 #else
-    return ares__socket_recv(channel, s, is_udp, data, data_len);
+    return ares_socket_recv(channel, s, is_udp, data, data_len);
 #endif
   }
 
@@ -333,10 +333,10 @@ ares_conn_err_t ares__socket_recvfrom(ares_channel_t *channel, ares_socket_t s,
   }
 
   /* If we're here, rv<0 */
-  return ares__socket_deref_error(SOCKERRNO);
+  return ares_socket_deref_error(SOCKERRNO);
 }
 
-ares_conn_err_t ares__conn_read(ares_conn_t *conn, void *data, size_t len,
+ares_conn_err_t ares_conn_read(ares_conn_t *conn, void *data, size_t len,
                                 size_t *read_bytes)
 {
   ares_channel_t *channel = conn->server->channel;
@@ -349,7 +349,7 @@ ares_conn_err_t ares__conn_read(ares_conn_t *conn, void *data, size_t len,
     memset(&sa_storage, 0, sizeof(sa_storage));
 
     err =
-      ares__socket_recvfrom(channel, conn->fd, ARES_FALSE, data, len, 0,
+      ares_socket_recvfrom(channel, conn->fd, ARES_FALSE, data, len, 0,
                             (struct sockaddr *)&sa_storage, &salen, read_bytes);
 
 #ifdef HAVE_RECVFROM
@@ -360,7 +360,7 @@ ares_conn_err_t ares__conn_read(ares_conn_t *conn, void *data, size_t len,
 #endif
   } else {
     err =
-      ares__socket_recv(channel, conn->fd, ARES_TRUE, data, len, read_bytes);
+      ares_socket_recv(channel, conn->fd, ARES_TRUE, data, len, read_bytes);
   }
 
   /* Toggle connected state if needed */
@@ -375,9 +375,9 @@ ares_conn_err_t ares__conn_read(ares_conn_t *conn, void *data, size_t len,
  *   struct sockaddr_storage sa_storage;
  *   ares_socklen_t          salen     = sizeof(sa_storage);
  *   struct sockaddr        *sa        = (struct sockaddr *)&sa_storage;
- *   ares__conn_set_sockaddr(conn, sa, &salen);
+ *   ares_conn_set_sockaddr(conn, sa, &salen);
  */
-static ares_status_t ares__conn_set_sockaddr(const ares_conn_t *conn,
+static ares_status_t ares_conn_set_sockaddr(const ares_conn_t *conn,
                                              struct sockaddr   *sa,
                                              ares_socklen_t    *salen)
 {
@@ -455,7 +455,7 @@ static ares_status_t ares_conn_set_self_ip(ares_conn_t *conn, ares_bool_t early)
   return ARES_SUCCESS;
 }
 
-ares_conn_err_t ares__conn_write(ares_conn_t *conn, const void *data,
+ares_conn_err_t ares_conn_write(ares_conn_t *conn, const void *data,
                                  size_t len, size_t *written)
 {
   ares_channel_t *channel = conn->server->channel;
@@ -484,7 +484,7 @@ ares_conn_err_t ares__conn_write(ares_conn_t *conn, const void *data,
     rv           = channel->sock_funcs->asendv(conn->fd, &vec, 1,
                                                channel->sock_func_cb_data);
     if (rv <= 0) {
-      err = ares__socket_deref_error(SOCKERRNO);
+      err = ares_socket_deref_error(SOCKERRNO);
     } else {
       *written = (size_t)rv;
     }
@@ -501,7 +501,7 @@ ares_conn_err_t ares__conn_write(ares_conn_t *conn, const void *data,
       ares_socklen_t          salen = sizeof(sa_storage);
       struct sockaddr        *sa    = (struct sockaddr *)&sa_storage;
 
-      if (ares__conn_set_sockaddr(conn, sa, &salen) != ARES_SUCCESS) {
+      if (ares_conn_set_sockaddr(conn, sa, &salen) != ARES_SUCCESS) {
         return ARES_CONN_ERR_FAILURE;
       }
 
@@ -509,7 +509,7 @@ ares_conn_err_t ares__conn_write(ares_conn_t *conn, const void *data,
                                 (SEND_TYPE_ARG3)len, (SEND_TYPE_ARG4)flags, sa,
                                 salen);
       if (rv <= 0) {
-        err = ares__socket_deref_error(SOCKERRNO);
+        err = ares_socket_deref_error(SOCKERRNO);
       } else {
         *written = (size_t)rv;
       }
@@ -526,7 +526,7 @@ ares_conn_err_t ares__conn_write(ares_conn_t *conn, const void *data,
   rv = (ares_ssize_t)send((SEND_TYPE_ARG1)conn->fd, (SEND_TYPE_ARG2)data,
                           (SEND_TYPE_ARG3)len, (SEND_TYPE_ARG4)flags);
   if (rv <= 0) {
-    err = ares__socket_deref_error(SOCKERRNO);
+    err = ares_socket_deref_error(SOCKERRNO);
   } else {
     *written = (size_t)rv;
   }
@@ -537,19 +537,19 @@ done:
     /* Wrote all data, make sure we're not listening for write events unless
      * using TFO, in which case we'll need a write event to know when
      * we're connected. */
-    ares__conn_sock_state_cb_update(
+    ares_conn_sock_state_cb_update(
       conn, ARES_CONN_STATE_READ |
               (is_tfo ? ARES_CONN_STATE_WRITE : ARES_CONN_STATE_NONE));
   } else if (err == ARES_CONN_ERR_WOULDBLOCK) {
     /* Need to wait on more buffer space to write */
-    ares__conn_sock_state_cb_update(conn, ARES_CONN_STATE_READ |
+    ares_conn_sock_state_cb_update(conn, ARES_CONN_STATE_READ |
                                             ARES_CONN_STATE_WRITE);
   }
 
   return err;
 }
 
-ares_status_t ares__conn_flush(ares_conn_t *conn)
+ares_status_t ares_conn_flush(ares_conn_t *conn)
 {
   const unsigned char *data;
   size_t               data_len;
@@ -567,25 +567,25 @@ ares_status_t ares__conn_flush(ares_conn_t *conn)
   }
 
   do {
-    if (ares__buf_len(conn->out_buf) == 0) {
+    if (ares_buf_len(conn->out_buf) == 0) {
       status = ARES_SUCCESS;
       goto done;
     }
 
     if (conn->flags & ARES_CONN_FLAG_TCP) {
-      data = ares__buf_peek(conn->out_buf, &data_len);
+      data = ares_buf_peek(conn->out_buf, &data_len);
     } else {
       unsigned short msg_len;
 
       /* Read length, then provide buffer without length */
-      ares__buf_tag(conn->out_buf);
-      status = ares__buf_fetch_be16(conn->out_buf, &msg_len);
+      ares_buf_tag(conn->out_buf);
+      status = ares_buf_fetch_be16(conn->out_buf, &msg_len);
       if (status != ARES_SUCCESS) {
         return status;
       }
-      ares__buf_tag_rollback(conn->out_buf);
+      ares_buf_tag_rollback(conn->out_buf);
 
-      data = ares__buf_peek(conn->out_buf, &data_len);
+      data = ares_buf_peek(conn->out_buf, &data_len);
       if (data_len < (size_t)(msg_len + 2)) {
         status = ARES_EFORMERR;
         goto done;
@@ -594,7 +594,7 @@ ares_status_t ares__conn_flush(ares_conn_t *conn)
       data_len  = msg_len;
     }
 
-    err = ares__conn_write(conn, data, data_len, &count);
+    err = ares_conn_write(conn, data, data_len, &count);
     if (err != ARES_CONN_ERR_SUCCESS) {
       if (err != ARES_CONN_ERR_WOULDBLOCK) {
         status = ARES_ECONNREFUSED;
@@ -610,7 +610,7 @@ ares_status_t ares__conn_flush(ares_conn_t *conn)
     }
 
     /* Strip data written from the buffer */
-    ares__buf_consume(conn->out_buf, count);
+    ares_buf_consume(conn->out_buf, count);
     status = ARES_SUCCESS;
 
     /* Loop only for UDP since we have to send per-packet.  We already
@@ -629,11 +629,11 @@ done:
 
     /* If using TCP and not all data was written (partial write), that means
      * we need to also wait on a write event */
-    if (conn->flags & ARES_CONN_FLAG_TCP && ares__buf_len(conn->out_buf)) {
+    if (conn->flags & ARES_CONN_FLAG_TCP && ares_buf_len(conn->out_buf)) {
       flags |= ARES_CONN_STATE_WRITE;
     }
 
-    ares__conn_sock_state_cb_update(conn, flags);
+    ares_conn_sock_state_cb_update(conn, flags);
   }
 
   return status;
@@ -861,12 +861,12 @@ ares_bool_t ares_sockaddr_to_ares_addr(struct ares_addr      *ares_addr,
   return ARES_FALSE;
 }
 
-static ares_status_t ares__conn_connect(ares_conn_t *conn, struct sockaddr *sa,
+static ares_status_t ares_conn_connect(ares_conn_t *conn, struct sockaddr *sa,
                                         ares_socklen_t salen)
 {
   /* Normal non TCPFastOpen style connect */
   if (!(conn->flags & ARES_CONN_FLAG_TFO)) {
-    return ares__connect_socket(conn->server->channel, conn->fd, sa, salen);
+    return ares_connect_socket(conn->server->channel, conn->fd, sa, salen);
   }
 
   /* FreeBSD don't want any sort of connect() so skip */
@@ -889,7 +889,7 @@ static ares_status_t ares__conn_connect(ares_conn_t *conn, struct sockaddr *sa,
                     NULL, 0, NULL, NULL);
 
       if (rv < 0) {
-        err = ares__socket_deref_error(SOCKERRNO);
+        err = ares_socket_deref_error(SOCKERRNO);
       } else {
         break;
       }
@@ -901,14 +901,14 @@ static ares_status_t ares__conn_connect(ares_conn_t *conn, struct sockaddr *sa,
   }
   return ARES_SUCCESS;
 #elif defined(TFO_SUPPORTED) && TFO_SUPPORTED
-  return ares__connect_socket(conn->server->channel, conn->fd, sa, salen);
+  return ares_connect_socket(conn->server->channel, conn->fd, sa, salen);
 #else
   /* Shouldn't be possible */
   return ARES_ECONNREFUSED;
 #endif
 }
 
-ares_status_t ares__open_connection(ares_conn_t   **conn_out,
+ares_status_t ares_open_connection(ares_conn_t   **conn_out,
                                     ares_channel_t *channel,
                                     ares_server_t *server, ares_bool_t is_tcp)
 {
@@ -917,7 +917,7 @@ ares_status_t ares__open_connection(ares_conn_t   **conn_out,
   ares_socklen_t          salen = sizeof(sa_storage);
   struct sockaddr        *sa    = (struct sockaddr *)&sa_storage;
   ares_conn_t            *conn;
-  ares__llist_node_t     *node  = NULL;
+  ares_llist_node_t     *node  = NULL;
   int                     stype = is_tcp ? SOCK_STREAM : SOCK_DGRAM;
   ares_conn_state_flags_t state_flags;
 
@@ -931,10 +931,10 @@ ares_status_t ares__open_connection(ares_conn_t   **conn_out,
   memset(conn, 0, sizeof(*conn));
   conn->fd              = ARES_SOCKET_BAD;
   conn->server          = server;
-  conn->queries_to_conn = ares__llist_create(NULL);
+  conn->queries_to_conn = ares_llist_create(NULL);
   conn->flags           = is_tcp ? ARES_CONN_FLAG_TCP : ARES_CONN_FLAG_NONE;
-  conn->out_buf         = ares__buf_create();
-  conn->in_buf          = ares__buf_create();
+  conn->out_buf         = ares_buf_create();
+  conn->in_buf          = ares_buf_create();
 
   if (conn->queries_to_conn == NULL || conn->out_buf == NULL ||
       conn->in_buf == NULL) {
@@ -953,13 +953,13 @@ ares_status_t ares__open_connection(ares_conn_t   **conn_out,
   }
 
   /* Convert into the struct sockaddr structure needed by the OS */
-  status = ares__conn_set_sockaddr(conn, sa, &salen);
+  status = ares_conn_set_sockaddr(conn, sa, &salen);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
   /* Acquire a socket. */
-  if (ares__open_socket(&conn->fd, channel, server->addr.family, stype, 0) !=
+  if (ares_open_socket(&conn->fd, channel, server->addr.family, stype, 0) !=
       ARES_CONN_ERR_SUCCESS) {
     status = ARES_ECONNREFUSED;
     goto done;
@@ -981,7 +981,7 @@ ares_status_t ares__open_connection(ares_conn_t   **conn_out,
   }
 
   /* Connect */
-  status = ares__conn_connect(conn, sa, salen);
+  status = ares_conn_connect(conn, sa, salen);
   if (status != ARES_SUCCESS) {
     goto done;
   }
@@ -1010,9 +1010,9 @@ ares_status_t ares__open_connection(ares_conn_t   **conn_out,
    * connections. UDP connections are put on front where the newest connection
    * can be quickly pulled */
   if (is_tcp) {
-    node = ares__llist_insert_last(server->connections, conn);
+    node = ares_llist_insert_last(server->connections, conn);
   } else {
-    node = ares__llist_insert_first(server->connections, conn);
+    node = ares_llist_insert_first(server->connections, conn);
   }
   if (node == NULL) {
     /* LCOV_EXCL_START: OutOfMemory */
@@ -1023,7 +1023,7 @@ ares_status_t ares__open_connection(ares_conn_t   **conn_out,
 
   /* Register globally to quickly map event on file descriptor to connection
    * node object */
-  if (!ares__htable_asvp_insert(channel->connnode_by_socket, conn->fd, node)) {
+  if (!ares_htable_asvp_insert(channel->connnode_by_socket, conn->fd, node)) {
     /* LCOV_EXCL_START: OutOfMemory */
     status = ARES_ENOMEM;
     goto done;
@@ -1042,7 +1042,7 @@ ares_status_t ares__open_connection(ares_conn_t   **conn_out,
    * an erroneous read can come in before the attempt to write the data which
    * might be used to set the ip address */
   if (!(conn->flags & ARES_CONN_FLAG_TFO_INITIAL)) {
-    ares__conn_sock_state_cb_update(conn, state_flags);
+    ares_conn_sock_state_cb_update(conn, state_flags);
   }
 
   if (is_tcp) {
@@ -1051,11 +1051,11 @@ ares_status_t ares__open_connection(ares_conn_t   **conn_out,
 
 done:
   if (status != ARES_SUCCESS) {
-    ares__llist_node_claim(node);
-    ares__llist_destroy(conn->queries_to_conn);
-    ares__close_socket(channel, conn->fd);
-    ares__buf_destroy(conn->out_buf);
-    ares__buf_destroy(conn->in_buf);
+    ares_llist_node_claim(node);
+    ares_llist_destroy(conn->queries_to_conn);
+    ares_close_socket(channel, conn->fd);
+    ares_buf_destroy(conn->out_buf);
+    ares_buf_destroy(conn->in_buf);
     ares_free(conn);
   } else {
     *conn_out = conn;
@@ -1063,7 +1063,7 @@ done:
   return status;
 }
 
-ares_conn_err_t ares__open_socket(ares_socket_t *sock, ares_channel_t *channel,
+ares_conn_err_t ares_open_socket(ares_socket_t *sock, ares_channel_t *channel,
                                   int af, int type, int protocol)
 {
   ares_socket_t s;
@@ -1078,7 +1078,7 @@ ares_conn_err_t ares__open_socket(ares_socket_t *sock, ares_channel_t *channel,
   }
 
   if (s == ARES_SOCKET_BAD) {
-    return ares__socket_deref_error(SOCKERRNO);
+    return ares_socket_deref_error(SOCKERRNO);
   }
 
   *sock = s;
@@ -1086,7 +1086,7 @@ ares_conn_err_t ares__open_socket(ares_socket_t *sock, ares_channel_t *channel,
   return ARES_CONN_ERR_SUCCESS;
 }
 
-ares_status_t ares__connect_socket(ares_channel_t        *channel,
+ares_status_t ares_connect_socket(ares_channel_t        *channel,
                                    ares_socket_t          sockfd,
                                    const struct sockaddr *addr,
                                    ares_socklen_t         addrlen)
@@ -1103,7 +1103,7 @@ ares_status_t ares__connect_socket(ares_channel_t        *channel,
     }
 
     if (rv < 0) {
-      err = ares__socket_deref_error(SOCKERRNO);
+      err = ares_socket_deref_error(SOCKERRNO);
     } else {
       break;
     }
@@ -1116,7 +1116,7 @@ ares_status_t ares__connect_socket(ares_channel_t        *channel,
   return ARES_SUCCESS;
 }
 
-void ares__close_socket(ares_channel_t *channel, ares_socket_t s)
+void ares_close_socket(ares_channel_t *channel, ares_socket_t s)
 {
   if (s == ARES_SOCKET_BAD) {
     return;

--- a/src/lib/ares_sortaddrinfo.c
+++ b/src/lib/ares_sortaddrinfo.c
@@ -387,7 +387,7 @@ static int find_src_addr(ares_channel_t *channel, const struct sockaddr *addr,
  * Will leave the list unchanged if an error occurs.
  */
 ares_status_t ares_sortaddrinfo(ares_channel_t            *channel,
-                                 struct ares_addrinfo_node *list_sentinel)
+                                struct ares_addrinfo_node *list_sentinel)
 {
   struct ares_addrinfo_node *cur;
   size_t                     nelem = 0;

--- a/src/lib/ares_sortaddrinfo.c
+++ b/src/lib/ares_sortaddrinfo.c
@@ -362,23 +362,23 @@ static int find_src_addr(ares_channel_t *channel, const struct sockaddr *addr,
   }
 
   err =
-    ares__open_socket(&sock, channel, addr->sa_family, SOCK_DGRAM, IPPROTO_UDP);
+    ares_open_socket(&sock, channel, addr->sa_family, SOCK_DGRAM, IPPROTO_UDP);
   if (err == ARES_CONN_ERR_AFNOSUPPORT) {
     return 0;
   } else if (err != ARES_CONN_ERR_SUCCESS) {
     return -1;
   }
 
-  if (ares__connect_socket(channel, sock, addr, len) != ARES_SUCCESS) {
-    ares__close_socket(channel, sock);
+  if (ares_connect_socket(channel, sock, addr, len) != ARES_SUCCESS) {
+    ares_close_socket(channel, sock);
     return 0;
   }
 
   if (getsockname(sock, src_addr, &len) != 0) {
-    ares__close_socket(channel, sock);
+    ares_close_socket(channel, sock);
     return -1;
   }
-  ares__close_socket(channel, sock);
+  ares_close_socket(channel, sock);
   return 1;
 }
 
@@ -386,7 +386,7 @@ static int find_src_addr(ares_channel_t *channel, const struct sockaddr *addr,
  * Sort the linked list starting at sentinel->ai_next in RFC6724 order.
  * Will leave the list unchanged if an error occurs.
  */
-ares_status_t ares__sortaddrinfo(ares_channel_t            *channel,
+ares_status_t ares_sortaddrinfo(ares_channel_t            *channel,
                                  struct ares_addrinfo_node *list_sentinel)
 {
   struct ares_addrinfo_node *cur;

--- a/src/lib/ares_sysconfig.c
+++ b/src/lib/ares_sysconfig.c
@@ -101,7 +101,7 @@ static ares_status_t ares_init_sysconfig_mvs(ares_sysconfig_t *sysconfig)
 
     status =
       ares_sconfig_append(&sysconfig->sconfig, &addr, htons(addr_in->sin_port),
-                           htons(addr_in->sin_port), NULL);
+                          htons(addr_in->sin_port), NULL);
 
     if (status != ARES_SUCCESS) {
       return status;
@@ -118,7 +118,7 @@ static ares_status_t ares_init_sysconfig_mvs(ares_sysconfig_t *sysconfig)
 
     status =
       ares_sconfig_append(&sysconfig->sconfig, &addr, htons(addr_in->sin_port),
-                           htons(addr_in->sin_port), NULL);
+                          htons(addr_in->sin_port), NULL);
 
     if (status != ARES_SUCCESS) {
       return status;
@@ -153,8 +153,7 @@ static ares_status_t ares_init_sysconfig_riscos(ares_sysconfig_t *sysconfig)
       if (space) {
         *space = '\0';
       }
-      status =
-        ares_sconfig_append_fromstr(&sysconfig->sconfig, pos, ARES_TRUE);
+      status = ares_sconfig_append_fromstr(&sysconfig->sconfig, pos, ARES_TRUE);
       if (status != ARES_SUCCESS) {
         break;
       }
@@ -212,7 +211,7 @@ static ares_status_t ares_init_sysconfig_android(ares_sysconfig_t *sysconfig)
   if (dns_servers != NULL) {
     for (i = 0; i < num_servers; i++) {
       status = ares_sconfig_append_fromstr(&sysconfig->sconfig, dns_servers[i],
-                                            ARES_TRUE);
+                                           ARES_TRUE);
       if (status != ARES_SUCCESS) {
         return status;
       }
@@ -265,7 +264,7 @@ static ares_status_t ares_init_sysconfig_libresolv(ares_sysconfig_t *sysconfig)
   int                      nscount;
   size_t                   i;
   size_t                   entries = 0;
-  ares_buf_t             *ipbuf   = NULL;
+  ares_buf_t              *ipbuf   = NULL;
 
   memset(&res, 0, sizeof(res));
 
@@ -345,8 +344,7 @@ static ares_status_t ares_init_sysconfig_libresolv(ares_sysconfig_t *sysconfig)
       goto done;
     }
 
-    status =
-      ares_sconfig_append_fromstr(&sysconfig->sconfig, ipstr, ARES_TRUE);
+    status = ares_sconfig_append_fromstr(&sysconfig->sconfig, ipstr, ARES_TRUE);
 
     ares_free(ipstr);
     if (status != ARES_SUCCESS) {

--- a/src/lib/ares_sysconfig.c
+++ b/src/lib/ares_sysconfig.c
@@ -60,7 +60,7 @@
 
 
 #if defined(__MVS__)
-static ares_status_t ares__init_sysconfig_mvs(ares_sysconfig_t *sysconfig)
+static ares_status_t ares_init_sysconfig_mvs(ares_sysconfig_t *sysconfig)
 {
   struct __res_state *res = 0;
   size_t              count4;
@@ -100,7 +100,7 @@ static ares_status_t ares__init_sysconfig_mvs(ares_sysconfig_t *sysconfig)
     addr.family            = AF_INET;
 
     status =
-      ares__sconfig_append(&sysconfig->sconfig, &addr, htons(addr_in->sin_port),
+      ares_sconfig_append(&sysconfig->sconfig, &addr, htons(addr_in->sin_port),
                            htons(addr_in->sin_port), NULL);
 
     if (status != ARES_SUCCESS) {
@@ -117,7 +117,7 @@ static ares_status_t ares__init_sysconfig_mvs(ares_sysconfig_t *sysconfig)
            sizeof(addr_in->sin6_addr));
 
     status =
-      ares__sconfig_append(&sysconfig->sconfig, &addr, htons(addr_in->sin_port),
+      ares_sconfig_append(&sysconfig->sconfig, &addr, htons(addr_in->sin_port),
                            htons(addr_in->sin_port), NULL);
 
     if (status != ARES_SUCCESS) {
@@ -130,7 +130,7 @@ static ares_status_t ares__init_sysconfig_mvs(ares_sysconfig_t *sysconfig)
 #endif
 
 #if defined(__riscos__)
-static ares_status_t ares__init_sysconfig_riscos(ares_sysconfig_t *sysconfig)
+static ares_status_t ares_init_sysconfig_riscos(ares_sysconfig_t *sysconfig)
 {
   char         *line;
   ares_status_t status = ARES_SUCCESS;
@@ -154,7 +154,7 @@ static ares_status_t ares__init_sysconfig_riscos(ares_sysconfig_t *sysconfig)
         *space = '\0';
       }
       status =
-        ares__sconfig_append_fromstr(&sysconfig->sconfig, pos, ARES_TRUE);
+        ares_sconfig_append_fromstr(&sysconfig->sconfig, pos, ARES_TRUE);
       if (status != ARES_SUCCESS) {
         break;
       }
@@ -169,7 +169,7 @@ static ares_status_t ares__init_sysconfig_riscos(ares_sysconfig_t *sysconfig)
 #endif
 
 #if defined(WATT32)
-static ares_status_t ares__init_sysconfig_watt32(ares_sysconfig_t *sysconfig)
+static ares_status_t ares_init_sysconfig_watt32(ares_sysconfig_t *sysconfig)
 {
   size_t        i;
   ares_status_t status;
@@ -182,7 +182,7 @@ static ares_status_t ares__init_sysconfig_watt32(ares_sysconfig_t *sysconfig)
     addr.family            = AF_INET;
     addr.addr.addr4.s_addr = htonl(def_nameservers[i]);
 
-    status = ares__sconfig_append(&sysconfig->sconfig, &addr, 0, 0, NULL);
+    status = ares_sconfig_append(&sysconfig->sconfig, &addr, 0, 0, NULL);
 
     if (status != ARES_SUCCESS) {
       return status;
@@ -194,7 +194,7 @@ static ares_status_t ares__init_sysconfig_watt32(ares_sysconfig_t *sysconfig)
 #endif
 
 #if defined(ANDROID) || defined(__ANDROID__)
-static ares_status_t ares__init_sysconfig_android(ares_sysconfig_t *sysconfig)
+static ares_status_t ares_init_sysconfig_android(ares_sysconfig_t *sysconfig)
 {
   size_t        i;
   char        **dns_servers;
@@ -211,7 +211,7 @@ static ares_status_t ares__init_sysconfig_android(ares_sysconfig_t *sysconfig)
   dns_servers = ares_get_android_server_list(MAX_DNS_PROPERTIES, &num_servers);
   if (dns_servers != NULL) {
     for (i = 0; i < num_servers; i++) {
-      status = ares__sconfig_append_fromstr(&sysconfig->sconfig, dns_servers[i],
+      status = ares_sconfig_append_fromstr(&sysconfig->sconfig, dns_servers[i],
                                             ARES_TRUE);
       if (status != ARES_SUCCESS) {
         return status;
@@ -224,7 +224,7 @@ static ares_status_t ares__init_sysconfig_android(ares_sysconfig_t *sysconfig)
   }
 
   domains            = ares_get_android_search_domains_list();
-  sysconfig->domains = ares__strsplit(domains, ", ", &sysconfig->ndomains);
+  sysconfig->domains = ares_strsplit(domains, ", ", &sysconfig->ndomains);
   ares_free(domains);
 
 #  ifdef HAVE___SYSTEM_PROPERTY_GET
@@ -244,7 +244,7 @@ static ares_status_t ares__init_sysconfig_android(ares_sysconfig_t *sysconfig)
         break;
       }
       status =
-        ares__sconfig_append_fromstr(&sysconfig->sconfig, propvalue, ARES_TRUE);
+        ares_sconfig_append_fromstr(&sysconfig->sconfig, propvalue, ARES_TRUE);
       if (status != ARES_SUCCESS) {
         return status;
       }
@@ -257,7 +257,7 @@ static ares_status_t ares__init_sysconfig_android(ares_sysconfig_t *sysconfig)
 #endif
 
 #if defined(CARES_USE_LIBRESOLV)
-static ares_status_t ares__init_sysconfig_libresolv(ares_sysconfig_t *sysconfig)
+static ares_status_t ares_init_sysconfig_libresolv(ares_sysconfig_t *sysconfig)
 {
   struct __res_state       res;
   ares_status_t            status = ARES_SUCCESS;
@@ -265,7 +265,7 @@ static ares_status_t ares__init_sysconfig_libresolv(ares_sysconfig_t *sysconfig)
   int                      nscount;
   size_t                   i;
   size_t                   entries = 0;
-  ares__buf_t             *ipbuf   = NULL;
+  ares_buf_t             *ipbuf   = NULL;
 
   memset(&res, 0, sizeof(res));
 
@@ -295,50 +295,50 @@ static ares_status_t ares__init_sysconfig_libresolv(ares_sysconfig_t *sysconfig)
 
 
     /* [ip]:port%iface */
-    ipbuf = ares__buf_create();
+    ipbuf = ares_buf_create();
     if (ipbuf == NULL) {
       status = ARES_ENOMEM;
       goto done;
     }
 
-    status = ares__buf_append_str(ipbuf, "[");
+    status = ares_buf_append_str(ipbuf, "[");
     if (status != ARES_SUCCESS) {
       goto done;
     }
 
-    status = ares__buf_append_str(ipbuf, ipaddr);
+    status = ares_buf_append_str(ipbuf, ipaddr);
     if (status != ARES_SUCCESS) {
       goto done;
     }
 
-    status = ares__buf_append_str(ipbuf, "]");
+    status = ares_buf_append_str(ipbuf, "]");
     if (status != ARES_SUCCESS) {
       goto done;
     }
 
     if (port) {
-      status = ares__buf_append_str(ipbuf, ":");
+      status = ares_buf_append_str(ipbuf, ":");
       if (status != ARES_SUCCESS) {
         goto done;
       }
-      status = ares__buf_append_num_dec(ipbuf, port, 0);
+      status = ares_buf_append_num_dec(ipbuf, port, 0);
       if (status != ARES_SUCCESS) {
         goto done;
       }
     }
 
     if (ll_scope) {
-      status = ares__buf_append_str(ipbuf, "%");
+      status = ares_buf_append_str(ipbuf, "%");
       if (status != ARES_SUCCESS) {
         goto done;
       }
-      status = ares__buf_append_num_dec(ipbuf, ll_scope, 0);
+      status = ares_buf_append_num_dec(ipbuf, ll_scope, 0);
       if (status != ARES_SUCCESS) {
         goto done;
       }
     }
 
-    ipstr = ares__buf_finish_str(ipbuf, NULL);
+    ipstr = ares_buf_finish_str(ipbuf, NULL);
     ipbuf = NULL;
     if (ipstr == NULL) {
       status = ARES_ENOMEM;
@@ -346,7 +346,7 @@ static ares_status_t ares__init_sysconfig_libresolv(ares_sysconfig_t *sysconfig)
     }
 
     status =
-      ares__sconfig_append_fromstr(&sysconfig->sconfig, ipstr, ARES_TRUE);
+      ares_sconfig_append_fromstr(&sysconfig->sconfig, ipstr, ARES_TRUE);
 
     ares_free(ipstr);
     if (status != ARES_SUCCESS) {
@@ -400,7 +400,7 @@ static ares_status_t ares__init_sysconfig_libresolv(ares_sysconfig_t *sysconfig)
   }
 
 done:
-  ares__buf_destroy(ipbuf);
+  ares_buf_destroy(ipbuf);
   res_ndestroy(&res);
   return status;
 }
@@ -408,8 +408,8 @@ done:
 
 static void ares_sysconfig_free(ares_sysconfig_t *sysconfig)
 {
-  ares__llist_destroy(sysconfig->sconfig);
-  ares__strsplit_free(sysconfig->domains, sysconfig->ndomains);
+  ares_llist_destroy(sysconfig->sconfig);
+  ares_strsplit_free(sysconfig->domains, sysconfig->ndomains);
   ares_free(sysconfig->sortlist);
   ares_free(sysconfig->lookups);
   memset(sysconfig, 0, sizeof(*sysconfig));
@@ -421,7 +421,7 @@ static ares_status_t ares_sysconfig_apply(ares_channel_t         *channel,
   ares_status_t status;
 
   if (sysconfig->sconfig && !(channel->optmask & ARES_OPT_SERVERS)) {
-    status = ares__servers_update(channel, sysconfig->sconfig, ARES_FALSE);
+    status = ares_servers_update(channel, sysconfig->sconfig, ARES_FALSE);
     if (status != ARES_SUCCESS) {
       return status;
     }
@@ -431,12 +431,12 @@ static ares_status_t ares_sysconfig_apply(ares_channel_t         *channel,
     /* Make sure we duplicate first then replace so even if there is
      * ARES_ENOMEM, the channel stays in a good state */
     char **temp =
-      ares__strsplit_duplicate(sysconfig->domains, sysconfig->ndomains);
+      ares_strsplit_duplicate(sysconfig->domains, sysconfig->ndomains);
     if (temp == NULL) {
       return ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
-    ares__strsplit_free(channel->domains, channel->ndomains);
+    ares_strsplit_free(channel->domains, channel->ndomains);
     channel->domains  = temp;
     channel->ndomains = sysconfig->ndomains;
   }
@@ -488,7 +488,7 @@ static ares_status_t ares_sysconfig_apply(ares_channel_t         *channel,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__init_by_sysconfig(ares_channel_t *channel)
+ares_status_t ares_init_by_sysconfig(ares_channel_t *channel)
 {
   ares_status_t    status;
   ares_sysconfig_t sysconfig;
@@ -497,21 +497,21 @@ ares_status_t ares__init_by_sysconfig(ares_channel_t *channel)
   sysconfig.ndots = 1; /* Default value if not otherwise set */
 
 #if defined(USE_WINSOCK)
-  status = ares__init_sysconfig_windows(&sysconfig);
+  status = ares_init_sysconfig_windows(&sysconfig);
 #elif defined(__MVS__)
-  status = ares__init_sysconfig_mvs(&sysconfig);
+  status = ares_init_sysconfig_mvs(&sysconfig);
 #elif defined(__riscos__)
-  status = ares__init_sysconfig_riscos(&sysconfig);
+  status = ares_init_sysconfig_riscos(&sysconfig);
 #elif defined(WATT32)
-  status = ares__init_sysconfig_watt32(&sysconfig);
+  status = ares_init_sysconfig_watt32(&sysconfig);
 #elif defined(ANDROID) || defined(__ANDROID__)
-  status = ares__init_sysconfig_android(&sysconfig);
+  status = ares_init_sysconfig_android(&sysconfig);
 #elif defined(__APPLE__)
-  status = ares__init_sysconfig_macos(&sysconfig);
+  status = ares_init_sysconfig_macos(&sysconfig);
 #elif defined(CARES_USE_LIBRESOLV)
-  status = ares__init_sysconfig_libresolv(&sysconfig);
+  status = ares_init_sysconfig_libresolv(&sysconfig);
 #else
-  status = ares__init_sysconfig_files(channel, &sysconfig);
+  status = ares_init_sysconfig_files(channel, &sysconfig);
 #endif
 
   if (status != ARES_SUCCESS) {
@@ -519,7 +519,7 @@ ares_status_t ares__init_by_sysconfig(ares_channel_t *channel)
   }
 
   /* Environment is supposed to override sysconfig */
-  status = ares__init_by_environment(&sysconfig);
+  status = ares_init_by_environment(&sysconfig);
   if (status != ARES_SUCCESS) {
     goto done;
   }
@@ -527,10 +527,10 @@ ares_status_t ares__init_by_sysconfig(ares_channel_t *channel)
   /* Lock when applying the configuration to the channel.  Don't need to
    * lock prior to this. */
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
 
   status = ares_sysconfig_apply(channel, &sysconfig);
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 
   if (status != ARES_SUCCESS) {
     goto done;

--- a/src/lib/ares_sysconfig_files.c
+++ b/src/lib/ares_sysconfig_files.c
@@ -110,7 +110,7 @@ static ares_bool_t sortlist_append(struct apattern **sortlist, size_t *nsort,
   return ARES_TRUE;
 }
 
-static ares_status_t parse_sort(ares__buf_t *buf, struct apattern *pat)
+static ares_status_t parse_sort(ares_buf_t *buf, struct apattern *pat)
 {
   ares_status_t       status;
   const unsigned char ip_charset[]             = "ABCDEFabcdef0123456789.:";
@@ -120,22 +120,22 @@ static ares_status_t parse_sort(ares__buf_t *buf, struct apattern *pat)
   memset(pat, 0, sizeof(*pat));
 
   /* Consume any leading whitespace */
-  ares__buf_consume_whitespace(buf, ARES_TRUE);
+  ares_buf_consume_whitespace(buf, ARES_TRUE);
 
   /* If no length, just ignore, return ENOTFOUND as an indicator */
-  if (ares__buf_len(buf) == 0) {
+  if (ares_buf_len(buf) == 0) {
     return ARES_ENOTFOUND;
   }
 
-  ares__buf_tag(buf);
+  ares_buf_tag(buf);
 
   /* Consume ip address */
-  if (ares__buf_consume_charset(buf, ip_charset, sizeof(ip_charset) - 1) == 0) {
+  if (ares_buf_consume_charset(buf, ip_charset, sizeof(ip_charset) - 1) == 0) {
     return ARES_EBADSTR;
   }
 
   /* Fetch ip address */
-  status = ares__buf_tag_fetch_string(buf, ipaddr, sizeof(ipaddr));
+  status = ares_buf_tag_fetch_string(buf, ipaddr, sizeof(ipaddr));
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -147,24 +147,24 @@ static ares_status_t parse_sort(ares__buf_t *buf, struct apattern *pat)
   }
 
   /* See if there is a subnet mask */
-  if (ares__buf_begins_with(buf, (const unsigned char *)"/", 1)) {
+  if (ares_buf_begins_with(buf, (const unsigned char *)"/", 1)) {
     char                maskstr[16];
     const unsigned char ipv4_charset[] = "0123456789.";
 
 
     /* Consume / */
-    ares__buf_consume(buf, 1);
+    ares_buf_consume(buf, 1);
 
-    ares__buf_tag(buf);
+    ares_buf_tag(buf);
 
     /* Consume mask */
-    if (ares__buf_consume_charset(buf, ipv4_charset,
+    if (ares_buf_consume_charset(buf, ipv4_charset,
                                   sizeof(ipv4_charset) - 1) == 0) {
       return ARES_EBADSTR;
     }
 
     /* Fetch mask */
-    status = ares__buf_tag_fetch_string(buf, maskstr, sizeof(maskstr));
+    status = ares_buf_tag_fetch_string(buf, maskstr, sizeof(maskstr));
     if (status != ARES_SUCCESS) {
       return status;
     }
@@ -190,33 +190,33 @@ static ares_status_t parse_sort(ares__buf_t *buf, struct apattern *pat)
         return ARES_EBADSTR;
       }
       ptr       = (const unsigned char *)&maskaddr.addr.addr4;
-      pat->mask = (unsigned char)(ares__count_bits_u8(ptr[0]) +
-                                  ares__count_bits_u8(ptr[1]) +
-                                  ares__count_bits_u8(ptr[2]) +
-                                  ares__count_bits_u8(ptr[3]));
+      pat->mask = (unsigned char)(ares_count_bits_u8(ptr[0]) +
+                                  ares_count_bits_u8(ptr[1]) +
+                                  ares_count_bits_u8(ptr[2]) +
+                                  ares_count_bits_u8(ptr[3]));
     }
   } else {
     pat->mask = ip_natural_mask(&pat->addr);
   }
 
   /* Consume any trailing whitespace */
-  ares__buf_consume_whitespace(buf, ARES_TRUE);
+  ares_buf_consume_whitespace(buf, ARES_TRUE);
 
   /* If we have any trailing bytes other than whitespace, its a parse failure */
-  if (ares__buf_len(buf) != 0) {
+  if (ares_buf_len(buf) != 0) {
     return ARES_EBADSTR;
   }
 
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__parse_sortlist(struct apattern **sortlist, size_t *nsort,
+ares_status_t ares_parse_sortlist(struct apattern **sortlist, size_t *nsort,
                                    const char *str)
 {
-  ares__buf_t        *buf    = NULL;
-  ares__llist_t      *list   = NULL;
+  ares_buf_t        *buf    = NULL;
+  ares_llist_t      *list   = NULL;
   ares_status_t       status = ARES_SUCCESS;
-  ares__llist_node_t *node   = NULL;
+  ares_llist_node_t *node   = NULL;
 
   if (sortlist == NULL || nsort == NULL || str == NULL) {
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
@@ -229,22 +229,22 @@ ares_status_t ares__parse_sortlist(struct apattern **sortlist, size_t *nsort,
   *sortlist = NULL;
   *nsort    = 0;
 
-  buf = ares__buf_create_const((const unsigned char *)str, ares_strlen(str));
+  buf = ares_buf_create_const((const unsigned char *)str, ares_strlen(str));
   if (buf == NULL) {
     status = ARES_ENOMEM;
     goto done;
   }
 
   /* Split on space or semicolon */
-  status = ares__buf_split(buf, (const unsigned char *)" ;", 2,
+  status = ares_buf_split(buf, (const unsigned char *)" ;", 2,
                            ARES_BUF_SPLIT_NONE, 0, &list);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  for (node = ares__llist_node_first(list); node != NULL;
-       node = ares__llist_node_next(node)) {
-    ares__buf_t    *entry = ares__llist_node_val(node);
+  for (node = ares_llist_node_first(list); node != NULL;
+       node = ares_llist_node_next(node)) {
+    ares_buf_t    *entry = ares_llist_node_val(node);
 
     struct apattern pat;
 
@@ -266,8 +266,8 @@ ares_status_t ares__parse_sortlist(struct apattern **sortlist, size_t *nsort,
   status = ARES_SUCCESS;
 
 done:
-  ares__buf_destroy(buf);
-  ares__llist_destroy(list);
+  ares_buf_destroy(buf);
+  ares_llist_destroy(list);
 
   if (status != ARES_SUCCESS) {
     ares_free(*sortlist);
@@ -283,12 +283,12 @@ static ares_status_t config_search(ares_sysconfig_t *sysconfig, const char *str,
 {
   if (sysconfig->domains && sysconfig->ndomains > 0) {
     /* if we already have some domains present, free them first */
-    ares__strsplit_free(sysconfig->domains, sysconfig->ndomains);
+    ares_strsplit_free(sysconfig->domains, sysconfig->ndomains);
     sysconfig->domains  = NULL;
     sysconfig->ndomains = 0;
   }
 
-  sysconfig->domains = ares__strsplit(str, ", ", &sysconfig->ndomains);
+  sysconfig->domains = ares_strsplit(str, ", ", &sysconfig->ndomains);
   if (sysconfig->domains == NULL) {
     return ARES_ENOMEM;
   }
@@ -306,28 +306,28 @@ static ares_status_t config_search(ares_sysconfig_t *sysconfig, const char *str,
   return ARES_SUCCESS;
 }
 
-static ares_status_t buf_fetch_string(ares__buf_t *buf, char *str,
+static ares_status_t buf_fetch_string(ares_buf_t *buf, char *str,
                                       size_t str_len)
 {
   ares_status_t status;
-  ares__buf_tag(buf);
-  ares__buf_consume(buf, ares__buf_len(buf));
+  ares_buf_tag(buf);
+  ares_buf_consume(buf, ares_buf_len(buf));
 
-  status = ares__buf_tag_fetch_string(buf, str, str_len);
+  status = ares_buf_tag_fetch_string(buf, str, str_len);
   return status;
 }
 
 static ares_status_t config_lookup(ares_sysconfig_t *sysconfig,
-                                   ares__buf_t *buf, const char *separators)
+                                   ares_buf_t *buf, const char *separators)
 {
   ares_status_t       status;
   char                lookupstr[32];
   size_t              lookupstr_cnt = 0;
-  ares__llist_t      *lookups       = NULL;
-  ares__llist_node_t *node;
+  ares_llist_t      *lookups       = NULL;
+  ares_llist_node_t *node;
   size_t              separators_len = ares_strlen(separators);
 
-  status = ares__buf_split(buf, (const unsigned char *)separators,
+  status = ares_buf_split(buf, (const unsigned char *)separators,
                            separators_len, ARES_BUF_SPLIT_TRIM, 0, &lookups);
   if (status != ARES_SUCCESS) {
     goto done;
@@ -335,11 +335,11 @@ static ares_status_t config_lookup(ares_sysconfig_t *sysconfig,
 
   memset(lookupstr, 0, sizeof(lookupstr));
 
-  for (node = ares__llist_node_first(lookups); node != NULL;
-       node = ares__llist_node_next(node)) {
+  for (node = ares_llist_node_first(lookups); node != NULL;
+       node = ares_llist_node_next(node)) {
     char         value[128];
     char         ch;
-    ares__buf_t *valbuf = ares__llist_node_val(node);
+    ares_buf_t *valbuf = ares_llist_node_val(node);
 
     status = buf_fetch_string(valbuf, value, sizeof(value));
     if (status != ARES_SUCCESS) {
@@ -377,32 +377,32 @@ done:
   if (status != ARES_ENOMEM) {
     status = ARES_SUCCESS;
   }
-  ares__llist_destroy(lookups);
+  ares_llist_destroy(lookups);
   return status;
 }
 
 static ares_status_t process_option(ares_sysconfig_t *sysconfig,
-                                    ares__buf_t      *option)
+                                    ares_buf_t      *option)
 {
-  ares__llist_t *kv      = NULL;
+  ares_llist_t *kv      = NULL;
   char           key[32] = "";
   char           val[32] = "";
   unsigned int   valint  = 0;
   ares_status_t  status;
 
   /* Split on : */
-  status = ares__buf_split(option, (const unsigned char *)":", 1,
+  status = ares_buf_split(option, (const unsigned char *)":", 1,
                            ARES_BUF_SPLIT_TRIM, 2, &kv);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  status = buf_fetch_string(ares__llist_first_val(kv), key, sizeof(key));
+  status = buf_fetch_string(ares_llist_first_val(kv), key, sizeof(key));
   if (status != ARES_SUCCESS) {
     goto done;
   }
-  if (ares__llist_len(kv) == 2) {
-    status = buf_fetch_string(ares__llist_last_val(kv), val, sizeof(val));
+  if (ares_llist_len(kv) == 2) {
+    status = buf_fetch_string(ares_llist_last_val(kv), val, sizeof(val));
     if (status != ARES_SUCCESS) {
       goto done;
     }
@@ -428,32 +428,32 @@ static ares_status_t process_option(ares_sysconfig_t *sysconfig,
   }
 
 done:
-  ares__llist_destroy(kv);
+  ares_llist_destroy(kv);
   return status;
 }
 
-ares_status_t ares__sysconfig_set_options(ares_sysconfig_t *sysconfig,
+ares_status_t ares_sysconfig_set_options(ares_sysconfig_t *sysconfig,
                                           const char       *str)
 {
-  ares__buf_t        *buf     = NULL;
-  ares__llist_t      *options = NULL;
+  ares_buf_t        *buf     = NULL;
+  ares_llist_t      *options = NULL;
   ares_status_t       status;
-  ares__llist_node_t *node;
+  ares_llist_node_t *node;
 
-  buf = ares__buf_create_const((const unsigned char *)str, ares_strlen(str));
+  buf = ares_buf_create_const((const unsigned char *)str, ares_strlen(str));
   if (buf == NULL) {
     return ARES_ENOMEM;
   }
 
-  status = ares__buf_split(buf, (const unsigned char *)" \t", 2,
+  status = ares_buf_split(buf, (const unsigned char *)" \t", 2,
                            ARES_BUF_SPLIT_TRIM, 0, &options);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  for (node = ares__llist_node_first(options); node != NULL;
-       node = ares__llist_node_next(node)) {
-    ares__buf_t *valbuf = ares__llist_node_val(node);
+  for (node = ares_llist_node_first(options); node != NULL;
+       node = ares_llist_node_next(node)) {
+    ares_buf_t *valbuf = ares_llist_node_val(node);
 
     status = process_option(sysconfig, valbuf);
     /* Out of memory is the only fatal condition */
@@ -465,12 +465,12 @@ ares_status_t ares__sysconfig_set_options(ares_sysconfig_t *sysconfig,
   status = ARES_SUCCESS;
 
 done:
-  ares__llist_destroy(options);
-  ares__buf_destroy(buf);
+  ares_llist_destroy(options);
+  ares_buf_destroy(buf);
   return status;
 }
 
-ares_status_t ares__init_by_environment(ares_sysconfig_t *sysconfig)
+ares_status_t ares_init_by_environment(ares_sysconfig_t *sysconfig)
 {
   const char   *localdomain;
   const char   *res_options;
@@ -491,7 +491,7 @@ ares_status_t ares__init_by_environment(ares_sysconfig_t *sysconfig)
 
   res_options = getenv("RES_OPTIONS");
   if (res_options) {
-    status = ares__sysconfig_set_options(sysconfig, res_options);
+    status = ares_sysconfig_set_options(sysconfig, res_options);
     if (status != ARES_SUCCESS) {
       return status;
     }
@@ -552,38 +552,38 @@ ares_status_t ares__init_by_environment(ares_sysconfig_t *sysconfig)
  * conditions are ignored.  Users may mess up config files, but we want to
  * process anything we can. */
 static ares_status_t parse_resolvconf_line(ares_sysconfig_t *sysconfig,
-                                           ares__buf_t      *line)
+                                           ares_buf_t      *line)
 {
   char          option[32];
   char          value[512];
   ares_status_t status = ARES_SUCCESS;
 
   /* Ignore lines beginning with a comment */
-  if (ares__buf_begins_with(line, (const unsigned char *)"#", 1) ||
-      ares__buf_begins_with(line, (const unsigned char *)";", 1)) {
+  if (ares_buf_begins_with(line, (const unsigned char *)"#", 1) ||
+      ares_buf_begins_with(line, (const unsigned char *)";", 1)) {
     return ARES_SUCCESS;
   }
 
-  ares__buf_tag(line);
+  ares_buf_tag(line);
 
   /* Shouldn't be possible, but if it happens, ignore the line. */
-  if (ares__buf_consume_nonwhitespace(line) == 0) {
+  if (ares_buf_consume_nonwhitespace(line) == 0) {
     return ARES_SUCCESS;
   }
 
-  status = ares__buf_tag_fetch_string(line, option, sizeof(option));
+  status = ares_buf_tag_fetch_string(line, option, sizeof(option));
   if (status != ARES_SUCCESS) {
     return ARES_SUCCESS;
   }
 
-  ares__buf_consume_whitespace(line, ARES_TRUE);
+  ares_buf_consume_whitespace(line, ARES_TRUE);
 
   status = buf_fetch_string(line, value, sizeof(value));
   if (status != ARES_SUCCESS) {
     return ARES_SUCCESS;
   }
 
-  ares__str_trim(value);
+  ares_str_trim(value);
   if (*value == 0) {
     return ARES_SUCCESS;
   }
@@ -597,24 +597,24 @@ static ares_status_t parse_resolvconf_line(ares_sysconfig_t *sysconfig,
     }
   } else if (ares_streq(option, "lookup") ||
              ares_streq(option, "hostresorder")) {
-    ares__buf_tag_rollback(line);
+    ares_buf_tag_rollback(line);
     status = config_lookup(sysconfig, line, " \t");
   } else if (ares_streq(option, "search")) {
     status = config_search(sysconfig, value, 0);
   } else if (ares_streq(option, "nameserver")) {
     status =
-      ares__sconfig_append_fromstr(&sysconfig->sconfig, value, ARES_TRUE);
+      ares_sconfig_append_fromstr(&sysconfig->sconfig, value, ARES_TRUE);
   } else if (ares_streq(option, "sortlist")) {
     /* Ignore all failures except ENOMEM.  If the sysadmin set a bad
      * sortlist, just ignore the sortlist, don't cause an inoperable
      * channel */
     status =
-      ares__parse_sortlist(&sysconfig->sortlist, &sysconfig->nsortlist, value);
+      ares_parse_sortlist(&sysconfig->sortlist, &sysconfig->nsortlist, value);
     if (status != ARES_ENOMEM) {
       status = ARES_SUCCESS;
     }
   } else if (ares_streq(option, "options")) {
-    status = ares__sysconfig_set_options(sysconfig, value);
+    status = ares_sysconfig_set_options(sysconfig, value);
   }
 
   return status;
@@ -624,27 +624,27 @@ static ares_status_t parse_resolvconf_line(ares_sysconfig_t *sysconfig,
  * conditions are ignored.  Users may mess up config files, but we want to
  * process anything we can. */
 static ares_status_t parse_nsswitch_line(ares_sysconfig_t *sysconfig,
-                                         ares__buf_t      *line)
+                                         ares_buf_t      *line)
 {
   char           option[32];
-  ares__buf_t   *buf;
+  ares_buf_t   *buf;
   ares_status_t  status = ARES_SUCCESS;
-  ares__llist_t *sects  = NULL;
+  ares_llist_t *sects  = NULL;
 
   /* Ignore lines beginning with a comment */
-  if (ares__buf_begins_with(line, (const unsigned char *)"#", 1)) {
+  if (ares_buf_begins_with(line, (const unsigned char *)"#", 1)) {
     return ARES_SUCCESS;
   }
 
   /* database : values (space delimited) */
-  status = ares__buf_split(line, (const unsigned char *)":", 1,
+  status = ares_buf_split(line, (const unsigned char *)":", 1,
                            ARES_BUF_SPLIT_TRIM, 2, &sects);
 
-  if (status != ARES_SUCCESS || ares__llist_len(sects) != 2) {
+  if (status != ARES_SUCCESS || ares_llist_len(sects) != 2) {
     goto done;
   }
 
-  buf    = ares__llist_first_val(sects);
+  buf    = ares_llist_first_val(sects);
   status = buf_fetch_string(buf, option, sizeof(option));
   if (status != ARES_SUCCESS) {
     goto done;
@@ -656,11 +656,11 @@ static ares_status_t parse_nsswitch_line(ares_sysconfig_t *sysconfig,
   }
 
   /* Values are space separated */
-  buf    = ares__llist_last_val(sects);
+  buf    = ares_llist_last_val(sects);
   status = config_lookup(sysconfig, buf, " \t");
 
 done:
-  ares__llist_destroy(sects);
+  ares_llist_destroy(sects);
   if (status != ARES_ENOMEM) {
     status = ARES_SUCCESS;
   }
@@ -671,27 +671,27 @@ done:
  * conditions are ignored.  Users may mess up config files, but we want to
  * process anything we can. */
 static ares_status_t parse_svcconf_line(ares_sysconfig_t *sysconfig,
-                                        ares__buf_t      *line)
+                                        ares_buf_t      *line)
 {
   char           option[32];
-  ares__buf_t   *buf;
+  ares_buf_t   *buf;
   ares_status_t  status = ARES_SUCCESS;
-  ares__llist_t *sects  = NULL;
+  ares_llist_t *sects  = NULL;
 
   /* Ignore lines beginning with a comment */
-  if (ares__buf_begins_with(line, (const unsigned char *)"#", 1)) {
+  if (ares_buf_begins_with(line, (const unsigned char *)"#", 1)) {
     return ARES_SUCCESS;
   }
 
   /* database = values (comma delimited)*/
-  status = ares__buf_split(line, (const unsigned char *)"=", 1,
+  status = ares_buf_split(line, (const unsigned char *)"=", 1,
                            ARES_BUF_SPLIT_TRIM, 2, &sects);
 
-  if (status != ARES_SUCCESS || ares__llist_len(sects) != 2) {
+  if (status != ARES_SUCCESS || ares_llist_len(sects) != 2) {
     goto done;
   }
 
-  buf    = ares__llist_first_val(sects);
+  buf    = ares_llist_first_val(sects);
   status = buf_fetch_string(buf, option, sizeof(option));
   if (status != ARES_SUCCESS) {
     goto done;
@@ -703,11 +703,11 @@ static ares_status_t parse_svcconf_line(ares_sysconfig_t *sysconfig,
   }
 
   /* Values are comma separated */
-  buf    = ares__llist_last_val(sects);
+  buf    = ares_llist_last_val(sects);
   status = config_lookup(sysconfig, buf, ",");
 
 done:
-  ares__llist_destroy(sects);
+  ares_llist_destroy(sects);
   if (status != ARES_ENOMEM) {
     status = ARES_SUCCESS;
   }
@@ -715,7 +715,7 @@ done:
 }
 
 typedef ares_status_t (*line_callback_t)(ares_sysconfig_t *sysconfig,
-                                         ares__buf_t      *line);
+                                         ares_buf_t      *line);
 
 /* Should only return:
  *  ARES_ENOTFOUND - file not found
@@ -729,30 +729,30 @@ static ares_status_t process_config_lines(const char       *filename,
                                           line_callback_t   cb)
 {
   ares_status_t       status = ARES_SUCCESS;
-  ares__llist_node_t *node;
-  ares__llist_t      *lines = NULL;
-  ares__buf_t        *buf   = NULL;
+  ares_llist_node_t *node;
+  ares_llist_t      *lines = NULL;
+  ares_buf_t        *buf   = NULL;
 
-  buf = ares__buf_create();
+  buf = ares_buf_create();
   if (buf == NULL) {
     status = ARES_ENOMEM;
     goto done;
   }
 
-  status = ares__buf_load_file(filename, buf);
+  status = ares_buf_load_file(filename, buf);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  status = ares__buf_split(buf, (const unsigned char *)"\n", 1,
+  status = ares_buf_split(buf, (const unsigned char *)"\n", 1,
                            ARES_BUF_SPLIT_TRIM, 0, &lines);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  for (node = ares__llist_node_first(lines); node != NULL;
-       node = ares__llist_node_next(node)) {
-    ares__buf_t *line = ares__llist_node_val(node);
+  for (node = ares_llist_node_first(lines); node != NULL;
+       node = ares_llist_node_next(node)) {
+    ares_buf_t *line = ares_llist_node_val(node);
 
     status = cb(sysconfig, line);
     if (status != ARES_SUCCESS) {
@@ -761,13 +761,13 @@ static ares_status_t process_config_lines(const char       *filename,
   }
 
 done:
-  ares__buf_destroy(buf);
-  ares__llist_destroy(lines);
+  ares_buf_destroy(buf);
+  ares_llist_destroy(lines);
 
   return status;
 }
 
-ares_status_t ares__init_sysconfig_files(const ares_channel_t *channel,
+ares_status_t ares_init_sysconfig_files(const ares_channel_t *channel,
                                          ares_sysconfig_t     *sysconfig)
 {
   ares_status_t status = ARES_SUCCESS;

--- a/src/lib/ares_sysconfig_files.c
+++ b/src/lib/ares_sysconfig_files.c
@@ -158,8 +158,8 @@ static ares_status_t parse_sort(ares_buf_t *buf, struct apattern *pat)
     ares_buf_tag(buf);
 
     /* Consume mask */
-    if (ares_buf_consume_charset(buf, ipv4_charset,
-                                  sizeof(ipv4_charset) - 1) == 0) {
+    if (ares_buf_consume_charset(buf, ipv4_charset, sizeof(ipv4_charset) - 1) ==
+        0) {
       return ARES_EBADSTR;
     }
 
@@ -211,11 +211,11 @@ static ares_status_t parse_sort(ares_buf_t *buf, struct apattern *pat)
 }
 
 ares_status_t ares_parse_sortlist(struct apattern **sortlist, size_t *nsort,
-                                   const char *str)
+                                  const char *str)
 {
   ares_buf_t        *buf    = NULL;
   ares_llist_t      *list   = NULL;
-  ares_status_t       status = ARES_SUCCESS;
+  ares_status_t      status = ARES_SUCCESS;
   ares_llist_node_t *node   = NULL;
 
   if (sortlist == NULL || nsort == NULL || str == NULL) {
@@ -237,14 +237,14 @@ ares_status_t ares_parse_sortlist(struct apattern **sortlist, size_t *nsort,
 
   /* Split on space or semicolon */
   status = ares_buf_split(buf, (const unsigned char *)" ;", 2,
-                           ARES_BUF_SPLIT_NONE, 0, &list);
+                          ARES_BUF_SPLIT_NONE, 0, &list);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
   for (node = ares_llist_node_first(list); node != NULL;
        node = ares_llist_node_next(node)) {
-    ares_buf_t    *entry = ares_llist_node_val(node);
+    ares_buf_t     *entry = ares_llist_node_val(node);
 
     struct apattern pat;
 
@@ -317,18 +317,18 @@ static ares_status_t buf_fetch_string(ares_buf_t *buf, char *str,
   return status;
 }
 
-static ares_status_t config_lookup(ares_sysconfig_t *sysconfig,
-                                   ares_buf_t *buf, const char *separators)
+static ares_status_t config_lookup(ares_sysconfig_t *sysconfig, ares_buf_t *buf,
+                                   const char *separators)
 {
-  ares_status_t       status;
-  char                lookupstr[32];
-  size_t              lookupstr_cnt = 0;
+  ares_status_t      status;
+  char               lookupstr[32];
+  size_t             lookupstr_cnt = 0;
   ares_llist_t      *lookups       = NULL;
   ares_llist_node_t *node;
-  size_t              separators_len = ares_strlen(separators);
+  size_t             separators_len = ares_strlen(separators);
 
   status = ares_buf_split(buf, (const unsigned char *)separators,
-                           separators_len, ARES_BUF_SPLIT_TRIM, 0, &lookups);
+                          separators_len, ARES_BUF_SPLIT_TRIM, 0, &lookups);
   if (status != ARES_SUCCESS) {
     goto done;
   }
@@ -337,8 +337,8 @@ static ares_status_t config_lookup(ares_sysconfig_t *sysconfig,
 
   for (node = ares_llist_node_first(lookups); node != NULL;
        node = ares_llist_node_next(node)) {
-    char         value[128];
-    char         ch;
+    char        value[128];
+    char        ch;
     ares_buf_t *valbuf = ares_llist_node_val(node);
 
     status = buf_fetch_string(valbuf, value, sizeof(value));
@@ -382,17 +382,17 @@ done:
 }
 
 static ares_status_t process_option(ares_sysconfig_t *sysconfig,
-                                    ares_buf_t      *option)
+                                    ares_buf_t       *option)
 {
   ares_llist_t *kv      = NULL;
-  char           key[32] = "";
-  char           val[32] = "";
-  unsigned int   valint  = 0;
-  ares_status_t  status;
+  char          key[32] = "";
+  char          val[32] = "";
+  unsigned int  valint  = 0;
+  ares_status_t status;
 
   /* Split on : */
   status = ares_buf_split(option, (const unsigned char *)":", 1,
-                           ARES_BUF_SPLIT_TRIM, 2, &kv);
+                          ARES_BUF_SPLIT_TRIM, 2, &kv);
   if (status != ARES_SUCCESS) {
     goto done;
   }
@@ -433,11 +433,11 @@ done:
 }
 
 ares_status_t ares_sysconfig_set_options(ares_sysconfig_t *sysconfig,
-                                          const char       *str)
+                                         const char       *str)
 {
   ares_buf_t        *buf     = NULL;
   ares_llist_t      *options = NULL;
-  ares_status_t       status;
+  ares_status_t      status;
   ares_llist_node_t *node;
 
   buf = ares_buf_create_const((const unsigned char *)str, ares_strlen(str));
@@ -446,7 +446,7 @@ ares_status_t ares_sysconfig_set_options(ares_sysconfig_t *sysconfig,
   }
 
   status = ares_buf_split(buf, (const unsigned char *)" \t", 2,
-                           ARES_BUF_SPLIT_TRIM, 0, &options);
+                          ARES_BUF_SPLIT_TRIM, 0, &options);
   if (status != ARES_SUCCESS) {
     goto done;
   }
@@ -552,7 +552,7 @@ ares_status_t ares_init_by_environment(ares_sysconfig_t *sysconfig)
  * conditions are ignored.  Users may mess up config files, but we want to
  * process anything we can. */
 static ares_status_t parse_resolvconf_line(ares_sysconfig_t *sysconfig,
-                                           ares_buf_t      *line)
+                                           ares_buf_t       *line)
 {
   char          option[32];
   char          value[512];
@@ -602,8 +602,7 @@ static ares_status_t parse_resolvconf_line(ares_sysconfig_t *sysconfig,
   } else if (ares_streq(option, "search")) {
     status = config_search(sysconfig, value, 0);
   } else if (ares_streq(option, "nameserver")) {
-    status =
-      ares_sconfig_append_fromstr(&sysconfig->sconfig, value, ARES_TRUE);
+    status = ares_sconfig_append_fromstr(&sysconfig->sconfig, value, ARES_TRUE);
   } else if (ares_streq(option, "sortlist")) {
     /* Ignore all failures except ENOMEM.  If the sysadmin set a bad
      * sortlist, just ignore the sortlist, don't cause an inoperable
@@ -624,11 +623,11 @@ static ares_status_t parse_resolvconf_line(ares_sysconfig_t *sysconfig,
  * conditions are ignored.  Users may mess up config files, but we want to
  * process anything we can. */
 static ares_status_t parse_nsswitch_line(ares_sysconfig_t *sysconfig,
-                                         ares_buf_t      *line)
+                                         ares_buf_t       *line)
 {
-  char           option[32];
+  char          option[32];
   ares_buf_t   *buf;
-  ares_status_t  status = ARES_SUCCESS;
+  ares_status_t status = ARES_SUCCESS;
   ares_llist_t *sects  = NULL;
 
   /* Ignore lines beginning with a comment */
@@ -638,7 +637,7 @@ static ares_status_t parse_nsswitch_line(ares_sysconfig_t *sysconfig,
 
   /* database : values (space delimited) */
   status = ares_buf_split(line, (const unsigned char *)":", 1,
-                           ARES_BUF_SPLIT_TRIM, 2, &sects);
+                          ARES_BUF_SPLIT_TRIM, 2, &sects);
 
   if (status != ARES_SUCCESS || ares_llist_len(sects) != 2) {
     goto done;
@@ -671,11 +670,11 @@ done:
  * conditions are ignored.  Users may mess up config files, but we want to
  * process anything we can. */
 static ares_status_t parse_svcconf_line(ares_sysconfig_t *sysconfig,
-                                        ares_buf_t      *line)
+                                        ares_buf_t       *line)
 {
-  char           option[32];
+  char          option[32];
   ares_buf_t   *buf;
-  ares_status_t  status = ARES_SUCCESS;
+  ares_status_t status = ARES_SUCCESS;
   ares_llist_t *sects  = NULL;
 
   /* Ignore lines beginning with a comment */
@@ -685,7 +684,7 @@ static ares_status_t parse_svcconf_line(ares_sysconfig_t *sysconfig,
 
   /* database = values (comma delimited)*/
   status = ares_buf_split(line, (const unsigned char *)"=", 1,
-                           ARES_BUF_SPLIT_TRIM, 2, &sects);
+                          ARES_BUF_SPLIT_TRIM, 2, &sects);
 
   if (status != ARES_SUCCESS || ares_llist_len(sects) != 2) {
     goto done;
@@ -715,7 +714,7 @@ done:
 }
 
 typedef ares_status_t (*line_callback_t)(ares_sysconfig_t *sysconfig,
-                                         ares_buf_t      *line);
+                                         ares_buf_t       *line);
 
 /* Should only return:
  *  ARES_ENOTFOUND - file not found
@@ -728,7 +727,7 @@ static ares_status_t process_config_lines(const char       *filename,
                                           ares_sysconfig_t *sysconfig,
                                           line_callback_t   cb)
 {
-  ares_status_t       status = ARES_SUCCESS;
+  ares_status_t      status = ARES_SUCCESS;
   ares_llist_node_t *node;
   ares_llist_t      *lines = NULL;
   ares_buf_t        *buf   = NULL;
@@ -745,7 +744,7 @@ static ares_status_t process_config_lines(const char       *filename,
   }
 
   status = ares_buf_split(buf, (const unsigned char *)"\n", 1,
-                           ARES_BUF_SPLIT_TRIM, 0, &lines);
+                          ARES_BUF_SPLIT_TRIM, 0, &lines);
   if (status != ARES_SUCCESS) {
     goto done;
   }
@@ -768,7 +767,7 @@ done:
 }
 
 ares_status_t ares_init_sysconfig_files(const ares_channel_t *channel,
-                                         ares_sysconfig_t     *sysconfig)
+                                        ares_sysconfig_t     *sysconfig)
 {
   ares_status_t status = ARES_SUCCESS;
 

--- a/src/lib/ares_sysconfig_mac.c
+++ b/src/lib/ares_sysconfig_mac.c
@@ -282,10 +282,10 @@ static ares_status_t read_resolver(const dns_resolver_t *resolver,
       addrport = port;
     }
 
-    if_name = ares_if_indextoname(resolver->if_index, if_name_str,
-                                   sizeof(if_name_str));
-    status  = ares_sconfig_append(&sysconfig->sconfig, &addr, addrport,
-                                   addrport, if_name);
+    if_name =
+      ares_if_indextoname(resolver->if_index, if_name_str, sizeof(if_name_str));
+    status = ares_sconfig_append(&sysconfig->sconfig, &addr, addrport, addrport,
+                                 if_name);
     if (status != ARES_SUCCESS) {
       return status;
     }

--- a/src/lib/ares_sysconfig_mac.c
+++ b/src/lib/ares_sysconfig_mac.c
@@ -243,7 +243,7 @@ static ares_status_t read_resolver(const dns_resolver_t *resolver,
 #  endif
 
   if (resolver->options != NULL) {
-    status = ares__sysconfig_set_options(sysconfig, resolver->options);
+    status = ares_sysconfig_set_options(sysconfig, resolver->options);
     if (status != ARES_SUCCESS) {
       return status;
     }
@@ -282,9 +282,9 @@ static ares_status_t read_resolver(const dns_resolver_t *resolver,
       addrport = port;
     }
 
-    if_name = ares__if_indextoname(resolver->if_index, if_name_str,
+    if_name = ares_if_indextoname(resolver->if_index, if_name_str,
                                    sizeof(if_name_str));
-    status  = ares__sconfig_append(&sysconfig->sconfig, &addr, addrport,
+    status  = ares_sconfig_append(&sysconfig->sconfig, &addr, addrport,
                                    addrport, if_name);
     if (status != ARES_SUCCESS) {
       return status;
@@ -315,7 +315,7 @@ static ares_status_t read_resolvers(dns_resolver_t **resolvers, int nresolvers,
   return status;
 }
 
-ares_status_t ares__init_sysconfig_macos(ares_sysconfig_t *sysconfig)
+ares_status_t ares_init_sysconfig_macos(ares_sysconfig_t *sysconfig)
 {
   dnsinfo_t    *dnsinfo = NULL;
   dns_config_t *sc_dns  = NULL;

--- a/src/lib/ares_sysconfig_win.c
+++ b/src/lib/ares_sysconfig_win.c
@@ -420,7 +420,7 @@ static ares_bool_t get_DNS_Windows(char **outptr)
         memset(&addr, 0, sizeof(addr));
         addr.family = AF_INET6;
         memcpy(&addr.addr.addr6, &namesrvr.sa6->sin6_addr, 16);
-        if (ares__addr_is_linklocal(&addr)) {
+        if (ares_addr_is_linklocal(&addr)) {
           ll_scope = ipaaEntry->Ipv6IfIndex;
         }
 
@@ -514,7 +514,7 @@ static ares_bool_t get_SuffixList_Windows(char **outptr)
 
   *outptr = NULL;
 
-  if (ares__getplatform() != WIN_NT) {
+  if (ares_getplatform() != WIN_NT) {
     return ARES_FALSE;
   }
 
@@ -589,13 +589,13 @@ static ares_bool_t get_SuffixList_Windows(char **outptr)
   return *outptr != NULL ? ARES_TRUE : ARES_FALSE;
 }
 
-ares_status_t ares__init_sysconfig_windows(ares_sysconfig_t *sysconfig)
+ares_status_t ares_init_sysconfig_windows(ares_sysconfig_t *sysconfig)
 {
   char         *line   = NULL;
   ares_status_t status = ARES_SUCCESS;
 
   if (get_DNS_Windows(&line)) {
-    status = ares__sconfig_append_fromstr(&sysconfig->sconfig, line, ARES_TRUE);
+    status = ares_sconfig_append_fromstr(&sysconfig->sconfig, line, ARES_TRUE);
     ares_free(line);
     if (status != ARES_SUCCESS) {
       goto done;
@@ -603,7 +603,7 @@ ares_status_t ares__init_sysconfig_windows(ares_sysconfig_t *sysconfig)
   }
 
   if (get_SuffixList_Windows(&line)) {
-    sysconfig->domains = ares__strsplit(line, ", ", &sysconfig->ndomains);
+    sysconfig->domains = ares_strsplit(line, ", ", &sysconfig->ndomains);
     ares_free(line);
     if (sysconfig->domains == NULL) {
       status = ARES_EFILE;

--- a/src/lib/ares_timeout.c
+++ b/src/lib/ares_timeout.c
@@ -33,8 +33,8 @@
 
 
 void ares_timeval_remaining(ares_timeval_t       *remaining,
-                             const ares_timeval_t *now,
-                             const ares_timeval_t *tout)
+                            const ares_timeval_t *now,
+                            const ares_timeval_t *tout)
 {
   memset(remaining, 0, sizeof(*remaining));
 
@@ -54,7 +54,7 @@ void ares_timeval_remaining(ares_timeval_t       *remaining,
 }
 
 void ares_timeval_diff(ares_timeval_t *tvdiff, const ares_timeval_t *tvstart,
-                        const ares_timeval_t *tvstop)
+                       const ares_timeval_t *tvstop)
 {
   tvdiff->sec = tvstop->sec - tvstart->sec;
   if (tvstop->usec > tvstart->usec) {
@@ -89,7 +89,7 @@ static struct timeval *ares_timeout_int(const ares_channel_t *channel,
                                         struct timeval       *tvbuf)
 {
   const ares_query_t *query;
-  ares_slist_node_t *node;
+  ares_slist_node_t  *node;
   ares_timeval_t      now;
   ares_timeval_t      atvbuf;
   ares_timeval_t      amaxtv;

--- a/src/lib/ares_timeout.c
+++ b/src/lib/ares_timeout.c
@@ -32,7 +32,7 @@
 #endif
 
 
-void ares__timeval_remaining(ares_timeval_t       *remaining,
+void ares_timeval_remaining(ares_timeval_t       *remaining,
                              const ares_timeval_t *now,
                              const ares_timeval_t *tout)
 {
@@ -53,7 +53,7 @@ void ares__timeval_remaining(ares_timeval_t       *remaining,
   }
 }
 
-void ares__timeval_diff(ares_timeval_t *tvdiff, const ares_timeval_t *tvstart,
+void ares_timeval_diff(ares_timeval_t *tvdiff, const ares_timeval_t *tvstart,
                         const ares_timeval_t *tvstop)
 {
   tvdiff->sec = tvstop->sec - tvstart->sec;
@@ -89,24 +89,24 @@ static struct timeval *ares_timeout_int(const ares_channel_t *channel,
                                         struct timeval       *tvbuf)
 {
   const ares_query_t *query;
-  ares__slist_node_t *node;
+  ares_slist_node_t *node;
   ares_timeval_t      now;
   ares_timeval_t      atvbuf;
   ares_timeval_t      amaxtv;
 
   /* The minimum timeout of all queries is always the first entry in
    * channel->queries_by_timeout */
-  node = ares__slist_node_first(channel->queries_by_timeout);
+  node = ares_slist_node_first(channel->queries_by_timeout);
   /* no queries/timeout */
   if (node == NULL) {
     return maxtv;
   }
 
-  query = ares__slist_node_val(node);
+  query = ares_slist_node_val(node);
 
-  ares__tvnow(&now);
+  ares_tvnow(&now);
 
-  ares__timeval_remaining(&atvbuf, &now, &query->timeout);
+  ares_timeval_remaining(&atvbuf, &now, &query->timeout);
 
   ares_timeval_to_struct_timeval(tvbuf, &atvbuf);
 
@@ -141,11 +141,11 @@ struct timeval *ares_timeout(const ares_channel_t *channel,
     return NULL;
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
 
   rv = ares_timeout_int(channel, maxtv, tvbuf);
 
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 
   return rv;
 }

--- a/src/lib/ares_update_servers.c
+++ b/src/lib/ares_update_servers.c
@@ -61,7 +61,7 @@ typedef struct {
   unsigned int     ll_scope;
 } ares_sconfig_t;
 
-static ares_bool_t ares__addr_match(const struct ares_addr *addr1,
+static ares_bool_t ares_addr_match(const struct ares_addr *addr1,
                                     const struct ares_addr *addr2)
 {
   if (addr1 == NULL && addr2 == NULL) {
@@ -90,7 +90,7 @@ static ares_bool_t ares__addr_match(const struct ares_addr *addr1,
   return ARES_FALSE;
 }
 
-ares_bool_t ares__subnet_match(const struct ares_addr *addr,
+ares_bool_t ares_subnet_match(const struct ares_addr *addr,
                                const struct ares_addr *subnet,
                                unsigned char           netmask)
 {
@@ -144,7 +144,7 @@ ares_bool_t ares__subnet_match(const struct ares_addr *addr,
   return ARES_TRUE;
 }
 
-ares_bool_t ares__addr_is_linklocal(const struct ares_addr *addr)
+ares_bool_t ares_addr_is_linklocal(const struct ares_addr *addr)
 {
   struct ares_addr    subnet;
   const unsigned char subnetaddr[16] = { 0xfe, 0x80, 0x00, 0x00, 0x00, 0x00,
@@ -155,7 +155,7 @@ ares_bool_t ares__addr_is_linklocal(const struct ares_addr *addr)
   subnet.family = AF_INET6;
   memcpy(&subnet.addr.addr6, subnetaddr, 16);
 
-  return ares__subnet_match(addr, &subnet, 10);
+  return ares_subnet_match(addr, &subnet, 10);
 }
 
 static ares_bool_t ares_server_blacklisted(const struct ares_addr *addr)
@@ -185,7 +185,7 @@ static ares_bool_t ares_server_blacklisted(const struct ares_addr *addr)
     struct ares_addr subnet;
     subnet.family = AF_INET6;
     memcpy(&subnet.addr.addr6, blacklist_v6[i].netbase, 16);
-    if (ares__subnet_match(addr, &subnet, blacklist_v6[i].netmask)) {
+    if (ares_subnet_match(addr, &subnet, blacklist_v6[i].netmask)) {
       return ARES_TRUE;
     }
   }
@@ -211,7 +211,7 @@ static ares_bool_t ares_server_blacklisted(const struct ares_addr *addr)
  * Returns an error code on failure, else ARES_SUCCESS
  */
 
-static ares_status_t parse_nameserver(ares__buf_t *buf, ares_sconfig_t *sconfig)
+static ares_status_t parse_nameserver(ares_buf_t *buf, ares_sconfig_t *sconfig)
 {
   ares_status_t status;
   char          ipaddr[INET6_ADDRSTRLEN] = "";
@@ -220,57 +220,57 @@ static ares_status_t parse_nameserver(ares__buf_t *buf, ares_sconfig_t *sconfig)
   memset(sconfig, 0, sizeof(*sconfig));
 
   /* Consume any leading whitespace */
-  ares__buf_consume_whitespace(buf, ARES_TRUE);
+  ares_buf_consume_whitespace(buf, ARES_TRUE);
 
   /* pop off IP address.  If it is in [ ] then it can be ipv4 or ipv6.  If
    * not, ipv4 only */
-  if (ares__buf_begins_with(buf, (const unsigned char *)"[", 1)) {
+  if (ares_buf_begins_with(buf, (const unsigned char *)"[", 1)) {
     /* Consume [ */
-    ares__buf_consume(buf, 1);
+    ares_buf_consume(buf, 1);
 
-    ares__buf_tag(buf);
+    ares_buf_tag(buf);
 
     /* Consume until ] */
-    if (ares__buf_consume_until_charset(buf, (const unsigned char *)"]", 1,
+    if (ares_buf_consume_until_charset(buf, (const unsigned char *)"]", 1,
                                         ARES_TRUE) == 0) {
       return ARES_EBADSTR;
     }
 
-    status = ares__buf_tag_fetch_string(buf, ipaddr, sizeof(ipaddr));
+    status = ares_buf_tag_fetch_string(buf, ipaddr, sizeof(ipaddr));
     if (status != ARES_SUCCESS) {
       return status;
     }
 
     /* Skip over ] */
-    ares__buf_consume(buf, 1);
+    ares_buf_consume(buf, 1);
   } else {
     size_t offset;
 
     /* Not in [ ], see if '.' is in first 4 characters, if it is, then its ipv4,
      * otherwise treat as ipv6 */
-    ares__buf_tag(buf);
+    ares_buf_tag(buf);
 
-    offset = ares__buf_consume_until_charset(buf, (const unsigned char *)".", 1,
+    offset = ares_buf_consume_until_charset(buf, (const unsigned char *)".", 1,
                                              ARES_TRUE);
-    ares__buf_tag_rollback(buf);
-    ares__buf_tag(buf);
+    ares_buf_tag_rollback(buf);
+    ares_buf_tag(buf);
 
     if (offset > 0 && offset < 4) {
       /* IPv4 */
-      if (ares__buf_consume_charset(buf, (const unsigned char *)"0123456789.",
+      if (ares_buf_consume_charset(buf, (const unsigned char *)"0123456789.",
                                     11) == 0) {
         return ARES_EBADSTR;
       }
     } else {
       /* IPv6 */
       const unsigned char ipv6_charset[] = "ABCDEFabcdef0123456789.:";
-      if (ares__buf_consume_charset(buf, ipv6_charset,
+      if (ares_buf_consume_charset(buf, ipv6_charset,
                                     sizeof(ipv6_charset) - 1) == 0) {
         return ARES_EBADSTR;
       }
     }
 
-    status = ares__buf_tag_fetch_string(buf, ipaddr, sizeof(ipaddr));
+    status = ares_buf_tag_fetch_string(buf, ipaddr, sizeof(ipaddr));
     if (status != ARES_SUCCESS) {
       return status;
     }
@@ -283,21 +283,21 @@ static ares_status_t parse_nameserver(ares__buf_t *buf, ares_sconfig_t *sconfig)
   }
 
   /* Pull off port */
-  if (ares__buf_begins_with(buf, (const unsigned char *)":", 1)) {
+  if (ares_buf_begins_with(buf, (const unsigned char *)":", 1)) {
     char portstr[6];
 
     /* Consume : */
-    ares__buf_consume(buf, 1);
+    ares_buf_consume(buf, 1);
 
-    ares__buf_tag(buf);
+    ares_buf_tag(buf);
 
     /* Read numbers */
-    if (ares__buf_consume_charset(buf, (const unsigned char *)"0123456789",
+    if (ares_buf_consume_charset(buf, (const unsigned char *)"0123456789",
                                   10) == 0) {
       return ARES_EBADSTR;
     }
 
-    status = ares__buf_tag_fetch_string(buf, portstr, sizeof(portstr));
+    status = ares_buf_tag_fetch_string(buf, portstr, sizeof(portstr));
     if (status != ARES_SUCCESS) {
       return status;
     }
@@ -307,21 +307,21 @@ static ares_status_t parse_nameserver(ares__buf_t *buf, ares_sconfig_t *sconfig)
   }
 
   /* Pull off interface modifier */
-  if (ares__buf_begins_with(buf, (const unsigned char *)"%", 1)) {
+  if (ares_buf_begins_with(buf, (const unsigned char *)"%", 1)) {
     const unsigned char iface_charset[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                           "abcdefghijklmnopqrstuvwxyz"
                                           "0123456789.-_\\:{}";
     /* Consume % */
-    ares__buf_consume(buf, 1);
+    ares_buf_consume(buf, 1);
 
-    ares__buf_tag(buf);
+    ares_buf_tag(buf);
 
-    if (ares__buf_consume_charset(buf, iface_charset,
+    if (ares_buf_consume_charset(buf, iface_charset,
                                   sizeof(iface_charset) - 1) == 0) {
       return ARES_EBADSTR;
     }
 
-    status = ares__buf_tag_fetch_string(buf, sconfig->ll_iface,
+    status = ares_buf_tag_fetch_string(buf, sconfig->ll_iface,
                                         sizeof(sconfig->ll_iface));
     if (status != ARES_SUCCESS) {
       return status;
@@ -330,16 +330,16 @@ static ares_status_t parse_nameserver(ares__buf_t *buf, ares_sconfig_t *sconfig)
 
   /* Consume any trailing whitespace so we can bail out if there is something
    * after we didn't read */
-  ares__buf_consume_whitespace(buf, ARES_TRUE);
+  ares_buf_consume_whitespace(buf, ARES_TRUE);
 
-  if (ares__buf_len(buf) != 0) {
+  if (ares_buf_len(buf) != 0) {
     return ARES_EBADSTR;
   }
 
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares__sconfig_linklocal(ares_sconfig_t *s,
+static ares_status_t ares_sconfig_linklocal(ares_sconfig_t *s,
                                              const char     *ll_iface)
 {
   unsigned int ll_scope = 0;
@@ -347,7 +347,7 @@ static ares_status_t ares__sconfig_linklocal(ares_sconfig_t *s,
   if (ares_str_isnum(ll_iface)) {
     char ifname[IF_NAMESIZE] = "";
     ll_scope                 = (unsigned int)atoi(ll_iface);
-    if (ares__if_indextoname(ll_scope, ifname, sizeof(ifname)) == NULL) {
+    if (ares_if_indextoname(ll_scope, ifname, sizeof(ifname)) == NULL) {
       DEBUGF(fprintf(stderr, "Interface %s for ipv6 Link Local not found\n",
                      ll_iface));
       return ARES_ENOTFOUND;
@@ -357,7 +357,7 @@ static ares_status_t ares__sconfig_linklocal(ares_sconfig_t *s,
     return ARES_SUCCESS;
   }
 
-  ll_scope = ares__if_nametoindex(ll_iface);
+  ll_scope = ares_if_nametoindex(ll_iface);
   if (ll_scope == 0) {
     DEBUGF(fprintf(stderr, "Interface %s for ipv6 Link Local not found\n",
                    ll_iface));
@@ -368,7 +368,7 @@ static ares_status_t ares__sconfig_linklocal(ares_sconfig_t *s,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__sconfig_append(ares__llist_t         **sconfig,
+ares_status_t ares_sconfig_append(ares_llist_t         **sconfig,
                                    const struct ares_addr *addr,
                                    unsigned short          udp_port,
                                    unsigned short          tcp_port,
@@ -392,7 +392,7 @@ ares_status_t ares__sconfig_append(ares__llist_t         **sconfig,
   }
 
   if (*sconfig == NULL) {
-    *sconfig = ares__llist_create(ares_free);
+    *sconfig = ares_llist_create(ares_free);
     if (*sconfig == NULL) {
       status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
       goto fail;            /* LCOV_EXCL_LINE: OutOfMemory */
@@ -405,13 +405,13 @@ ares_status_t ares__sconfig_append(ares__llist_t         **sconfig,
 
   /* Handle link-local enumeration. If an interface is specified on a
    * non-link-local address, we'll simply end up ignoring that */
-  if (ares__addr_is_linklocal(&s->addr)) {
+  if (ares_addr_is_linklocal(&s->addr)) {
     if (ares_strlen(ll_iface) == 0) {
       /* Silently ignore this entry, we require an interface */
       status = ARES_SUCCESS;
       goto fail;
     }
-    status = ares__sconfig_linklocal(s, ll_iface);
+    status = ares_sconfig_linklocal(s, ll_iface);
     /* Silently ignore this entry, we can't validate the interface */
     if (status != ARES_SUCCESS) {
       status = ARES_SUCCESS;
@@ -419,7 +419,7 @@ ares_status_t ares__sconfig_append(ares__llist_t         **sconfig,
     }
   }
 
-  if (ares__llist_insert_last(*sconfig, s) == NULL) {
+  if (ares_llist_insert_last(*sconfig, s) == NULL) {
     status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
     goto fail;            /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -448,33 +448,33 @@ fail:
  *
  * Returns an error code on failure, else ARES_SUCCESS.
  */
-ares_status_t ares__sconfig_append_fromstr(ares__llist_t **sconfig,
+ares_status_t ares_sconfig_append_fromstr(ares_llist_t **sconfig,
                                            const char     *str,
                                            ares_bool_t     ignore_invalid)
 {
   ares_status_t       status = ARES_SUCCESS;
-  ares__buf_t        *buf    = NULL;
-  ares__llist_t      *list   = NULL;
-  ares__llist_node_t *node;
+  ares_buf_t        *buf    = NULL;
+  ares_llist_t      *list   = NULL;
+  ares_llist_node_t *node;
 
   /* On Windows, there may be more than one nameserver specified in the same
    * registry key, so we parse input as a space or comma separated list.
    */
-  buf = ares__buf_create_const((const unsigned char *)str, ares_strlen(str));
+  buf = ares_buf_create_const((const unsigned char *)str, ares_strlen(str));
   if (buf == NULL) {
     status = ARES_ENOMEM;
     goto done;
   }
 
-  status = ares__buf_split(buf, (const unsigned char *)" ,", 2,
+  status = ares_buf_split(buf, (const unsigned char *)" ,", 2,
                            ARES_BUF_SPLIT_NONE, 0, &list);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  for (node = ares__llist_node_first(list); node != NULL;
-       node = ares__llist_node_next(node)) {
-    ares__buf_t   *entry = ares__llist_node_val(node);
+  for (node = ares_llist_node_first(list); node != NULL;
+       node = ares_llist_node_next(node)) {
+    ares_buf_t   *entry = ares_llist_node_val(node);
     ares_sconfig_t s;
 
     status = parse_nameserver(entry, &s);
@@ -486,7 +486,7 @@ ares_status_t ares__sconfig_append_fromstr(ares__llist_t **sconfig,
       }
     }
 
-    status = ares__sconfig_append(sconfig, &s.addr, s.udp_port, s.tcp_port,
+    status = ares_sconfig_append(sconfig, &s.addr, s.udp_port, s.tcp_port,
                                   s.ll_iface);
     if (status != ARES_SUCCESS) {
       goto done; /* LCOV_EXCL_LINE: OutOfMemory */
@@ -496,12 +496,12 @@ ares_status_t ares__sconfig_append_fromstr(ares__llist_t **sconfig,
   status = ARES_SUCCESS;
 
 done:
-  ares__llist_destroy(list);
-  ares__buf_destroy(buf);
+  ares_llist_destroy(list);
+  ares_buf_destroy(buf);
   return status;
 }
 
-static unsigned short ares__sconfig_get_port(const ares_channel_t *channel,
+static unsigned short ares_sconfig_get_port(const ares_channel_t *channel,
                                              const ares_sconfig_t *s,
                                              ares_bool_t           is_tcp)
 {
@@ -518,24 +518,24 @@ static unsigned short ares__sconfig_get_port(const ares_channel_t *channel,
   return port;
 }
 
-static ares__slist_node_t *ares__server_find(ares_channel_t       *channel,
+static ares_slist_node_t *ares_server_find(ares_channel_t       *channel,
                                              const ares_sconfig_t *s)
 {
-  ares__slist_node_t *node;
+  ares_slist_node_t *node;
 
-  for (node = ares__slist_node_first(channel->servers); node != NULL;
-       node = ares__slist_node_next(node)) {
-    const ares_server_t *server = ares__slist_node_val(node);
+  for (node = ares_slist_node_first(channel->servers); node != NULL;
+       node = ares_slist_node_next(node)) {
+    const ares_server_t *server = ares_slist_node_val(node);
 
-    if (!ares__addr_match(&server->addr, &s->addr)) {
+    if (!ares_addr_match(&server->addr, &s->addr)) {
       continue;
     }
 
-    if (server->tcp_port != ares__sconfig_get_port(channel, s, ARES_TRUE)) {
+    if (server->tcp_port != ares_sconfig_get_port(channel, s, ARES_TRUE)) {
       continue;
     }
 
-    if (server->udp_port != ares__sconfig_get_port(channel, s, ARES_FALSE)) {
+    if (server->udp_port != ares_sconfig_get_port(channel, s, ARES_FALSE)) {
       continue;
     }
 
@@ -544,28 +544,28 @@ static ares__slist_node_t *ares__server_find(ares_channel_t       *channel,
   return NULL;
 }
 
-static ares_bool_t ares__server_isdup(const ares_channel_t *channel,
-                                      ares__llist_node_t   *s)
+static ares_bool_t ares_server_isdup(const ares_channel_t *channel,
+                                      ares_llist_node_t   *s)
 {
   /* Scan backwards to see if this is a duplicate */
-  ares__llist_node_t   *prev;
-  const ares_sconfig_t *server = ares__llist_node_val(s);
+  ares_llist_node_t   *prev;
+  const ares_sconfig_t *server = ares_llist_node_val(s);
 
-  for (prev = ares__llist_node_prev(s); prev != NULL;
-       prev = ares__llist_node_prev(prev)) {
-    const ares_sconfig_t *p = ares__llist_node_val(prev);
+  for (prev = ares_llist_node_prev(s); prev != NULL;
+       prev = ares_llist_node_prev(prev)) {
+    const ares_sconfig_t *p = ares_llist_node_val(prev);
 
-    if (!ares__addr_match(&server->addr, &p->addr)) {
+    if (!ares_addr_match(&server->addr, &p->addr)) {
       continue;
     }
 
-    if (ares__sconfig_get_port(channel, server, ARES_TRUE) !=
-        ares__sconfig_get_port(channel, p, ARES_TRUE)) {
+    if (ares_sconfig_get_port(channel, server, ARES_TRUE) !=
+        ares_sconfig_get_port(channel, p, ARES_TRUE)) {
       continue;
     }
 
-    if (ares__sconfig_get_port(channel, server, ARES_FALSE) !=
-        ares__sconfig_get_port(channel, p, ARES_FALSE)) {
+    if (ares_sconfig_get_port(channel, server, ARES_FALSE) !=
+        ares_sconfig_get_port(channel, p, ARES_FALSE)) {
       continue;
     }
 
@@ -575,7 +575,7 @@ static ares_bool_t ares__server_isdup(const ares_channel_t *channel,
   return ARES_FALSE;
 }
 
-static ares_status_t ares__server_create(ares_channel_t       *channel,
+static ares_status_t ares_server_create(ares_channel_t       *channel,
                                          const ares_sconfig_t *sconfig,
                                          size_t                idx)
 {
@@ -588,8 +588,8 @@ static ares_status_t ares__server_create(ares_channel_t       *channel,
 
   server->idx         = idx;
   server->channel     = channel;
-  server->udp_port    = ares__sconfig_get_port(channel, sconfig, ARES_FALSE);
-  server->tcp_port    = ares__sconfig_get_port(channel, sconfig, ARES_TRUE);
+  server->udp_port    = ares_sconfig_get_port(channel, sconfig, ARES_FALSE);
+  server->tcp_port    = ares_sconfig_get_port(channel, sconfig, ARES_TRUE);
   server->addr.family = sconfig->addr.family;
   server->next_retry_time.sec  = 0;
   server->next_retry_time.usec = 0;
@@ -608,13 +608,13 @@ static ares_status_t ares__server_create(ares_channel_t       *channel,
     server->ll_scope = sconfig->ll_scope;
   }
 
-  server->connections = ares__llist_create(NULL);
+  server->connections = ares_llist_create(NULL);
   if (server->connections == NULL) {
     status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
     goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  if (ares__slist_insert(channel->servers, server) == NULL) {
+  if (ares_slist_insert(channel->servers, server) == NULL) {
     status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
     goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -623,31 +623,31 @@ static ares_status_t ares__server_create(ares_channel_t       *channel,
 
 done:
   if (status != ARES_SUCCESS) {
-    ares__destroy_server(server); /* LCOV_EXCL_LINE: OutOfMemory */
+    ares_destroy_server(server); /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   return status;
 }
 
-static ares_bool_t ares__server_in_newconfig(const ares_server_t *server,
-                                             ares__llist_t       *srvlist)
+static ares_bool_t ares_server_in_newconfig(const ares_server_t *server,
+                                             ares_llist_t       *srvlist)
 {
-  ares__llist_node_t   *node;
+  ares_llist_node_t   *node;
   const ares_channel_t *channel = server->channel;
 
-  for (node = ares__llist_node_first(srvlist); node != NULL;
-       node = ares__llist_node_next(node)) {
-    const ares_sconfig_t *s = ares__llist_node_val(node);
+  for (node = ares_llist_node_first(srvlist); node != NULL;
+       node = ares_llist_node_next(node)) {
+    const ares_sconfig_t *s = ares_llist_node_val(node);
 
-    if (!ares__addr_match(&server->addr, &s->addr)) {
+    if (!ares_addr_match(&server->addr, &s->addr)) {
       continue;
     }
 
-    if (server->tcp_port != ares__sconfig_get_port(channel, s, ARES_TRUE)) {
+    if (server->tcp_port != ares_sconfig_get_port(channel, s, ARES_TRUE)) {
       continue;
     }
 
-    if (server->udp_port != ares__sconfig_get_port(channel, s, ARES_FALSE)) {
+    if (server->udp_port != ares_sconfig_get_port(channel, s, ARES_FALSE)) {
       continue;
     }
 
@@ -657,19 +657,19 @@ static ares_bool_t ares__server_in_newconfig(const ares_server_t *server,
   return ARES_FALSE;
 }
 
-static ares_bool_t ares__servers_remove_stale(ares_channel_t *channel,
-                                              ares__llist_t  *srvlist)
+static ares_bool_t ares_servers_remove_stale(ares_channel_t *channel,
+                                              ares_llist_t  *srvlist)
 {
   ares_bool_t         stale_removed = ARES_FALSE;
-  ares__slist_node_t *snode         = ares__slist_node_first(channel->servers);
+  ares_slist_node_t *snode         = ares_slist_node_first(channel->servers);
 
   while (snode != NULL) {
-    ares__slist_node_t  *snext  = ares__slist_node_next(snode);
-    const ares_server_t *server = ares__slist_node_val(snode);
-    if (!ares__server_in_newconfig(server, srvlist)) {
+    ares_slist_node_t  *snext  = ares_slist_node_next(snode);
+    const ares_server_t *server = ares_slist_node_val(snode);
+    if (!ares_server_in_newconfig(server, srvlist)) {
       /* This will clean up all server state via the destruction callback and
        * move any queries to new servers */
-      ares__slist_node_destroy(snode);
+      ares_slist_node_destroy(snode);
       stale_removed = ARES_TRUE;
     }
     snode = snext;
@@ -677,18 +677,18 @@ static ares_bool_t ares__servers_remove_stale(ares_channel_t *channel,
   return stale_removed;
 }
 
-static void ares__servers_trim_single(ares_channel_t *channel)
+static void ares_servers_trim_single(ares_channel_t *channel)
 {
-  while (ares__slist_len(channel->servers) > 1) {
-    ares__slist_node_destroy(ares__slist_node_last(channel->servers));
+  while (ares_slist_len(channel->servers) > 1) {
+    ares_slist_node_destroy(ares_slist_node_last(channel->servers));
   }
 }
 
-ares_status_t ares__servers_update(ares_channel_t *channel,
-                                   ares__llist_t  *server_list,
+ares_status_t ares_servers_update(ares_channel_t *channel,
+                                   ares_llist_t  *server_list,
                                    ares_bool_t     user_specified)
 {
-  ares__llist_node_t *node;
+  ares_llist_node_t *node;
   size_t              idx = 0;
   ares_status_t       status;
   ares_bool_t         list_changed = ARES_FALSE;
@@ -702,19 +702,19 @@ ares_status_t ares__servers_update(ares_channel_t *channel,
    */
 
   /* Add new entries */
-  for (node = ares__llist_node_first(server_list); node != NULL;
-       node = ares__llist_node_next(node)) {
-    const ares_sconfig_t *sconfig = ares__llist_node_val(node);
-    ares__slist_node_t   *snode;
+  for (node = ares_llist_node_first(server_list); node != NULL;
+       node = ares_llist_node_next(node)) {
+    const ares_sconfig_t *sconfig = ares_llist_node_val(node);
+    ares_slist_node_t   *snode;
 
     /* If a server has already appeared in the list of new servers, skip it. */
-    if (ares__server_isdup(channel, node)) {
+    if (ares_server_isdup(channel, node)) {
       continue;
     }
 
-    snode = ares__server_find(channel, sconfig);
+    snode = ares_server_find(channel, sconfig);
     if (snode != NULL) {
-      ares_server_t *server = ares__slist_node_val(snode);
+      ares_server_t *server = ares_slist_node_val(snode);
 
       /* Copy over link-local settings.  Its possible some of this data has
        * changed, maybe ...  */
@@ -728,10 +728,10 @@ ares_status_t ares__servers_update(ares_channel_t *channel,
         server->idx = idx;
         /* Index changed, reinsert node, doesn't require any memory
          * allocations so can't fail. */
-        ares__slist_node_reinsert(snode);
+        ares_slist_node_reinsert(snode);
       }
     } else {
-      status = ares__server_create(channel, sconfig, idx);
+      status = ares_server_create(channel, sconfig, idx);
       if (status != ARES_SUCCESS) {
         goto done;
       }
@@ -743,13 +743,13 @@ ares_status_t ares__servers_update(ares_channel_t *channel,
   }
 
   /* Remove any servers that don't exist in the current configuration */
-  if (ares__servers_remove_stale(channel, server_list)) {
+  if (ares_servers_remove_stale(channel, server_list)) {
     list_changed = ARES_TRUE;
   }
 
   /* Trim to one server if ARES_FLAG_PRIMARY is set. */
   if (channel->flags & ARES_FLAG_PRIMARY) {
-    ares__servers_trim_single(channel);
+    ares_servers_trim_single(channel);
   }
 
   if (user_specified) {
@@ -759,7 +759,7 @@ ares_status_t ares__servers_update(ares_channel_t *channel,
 
   /* Clear any cached query results only if the server list changed */
   if (list_changed) {
-    ares__qcache_flush(channel->qcache);
+    ares_qcache_flush(channel->qcache);
   }
 
   status = ARES_SUCCESS;
@@ -770,14 +770,14 @@ done:
 
 static ares_status_t
   ares_addr_node_to_sconfig_llist(const struct ares_addr_node *servers,
-                                  ares__llist_t              **llist)
+                                  ares_llist_t              **llist)
 {
   const struct ares_addr_node *node;
-  ares__llist_t               *s;
+  ares_llist_t               *s;
 
   *llist = NULL;
 
-  s = ares__llist_create(ares_free);
+  s = ares_llist_create(ares_free);
   if (s == NULL) {
     goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -804,7 +804,7 @@ static ares_status_t
              sizeof(sconfig->addr.addr.addr6));
     }
 
-    if (ares__llist_insert_last(s, sconfig) == NULL) {
+    if (ares_llist_insert_last(s, sconfig) == NULL) {
       ares_free(sconfig); /* LCOV_EXCL_LINE: OutOfMemory */
       goto fail;          /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -815,21 +815,21 @@ static ares_status_t
 
 /* LCOV_EXCL_START: OutOfMemory */
 fail:
-  ares__llist_destroy(s);
+  ares_llist_destroy(s);
   return ARES_ENOMEM;
   /* LCOV_EXCL_STOP */
 }
 
 static ares_status_t
   ares_addrpnode_to_sconfig_llist(const struct ares_addr_port_node *servers,
-                                  ares__llist_t                   **llist)
+                                  ares_llist_t                   **llist)
 {
   const struct ares_addr_port_node *node;
-  ares__llist_t                    *s;
+  ares_llist_t                    *s;
 
   *llist = NULL;
 
-  s = ares__llist_create(ares_free);
+  s = ares_llist_create(ares_free);
   if (s == NULL) {
     goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -859,7 +859,7 @@ static ares_status_t
     sconfig->tcp_port = (unsigned short)node->tcp_port;
     sconfig->udp_port = (unsigned short)node->udp_port;
 
-    if (ares__llist_insert_last(s, sconfig) == NULL) {
+    if (ares_llist_insert_last(s, sconfig) == NULL) {
       ares_free(sconfig); /* LCOV_EXCL_LINE: OutOfMemory */
       goto fail;          /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -870,21 +870,21 @@ static ares_status_t
 
 /* LCOV_EXCL_START: OutOfMemory */
 fail:
-  ares__llist_destroy(s);
+  ares_llist_destroy(s);
   return ARES_ENOMEM;
   /* LCOV_EXCL_STOP */
 }
 
 ares_status_t ares_in_addr_to_sconfig_llist(const struct in_addr *servers,
                                             size_t                nservers,
-                                            ares__llist_t       **llist)
+                                            ares_llist_t       **llist)
 {
   size_t         i;
-  ares__llist_t *s;
+  ares_llist_t *s;
 
   *llist = NULL;
 
-  s = ares__llist_create(ares_free);
+  s = ares_llist_create(ares_free);
   if (s == NULL) {
     goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -901,7 +901,7 @@ ares_status_t ares_in_addr_to_sconfig_llist(const struct in_addr *servers,
     memcpy(&sconfig->addr.addr.addr4, &servers[i],
            sizeof(sconfig->addr.addr.addr4));
 
-    if (ares__llist_insert_last(s, sconfig) == NULL) {
+    if (ares_llist_insert_last(s, sconfig) == NULL) {
       goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
@@ -911,21 +911,21 @@ ares_status_t ares_in_addr_to_sconfig_llist(const struct in_addr *servers,
 
 /* LCOV_EXCL_START: OutOfMemory */
 fail:
-  ares__llist_destroy(s);
+  ares_llist_destroy(s);
   return ARES_ENOMEM;
   /* LCOV_EXCL_STOP */
 }
 
 /* Write out the details of a server to a buffer */
 ares_status_t ares_get_server_addr(const ares_server_t *server,
-                                   ares__buf_t         *buf)
+                                   ares_buf_t         *buf)
 {
   ares_status_t status;
   char          addr[INET6_ADDRSTRLEN];
 
   /* ipv4addr or [ipv6addr] */
   if (server->addr.family == AF_INET6) {
-    status = ares__buf_append_byte(buf, '[');
+    status = ares_buf_append_byte(buf, '[');
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -933,37 +933,37 @@ ares_status_t ares_get_server_addr(const ares_server_t *server,
 
   ares_inet_ntop(server->addr.family, &server->addr.addr, addr, sizeof(addr));
 
-  status = ares__buf_append_str(buf, addr);
+  status = ares_buf_append_str(buf, addr);
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   if (server->addr.family == AF_INET6) {
-    status = ares__buf_append_byte(buf, ']');
+    status = ares_buf_append_byte(buf, ']');
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
 
   /* :port */
-  status = ares__buf_append_byte(buf, ':');
+  status = ares_buf_append_byte(buf, ':');
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  status = ares__buf_append_num_dec(buf, server->udp_port, 0);
+  status = ares_buf_append_num_dec(buf, server->udp_port, 0);
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   /* %iface */
   if (ares_strlen(server->ll_iface)) {
-    status = ares__buf_append_byte(buf, '%');
+    status = ares_buf_append_byte(buf, '%');
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
-    status = ares__buf_append_str(buf, server->ll_iface);
+    status = ares_buf_append_str(buf, server->ll_iface);
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -979,17 +979,17 @@ int ares_get_servers(const ares_channel_t   *channel,
   struct ares_addr_node *srvr_last = NULL;
   struct ares_addr_node *srvr_curr;
   ares_status_t          status = ARES_SUCCESS;
-  ares__slist_node_t    *node;
+  ares_slist_node_t    *node;
 
   if (channel == NULL) {
     return ARES_ENODATA;
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
 
-  for (node = ares__slist_node_first(channel->servers); node != NULL;
-       node = ares__slist_node_next(node)) {
-    const ares_server_t *server = ares__slist_node_val(node);
+  for (node = ares_slist_node_first(channel->servers); node != NULL;
+       node = ares_slist_node_next(node)) {
+    const ares_server_t *server = ares_slist_node_val(node);
 
     /* Allocate storage for this server node appending it to the list */
     srvr_curr = ares_malloc_data(ARES_DATATYPE_ADDR_NODE);
@@ -1022,7 +1022,7 @@ int ares_get_servers(const ares_channel_t   *channel,
 
   *servers = srvr_head;
 
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
 
   return (int)status;
 }
@@ -1034,17 +1034,17 @@ int ares_get_servers_ports(const ares_channel_t        *channel,
   struct ares_addr_port_node *srvr_last = NULL;
   struct ares_addr_port_node *srvr_curr;
   ares_status_t               status = ARES_SUCCESS;
-  ares__slist_node_t         *node;
+  ares_slist_node_t         *node;
 
   if (channel == NULL) {
     return ARES_ENODATA;
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
 
-  for (node = ares__slist_node_first(channel->servers); node != NULL;
-       node = ares__slist_node_next(node)) {
-    const ares_server_t *server = ares__slist_node_val(node);
+  for (node = ares_slist_node_first(channel->servers); node != NULL;
+       node = ares_slist_node_next(node)) {
+    const ares_server_t *server = ares_slist_node_val(node);
 
     /* Allocate storage for this server node appending it to the list */
     srvr_curr = ares_malloc_data(ARES_DATATYPE_ADDR_PORT_NODE);
@@ -1080,14 +1080,14 @@ int ares_get_servers_ports(const ares_channel_t        *channel,
 
   *servers = srvr_head;
 
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
   return (int)status;
 }
 
 int ares_set_servers(ares_channel_t              *channel,
                      const struct ares_addr_node *servers)
 {
-  ares__llist_t *slist;
+  ares_llist_t *slist;
   ares_status_t  status;
 
   if (channel == NULL) {
@@ -1099,11 +1099,11 @@ int ares_set_servers(ares_channel_t              *channel,
     return (int)status;
   }
 
-  ares__channel_lock(channel);
-  status = ares__servers_update(channel, slist, ARES_TRUE);
-  ares__channel_unlock(channel);
+  ares_channel_lock(channel);
+  status = ares_servers_update(channel, slist, ARES_TRUE);
+  ares_channel_unlock(channel);
 
-  ares__llist_destroy(slist);
+  ares_llist_destroy(slist);
 
   return (int)status;
 }
@@ -1111,7 +1111,7 @@ int ares_set_servers(ares_channel_t              *channel,
 int ares_set_servers_ports(ares_channel_t                   *channel,
                            const struct ares_addr_port_node *servers)
 {
-  ares__llist_t *slist;
+  ares_llist_t *slist;
   ares_status_t  status;
 
   if (channel == NULL) {
@@ -1123,11 +1123,11 @@ int ares_set_servers_ports(ares_channel_t                   *channel,
     return (int)status;
   }
 
-  ares__channel_lock(channel);
-  status = ares__servers_update(channel, slist, ARES_TRUE);
-  ares__channel_unlock(channel);
+  ares_channel_lock(channel);
+  status = ares_servers_update(channel, slist, ARES_TRUE);
+  ares_channel_unlock(channel);
 
-  ares__llist_destroy(slist);
+  ares_llist_destroy(slist);
 
   return (int)status;
 }
@@ -1137,7 +1137,7 @@ int ares_set_servers_ports(ares_channel_t                   *channel,
 static ares_status_t set_servers_csv(ares_channel_t *channel, const char *_csv)
 {
   ares_status_t  status;
-  ares__llist_t *slist = NULL;
+  ares_llist_t *slist = NULL;
 
   if (channel == NULL) {
     return ARES_ENODATA;
@@ -1145,23 +1145,23 @@ static ares_status_t set_servers_csv(ares_channel_t *channel, const char *_csv)
 
   if (ares_strlen(_csv) == 0) {
     /* blank all servers */
-    ares__channel_lock(channel);
-    status = ares__servers_update(channel, NULL, ARES_TRUE);
-    ares__channel_unlock(channel);
+    ares_channel_lock(channel);
+    status = ares_servers_update(channel, NULL, ARES_TRUE);
+    ares_channel_unlock(channel);
     return status;
   }
 
-  status = ares__sconfig_append_fromstr(&slist, _csv, ARES_FALSE);
+  status = ares_sconfig_append_fromstr(&slist, _csv, ARES_FALSE);
   if (status != ARES_SUCCESS) {
-    ares__llist_destroy(slist);
+    ares_llist_destroy(slist);
     return status;
   }
 
-  ares__channel_lock(channel);
-  status = ares__servers_update(channel, slist, ARES_TRUE);
-  ares__channel_unlock(channel);
+  ares_channel_lock(channel);
+  status = ares_servers_update(channel, slist, ARES_TRUE);
+  ares_channel_unlock(channel);
 
-  ares__llist_destroy(slist);
+  ares_llist_destroy(slist);
 
   return status;
 }
@@ -1179,24 +1179,24 @@ int ares_set_servers_ports_csv(ares_channel_t *channel, const char *_csv)
 
 char *ares_get_servers_csv(const ares_channel_t *channel)
 {
-  ares__buf_t        *buf = NULL;
+  ares_buf_t        *buf = NULL;
   char               *out = NULL;
-  ares__slist_node_t *node;
+  ares_slist_node_t *node;
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
 
-  buf = ares__buf_create();
+  buf = ares_buf_create();
   if (buf == NULL) {
     goto done; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  for (node = ares__slist_node_first(channel->servers); node != NULL;
-       node = ares__slist_node_next(node)) {
+  for (node = ares_slist_node_first(channel->servers); node != NULL;
+       node = ares_slist_node_next(node)) {
     ares_status_t        status;
-    const ares_server_t *server = ares__slist_node_val(node);
+    const ares_server_t *server = ares_slist_node_val(node);
 
-    if (ares__buf_len(buf)) {
-      status = ares__buf_append_byte(buf, ',');
+    if (ares_buf_len(buf)) {
+      status = ares_buf_append_byte(buf, ',');
       if (status != ARES_SUCCESS) {
         goto done; /* LCOV_EXCL_LINE: OutOfMemory */
       }
@@ -1208,12 +1208,12 @@ char *ares_get_servers_csv(const ares_channel_t *channel)
     }
   }
 
-  out = ares__buf_finish_str(buf, NULL);
+  out = ares_buf_finish_str(buf, NULL);
   buf = NULL;
 
 done:
-  ares__channel_unlock(channel);
-  ares__buf_destroy(buf);
+  ares_channel_unlock(channel);
+  ares_buf_destroy(buf);
   return out;
 }
 

--- a/src/lib/ares_update_servers.c
+++ b/src/lib/ares_update_servers.c
@@ -62,7 +62,7 @@ typedef struct {
 } ares_sconfig_t;
 
 static ares_bool_t ares_addr_match(const struct ares_addr *addr1,
-                                    const struct ares_addr *addr2)
+                                   const struct ares_addr *addr2)
 {
   if (addr1 == NULL && addr2 == NULL) {
     return ARES_TRUE; /* LCOV_EXCL_LINE: DefensiveCoding */
@@ -91,8 +91,8 @@ static ares_bool_t ares_addr_match(const struct ares_addr *addr1,
 }
 
 ares_bool_t ares_subnet_match(const struct ares_addr *addr,
-                               const struct ares_addr *subnet,
-                               unsigned char           netmask)
+                              const struct ares_addr *subnet,
+                              unsigned char           netmask)
 {
   const unsigned char *addr_ptr;
   const unsigned char *subnet_ptr;
@@ -232,7 +232,7 @@ static ares_status_t parse_nameserver(ares_buf_t *buf, ares_sconfig_t *sconfig)
 
     /* Consume until ] */
     if (ares_buf_consume_until_charset(buf, (const unsigned char *)"]", 1,
-                                        ARES_TRUE) == 0) {
+                                       ARES_TRUE) == 0) {
       return ARES_EBADSTR;
     }
 
@@ -251,21 +251,21 @@ static ares_status_t parse_nameserver(ares_buf_t *buf, ares_sconfig_t *sconfig)
     ares_buf_tag(buf);
 
     offset = ares_buf_consume_until_charset(buf, (const unsigned char *)".", 1,
-                                             ARES_TRUE);
+                                            ARES_TRUE);
     ares_buf_tag_rollback(buf);
     ares_buf_tag(buf);
 
     if (offset > 0 && offset < 4) {
       /* IPv4 */
       if (ares_buf_consume_charset(buf, (const unsigned char *)"0123456789.",
-                                    11) == 0) {
+                                   11) == 0) {
         return ARES_EBADSTR;
       }
     } else {
       /* IPv6 */
       const unsigned char ipv6_charset[] = "ABCDEFabcdef0123456789.:";
       if (ares_buf_consume_charset(buf, ipv6_charset,
-                                    sizeof(ipv6_charset) - 1) == 0) {
+                                   sizeof(ipv6_charset) - 1) == 0) {
         return ARES_EBADSTR;
       }
     }
@@ -293,7 +293,7 @@ static ares_status_t parse_nameserver(ares_buf_t *buf, ares_sconfig_t *sconfig)
 
     /* Read numbers */
     if (ares_buf_consume_charset(buf, (const unsigned char *)"0123456789",
-                                  10) == 0) {
+                                 10) == 0) {
       return ARES_EBADSTR;
     }
 
@@ -317,12 +317,12 @@ static ares_status_t parse_nameserver(ares_buf_t *buf, ares_sconfig_t *sconfig)
     ares_buf_tag(buf);
 
     if (ares_buf_consume_charset(buf, iface_charset,
-                                  sizeof(iface_charset) - 1) == 0) {
+                                 sizeof(iface_charset) - 1) == 0) {
       return ARES_EBADSTR;
     }
 
     status = ares_buf_tag_fetch_string(buf, sconfig->ll_iface,
-                                        sizeof(sconfig->ll_iface));
+                                       sizeof(sconfig->ll_iface));
     if (status != ARES_SUCCESS) {
       return status;
     }
@@ -340,7 +340,7 @@ static ares_status_t parse_nameserver(ares_buf_t *buf, ares_sconfig_t *sconfig)
 }
 
 static ares_status_t ares_sconfig_linklocal(ares_sconfig_t *s,
-                                             const char     *ll_iface)
+                                            const char     *ll_iface)
 {
   unsigned int ll_scope = 0;
 
@@ -368,11 +368,10 @@ static ares_status_t ares_sconfig_linklocal(ares_sconfig_t *s,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares_sconfig_append(ares_llist_t         **sconfig,
-                                   const struct ares_addr *addr,
-                                   unsigned short          udp_port,
-                                   unsigned short          tcp_port,
-                                   const char             *ll_iface)
+ares_status_t ares_sconfig_append(ares_llist_t          **sconfig,
+                                  const struct ares_addr *addr,
+                                  unsigned short          udp_port,
+                                  unsigned short tcp_port, const char *ll_iface)
 {
   ares_sconfig_t *s;
   ares_status_t   status;
@@ -449,10 +448,10 @@ fail:
  * Returns an error code on failure, else ARES_SUCCESS.
  */
 ares_status_t ares_sconfig_append_fromstr(ares_llist_t **sconfig,
-                                           const char     *str,
-                                           ares_bool_t     ignore_invalid)
+                                          const char    *str,
+                                          ares_bool_t    ignore_invalid)
 {
-  ares_status_t       status = ARES_SUCCESS;
+  ares_status_t      status = ARES_SUCCESS;
   ares_buf_t        *buf    = NULL;
   ares_llist_t      *list   = NULL;
   ares_llist_node_t *node;
@@ -467,14 +466,14 @@ ares_status_t ares_sconfig_append_fromstr(ares_llist_t **sconfig,
   }
 
   status = ares_buf_split(buf, (const unsigned char *)" ,", 2,
-                           ARES_BUF_SPLIT_NONE, 0, &list);
+                          ARES_BUF_SPLIT_NONE, 0, &list);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
   for (node = ares_llist_node_first(list); node != NULL;
        node = ares_llist_node_next(node)) {
-    ares_buf_t   *entry = ares_llist_node_val(node);
+    ares_buf_t    *entry = ares_llist_node_val(node);
     ares_sconfig_t s;
 
     status = parse_nameserver(entry, &s);
@@ -486,8 +485,8 @@ ares_status_t ares_sconfig_append_fromstr(ares_llist_t **sconfig,
       }
     }
 
-    status = ares_sconfig_append(sconfig, &s.addr, s.udp_port, s.tcp_port,
-                                  s.ll_iface);
+    status =
+      ares_sconfig_append(sconfig, &s.addr, s.udp_port, s.tcp_port, s.ll_iface);
     if (status != ARES_SUCCESS) {
       goto done; /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -502,8 +501,8 @@ done:
 }
 
 static unsigned short ares_sconfig_get_port(const ares_channel_t *channel,
-                                             const ares_sconfig_t *s,
-                                             ares_bool_t           is_tcp)
+                                            const ares_sconfig_t *s,
+                                            ares_bool_t           is_tcp)
 {
   unsigned short port = is_tcp ? s->tcp_port : s->udp_port;
 
@@ -519,7 +518,7 @@ static unsigned short ares_sconfig_get_port(const ares_channel_t *channel,
 }
 
 static ares_slist_node_t *ares_server_find(ares_channel_t       *channel,
-                                             const ares_sconfig_t *s)
+                                           const ares_sconfig_t *s)
 {
   ares_slist_node_t *node;
 
@@ -545,10 +544,10 @@ static ares_slist_node_t *ares_server_find(ares_channel_t       *channel,
 }
 
 static ares_bool_t ares_server_isdup(const ares_channel_t *channel,
-                                      ares_llist_node_t   *s)
+                                     ares_llist_node_t    *s)
 {
   /* Scan backwards to see if this is a duplicate */
-  ares_llist_node_t   *prev;
+  ares_llist_node_t    *prev;
   const ares_sconfig_t *server = ares_llist_node_val(s);
 
   for (prev = ares_llist_node_prev(s); prev != NULL;
@@ -576,8 +575,8 @@ static ares_bool_t ares_server_isdup(const ares_channel_t *channel,
 }
 
 static ares_status_t ares_server_create(ares_channel_t       *channel,
-                                         const ares_sconfig_t *sconfig,
-                                         size_t                idx)
+                                        const ares_sconfig_t *sconfig,
+                                        size_t                idx)
 {
   ares_status_t  status;
   ares_server_t *server = ares_malloc_zero(sizeof(*server));
@@ -630,9 +629,9 @@ done:
 }
 
 static ares_bool_t ares_server_in_newconfig(const ares_server_t *server,
-                                             ares_llist_t       *srvlist)
+                                            ares_llist_t        *srvlist)
 {
-  ares_llist_node_t   *node;
+  ares_llist_node_t    *node;
   const ares_channel_t *channel = server->channel;
 
   for (node = ares_llist_node_first(srvlist); node != NULL;
@@ -658,13 +657,13 @@ static ares_bool_t ares_server_in_newconfig(const ares_server_t *server,
 }
 
 static ares_bool_t ares_servers_remove_stale(ares_channel_t *channel,
-                                              ares_llist_t  *srvlist)
+                                             ares_llist_t   *srvlist)
 {
-  ares_bool_t         stale_removed = ARES_FALSE;
+  ares_bool_t        stale_removed = ARES_FALSE;
   ares_slist_node_t *snode         = ares_slist_node_first(channel->servers);
 
   while (snode != NULL) {
-    ares_slist_node_t  *snext  = ares_slist_node_next(snode);
+    ares_slist_node_t   *snext  = ares_slist_node_next(snode);
     const ares_server_t *server = ares_slist_node_val(snode);
     if (!ares_server_in_newconfig(server, srvlist)) {
       /* This will clean up all server state via the destruction callback and
@@ -685,13 +684,13 @@ static void ares_servers_trim_single(ares_channel_t *channel)
 }
 
 ares_status_t ares_servers_update(ares_channel_t *channel,
-                                   ares_llist_t  *server_list,
-                                   ares_bool_t     user_specified)
+                                  ares_llist_t   *server_list,
+                                  ares_bool_t     user_specified)
 {
   ares_llist_node_t *node;
-  size_t              idx = 0;
-  ares_status_t       status;
-  ares_bool_t         list_changed = ARES_FALSE;
+  size_t             idx = 0;
+  ares_status_t      status;
+  ares_bool_t        list_changed = ARES_FALSE;
 
   if (channel == NULL) {
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
@@ -705,7 +704,7 @@ ares_status_t ares_servers_update(ares_channel_t *channel,
   for (node = ares_llist_node_first(server_list); node != NULL;
        node = ares_llist_node_next(node)) {
     const ares_sconfig_t *sconfig = ares_llist_node_val(node);
-    ares_slist_node_t   *snode;
+    ares_slist_node_t    *snode;
 
     /* If a server has already appeared in the list of new servers, skip it. */
     if (ares_server_isdup(channel, node)) {
@@ -770,10 +769,10 @@ done:
 
 static ares_status_t
   ares_addr_node_to_sconfig_llist(const struct ares_addr_node *servers,
-                                  ares_llist_t              **llist)
+                                  ares_llist_t               **llist)
 {
   const struct ares_addr_node *node;
-  ares_llist_t               *s;
+  ares_llist_t                *s;
 
   *llist = NULL;
 
@@ -822,10 +821,10 @@ fail:
 
 static ares_status_t
   ares_addrpnode_to_sconfig_llist(const struct ares_addr_port_node *servers,
-                                  ares_llist_t                   **llist)
+                                  ares_llist_t                    **llist)
 {
   const struct ares_addr_port_node *node;
-  ares_llist_t                    *s;
+  ares_llist_t                     *s;
 
   *llist = NULL;
 
@@ -877,9 +876,9 @@ fail:
 
 ares_status_t ares_in_addr_to_sconfig_llist(const struct in_addr *servers,
                                             size_t                nservers,
-                                            ares_llist_t       **llist)
+                                            ares_llist_t        **llist)
 {
-  size_t         i;
+  size_t        i;
   ares_llist_t *s;
 
   *llist = NULL;
@@ -917,8 +916,7 @@ fail:
 }
 
 /* Write out the details of a server to a buffer */
-ares_status_t ares_get_server_addr(const ares_server_t *server,
-                                   ares_buf_t         *buf)
+ares_status_t ares_get_server_addr(const ares_server_t *server, ares_buf_t *buf)
 {
   ares_status_t status;
   char          addr[INET6_ADDRSTRLEN];
@@ -979,7 +977,7 @@ int ares_get_servers(const ares_channel_t   *channel,
   struct ares_addr_node *srvr_last = NULL;
   struct ares_addr_node *srvr_curr;
   ares_status_t          status = ARES_SUCCESS;
-  ares_slist_node_t    *node;
+  ares_slist_node_t     *node;
 
   if (channel == NULL) {
     return ARES_ENODATA;
@@ -1034,7 +1032,7 @@ int ares_get_servers_ports(const ares_channel_t        *channel,
   struct ares_addr_port_node *srvr_last = NULL;
   struct ares_addr_port_node *srvr_curr;
   ares_status_t               status = ARES_SUCCESS;
-  ares_slist_node_t         *node;
+  ares_slist_node_t          *node;
 
   if (channel == NULL) {
     return ARES_ENODATA;
@@ -1088,7 +1086,7 @@ int ares_set_servers(ares_channel_t              *channel,
                      const struct ares_addr_node *servers)
 {
   ares_llist_t *slist;
-  ares_status_t  status;
+  ares_status_t status;
 
   if (channel == NULL) {
     return ARES_ENODATA;
@@ -1112,7 +1110,7 @@ int ares_set_servers_ports(ares_channel_t                   *channel,
                            const struct ares_addr_port_node *servers)
 {
   ares_llist_t *slist;
-  ares_status_t  status;
+  ares_status_t status;
 
   if (channel == NULL) {
     return ARES_ENODATA;
@@ -1136,7 +1134,7 @@ int ares_set_servers_ports(ares_channel_t                   *channel,
 /* IPv6 addresses with ports require square brackets [fe80::1]:53 */
 static ares_status_t set_servers_csv(ares_channel_t *channel, const char *_csv)
 {
-  ares_status_t  status;
+  ares_status_t status;
   ares_llist_t *slist = NULL;
 
   if (channel == NULL) {
@@ -1180,7 +1178,7 @@ int ares_set_servers_ports_csv(ares_channel_t *channel, const char *_csv)
 char *ares_get_servers_csv(const ares_channel_t *channel)
 {
   ares_buf_t        *buf = NULL;
-  char               *out = NULL;
+  char              *out = NULL;
   ares_slist_node_t *node;
 
   ares_channel_lock(channel);

--- a/src/lib/dsa/ares_array.c
+++ b/src/lib/dsa/ares_array.c
@@ -24,12 +24,12 @@
  * SPDX-License-Identifier: MIT
  */
 #include "ares_private.h"
-#include "ares__array.h"
+#include "ares_array.h"
 
 #define ARES__ARRAY_MIN 4
 
-struct ares__array {
-  ares__array_destructor_t destruct;
+struct ares_array {
+  ares_array_destructor_t destruct;
   void                    *arr;
   size_t                   member_size;
   size_t                   cnt;
@@ -37,10 +37,10 @@ struct ares__array {
   size_t                   alloc_cnt;
 };
 
-ares__array_t *ares__array_create(size_t                   member_size,
-                                  ares__array_destructor_t destruct)
+ares_array_t *ares_array_create(size_t                   member_size,
+                                  ares_array_destructor_t destruct)
 {
-  ares__array_t *arr;
+  ares_array_t *arr;
 
   if (member_size == 0) {
     return NULL;
@@ -56,7 +56,7 @@ ares__array_t *ares__array_create(size_t                   member_size,
   return arr;
 }
 
-size_t ares__array_len(const ares__array_t *arr)
+size_t ares_array_len(const ares_array_t *arr)
 {
   if (arr == NULL) {
     return 0;
@@ -64,7 +64,7 @@ size_t ares__array_len(const ares__array_t *arr)
   return arr->cnt;
 }
 
-void *ares__array_at(ares__array_t *arr, size_t idx)
+void *ares_array_at(ares_array_t *arr, size_t idx)
 {
   if (arr == NULL || idx >= arr->cnt) {
     return NULL;
@@ -72,7 +72,7 @@ void *ares__array_at(ares__array_t *arr, size_t idx)
   return (unsigned char *)arr->arr + ((idx + arr->offset) * arr->member_size);
 }
 
-const void *ares__array_at_const(const ares__array_t *arr, size_t idx)
+const void *ares_array_at_const(const ares_array_t *arr, size_t idx)
 {
   if (arr == NULL || idx >= arr->cnt) {
     return NULL;
@@ -80,7 +80,7 @@ const void *ares__array_at_const(const ares__array_t *arr, size_t idx)
   return (unsigned char *)arr->arr + ((idx + arr->offset) * arr->member_size);
 }
 
-ares_status_t ares__array_sort(ares__array_t *arr, ares__array_cmp_t cmp)
+ares_status_t ares_array_sort(ares_array_t *arr, ares_array_cmp_t cmp)
 {
   if (arr == NULL || cmp == NULL) {
     return ARES_EFORMERR;
@@ -96,7 +96,7 @@ ares_status_t ares__array_sort(ares__array_t *arr, ares__array_cmp_t cmp)
   return ARES_SUCCESS;
 }
 
-void ares__array_destroy(ares__array_t *arr)
+void ares_array_destroy(ares_array_t *arr)
 {
   size_t i;
 
@@ -106,7 +106,7 @@ void ares__array_destroy(ares__array_t *arr)
 
   if (arr->destruct != NULL) {
     for (i = 0; i < arr->cnt; i++) {
-      arr->destruct(ares__array_at(arr, i));
+      arr->destruct(ares_array_at(arr, i));
     }
   }
 
@@ -116,7 +116,7 @@ void ares__array_destroy(ares__array_t *arr)
 
 /* NOTE: this function operates on actual indexes, NOT indexes using the
  *       arr->offset */
-static ares_status_t ares__array_move(ares__array_t *arr, size_t dest_idx,
+static ares_status_t ares_array_move(ares_array_t *arr, size_t dest_idx,
                                       size_t src_idx)
 {
   void       *dest_ptr;
@@ -151,7 +151,7 @@ static ares_status_t ares__array_move(ares__array_t *arr, size_t dest_idx,
   return ARES_SUCCESS;
 }
 
-void *ares__array_finish(ares__array_t *arr, size_t *num_members)
+void *ares_array_finish(ares_array_t *arr, size_t *num_members)
 {
   void *ptr;
 
@@ -161,7 +161,7 @@ void *ares__array_finish(ares__array_t *arr, size_t *num_members)
 
   /* Make sure we move data to beginning of allocation */
   if (arr->offset != 0) {
-    if (ares__array_move(arr, 0, arr->offset) != ARES_SUCCESS) {
+    if (ares_array_move(arr, 0, arr->offset) != ARES_SUCCESS) {
       return NULL;
     }
     arr->offset = 0;
@@ -173,7 +173,7 @@ void *ares__array_finish(ares__array_t *arr, size_t *num_members)
   return ptr;
 }
 
-ares_status_t ares__array_set_size(ares__array_t *arr, size_t size)
+ares_status_t ares_array_set_size(ares_array_t *arr, size_t size)
 {
   void *temp;
 
@@ -182,7 +182,7 @@ ares_status_t ares__array_set_size(ares__array_t *arr, size_t size)
   }
 
   /* Always operate on powers of 2 */
-  size = ares__round_up_pow2(size);
+  size = ares_round_up_pow2(size);
 
   if (size < ARES__ARRAY_MIN) {
     size = ARES__ARRAY_MIN;
@@ -203,7 +203,7 @@ ares_status_t ares__array_set_size(ares__array_t *arr, size_t size)
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__array_insert_at(void **elem_ptr, ares__array_t *arr,
+ares_status_t ares_array_insert_at(void **elem_ptr, ares_array_t *arr,
                                     size_t idx)
 {
   void         *ptr;
@@ -219,14 +219,14 @@ ares_status_t ares__array_insert_at(void **elem_ptr, ares__array_t *arr,
   }
 
   /* Allocate more if needed */
-  status = ares__array_set_size(arr, arr->cnt + 1);
+  status = ares_array_set_size(arr, arr->cnt + 1);
   if (status != ARES_SUCCESS) {
     return status;
   }
 
   /* Shift if we have memory but not enough room at the end */
   if (arr->cnt + 1 + arr->offset > arr->alloc_cnt) {
-    status = ares__array_move(arr, 0, arr->offset);
+    status = ares_array_move(arr, 0, arr->offset);
     if (status != ARES_SUCCESS) {
       return status;
     }
@@ -236,7 +236,7 @@ ares_status_t ares__array_insert_at(void **elem_ptr, ares__array_t *arr,
   /* If we're inserting anywhere other than the end, we need to move some
    * elements out of the way */
   if (idx != arr->cnt) {
-    status = ares__array_move(arr, idx + arr->offset + 1, idx + arr->offset);
+    status = ares_array_move(arr, idx + arr->offset + 1, idx + arr->offset);
     if (status != ARES_SUCCESS) {
       return status;
     }
@@ -255,23 +255,23 @@ ares_status_t ares__array_insert_at(void **elem_ptr, ares__array_t *arr,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__array_insert_last(void **elem_ptr, ares__array_t *arr)
+ares_status_t ares_array_insert_last(void **elem_ptr, ares_array_t *arr)
 {
-  return ares__array_insert_at(elem_ptr, arr, ares__array_len(arr));
+  return ares_array_insert_at(elem_ptr, arr, ares_array_len(arr));
 }
 
-ares_status_t ares__array_insert_first(void **elem_ptr, ares__array_t *arr)
+ares_status_t ares_array_insert_first(void **elem_ptr, ares_array_t *arr)
 {
-  return ares__array_insert_at(elem_ptr, arr, 0);
+  return ares_array_insert_at(elem_ptr, arr, 0);
 }
 
-ares_status_t ares__array_insertdata_at(ares__array_t *arr, size_t idx,
+ares_status_t ares_array_insertdata_at(ares_array_t *arr, size_t idx,
                                         const void *data_ptr)
 {
   ares_status_t status;
   void         *ptr = NULL;
 
-  status = ares__array_insert_at(&ptr, arr, idx);
+  status = ares_array_insert_at(&ptr, arr, idx);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -279,13 +279,13 @@ ares_status_t ares__array_insertdata_at(ares__array_t *arr, size_t idx,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__array_insertdata_last(ares__array_t *arr,
+ares_status_t ares_array_insertdata_last(ares_array_t *arr,
                                           const void    *data_ptr)
 {
   ares_status_t status;
   void         *ptr = NULL;
 
-  status = ares__array_insert_last(&ptr, arr);
+  status = ares_array_insert_last(&ptr, arr);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -293,13 +293,13 @@ ares_status_t ares__array_insertdata_last(ares__array_t *arr,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__array_insertdata_first(ares__array_t *arr,
+ares_status_t ares_array_insertdata_first(ares_array_t *arr,
                                            const void    *data_ptr)
 {
   ares_status_t status;
   void         *ptr = NULL;
 
-  status = ares__array_insert_last(&ptr, arr);
+  status = ares_array_insert_last(&ptr, arr);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -307,36 +307,36 @@ ares_status_t ares__array_insertdata_first(ares__array_t *arr,
   return ARES_SUCCESS;
 }
 
-void *ares__array_first(ares__array_t *arr)
+void *ares_array_first(ares_array_t *arr)
 {
-  return ares__array_at(arr, 0);
+  return ares_array_at(arr, 0);
 }
 
-void *ares__array_last(ares__array_t *arr)
+void *ares_array_last(ares_array_t *arr)
 {
-  size_t cnt = ares__array_len(arr);
+  size_t cnt = ares_array_len(arr);
   if (cnt == 0) {
     return NULL;
   }
-  return ares__array_at(arr, cnt - 1);
+  return ares_array_at(arr, cnt - 1);
 }
 
-const void *ares__array_first_const(const ares__array_t *arr)
+const void *ares_array_first_const(const ares_array_t *arr)
 {
-  return ares__array_at_const(arr, 0);
+  return ares_array_at_const(arr, 0);
 }
 
-const void *ares__array_last_const(const ares__array_t *arr)
+const void *ares_array_last_const(const ares_array_t *arr)
 {
-  size_t cnt = ares__array_len(arr);
+  size_t cnt = ares_array_len(arr);
   if (cnt == 0) {
     return NULL;
   }
-  return ares__array_at_const(arr, cnt - 1);
+  return ares_array_at_const(arr, cnt - 1);
 }
 
-ares_status_t ares__array_claim_at(void *dest, size_t dest_size,
-                                   ares__array_t *arr, size_t idx)
+ares_status_t ares_array_claim_at(void *dest, size_t dest_size,
+                                   ares_array_t *arr, size_t idx)
 {
   ares_status_t status;
 
@@ -349,7 +349,7 @@ ares_status_t ares__array_claim_at(void *dest, size_t dest_size,
   }
 
   if (dest) {
-    memcpy(dest, ares__array_at(arr, idx), arr->member_size);
+    memcpy(dest, ares_array_at(arr, idx), arr->member_size);
   }
 
   if (idx == 0) {
@@ -359,7 +359,7 @@ ares_status_t ares__array_claim_at(void *dest, size_t dest_size,
   } else if (idx != arr->cnt - 1) {
     /* Must shift entire array if removing an element from the middle. Does
      * nothing if removing last element other than decrement count. */
-    status = ares__array_move(arr, idx + arr->offset, idx + arr->offset + 1);
+    status = ares_array_move(arr, idx + arr->offset, idx + arr->offset + 1);
     if (status != ARES_SUCCESS) {
       return status;
     }
@@ -369,9 +369,9 @@ ares_status_t ares__array_claim_at(void *dest, size_t dest_size,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__array_remove_at(ares__array_t *arr, size_t idx)
+ares_status_t ares_array_remove_at(ares_array_t *arr, size_t idx)
 {
-  void *ptr = ares__array_at(arr, idx);
+  void *ptr = ares_array_at(arr, idx);
   if (arr == NULL || ptr == NULL) {
     return ARES_EFORMERR;
   }
@@ -380,19 +380,19 @@ ares_status_t ares__array_remove_at(ares__array_t *arr, size_t idx)
     arr->destruct(ptr);
   }
 
-  return ares__array_claim_at(NULL, 0, arr, idx);
+  return ares_array_claim_at(NULL, 0, arr, idx);
 }
 
-ares_status_t ares__array_remove_first(ares__array_t *arr)
+ares_status_t ares_array_remove_first(ares_array_t *arr)
 {
-  return ares__array_remove_at(arr, 0);
+  return ares_array_remove_at(arr, 0);
 }
 
-ares_status_t ares__array_remove_last(ares__array_t *arr)
+ares_status_t ares_array_remove_last(ares_array_t *arr)
 {
-  size_t cnt = ares__array_len(arr);
+  size_t cnt = ares_array_len(arr);
   if (cnt == 0) {
     return ARES_EFORMERR;
   }
-  return ares__array_remove_at(arr, cnt - 1);
+  return ares_array_remove_at(arr, cnt - 1);
 }

--- a/src/lib/dsa/ares_array.c
+++ b/src/lib/dsa/ares_array.c
@@ -30,15 +30,15 @@
 
 struct ares_array {
   ares_array_destructor_t destruct;
-  void                    *arr;
-  size_t                   member_size;
-  size_t                   cnt;
-  size_t                   offset;
-  size_t                   alloc_cnt;
+  void                   *arr;
+  size_t                  member_size;
+  size_t                  cnt;
+  size_t                  offset;
+  size_t                  alloc_cnt;
 };
 
-ares_array_t *ares_array_create(size_t                   member_size,
-                                  ares_array_destructor_t destruct)
+ares_array_t *ares_array_create(size_t                  member_size,
+                                ares_array_destructor_t destruct)
 {
   ares_array_t *arr;
 
@@ -117,7 +117,7 @@ void ares_array_destroy(ares_array_t *arr)
 /* NOTE: this function operates on actual indexes, NOT indexes using the
  *       arr->offset */
 static ares_status_t ares_array_move(ares_array_t *arr, size_t dest_idx,
-                                      size_t src_idx)
+                                     size_t src_idx)
 {
   void       *dest_ptr;
   const void *src_ptr;
@@ -204,7 +204,7 @@ ares_status_t ares_array_set_size(ares_array_t *arr, size_t size)
 }
 
 ares_status_t ares_array_insert_at(void **elem_ptr, ares_array_t *arr,
-                                    size_t idx)
+                                   size_t idx)
 {
   void         *ptr;
   ares_status_t status;
@@ -266,7 +266,7 @@ ares_status_t ares_array_insert_first(void **elem_ptr, ares_array_t *arr)
 }
 
 ares_status_t ares_array_insertdata_at(ares_array_t *arr, size_t idx,
-                                        const void *data_ptr)
+                                       const void *data_ptr)
 {
   ares_status_t status;
   void         *ptr = NULL;
@@ -280,7 +280,7 @@ ares_status_t ares_array_insertdata_at(ares_array_t *arr, size_t idx,
 }
 
 ares_status_t ares_array_insertdata_last(ares_array_t *arr,
-                                          const void    *data_ptr)
+                                         const void   *data_ptr)
 {
   ares_status_t status;
   void         *ptr = NULL;
@@ -294,7 +294,7 @@ ares_status_t ares_array_insertdata_last(ares_array_t *arr,
 }
 
 ares_status_t ares_array_insertdata_first(ares_array_t *arr,
-                                           const void    *data_ptr)
+                                          const void   *data_ptr)
 {
   ares_status_t status;
   void         *ptr = NULL;
@@ -336,7 +336,7 @@ const void *ares_array_last_const(const ares_array_t *arr)
 }
 
 ares_status_t ares_array_claim_at(void *dest, size_t dest_size,
-                                   ares_array_t *arr, size_t idx)
+                                  ares_array_t *arr, size_t idx)
 {
   ares_status_t status;
 

--- a/src/lib/dsa/ares_htable.c
+++ b/src/lib/dsa/ares_htable.c
@@ -36,10 +36,10 @@ struct ares_htable {
   ares_htable_bucket_key_t  bucket_key;
   ares_htable_bucket_free_t bucket_free;
   ares_htable_key_eq_t      key_eq;
-  unsigned int               seed;
-  unsigned int               size;
-  size_t                     num_keys;
-  size_t                     num_collisions;
+  unsigned int              seed;
+  unsigned int              size;
+  size_t                    num_keys;
+  size_t                    num_collisions;
   /* NOTE: if we converted buckets into ares_slist_t we could guarantee on
    *       hash collisions we would have O(log n) worst case insert and search
    *       performance.  (We'd also need to make key_eq into a key_cmp to
@@ -69,8 +69,8 @@ static unsigned int ares_htable_generate_seed(ares_htable_t *htable)
 }
 
 static void ares_htable_buckets_destroy(ares_llist_t **buckets,
-                                         unsigned int    size,
-                                         ares_bool_t     destroy_vals)
+                                        unsigned int   size,
+                                        ares_bool_t    destroy_vals)
 {
   unsigned int i;
 
@@ -103,9 +103,9 @@ void ares_htable_destroy(ares_htable_t *htable)
 }
 
 ares_htable_t *ares_htable_create(ares_htable_hashfunc_t    hash_func,
-                                    ares_htable_bucket_key_t  bucket_key,
-                                    ares_htable_bucket_free_t bucket_free,
-                                    ares_htable_key_eq_t      key_eq)
+                                  ares_htable_bucket_key_t  bucket_key,
+                                  ares_htable_bucket_free_t bucket_free,
+                                  ares_htable_key_eq_t      key_eq)
 {
   ares_htable_t *htable = NULL;
 
@@ -175,7 +175,7 @@ const void **ares_htable_all_buckets(const ares_htable_t *htable, size_t *num)
 #define HASH_IDX(h, key) h->hash(key, h->seed) & (h->size - 1)
 
 static ares_llist_node_t *ares_htable_find(const ares_htable_t *htable,
-                                             unsigned int idx, const void *key)
+                                           unsigned int idx, const void *key)
 {
   ares_llist_node_t *node = NULL;
 
@@ -192,11 +192,11 @@ static ares_llist_node_t *ares_htable_find(const ares_htable_t *htable,
 static ares_bool_t ares_htable_expand(ares_htable_t *htable)
 {
   ares_llist_t **buckets  = NULL;
-  unsigned int    old_size = htable->size;
-  size_t          i;
+  unsigned int   old_size = htable->size;
+  size_t         i;
   ares_llist_t **prealloc_llist     = NULL;
-  size_t          prealloc_llist_len = 0;
-  ares_bool_t     rv                 = ARES_FALSE;
+  size_t         prealloc_llist_len = 0;
+  ares_bool_t    rv                 = ARES_FALSE;
 
   /* Not a failure, just won't expand */
   if (old_size == ARES__HTABLE_MAX_BUCKETS) {
@@ -303,7 +303,7 @@ done:
   ares_free(buckets);
   /* destroy any unused preallocated buckets */
   ares_htable_buckets_destroy(prealloc_llist, (unsigned int)prealloc_llist_len,
-                               ARES_FALSE);
+                              ARES_FALSE);
 
   /* On failure, we need to restore the htable size */
   if (rv != ARES_TRUE) {
@@ -315,9 +315,9 @@ done:
 
 ares_bool_t ares_htable_insert(ares_htable_t *htable, void *bucket)
 {
-  unsigned int        idx  = 0;
+  unsigned int       idx  = 0;
   ares_llist_node_t *node = NULL;
-  const void         *key  = NULL;
+  const void        *key  = NULL;
 
   if (htable == NULL || bucket == NULL) {
     return ARES_FALSE;
@@ -384,7 +384,7 @@ void *ares_htable_get(const ares_htable_t *htable, const void *key)
 ares_bool_t ares_htable_remove(ares_htable_t *htable, const void *key)
 {
   ares_llist_node_t *node;
-  unsigned int        idx;
+  unsigned int       idx;
 
   if (htable == NULL || key == NULL) {
     return ARES_FALSE;
@@ -416,7 +416,7 @@ size_t ares_htable_num_keys(const ares_htable_t *htable)
 }
 
 unsigned int ares_htable_hash_FNV1a(const unsigned char *key, size_t key_len,
-                                     unsigned int seed)
+                                    unsigned int seed)
 {
   unsigned int hv = seed ^ 2166136261U;
   size_t       i;
@@ -432,7 +432,7 @@ unsigned int ares_htable_hash_FNV1a(const unsigned char *key, size_t key_len,
 
 /* Case insensitive version, meant for ASCII strings */
 unsigned int ares_htable_hash_FNV1a_casecmp(const unsigned char *key,
-                                             size_t key_len, unsigned int seed)
+                                            size_t key_len, unsigned int seed)
 {
   unsigned int hv = seed ^ 2166136261U;
   size_t       i;

--- a/src/lib/dsa/ares_htable.c
+++ b/src/lib/dsa/ares_htable.c
@@ -24,32 +24,32 @@
  * SPDX-License-Identifier: MIT
  */
 #include "ares_private.h"
-#include "ares__llist.h"
-#include "ares__htable.h"
+#include "ares_llist.h"
+#include "ares_htable.h"
 
 #define ARES__HTABLE_MAX_BUCKETS    (1U << 24)
 #define ARES__HTABLE_MIN_BUCKETS    (1U << 4)
 #define ARES__HTABLE_EXPAND_PERCENT 75
 
-struct ares__htable {
-  ares__htable_hashfunc_t    hash;
-  ares__htable_bucket_key_t  bucket_key;
-  ares__htable_bucket_free_t bucket_free;
-  ares__htable_key_eq_t      key_eq;
+struct ares_htable {
+  ares_htable_hashfunc_t    hash;
+  ares_htable_bucket_key_t  bucket_key;
+  ares_htable_bucket_free_t bucket_free;
+  ares_htable_key_eq_t      key_eq;
   unsigned int               seed;
   unsigned int               size;
   size_t                     num_keys;
   size_t                     num_collisions;
-  /* NOTE: if we converted buckets into ares__slist_t we could guarantee on
+  /* NOTE: if we converted buckets into ares_slist_t we could guarantee on
    *       hash collisions we would have O(log n) worst case insert and search
    *       performance.  (We'd also need to make key_eq into a key_cmp to
    *       support sort).  That said, risk with a random hash seed is near zero,
-   *       and ares__slist_t is heavier weight, so I think using ares__llist_t
+   *       and ares_slist_t is heavier weight, so I think using ares_llist_t
    *       is an overall win. */
-  ares__llist_t            **buckets;
+  ares_llist_t            **buckets;
 };
 
-static unsigned int ares__htable_generate_seed(ares__htable_t *htable)
+static unsigned int ares_htable_generate_seed(ares_htable_t *htable)
 {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
   /* Seed needs to be static for fuzzing */
@@ -68,7 +68,7 @@ static unsigned int ares__htable_generate_seed(ares__htable_t *htable)
 #endif
 }
 
-static void ares__htable_buckets_destroy(ares__llist_t **buckets,
+static void ares_htable_buckets_destroy(ares_llist_t **buckets,
                                          unsigned int    size,
                                          ares_bool_t     destroy_vals)
 {
@@ -84,30 +84,30 @@ static void ares__htable_buckets_destroy(ares__llist_t **buckets,
     }
 
     if (!destroy_vals) {
-      ares__llist_replace_destructor(buckets[i], NULL);
+      ares_llist_replace_destructor(buckets[i], NULL);
     }
 
-    ares__llist_destroy(buckets[i]);
+    ares_llist_destroy(buckets[i]);
   }
 
   ares_free(buckets);
 }
 
-void ares__htable_destroy(ares__htable_t *htable)
+void ares_htable_destroy(ares_htable_t *htable)
 {
   if (htable == NULL) {
     return;
   }
-  ares__htable_buckets_destroy(htable->buckets, htable->size, ARES_TRUE);
+  ares_htable_buckets_destroy(htable->buckets, htable->size, ARES_TRUE);
   ares_free(htable);
 }
 
-ares__htable_t *ares__htable_create(ares__htable_hashfunc_t    hash_func,
-                                    ares__htable_bucket_key_t  bucket_key,
-                                    ares__htable_bucket_free_t bucket_free,
-                                    ares__htable_key_eq_t      key_eq)
+ares_htable_t *ares_htable_create(ares_htable_hashfunc_t    hash_func,
+                                    ares_htable_bucket_key_t  bucket_key,
+                                    ares_htable_bucket_free_t bucket_free,
+                                    ares_htable_key_eq_t      key_eq)
 {
-  ares__htable_t *htable = NULL;
+  ares_htable_t *htable = NULL;
 
   if (hash_func == NULL || bucket_key == NULL || bucket_free == NULL ||
       key_eq == NULL) {
@@ -123,7 +123,7 @@ ares__htable_t *ares__htable_create(ares__htable_hashfunc_t    hash_func,
   htable->bucket_key  = bucket_key;
   htable->bucket_free = bucket_free;
   htable->key_eq      = key_eq;
-  htable->seed        = ares__htable_generate_seed(htable);
+  htable->seed        = ares_htable_generate_seed(htable);
   htable->size        = ARES__HTABLE_MIN_BUCKETS;
   htable->buckets = ares_malloc_zero(sizeof(*htable->buckets) * htable->size);
 
@@ -134,11 +134,11 @@ ares__htable_t *ares__htable_create(ares__htable_hashfunc_t    hash_func,
   return htable;
 
 fail:
-  ares__htable_destroy(htable);
+  ares_htable_destroy(htable);
   return NULL;
 }
 
-const void **ares__htable_all_buckets(const ares__htable_t *htable, size_t *num)
+const void **ares_htable_all_buckets(const ares_htable_t *htable, size_t *num)
 {
   const void **out = NULL;
   size_t       cnt = 0;
@@ -156,10 +156,10 @@ const void **ares__htable_all_buckets(const ares__htable_t *htable, size_t *num)
   }
 
   for (i = 0; i < htable->size; i++) {
-    ares__llist_node_t *node;
-    for (node = ares__llist_node_first(htable->buckets[i]); node != NULL;
-         node = ares__llist_node_next(node)) {
-      out[cnt++] = ares__llist_node_val(node);
+    ares_llist_node_t *node;
+    for (node = ares_llist_node_first(htable->buckets[i]); node != NULL;
+         node = ares_llist_node_next(node)) {
+      out[cnt++] = ares_llist_node_val(node);
     }
   }
 
@@ -174,14 +174,14 @@ const void **ares__htable_all_buckets(const ares__htable_t *htable, size_t *num)
  * efficient */
 #define HASH_IDX(h, key) h->hash(key, h->seed) & (h->size - 1)
 
-static ares__llist_node_t *ares__htable_find(const ares__htable_t *htable,
+static ares_llist_node_t *ares_htable_find(const ares_htable_t *htable,
                                              unsigned int idx, const void *key)
 {
-  ares__llist_node_t *node = NULL;
+  ares_llist_node_t *node = NULL;
 
-  for (node = ares__llist_node_first(htable->buckets[idx]); node != NULL;
-       node = ares__llist_node_next(node)) {
-    if (htable->key_eq(key, htable->bucket_key(ares__llist_node_val(node)))) {
+  for (node = ares_llist_node_first(htable->buckets[idx]); node != NULL;
+       node = ares_llist_node_next(node)) {
+    if (htable->key_eq(key, htable->bucket_key(ares_llist_node_val(node)))) {
       break;
     }
   }
@@ -189,12 +189,12 @@ static ares__llist_node_t *ares__htable_find(const ares__htable_t *htable,
   return node;
 }
 
-static ares_bool_t ares__htable_expand(ares__htable_t *htable)
+static ares_bool_t ares_htable_expand(ares_htable_t *htable)
 {
-  ares__llist_t **buckets  = NULL;
+  ares_llist_t **buckets  = NULL;
   unsigned int    old_size = htable->size;
   size_t          i;
-  ares__llist_t **prealloc_llist     = NULL;
+  ares_llist_t **prealloc_llist     = NULL;
   size_t          prealloc_llist_len = 0;
   ares_bool_t     rv                 = ARES_FALSE;
 
@@ -224,7 +224,7 @@ static ares_bool_t ares__htable_expand(ares__htable_t *htable)
     }
   }
   for (i = 0; i < prealloc_llist_len; i++) {
-    prealloc_llist[i] = ares__llist_create(htable->bucket_free);
+    prealloc_llist[i] = ares_llist_create(htable->bucket_free);
     if (prealloc_llist[i] == NULL) {
       goto done;
     }
@@ -233,7 +233,7 @@ static ares_bool_t ares__htable_expand(ares__htable_t *htable)
   /* Iterate across all buckets and move the entries to the new buckets */
   htable->num_collisions = 0;
   for (i = 0; i < old_size; i++) {
-    ares__llist_node_t *node;
+    ares_llist_node_t *node;
 
     /* Nothing in this bucket */
     if (htable->buckets[i] == NULL) {
@@ -243,8 +243,8 @@ static ares_bool_t ares__htable_expand(ares__htable_t *htable)
     /* Fast path optimization (most likely case), there is likely only a single
      * entry in both the source and destination, check for this to confirm and
      * if so, just move the bucket over */
-    if (ares__llist_len(htable->buckets[i]) == 1) {
-      const void *val = ares__llist_first_val(htable->buckets[i]);
+    if (ares_llist_len(htable->buckets[i]) == 1) {
+      const void *val = ares_llist_first_val(htable->buckets[i]);
       size_t      idx = HASH_IDX(htable, htable->bucket_key(val));
 
       if (buckets[idx] == NULL) {
@@ -256,13 +256,13 @@ static ares_bool_t ares__htable_expand(ares__htable_t *htable)
     }
 
     /* Slow path, collisions */
-    while ((node = ares__llist_node_first(htable->buckets[i])) != NULL) {
-      const void *val = ares__llist_node_val(node);
+    while ((node = ares_llist_node_first(htable->buckets[i])) != NULL) {
+      const void *val = ares_llist_node_val(node);
       size_t      idx = HASH_IDX(htable, htable->bucket_key(val));
 
       /* Try fast path again as maybe we popped one collision off and the
        * next we can reuse the llist parent */
-      if (buckets[idx] == NULL && ares__llist_len(htable->buckets[i]) == 1) {
+      if (buckets[idx] == NULL && ares_llist_len(htable->buckets[i]) == 1) {
         /* Swap! */
         buckets[idx]       = htable->buckets[i];
         htable->buckets[i] = NULL;
@@ -282,12 +282,12 @@ static ares_bool_t ares__htable_expand(ares__htable_t *htable)
         htable->num_collisions++;
       }
 
-      ares__llist_node_mvparent_first(node, buckets[idx]);
+      ares_llist_node_mvparent_first(node, buckets[idx]);
     }
 
     /* Abandoned bucket, destroy */
     if (htable->buckets[i] != NULL) {
-      ares__llist_destroy(htable->buckets[i]);
+      ares_llist_destroy(htable->buckets[i]);
       htable->buckets[i] = NULL;
     }
   }
@@ -302,7 +302,7 @@ static ares_bool_t ares__htable_expand(ares__htable_t *htable)
 done:
   ares_free(buckets);
   /* destroy any unused preallocated buckets */
-  ares__htable_buckets_destroy(prealloc_llist, (unsigned int)prealloc_llist_len,
+  ares_htable_buckets_destroy(prealloc_llist, (unsigned int)prealloc_llist_len,
                                ARES_FALSE);
 
   /* On failure, we need to restore the htable size */
@@ -313,10 +313,10 @@ done:
   return rv;
 }
 
-ares_bool_t ares__htable_insert(ares__htable_t *htable, void *bucket)
+ares_bool_t ares_htable_insert(ares_htable_t *htable, void *bucket)
 {
   unsigned int        idx  = 0;
-  ares__llist_node_t *node = NULL;
+  ares_llist_node_t *node = NULL;
   const void         *key  = NULL;
 
   if (htable == NULL || bucket == NULL) {
@@ -328,9 +328,9 @@ ares_bool_t ares__htable_insert(ares__htable_t *htable, void *bucket)
   idx = HASH_IDX(htable, key);
 
   /* See if we have a matching bucket already, if so, replace it */
-  node = ares__htable_find(htable, idx, key);
+  node = ares_htable_find(htable, idx, key);
   if (node != NULL) {
-    ares__llist_node_replace(node, bucket);
+    ares_llist_node_replace(node, bucket);
     return ARES_TRUE;
   }
 
@@ -338,7 +338,7 @@ ares_bool_t ares__htable_insert(ares__htable_t *htable, void *bucket)
    * increased beyond our threshold */
   if (htable->num_keys + 1 >
       (htable->size * ARES__HTABLE_EXPAND_PERCENT) / 100) {
-    if (!ares__htable_expand(htable)) {
+    if (!ares_htable_expand(htable)) {
       return ARES_FALSE; /* LCOV_EXCL_LINE */
     }
     /* If we expanded, need to calculate a new index */
@@ -347,19 +347,19 @@ ares_bool_t ares__htable_insert(ares__htable_t *htable, void *bucket)
 
   /* We lazily allocate the linked list */
   if (htable->buckets[idx] == NULL) {
-    htable->buckets[idx] = ares__llist_create(htable->bucket_free);
+    htable->buckets[idx] = ares_llist_create(htable->bucket_free);
     if (htable->buckets[idx] == NULL) {
       return ARES_FALSE;
     }
   }
 
-  node = ares__llist_insert_first(htable->buckets[idx], bucket);
+  node = ares_llist_insert_first(htable->buckets[idx], bucket);
   if (node == NULL) {
     return ARES_FALSE;
   }
 
   /* Track collisions for rehash stability */
-  if (ares__llist_len(htable->buckets[idx]) > 1) {
+  if (ares_llist_len(htable->buckets[idx]) > 1) {
     htable->num_collisions++;
   }
 
@@ -368,7 +368,7 @@ ares_bool_t ares__htable_insert(ares__htable_t *htable, void *bucket)
   return ARES_TRUE;
 }
 
-void *ares__htable_get(const ares__htable_t *htable, const void *key)
+void *ares_htable_get(const ares_htable_t *htable, const void *key)
 {
   unsigned int idx;
 
@@ -378,12 +378,12 @@ void *ares__htable_get(const ares__htable_t *htable, const void *key)
 
   idx = HASH_IDX(htable, key);
 
-  return ares__llist_node_val(ares__htable_find(htable, idx, key));
+  return ares_llist_node_val(ares_htable_find(htable, idx, key));
 }
 
-ares_bool_t ares__htable_remove(ares__htable_t *htable, const void *key)
+ares_bool_t ares_htable_remove(ares_htable_t *htable, const void *key)
 {
-  ares__llist_node_t *node;
+  ares_llist_node_t *node;
   unsigned int        idx;
 
   if (htable == NULL || key == NULL) {
@@ -391,7 +391,7 @@ ares_bool_t ares__htable_remove(ares__htable_t *htable, const void *key)
   }
 
   idx  = HASH_IDX(htable, key);
-  node = ares__htable_find(htable, idx, key);
+  node = ares_htable_find(htable, idx, key);
   if (node == NULL) {
     return ARES_FALSE;
   }
@@ -399,15 +399,15 @@ ares_bool_t ares__htable_remove(ares__htable_t *htable, const void *key)
   htable->num_keys--;
 
   /* Reduce collisions */
-  if (ares__llist_len(ares__llist_node_parent(node)) > 1) {
+  if (ares_llist_len(ares_llist_node_parent(node)) > 1) {
     htable->num_collisions--;
   }
 
-  ares__llist_node_destroy(node);
+  ares_llist_node_destroy(node);
   return ARES_TRUE;
 }
 
-size_t ares__htable_num_keys(const ares__htable_t *htable)
+size_t ares_htable_num_keys(const ares_htable_t *htable)
 {
   if (htable == NULL) {
     return 0;
@@ -415,7 +415,7 @@ size_t ares__htable_num_keys(const ares__htable_t *htable)
   return htable->num_keys;
 }
 
-unsigned int ares__htable_hash_FNV1a(const unsigned char *key, size_t key_len,
+unsigned int ares_htable_hash_FNV1a(const unsigned char *key, size_t key_len,
                                      unsigned int seed)
 {
   unsigned int hv = seed ^ 2166136261U;
@@ -431,14 +431,14 @@ unsigned int ares__htable_hash_FNV1a(const unsigned char *key, size_t key_len,
 }
 
 /* Case insensitive version, meant for ASCII strings */
-unsigned int ares__htable_hash_FNV1a_casecmp(const unsigned char *key,
+unsigned int ares_htable_hash_FNV1a_casecmp(const unsigned char *key,
                                              size_t key_len, unsigned int seed)
 {
   unsigned int hv = seed ^ 2166136261U;
   size_t       i;
 
   for (i = 0; i < key_len; i++) {
-    hv ^= (unsigned int)ares__tolower(key[i]);
+    hv ^= (unsigned int)ares_tolower(key[i]);
     /* hv *= 16777619 (0x01000193) */
     hv += (hv << 1) + (hv << 4) + (hv << 7) + (hv << 8) + (hv << 24);
   }

--- a/src/lib/dsa/ares_htable.h
+++ b/src/lib/dsa/ares_htable.h
@@ -59,7 +59,7 @@ typedef struct ares_htable ares_htable_t;
  *  \return hash
  */
 typedef unsigned int (*ares_htable_hashfunc_t)(const void  *key,
-                                                unsigned int seed);
+                                               unsigned int seed);
 
 /*! Callback to free the bucket
  *
@@ -80,15 +80,14 @@ typedef const void *(*ares_htable_bucket_key_t)(const void *bucket);
  *  \param[in] key2  second key
  *  \return ARES_TRUE if equal, ARES_FALSE if not
  */
-typedef ares_bool_t (*ares_htable_key_eq_t)(const void *key1,
-                                             const void *key2);
+typedef ares_bool_t (*ares_htable_key_eq_t)(const void *key1, const void *key2);
 
 
 /*! Destroy the initialized hashtable
  *
  *  \param[in] htable initialized hashtable
  */
-void            ares_htable_destroy(ares_htable_t *htable);
+void           ares_htable_destroy(ares_htable_t *htable);
 
 /*! Create a new hashtable
  *
@@ -99,16 +98,16 @@ void            ares_htable_destroy(ares_htable_t *htable);
  *  \return initialized hashtable.  NULL if out of memory or misuse.
  */
 ares_htable_t *ares_htable_create(ares_htable_hashfunc_t    hash_func,
-                                    ares_htable_bucket_key_t  bucket_key,
-                                    ares_htable_bucket_free_t bucket_free,
-                                    ares_htable_key_eq_t      key_eq);
+                                  ares_htable_bucket_key_t  bucket_key,
+                                  ares_htable_bucket_free_t bucket_free,
+                                  ares_htable_key_eq_t      key_eq);
 
 /*! Count of keys from initialized hashtable
  *
  *  \param[in] htable  Initialized hashtable.
  *  \return count of keys
  */
-size_t          ares_htable_num_keys(const ares_htable_t *htable);
+size_t         ares_htable_num_keys(const ares_htable_t *htable);
 
 /*! Retrieve an array of buckets from the hashtable.  This is mainly used as
  *  a helper for retrieving an array of keys.
@@ -120,8 +119,7 @@ size_t          ares_htable_num_keys(const ares_htable_t *htable);
  *          will be a dangling pointer.  It is expected wrappers will make
  *          such values safe by duplicating them.
  */
-const void    **ares_htable_all_buckets(const ares_htable_t *htable,
-                                         size_t               *num);
+const void **ares_htable_all_buckets(const ares_htable_t *htable, size_t *num);
 
 /*! Insert bucket into hashtable
  *
@@ -130,7 +128,7 @@ const void    **ares_htable_all_buckets(const ares_htable_t *htable,
  *                     allowed to be NULL.
  *  \return ARES_TRUE on success, ARES_FALSE if out of memory
  */
-ares_bool_t     ares_htable_insert(ares_htable_t *htable, void *bucket);
+ares_bool_t  ares_htable_insert(ares_htable_t *htable, void *bucket);
 
 /*! Retrieve bucket from hashtable based on key.
  *
@@ -138,7 +136,7 @@ ares_bool_t     ares_htable_insert(ares_htable_t *htable, void *bucket);
  *  \param[in] key     Pointer to key to use for comparison.
  *  \return matching bucket, or NULL if not found.
  */
-void           *ares_htable_get(const ares_htable_t *htable, const void *key);
+void        *ares_htable_get(const ares_htable_t *htable, const void *key);
 
 /*! Remove bucket from hashtable by key
  *
@@ -146,7 +144,7 @@ void           *ares_htable_get(const ares_htable_t *htable, const void *key);
  *  \param[in] key     Pointer to key to use for comparison
  *  \return ARES_TRUE if found, ARES_FALSE if not found
  */
-ares_bool_t     ares_htable_remove(ares_htable_t *htable, const void *key);
+ares_bool_t  ares_htable_remove(ares_htable_t *htable, const void *key);
 
 /*! FNV1a hash algorithm.  Can be used as underlying primitive for building
  *  a wrapper hashtable.
@@ -157,7 +155,7 @@ ares_bool_t     ares_htable_remove(ares_htable_t *htable, const void *key);
  *  \return hash value
  */
 unsigned int ares_htable_hash_FNV1a(const unsigned char *key, size_t key_len,
-                                     unsigned int seed);
+                                    unsigned int seed);
 
 /*! FNV1a hash algorithm, but converts all characters to lowercase before
  *  hashing to make the hash case-insensitive. Can be used as underlying
@@ -169,7 +167,7 @@ unsigned int ares_htable_hash_FNV1a(const unsigned char *key, size_t key_len,
  *  \return hash value
  */
 unsigned int ares_htable_hash_FNV1a_casecmp(const unsigned char *key,
-                                             size_t key_len, unsigned int seed);
+                                            size_t key_len, unsigned int seed);
 
 /*! @} */
 

--- a/src/lib/dsa/ares_htable.h
+++ b/src/lib/dsa/ares_htable.h
@@ -27,7 +27,7 @@
 #define __ARES__HTABLE_H
 
 
-/*! \addtogroup ares__htable Base HashTable Data Structure
+/*! \addtogroup ares_htable Base HashTable Data Structure
  *
  * This is a basic hashtable data structure that is meant to be wrapped
  * by a higher level implementation.  This data structure is designed to
@@ -45,10 +45,10 @@
  * @{
  */
 
-struct ares__htable;
+struct ares_htable;
 
 /*! Opaque data type for generic hash table implementation */
-typedef struct ares__htable ares__htable_t;
+typedef struct ares_htable ares_htable_t;
 
 /*! Callback for generating a hash of the key.
  *
@@ -58,21 +58,21 @@ typedef struct ares__htable ares__htable_t;
  *                   but otherwise will not change between calls.
  *  \return hash
  */
-typedef unsigned int (*ares__htable_hashfunc_t)(const void  *key,
+typedef unsigned int (*ares_htable_hashfunc_t)(const void  *key,
                                                 unsigned int seed);
 
 /*! Callback to free the bucket
  *
  *  \param[in] bucket  user provided bucket
  */
-typedef void (*ares__htable_bucket_free_t)(void *bucket);
+typedef void (*ares_htable_bucket_free_t)(void *bucket);
 
 /*! Callback to extract the key from the user-provided bucket
  *
  *  \param[in] bucket  user provided bucket
  *  \return pointer to key held in bucket
  */
-typedef const void *(*ares__htable_bucket_key_t)(const void *bucket);
+typedef const void *(*ares_htable_bucket_key_t)(const void *bucket);
 
 /*! Callback to compare two keys for equality
  *
@@ -80,7 +80,7 @@ typedef const void *(*ares__htable_bucket_key_t)(const void *bucket);
  *  \param[in] key2  second key
  *  \return ARES_TRUE if equal, ARES_FALSE if not
  */
-typedef ares_bool_t (*ares__htable_key_eq_t)(const void *key1,
+typedef ares_bool_t (*ares_htable_key_eq_t)(const void *key1,
                                              const void *key2);
 
 
@@ -88,7 +88,7 @@ typedef ares_bool_t (*ares__htable_key_eq_t)(const void *key1,
  *
  *  \param[in] htable initialized hashtable
  */
-void            ares__htable_destroy(ares__htable_t *htable);
+void            ares_htable_destroy(ares_htable_t *htable);
 
 /*! Create a new hashtable
  *
@@ -98,17 +98,17 @@ void            ares__htable_destroy(ares__htable_t *htable);
  *  \param[in] key_eq      Required. Callback to check for key equality.
  *  \return initialized hashtable.  NULL if out of memory or misuse.
  */
-ares__htable_t *ares__htable_create(ares__htable_hashfunc_t    hash_func,
-                                    ares__htable_bucket_key_t  bucket_key,
-                                    ares__htable_bucket_free_t bucket_free,
-                                    ares__htable_key_eq_t      key_eq);
+ares_htable_t *ares_htable_create(ares_htable_hashfunc_t    hash_func,
+                                    ares_htable_bucket_key_t  bucket_key,
+                                    ares_htable_bucket_free_t bucket_free,
+                                    ares_htable_key_eq_t      key_eq);
 
 /*! Count of keys from initialized hashtable
  *
  *  \param[in] htable  Initialized hashtable.
  *  \return count of keys
  */
-size_t          ares__htable_num_keys(const ares__htable_t *htable);
+size_t          ares_htable_num_keys(const ares_htable_t *htable);
 
 /*! Retrieve an array of buckets from the hashtable.  This is mainly used as
  *  a helper for retrieving an array of keys.
@@ -120,7 +120,7 @@ size_t          ares__htable_num_keys(const ares__htable_t *htable);
  *          will be a dangling pointer.  It is expected wrappers will make
  *          such values safe by duplicating them.
  */
-const void    **ares__htable_all_buckets(const ares__htable_t *htable,
+const void    **ares_htable_all_buckets(const ares_htable_t *htable,
                                          size_t               *num);
 
 /*! Insert bucket into hashtable
@@ -130,7 +130,7 @@ const void    **ares__htable_all_buckets(const ares__htable_t *htable,
  *                     allowed to be NULL.
  *  \return ARES_TRUE on success, ARES_FALSE if out of memory
  */
-ares_bool_t     ares__htable_insert(ares__htable_t *htable, void *bucket);
+ares_bool_t     ares_htable_insert(ares_htable_t *htable, void *bucket);
 
 /*! Retrieve bucket from hashtable based on key.
  *
@@ -138,7 +138,7 @@ ares_bool_t     ares__htable_insert(ares__htable_t *htable, void *bucket);
  *  \param[in] key     Pointer to key to use for comparison.
  *  \return matching bucket, or NULL if not found.
  */
-void           *ares__htable_get(const ares__htable_t *htable, const void *key);
+void           *ares_htable_get(const ares_htable_t *htable, const void *key);
 
 /*! Remove bucket from hashtable by key
  *
@@ -146,7 +146,7 @@ void           *ares__htable_get(const ares__htable_t *htable, const void *key);
  *  \param[in] key     Pointer to key to use for comparison
  *  \return ARES_TRUE if found, ARES_FALSE if not found
  */
-ares_bool_t     ares__htable_remove(ares__htable_t *htable, const void *key);
+ares_bool_t     ares_htable_remove(ares_htable_t *htable, const void *key);
 
 /*! FNV1a hash algorithm.  Can be used as underlying primitive for building
  *  a wrapper hashtable.
@@ -156,7 +156,7 @@ ares_bool_t     ares__htable_remove(ares__htable_t *htable, const void *key);
  *  \param[in] seed     Seed for generating hash
  *  \return hash value
  */
-unsigned int ares__htable_hash_FNV1a(const unsigned char *key, size_t key_len,
+unsigned int ares_htable_hash_FNV1a(const unsigned char *key, size_t key_len,
                                      unsigned int seed);
 
 /*! FNV1a hash algorithm, but converts all characters to lowercase before
@@ -168,7 +168,7 @@ unsigned int ares__htable_hash_FNV1a(const unsigned char *key, size_t key_len,
  *  \param[in] seed     Seed for generating hash
  *  \return hash value
  */
-unsigned int ares__htable_hash_FNV1a_casecmp(const unsigned char *key,
+unsigned int ares_htable_hash_FNV1a_casecmp(const unsigned char *key,
                                              size_t key_len, unsigned int seed);
 
 /*! @} */

--- a/src/lib/dsa/ares_htable_asvp.c
+++ b/src/lib/dsa/ares_htable_asvp.c
@@ -33,8 +33,8 @@ struct ares_htable_asvp {
 };
 
 typedef struct {
-  ares_socket_t        key;
-  void                *val;
+  ares_socket_t       key;
+  void               *val;
   ares_htable_asvp_t *parent;
 } ares_htable_asvp_bucket_t;
 
@@ -51,8 +51,7 @@ void ares_htable_asvp_destroy(ares_htable_asvp_t *htable)
 static unsigned int hash_func(const void *key, unsigned int seed)
 {
   const ares_socket_t *arg = key;
-  return ares_htable_hash_FNV1a((const unsigned char *)arg, sizeof(*arg),
-                                 seed);
+  return ares_htable_hash_FNV1a((const unsigned char *)arg, sizeof(*arg), seed);
 }
 
 static const void *bucket_key(const void *bucket)
@@ -92,8 +91,7 @@ ares_htable_asvp_t *
     goto fail;
   }
 
-  htable->hash =
-    ares_htable_create(hash_func, bucket_key, bucket_free, key_eq);
+  htable->hash = ares_htable_create(hash_func, bucket_key, bucket_free, key_eq);
   if (htable->hash == NULL) {
     goto fail;
   }
@@ -111,7 +109,7 @@ fail:
 }
 
 ares_socket_t *ares_htable_asvp_keys(const ares_htable_asvp_t *htable,
-                                      size_t                    *num)
+                                     size_t                   *num)
 {
   const void   **buckets = NULL;
   size_t         cnt     = 0;
@@ -145,7 +143,7 @@ ares_socket_t *ares_htable_asvp_keys(const ares_htable_asvp_t *htable,
 }
 
 ares_bool_t ares_htable_asvp_insert(ares_htable_asvp_t *htable,
-                                     ares_socket_t key, void *val)
+                                    ares_socket_t key, void *val)
 {
   ares_htable_asvp_bucket_t *bucket = NULL;
 
@@ -176,7 +174,7 @@ fail:
 }
 
 ares_bool_t ares_htable_asvp_get(const ares_htable_asvp_t *htable,
-                                  ares_socket_t key, void **val)
+                                 ares_socket_t key, void **val)
 {
   ares_htable_asvp_bucket_t *bucket = NULL;
 
@@ -200,7 +198,7 @@ ares_bool_t ares_htable_asvp_get(const ares_htable_asvp_t *htable,
 }
 
 void *ares_htable_asvp_get_direct(const ares_htable_asvp_t *htable,
-                                   ares_socket_t              key)
+                                  ares_socket_t             key)
 {
   void *val = NULL;
   ares_htable_asvp_get(htable, key, &val);
@@ -208,7 +206,7 @@ void *ares_htable_asvp_get_direct(const ares_htable_asvp_t *htable,
 }
 
 ares_bool_t ares_htable_asvp_remove(ares_htable_asvp_t *htable,
-                                     ares_socket_t        key)
+                                    ares_socket_t       key)
 {
   if (htable == NULL) {
     return ARES_FALSE;

--- a/src/lib/dsa/ares_htable_asvp.c
+++ b/src/lib/dsa/ares_htable_asvp.c
@@ -24,46 +24,46 @@
  * SPDX-License-Identifier: MIT
  */
 #include "ares_private.h"
-#include "ares__htable.h"
-#include "ares__htable_asvp.h"
+#include "ares_htable.h"
+#include "ares_htable_asvp.h"
 
-struct ares__htable_asvp {
-  ares__htable_asvp_val_free_t free_val;
-  ares__htable_t              *hash;
+struct ares_htable_asvp {
+  ares_htable_asvp_val_free_t free_val;
+  ares_htable_t              *hash;
 };
 
 typedef struct {
   ares_socket_t        key;
   void                *val;
-  ares__htable_asvp_t *parent;
-} ares__htable_asvp_bucket_t;
+  ares_htable_asvp_t *parent;
+} ares_htable_asvp_bucket_t;
 
-void ares__htable_asvp_destroy(ares__htable_asvp_t *htable)
+void ares_htable_asvp_destroy(ares_htable_asvp_t *htable)
 {
   if (htable == NULL) {
     return;
   }
 
-  ares__htable_destroy(htable->hash);
+  ares_htable_destroy(htable->hash);
   ares_free(htable);
 }
 
 static unsigned int hash_func(const void *key, unsigned int seed)
 {
   const ares_socket_t *arg = key;
-  return ares__htable_hash_FNV1a((const unsigned char *)arg, sizeof(*arg),
+  return ares_htable_hash_FNV1a((const unsigned char *)arg, sizeof(*arg),
                                  seed);
 }
 
 static const void *bucket_key(const void *bucket)
 {
-  const ares__htable_asvp_bucket_t *arg = bucket;
+  const ares_htable_asvp_bucket_t *arg = bucket;
   return &arg->key;
 }
 
 static void bucket_free(void *bucket)
 {
-  ares__htable_asvp_bucket_t *arg = bucket;
+  ares_htable_asvp_bucket_t *arg = bucket;
 
   if (arg->parent->free_val) {
     arg->parent->free_val(arg->val);
@@ -84,16 +84,16 @@ static ares_bool_t key_eq(const void *key1, const void *key2)
   return ARES_FALSE;
 }
 
-ares__htable_asvp_t *
-  ares__htable_asvp_create(ares__htable_asvp_val_free_t val_free)
+ares_htable_asvp_t *
+  ares_htable_asvp_create(ares_htable_asvp_val_free_t val_free)
 {
-  ares__htable_asvp_t *htable = ares_malloc(sizeof(*htable));
+  ares_htable_asvp_t *htable = ares_malloc(sizeof(*htable));
   if (htable == NULL) {
     goto fail;
   }
 
   htable->hash =
-    ares__htable_create(hash_func, bucket_key, bucket_free, key_eq);
+    ares_htable_create(hash_func, bucket_key, bucket_free, key_eq);
   if (htable->hash == NULL) {
     goto fail;
   }
@@ -104,13 +104,13 @@ ares__htable_asvp_t *
 
 fail:
   if (htable) {
-    ares__htable_destroy(htable->hash);
+    ares_htable_destroy(htable->hash);
     ares_free(htable);
   }
   return NULL;
 }
 
-ares_socket_t *ares__htable_asvp_keys(const ares__htable_asvp_t *htable,
+ares_socket_t *ares_htable_asvp_keys(const ares_htable_asvp_t *htable,
                                       size_t                    *num)
 {
   const void   **buckets = NULL;
@@ -124,7 +124,7 @@ ares_socket_t *ares__htable_asvp_keys(const ares__htable_asvp_t *htable,
 
   *num = 0;
 
-  buckets = ares__htable_all_buckets(htable->hash, &cnt);
+  buckets = ares_htable_all_buckets(htable->hash, &cnt);
   if (buckets == NULL || cnt == 0) {
     return NULL;
   }
@@ -136,7 +136,7 @@ ares_socket_t *ares__htable_asvp_keys(const ares__htable_asvp_t *htable,
   }
 
   for (i = 0; i < cnt; i++) {
-    out[i] = ((const ares__htable_asvp_bucket_t *)buckets[i])->key;
+    out[i] = ((const ares_htable_asvp_bucket_t *)buckets[i])->key;
   }
 
   ares_free(buckets);
@@ -144,10 +144,10 @@ ares_socket_t *ares__htable_asvp_keys(const ares__htable_asvp_t *htable,
   return out;
 }
 
-ares_bool_t ares__htable_asvp_insert(ares__htable_asvp_t *htable,
+ares_bool_t ares_htable_asvp_insert(ares_htable_asvp_t *htable,
                                      ares_socket_t key, void *val)
 {
-  ares__htable_asvp_bucket_t *bucket = NULL;
+  ares_htable_asvp_bucket_t *bucket = NULL;
 
   if (htable == NULL) {
     goto fail;
@@ -162,7 +162,7 @@ ares_bool_t ares__htable_asvp_insert(ares__htable_asvp_t *htable,
   bucket->key    = key;
   bucket->val    = val;
 
-  if (!ares__htable_insert(htable->hash, bucket)) {
+  if (!ares_htable_insert(htable->hash, bucket)) {
     goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
@@ -175,10 +175,10 @@ fail:
   return ARES_FALSE;
 }
 
-ares_bool_t ares__htable_asvp_get(const ares__htable_asvp_t *htable,
+ares_bool_t ares_htable_asvp_get(const ares_htable_asvp_t *htable,
                                   ares_socket_t key, void **val)
 {
-  ares__htable_asvp_bucket_t *bucket = NULL;
+  ares_htable_asvp_bucket_t *bucket = NULL;
 
   if (val) {
     *val = NULL;
@@ -188,7 +188,7 @@ ares_bool_t ares__htable_asvp_get(const ares__htable_asvp_t *htable,
     return ARES_FALSE;
   }
 
-  bucket = ares__htable_get(htable->hash, &key);
+  bucket = ares_htable_get(htable->hash, &key);
   if (bucket == NULL) {
     return ARES_FALSE;
   }
@@ -199,28 +199,28 @@ ares_bool_t ares__htable_asvp_get(const ares__htable_asvp_t *htable,
   return ARES_TRUE;
 }
 
-void *ares__htable_asvp_get_direct(const ares__htable_asvp_t *htable,
+void *ares_htable_asvp_get_direct(const ares_htable_asvp_t *htable,
                                    ares_socket_t              key)
 {
   void *val = NULL;
-  ares__htable_asvp_get(htable, key, &val);
+  ares_htable_asvp_get(htable, key, &val);
   return val;
 }
 
-ares_bool_t ares__htable_asvp_remove(ares__htable_asvp_t *htable,
+ares_bool_t ares_htable_asvp_remove(ares_htable_asvp_t *htable,
                                      ares_socket_t        key)
 {
   if (htable == NULL) {
     return ARES_FALSE;
   }
 
-  return ares__htable_remove(htable->hash, &key);
+  return ares_htable_remove(htable->hash, &key);
 }
 
-size_t ares__htable_asvp_num_keys(const ares__htable_asvp_t *htable)
+size_t ares_htable_asvp_num_keys(const ares_htable_asvp_t *htable)
 {
   if (htable == NULL) {
     return 0;
   }
-  return ares__htable_num_keys(htable->hash);
+  return ares_htable_num_keys(htable->hash);
 }

--- a/src/lib/dsa/ares_htable_strvp.c
+++ b/src/lib/dsa/ares_htable_strvp.c
@@ -24,46 +24,46 @@
  * SPDX-License-Identifier: MIT
  */
 #include "ares_private.h"
-#include "ares__htable.h"
-#include "ares__htable_strvp.h"
+#include "ares_htable.h"
+#include "ares_htable_strvp.h"
 
-struct ares__htable_strvp {
-  ares__htable_strvp_val_free_t free_val;
-  ares__htable_t               *hash;
+struct ares_htable_strvp {
+  ares_htable_strvp_val_free_t free_val;
+  ares_htable_t               *hash;
 };
 
 typedef struct {
   char                 *key;
   void                 *val;
-  ares__htable_strvp_t *parent;
-} ares__htable_strvp_bucket_t;
+  ares_htable_strvp_t *parent;
+} ares_htable_strvp_bucket_t;
 
-void ares__htable_strvp_destroy(ares__htable_strvp_t *htable)
+void ares_htable_strvp_destroy(ares_htable_strvp_t *htable)
 {
   if (htable == NULL) {
     return;
   }
 
-  ares__htable_destroy(htable->hash);
+  ares_htable_destroy(htable->hash);
   ares_free(htable);
 }
 
 static unsigned int hash_func(const void *key, unsigned int seed)
 {
   const char *arg = key;
-  return ares__htable_hash_FNV1a_casecmp((const unsigned char *)arg,
+  return ares_htable_hash_FNV1a_casecmp((const unsigned char *)arg,
                                          ares_strlen(arg), seed);
 }
 
 static const void *bucket_key(const void *bucket)
 {
-  const ares__htable_strvp_bucket_t *arg = bucket;
+  const ares_htable_strvp_bucket_t *arg = bucket;
   return arg->key;
 }
 
 static void bucket_free(void *bucket)
 {
-  ares__htable_strvp_bucket_t *arg = bucket;
+  ares_htable_strvp_bucket_t *arg = bucket;
 
   if (arg->parent->free_val) {
     arg->parent->free_val(arg->val);
@@ -77,16 +77,16 @@ static ares_bool_t key_eq(const void *key1, const void *key2)
   return ares_strcaseeq(key1, key2);
 }
 
-ares__htable_strvp_t *
-  ares__htable_strvp_create(ares__htable_strvp_val_free_t val_free)
+ares_htable_strvp_t *
+  ares_htable_strvp_create(ares_htable_strvp_val_free_t val_free)
 {
-  ares__htable_strvp_t *htable = ares_malloc(sizeof(*htable));
+  ares_htable_strvp_t *htable = ares_malloc(sizeof(*htable));
   if (htable == NULL) {
     goto fail;
   }
 
   htable->hash =
-    ares__htable_create(hash_func, bucket_key, bucket_free, key_eq);
+    ares_htable_create(hash_func, bucket_key, bucket_free, key_eq);
   if (htable->hash == NULL) {
     goto fail;
   }
@@ -97,16 +97,16 @@ ares__htable_strvp_t *
 
 fail:
   if (htable) {
-    ares__htable_destroy(htable->hash);
+    ares_htable_destroy(htable->hash);
     ares_free(htable);
   }
   return NULL;
 }
 
-ares_bool_t ares__htable_strvp_insert(ares__htable_strvp_t *htable,
+ares_bool_t ares_htable_strvp_insert(ares_htable_strvp_t *htable,
                                       const char *key, void *val)
 {
-  ares__htable_strvp_bucket_t *bucket = NULL;
+  ares_htable_strvp_bucket_t *bucket = NULL;
 
   if (htable == NULL || key == NULL) {
     goto fail;
@@ -124,7 +124,7 @@ ares_bool_t ares__htable_strvp_insert(ares__htable_strvp_t *htable,
   }
   bucket->val = val;
 
-  if (!ares__htable_insert(htable->hash, bucket)) {
+  if (!ares_htable_insert(htable->hash, bucket)) {
     goto fail;
   }
 
@@ -138,10 +138,10 @@ fail:
   return ARES_FALSE;
 }
 
-ares_bool_t ares__htable_strvp_get(const ares__htable_strvp_t *htable,
+ares_bool_t ares_htable_strvp_get(const ares_htable_strvp_t *htable,
                                    const char *key, void **val)
 {
-  ares__htable_strvp_bucket_t *bucket = NULL;
+  ares_htable_strvp_bucket_t *bucket = NULL;
 
   if (val) {
     *val = NULL;
@@ -151,7 +151,7 @@ ares_bool_t ares__htable_strvp_get(const ares__htable_strvp_t *htable,
     return ARES_FALSE;
   }
 
-  bucket = ares__htable_get(htable->hash, key);
+  bucket = ares_htable_get(htable->hash, key);
   if (bucket == NULL) {
     return ARES_FALSE;
   }
@@ -162,28 +162,28 @@ ares_bool_t ares__htable_strvp_get(const ares__htable_strvp_t *htable,
   return ARES_TRUE;
 }
 
-void *ares__htable_strvp_get_direct(const ares__htable_strvp_t *htable,
+void *ares_htable_strvp_get_direct(const ares_htable_strvp_t *htable,
                                     const char                 *key)
 {
   void *val = NULL;
-  ares__htable_strvp_get(htable, key, &val);
+  ares_htable_strvp_get(htable, key, &val);
   return val;
 }
 
-ares_bool_t ares__htable_strvp_remove(ares__htable_strvp_t *htable,
+ares_bool_t ares_htable_strvp_remove(ares_htable_strvp_t *htable,
                                       const char           *key)
 {
   if (htable == NULL) {
     return ARES_FALSE;
   }
 
-  return ares__htable_remove(htable->hash, key);
+  return ares_htable_remove(htable->hash, key);
 }
 
-size_t ares__htable_strvp_num_keys(const ares__htable_strvp_t *htable)
+size_t ares_htable_strvp_num_keys(const ares_htable_strvp_t *htable)
 {
   if (htable == NULL) {
     return 0;
   }
-  return ares__htable_num_keys(htable->hash);
+  return ares_htable_num_keys(htable->hash);
 }

--- a/src/lib/dsa/ares_htable_strvp.c
+++ b/src/lib/dsa/ares_htable_strvp.c
@@ -33,8 +33,8 @@ struct ares_htable_strvp {
 };
 
 typedef struct {
-  char                 *key;
-  void                 *val;
+  char                *key;
+  void                *val;
   ares_htable_strvp_t *parent;
 } ares_htable_strvp_bucket_t;
 
@@ -52,7 +52,7 @@ static unsigned int hash_func(const void *key, unsigned int seed)
 {
   const char *arg = key;
   return ares_htable_hash_FNV1a_casecmp((const unsigned char *)arg,
-                                         ares_strlen(arg), seed);
+                                        ares_strlen(arg), seed);
 }
 
 static const void *bucket_key(const void *bucket)
@@ -85,8 +85,7 @@ ares_htable_strvp_t *
     goto fail;
   }
 
-  htable->hash =
-    ares_htable_create(hash_func, bucket_key, bucket_free, key_eq);
+  htable->hash = ares_htable_create(hash_func, bucket_key, bucket_free, key_eq);
   if (htable->hash == NULL) {
     goto fail;
   }
@@ -104,7 +103,7 @@ fail:
 }
 
 ares_bool_t ares_htable_strvp_insert(ares_htable_strvp_t *htable,
-                                      const char *key, void *val)
+                                     const char *key, void *val)
 {
   ares_htable_strvp_bucket_t *bucket = NULL;
 
@@ -139,7 +138,7 @@ fail:
 }
 
 ares_bool_t ares_htable_strvp_get(const ares_htable_strvp_t *htable,
-                                   const char *key, void **val)
+                                  const char *key, void **val)
 {
   ares_htable_strvp_bucket_t *bucket = NULL;
 
@@ -163,7 +162,7 @@ ares_bool_t ares_htable_strvp_get(const ares_htable_strvp_t *htable,
 }
 
 void *ares_htable_strvp_get_direct(const ares_htable_strvp_t *htable,
-                                    const char                 *key)
+                                   const char                *key)
 {
   void *val = NULL;
   ares_htable_strvp_get(htable, key, &val);
@@ -171,7 +170,7 @@ void *ares_htable_strvp_get_direct(const ares_htable_strvp_t *htable,
 }
 
 ares_bool_t ares_htable_strvp_remove(ares_htable_strvp_t *htable,
-                                      const char           *key)
+                                     const char          *key)
 {
   if (htable == NULL) {
     return ARES_FALSE;

--- a/src/lib/dsa/ares_htable_szvp.c
+++ b/src/lib/dsa/ares_htable_szvp.c
@@ -1,6 +1,6 @@
 /* MIT License
  *
- * Copyright (c) 2024 Brad House
+ * Copyright (c) 2023 Brad House
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,50 +24,46 @@
  * SPDX-License-Identifier: MIT
  */
 #include "ares_private.h"
-#include "ares__htable.h"
-#include "ares__htable_vpvp.h"
+#include "ares_htable.h"
+#include "ares_htable_szvp.h"
 
-struct ares__htable_vpvp {
-  ares__htable_vpvp_key_free_t free_key;
-  ares__htable_vpvp_val_free_t free_val;
-  ares__htable_t              *hash;
+struct ares_htable_szvp {
+  ares_htable_szvp_val_free_t free_val;
+  ares_htable_t              *hash;
 };
 
 typedef struct {
-  void                *key;
+  size_t               key;
   void                *val;
-  ares__htable_vpvp_t *parent;
-} ares__htable_vpvp_bucket_t;
+  ares_htable_szvp_t *parent;
+} ares_htable_szvp_bucket_t;
 
-void ares__htable_vpvp_destroy(ares__htable_vpvp_t *htable)
+void ares_htable_szvp_destroy(ares_htable_szvp_t *htable)
 {
   if (htable == NULL) {
-    return; /* LCOV_EXCL_LINE: DefensiveCoding */
+    return;
   }
 
-  ares__htable_destroy(htable->hash);
+  ares_htable_destroy(htable->hash);
   ares_free(htable);
 }
 
 static unsigned int hash_func(const void *key, unsigned int seed)
 {
-  return ares__htable_hash_FNV1a((const unsigned char *)&key, sizeof(key),
+  const size_t *arg = key;
+  return ares_htable_hash_FNV1a((const unsigned char *)arg, sizeof(*arg),
                                  seed);
 }
 
 static const void *bucket_key(const void *bucket)
 {
-  const ares__htable_vpvp_bucket_t *arg = bucket;
-  return arg->key;
+  const ares_htable_szvp_bucket_t *arg = bucket;
+  return &arg->key;
 }
 
 static void bucket_free(void *bucket)
 {
-  ares__htable_vpvp_bucket_t *arg = bucket;
-
-  if (arg->parent->free_key) {
-    arg->parent->free_key(arg->key);
-  }
+  ares_htable_szvp_bucket_t *arg = bucket;
 
   if (arg->parent->free_val) {
     arg->parent->free_val(arg->val);
@@ -78,47 +74,46 @@ static void bucket_free(void *bucket)
 
 static ares_bool_t key_eq(const void *key1, const void *key2)
 {
-  if (key1 == key2) {
+  const size_t *k1 = key1;
+  const size_t *k2 = key2;
+
+  if (*k1 == *k2) {
     return ARES_TRUE;
   }
 
   return ARES_FALSE;
 }
 
-ares__htable_vpvp_t *
-  ares__htable_vpvp_create(ares__htable_vpvp_key_free_t key_free,
-                           ares__htable_vpvp_val_free_t val_free)
+ares_htable_szvp_t *
+  ares_htable_szvp_create(ares_htable_szvp_val_free_t val_free)
 {
-  ares__htable_vpvp_t *htable = ares_malloc(sizeof(*htable));
+  ares_htable_szvp_t *htable = ares_malloc(sizeof(*htable));
   if (htable == NULL) {
-    goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
+    goto fail;
   }
 
   htable->hash =
-    ares__htable_create(hash_func, bucket_key, bucket_free, key_eq);
+    ares_htable_create(hash_func, bucket_key, bucket_free, key_eq);
   if (htable->hash == NULL) {
-    goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
+    goto fail;
   }
 
-  htable->free_key = key_free;
   htable->free_val = val_free;
 
   return htable;
 
-/* LCOV_EXCL_START: OutOfMemory */
 fail:
   if (htable) {
-    ares__htable_destroy(htable->hash);
+    ares_htable_destroy(htable->hash);
     ares_free(htable);
   }
   return NULL;
-  /* LCOV_EXCL_STOP */
 }
 
-ares_bool_t ares__htable_vpvp_insert(ares__htable_vpvp_t *htable, void *key,
+ares_bool_t ares_htable_szvp_insert(ares_htable_szvp_t *htable, size_t key,
                                      void *val)
 {
-  ares__htable_vpvp_bucket_t *bucket = NULL;
+  ares_htable_szvp_bucket_t *bucket = NULL;
 
   if (htable == NULL) {
     goto fail;
@@ -126,30 +121,30 @@ ares_bool_t ares__htable_vpvp_insert(ares__htable_vpvp_t *htable, void *key,
 
   bucket = ares_malloc(sizeof(*bucket));
   if (bucket == NULL) {
-    goto fail;
+    goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   bucket->parent = htable;
   bucket->key    = key;
   bucket->val    = val;
 
-  if (!ares__htable_insert(htable->hash, bucket)) {
-    goto fail;
+  if (!ares_htable_insert(htable->hash, bucket)) {
+    goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   return ARES_TRUE;
 
 fail:
   if (bucket) {
-    ares_free(bucket);
+    ares_free(bucket); /* LCOV_EXCL_LINE: OutOfMemory */
   }
   return ARES_FALSE;
 }
 
-ares_bool_t ares__htable_vpvp_get(const ares__htable_vpvp_t *htable,
-                                  const void *key, void **val)
+ares_bool_t ares_htable_szvp_get(const ares_htable_szvp_t *htable, size_t key,
+                                  void **val)
 {
-  ares__htable_vpvp_bucket_t *bucket = NULL;
+  ares_htable_szvp_bucket_t *bucket = NULL;
 
   if (val) {
     *val = NULL;
@@ -159,7 +154,7 @@ ares_bool_t ares__htable_vpvp_get(const ares__htable_vpvp_t *htable,
     return ARES_FALSE;
   }
 
-  bucket = ares__htable_get(htable->hash, key);
+  bucket = ares_htable_get(htable->hash, &key);
   if (bucket == NULL) {
     return ARES_FALSE;
   }
@@ -170,28 +165,27 @@ ares_bool_t ares__htable_vpvp_get(const ares__htable_vpvp_t *htable,
   return ARES_TRUE;
 }
 
-void *ares__htable_vpvp_get_direct(const ares__htable_vpvp_t *htable,
-                                   const void                *key)
+void *ares_htable_szvp_get_direct(const ares_htable_szvp_t *htable,
+                                   size_t                     key)
 {
   void *val = NULL;
-  ares__htable_vpvp_get(htable, key, &val);
+  ares_htable_szvp_get(htable, key, &val);
   return val;
 }
 
-ares_bool_t ares__htable_vpvp_remove(ares__htable_vpvp_t *htable,
-                                     const void          *key)
+ares_bool_t ares_htable_szvp_remove(ares_htable_szvp_t *htable, size_t key)
 {
   if (htable == NULL) {
     return ARES_FALSE;
   }
 
-  return ares__htable_remove(htable->hash, key);
+  return ares_htable_remove(htable->hash, &key);
 }
 
-size_t ares__htable_vpvp_num_keys(const ares__htable_vpvp_t *htable)
+size_t ares_htable_szvp_num_keys(const ares_htable_szvp_t *htable)
 {
   if (htable == NULL) {
     return 0;
   }
-  return ares__htable_num_keys(htable->hash);
+  return ares_htable_num_keys(htable->hash);
 }

--- a/src/lib/dsa/ares_htable_szvp.c
+++ b/src/lib/dsa/ares_htable_szvp.c
@@ -33,8 +33,8 @@ struct ares_htable_szvp {
 };
 
 typedef struct {
-  size_t               key;
-  void                *val;
+  size_t              key;
+  void               *val;
   ares_htable_szvp_t *parent;
 } ares_htable_szvp_bucket_t;
 
@@ -51,8 +51,7 @@ void ares_htable_szvp_destroy(ares_htable_szvp_t *htable)
 static unsigned int hash_func(const void *key, unsigned int seed)
 {
   const size_t *arg = key;
-  return ares_htable_hash_FNV1a((const unsigned char *)arg, sizeof(*arg),
-                                 seed);
+  return ares_htable_hash_FNV1a((const unsigned char *)arg, sizeof(*arg), seed);
 }
 
 static const void *bucket_key(const void *bucket)
@@ -92,8 +91,7 @@ ares_htable_szvp_t *
     goto fail;
   }
 
-  htable->hash =
-    ares_htable_create(hash_func, bucket_key, bucket_free, key_eq);
+  htable->hash = ares_htable_create(hash_func, bucket_key, bucket_free, key_eq);
   if (htable->hash == NULL) {
     goto fail;
   }
@@ -111,7 +109,7 @@ fail:
 }
 
 ares_bool_t ares_htable_szvp_insert(ares_htable_szvp_t *htable, size_t key,
-                                     void *val)
+                                    void *val)
 {
   ares_htable_szvp_bucket_t *bucket = NULL;
 
@@ -142,7 +140,7 @@ fail:
 }
 
 ares_bool_t ares_htable_szvp_get(const ares_htable_szvp_t *htable, size_t key,
-                                  void **val)
+                                 void **val)
 {
   ares_htable_szvp_bucket_t *bucket = NULL;
 
@@ -165,8 +163,7 @@ ares_bool_t ares_htable_szvp_get(const ares_htable_szvp_t *htable, size_t key,
   return ARES_TRUE;
 }
 
-void *ares_htable_szvp_get_direct(const ares_htable_szvp_t *htable,
-                                   size_t                     key)
+void *ares_htable_szvp_get_direct(const ares_htable_szvp_t *htable, size_t key)
 {
   void *val = NULL;
   ares_htable_szvp_get(htable, key, &val);

--- a/src/lib/dsa/ares_htable_vpvp.c
+++ b/src/lib/dsa/ares_htable_vpvp.c
@@ -34,8 +34,8 @@ struct ares_htable_vpvp {
 };
 
 typedef struct {
-  void                *key;
-  void                *val;
+  void               *key;
+  void               *val;
   ares_htable_vpvp_t *parent;
 } ares_htable_vpvp_bucket_t;
 
@@ -51,8 +51,7 @@ void ares_htable_vpvp_destroy(ares_htable_vpvp_t *htable)
 
 static unsigned int hash_func(const void *key, unsigned int seed)
 {
-  return ares_htable_hash_FNV1a((const unsigned char *)&key, sizeof(key),
-                                 seed);
+  return ares_htable_hash_FNV1a((const unsigned char *)&key, sizeof(key), seed);
 }
 
 static const void *bucket_key(const void *bucket)
@@ -87,15 +86,14 @@ static ares_bool_t key_eq(const void *key1, const void *key2)
 
 ares_htable_vpvp_t *
   ares_htable_vpvp_create(ares_htable_vpvp_key_free_t key_free,
-                           ares_htable_vpvp_val_free_t val_free)
+                          ares_htable_vpvp_val_free_t val_free)
 {
   ares_htable_vpvp_t *htable = ares_malloc(sizeof(*htable));
   if (htable == NULL) {
     goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  htable->hash =
-    ares_htable_create(hash_func, bucket_key, bucket_free, key_eq);
+  htable->hash = ares_htable_create(hash_func, bucket_key, bucket_free, key_eq);
   if (htable->hash == NULL) {
     goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -116,7 +114,7 @@ fail:
 }
 
 ares_bool_t ares_htable_vpvp_insert(ares_htable_vpvp_t *htable, void *key,
-                                     void *val)
+                                    void *val)
 {
   ares_htable_vpvp_bucket_t *bucket = NULL;
 
@@ -147,7 +145,7 @@ fail:
 }
 
 ares_bool_t ares_htable_vpvp_get(const ares_htable_vpvp_t *htable,
-                                  const void *key, void **val)
+                                 const void *key, void **val)
 {
   ares_htable_vpvp_bucket_t *bucket = NULL;
 
@@ -171,15 +169,14 @@ ares_bool_t ares_htable_vpvp_get(const ares_htable_vpvp_t *htable,
 }
 
 void *ares_htable_vpvp_get_direct(const ares_htable_vpvp_t *htable,
-                                   const void                *key)
+                                  const void               *key)
 {
   void *val = NULL;
   ares_htable_vpvp_get(htable, key, &val);
   return val;
 }
 
-ares_bool_t ares_htable_vpvp_remove(ares_htable_vpvp_t *htable,
-                                     const void          *key)
+ares_bool_t ares_htable_vpvp_remove(ares_htable_vpvp_t *htable, const void *key)
 {
   if (htable == NULL) {
     return ARES_FALSE;

--- a/src/lib/dsa/ares_htable_vpvp.c
+++ b/src/lib/dsa/ares_htable_vpvp.c
@@ -1,6 +1,6 @@
 /* MIT License
  *
- * Copyright (c) 2023 Brad House
+ * Copyright (c) 2024 Brad House
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,46 +24,50 @@
  * SPDX-License-Identifier: MIT
  */
 #include "ares_private.h"
-#include "ares__htable.h"
-#include "ares__htable_szvp.h"
+#include "ares_htable.h"
+#include "ares_htable_vpvp.h"
 
-struct ares__htable_szvp {
-  ares__htable_szvp_val_free_t free_val;
-  ares__htable_t              *hash;
+struct ares_htable_vpvp {
+  ares_htable_vpvp_key_free_t free_key;
+  ares_htable_vpvp_val_free_t free_val;
+  ares_htable_t              *hash;
 };
 
 typedef struct {
-  size_t               key;
+  void                *key;
   void                *val;
-  ares__htable_szvp_t *parent;
-} ares__htable_szvp_bucket_t;
+  ares_htable_vpvp_t *parent;
+} ares_htable_vpvp_bucket_t;
 
-void ares__htable_szvp_destroy(ares__htable_szvp_t *htable)
+void ares_htable_vpvp_destroy(ares_htable_vpvp_t *htable)
 {
   if (htable == NULL) {
-    return;
+    return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  ares__htable_destroy(htable->hash);
+  ares_htable_destroy(htable->hash);
   ares_free(htable);
 }
 
 static unsigned int hash_func(const void *key, unsigned int seed)
 {
-  const size_t *arg = key;
-  return ares__htable_hash_FNV1a((const unsigned char *)arg, sizeof(*arg),
+  return ares_htable_hash_FNV1a((const unsigned char *)&key, sizeof(key),
                                  seed);
 }
 
 static const void *bucket_key(const void *bucket)
 {
-  const ares__htable_szvp_bucket_t *arg = bucket;
-  return &arg->key;
+  const ares_htable_vpvp_bucket_t *arg = bucket;
+  return arg->key;
 }
 
 static void bucket_free(void *bucket)
 {
-  ares__htable_szvp_bucket_t *arg = bucket;
+  ares_htable_vpvp_bucket_t *arg = bucket;
+
+  if (arg->parent->free_key) {
+    arg->parent->free_key(arg->key);
+  }
 
   if (arg->parent->free_val) {
     arg->parent->free_val(arg->val);
@@ -74,46 +78,47 @@ static void bucket_free(void *bucket)
 
 static ares_bool_t key_eq(const void *key1, const void *key2)
 {
-  const size_t *k1 = key1;
-  const size_t *k2 = key2;
-
-  if (*k1 == *k2) {
+  if (key1 == key2) {
     return ARES_TRUE;
   }
 
   return ARES_FALSE;
 }
 
-ares__htable_szvp_t *
-  ares__htable_szvp_create(ares__htable_szvp_val_free_t val_free)
+ares_htable_vpvp_t *
+  ares_htable_vpvp_create(ares_htable_vpvp_key_free_t key_free,
+                           ares_htable_vpvp_val_free_t val_free)
 {
-  ares__htable_szvp_t *htable = ares_malloc(sizeof(*htable));
+  ares_htable_vpvp_t *htable = ares_malloc(sizeof(*htable));
   if (htable == NULL) {
-    goto fail;
+    goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   htable->hash =
-    ares__htable_create(hash_func, bucket_key, bucket_free, key_eq);
+    ares_htable_create(hash_func, bucket_key, bucket_free, key_eq);
   if (htable->hash == NULL) {
-    goto fail;
+    goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
+  htable->free_key = key_free;
   htable->free_val = val_free;
 
   return htable;
 
+/* LCOV_EXCL_START: OutOfMemory */
 fail:
   if (htable) {
-    ares__htable_destroy(htable->hash);
+    ares_htable_destroy(htable->hash);
     ares_free(htable);
   }
   return NULL;
+  /* LCOV_EXCL_STOP */
 }
 
-ares_bool_t ares__htable_szvp_insert(ares__htable_szvp_t *htable, size_t key,
+ares_bool_t ares_htable_vpvp_insert(ares_htable_vpvp_t *htable, void *key,
                                      void *val)
 {
-  ares__htable_szvp_bucket_t *bucket = NULL;
+  ares_htable_vpvp_bucket_t *bucket = NULL;
 
   if (htable == NULL) {
     goto fail;
@@ -121,30 +126,30 @@ ares_bool_t ares__htable_szvp_insert(ares__htable_szvp_t *htable, size_t key,
 
   bucket = ares_malloc(sizeof(*bucket));
   if (bucket == NULL) {
-    goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
+    goto fail;
   }
 
   bucket->parent = htable;
   bucket->key    = key;
   bucket->val    = val;
 
-  if (!ares__htable_insert(htable->hash, bucket)) {
-    goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
+  if (!ares_htable_insert(htable->hash, bucket)) {
+    goto fail;
   }
 
   return ARES_TRUE;
 
 fail:
   if (bucket) {
-    ares_free(bucket); /* LCOV_EXCL_LINE: OutOfMemory */
+    ares_free(bucket);
   }
   return ARES_FALSE;
 }
 
-ares_bool_t ares__htable_szvp_get(const ares__htable_szvp_t *htable, size_t key,
-                                  void **val)
+ares_bool_t ares_htable_vpvp_get(const ares_htable_vpvp_t *htable,
+                                  const void *key, void **val)
 {
-  ares__htable_szvp_bucket_t *bucket = NULL;
+  ares_htable_vpvp_bucket_t *bucket = NULL;
 
   if (val) {
     *val = NULL;
@@ -154,7 +159,7 @@ ares_bool_t ares__htable_szvp_get(const ares__htable_szvp_t *htable, size_t key,
     return ARES_FALSE;
   }
 
-  bucket = ares__htable_get(htable->hash, &key);
+  bucket = ares_htable_get(htable->hash, key);
   if (bucket == NULL) {
     return ARES_FALSE;
   }
@@ -165,27 +170,28 @@ ares_bool_t ares__htable_szvp_get(const ares__htable_szvp_t *htable, size_t key,
   return ARES_TRUE;
 }
 
-void *ares__htable_szvp_get_direct(const ares__htable_szvp_t *htable,
-                                   size_t                     key)
+void *ares_htable_vpvp_get_direct(const ares_htable_vpvp_t *htable,
+                                   const void                *key)
 {
   void *val = NULL;
-  ares__htable_szvp_get(htable, key, &val);
+  ares_htable_vpvp_get(htable, key, &val);
   return val;
 }
 
-ares_bool_t ares__htable_szvp_remove(ares__htable_szvp_t *htable, size_t key)
+ares_bool_t ares_htable_vpvp_remove(ares_htable_vpvp_t *htable,
+                                     const void          *key)
 {
   if (htable == NULL) {
     return ARES_FALSE;
   }
 
-  return ares__htable_remove(htable->hash, &key);
+  return ares_htable_remove(htable->hash, key);
 }
 
-size_t ares__htable_szvp_num_keys(const ares__htable_szvp_t *htable)
+size_t ares_htable_vpvp_num_keys(const ares_htable_vpvp_t *htable)
 {
   if (htable == NULL) {
     return 0;
   }
-  return ares__htable_num_keys(htable->hash);
+  return ares_htable_num_keys(htable->hash);
 }

--- a/src/lib/dsa/ares_llist.c
+++ b/src/lib/dsa/ares_llist.c
@@ -24,25 +24,25 @@
  * SPDX-License-Identifier: MIT
  */
 #include "ares_private.h"
-#include "ares__llist.h"
+#include "ares_llist.h"
 
-struct ares__llist {
-  ares__llist_node_t      *head;
-  ares__llist_node_t      *tail;
-  ares__llist_destructor_t destruct;
+struct ares_llist {
+  ares_llist_node_t      *head;
+  ares_llist_node_t      *tail;
+  ares_llist_destructor_t destruct;
   size_t                   cnt;
 };
 
-struct ares__llist_node {
+struct ares_llist_node {
   void               *data;
-  ares__llist_node_t *prev;
-  ares__llist_node_t *next;
-  ares__llist_t      *parent;
+  ares_llist_node_t *prev;
+  ares_llist_node_t *next;
+  ares_llist_t      *parent;
 };
 
-ares__llist_t *ares__llist_create(ares__llist_destructor_t destruct)
+ares_llist_t *ares_llist_create(ares_llist_destructor_t destruct)
 {
-  ares__llist_t *list = ares_malloc_zero(sizeof(*list));
+  ares_llist_t *list = ares_malloc_zero(sizeof(*list));
 
   if (list == NULL) {
     return NULL;
@@ -53,8 +53,8 @@ ares__llist_t *ares__llist_create(ares__llist_destructor_t destruct)
   return list;
 }
 
-void ares__llist_replace_destructor(ares__llist_t           *list,
-                                    ares__llist_destructor_t destruct)
+void ares_llist_replace_destructor(ares_llist_t           *list,
+                                    ares_llist_destructor_t destruct)
 {
   if (list == NULL) {
     return;
@@ -67,12 +67,12 @@ typedef enum {
   ARES__LLIST_INSERT_HEAD,
   ARES__LLIST_INSERT_TAIL,
   ARES__LLIST_INSERT_BEFORE
-} ares__llist_insert_type_t;
+} ares_llist_insert_type_t;
 
-static void ares__llist_attach_at(ares__llist_t            *list,
-                                  ares__llist_insert_type_t type,
-                                  ares__llist_node_t       *at,
-                                  ares__llist_node_t       *node)
+static void ares_llist_attach_at(ares_llist_t            *list,
+                                  ares_llist_insert_type_t type,
+                                  ares_llist_node_t       *at,
+                                  ares_llist_node_t       *node)
 {
   if (list == NULL || node == NULL) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
@@ -117,12 +117,12 @@ static void ares__llist_attach_at(ares__llist_t            *list,
   list->cnt++;
 }
 
-static ares__llist_node_t *ares__llist_insert_at(ares__llist_t            *list,
-                                                 ares__llist_insert_type_t type,
-                                                 ares__llist_node_t       *at,
+static ares_llist_node_t *ares_llist_insert_at(ares_llist_t            *list,
+                                                 ares_llist_insert_type_t type,
+                                                 ares_llist_node_t       *at,
                                                  void                     *val)
 {
-  ares__llist_node_t *node = NULL;
+  ares_llist_node_t *node = NULL;
 
   if (list == NULL || val == NULL) {
     return NULL; /* LCOV_EXCL_LINE: DefensiveCoding */
@@ -135,33 +135,33 @@ static ares__llist_node_t *ares__llist_insert_at(ares__llist_t            *list,
   }
 
   node->data = val;
-  ares__llist_attach_at(list, type, at, node);
+  ares_llist_attach_at(list, type, at, node);
 
   return node;
 }
 
-ares__llist_node_t *ares__llist_insert_first(ares__llist_t *list, void *val)
+ares_llist_node_t *ares_llist_insert_first(ares_llist_t *list, void *val)
 {
-  return ares__llist_insert_at(list, ARES__LLIST_INSERT_HEAD, NULL, val);
+  return ares_llist_insert_at(list, ARES__LLIST_INSERT_HEAD, NULL, val);
 }
 
-ares__llist_node_t *ares__llist_insert_last(ares__llist_t *list, void *val)
+ares_llist_node_t *ares_llist_insert_last(ares_llist_t *list, void *val)
 {
-  return ares__llist_insert_at(list, ARES__LLIST_INSERT_TAIL, NULL, val);
+  return ares_llist_insert_at(list, ARES__LLIST_INSERT_TAIL, NULL, val);
 }
 
-ares__llist_node_t *ares__llist_insert_before(ares__llist_node_t *node,
+ares_llist_node_t *ares_llist_insert_before(ares_llist_node_t *node,
                                               void               *val)
 {
   if (node == NULL) {
     return NULL;
   }
 
-  return ares__llist_insert_at(node->parent, ARES__LLIST_INSERT_BEFORE, node,
+  return ares_llist_insert_at(node->parent, ARES__LLIST_INSERT_BEFORE, node,
                                val);
 }
 
-ares__llist_node_t *ares__llist_insert_after(ares__llist_node_t *node,
+ares_llist_node_t *ares_llist_insert_after(ares_llist_node_t *node,
                                              void               *val)
 {
   if (node == NULL) {
@@ -169,14 +169,14 @@ ares__llist_node_t *ares__llist_insert_after(ares__llist_node_t *node,
   }
 
   if (node->next == NULL) {
-    return ares__llist_insert_last(node->parent, val);
+    return ares_llist_insert_last(node->parent, val);
   }
 
-  return ares__llist_insert_at(node->parent, ARES__LLIST_INSERT_BEFORE,
+  return ares_llist_insert_at(node->parent, ARES__LLIST_INSERT_BEFORE,
                                node->next, val);
 }
 
-ares__llist_node_t *ares__llist_node_first(ares__llist_t *list)
+ares_llist_node_t *ares_llist_node_first(ares_llist_t *list)
 {
   if (list == NULL) {
     return NULL;
@@ -184,9 +184,9 @@ ares__llist_node_t *ares__llist_node_first(ares__llist_t *list)
   return list->head;
 }
 
-ares__llist_node_t *ares__llist_node_idx(ares__llist_t *list, size_t idx)
+ares_llist_node_t *ares_llist_node_idx(ares_llist_t *list, size_t idx)
 {
-  ares__llist_node_t *node;
+  ares_llist_node_t *node;
   size_t              cnt;
 
   if (list == NULL) {
@@ -204,7 +204,7 @@ ares__llist_node_t *ares__llist_node_idx(ares__llist_t *list, size_t idx)
   return node;
 }
 
-ares__llist_node_t *ares__llist_node_last(ares__llist_t *list)
+ares_llist_node_t *ares_llist_node_last(ares_llist_t *list)
 {
   if (list == NULL) {
     return NULL;
@@ -212,7 +212,7 @@ ares__llist_node_t *ares__llist_node_last(ares__llist_t *list)
   return list->tail;
 }
 
-ares__llist_node_t *ares__llist_node_next(ares__llist_node_t *node)
+ares_llist_node_t *ares_llist_node_next(ares_llist_node_t *node)
 {
   if (node == NULL) {
     return NULL;
@@ -220,7 +220,7 @@ ares__llist_node_t *ares__llist_node_next(ares__llist_node_t *node)
   return node->next;
 }
 
-ares__llist_node_t *ares__llist_node_prev(ares__llist_node_t *node)
+ares_llist_node_t *ares_llist_node_prev(ares_llist_node_t *node)
 {
   if (node == NULL) {
     return NULL;
@@ -228,7 +228,7 @@ ares__llist_node_t *ares__llist_node_prev(ares__llist_node_t *node)
   return node->prev;
 }
 
-void *ares__llist_node_val(ares__llist_node_t *node)
+void *ares_llist_node_val(ares_llist_node_t *node)
 {
   if (node == NULL) {
     return NULL;
@@ -237,7 +237,7 @@ void *ares__llist_node_val(ares__llist_node_t *node)
   return node->data;
 }
 
-size_t ares__llist_len(const ares__llist_t *list)
+size_t ares_llist_len(const ares_llist_t *list)
 {
   if (list == NULL) {
     return 0;
@@ -245,7 +245,7 @@ size_t ares__llist_len(const ares__llist_t *list)
   return list->cnt;
 }
 
-ares__llist_t *ares__llist_node_parent(ares__llist_node_t *node)
+ares_llist_t *ares_llist_node_parent(ares_llist_node_t *node)
 {
   if (node == NULL) {
     return NULL;
@@ -253,19 +253,19 @@ ares__llist_t *ares__llist_node_parent(ares__llist_node_t *node)
   return node->parent;
 }
 
-void *ares__llist_first_val(ares__llist_t *list)
+void *ares_llist_first_val(ares_llist_t *list)
 {
-  return ares__llist_node_val(ares__llist_node_first(list));
+  return ares_llist_node_val(ares_llist_node_first(list));
 }
 
-void *ares__llist_last_val(ares__llist_t *list)
+void *ares_llist_last_val(ares_llist_t *list)
 {
-  return ares__llist_node_val(ares__llist_node_last(list));
+  return ares_llist_node_val(ares_llist_node_last(list));
 }
 
-static void ares__llist_node_detach(ares__llist_node_t *node)
+static void ares_llist_node_detach(ares_llist_node_t *node)
 {
-  ares__llist_t *list;
+  ares_llist_t *list;
 
   if (node == NULL) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
@@ -293,7 +293,7 @@ static void ares__llist_node_detach(ares__llist_node_t *node)
   list->cnt--;
 }
 
-void *ares__llist_node_claim(ares__llist_node_t *node)
+void *ares_llist_node_claim(ares_llist_node_t *node)
 {
   void *val;
 
@@ -302,15 +302,15 @@ void *ares__llist_node_claim(ares__llist_node_t *node)
   }
 
   val = node->data;
-  ares__llist_node_detach(node);
+  ares_llist_node_detach(node);
   ares_free(node);
 
   return val;
 }
 
-void ares__llist_node_destroy(ares__llist_node_t *node)
+void ares_llist_node_destroy(ares_llist_node_t *node)
 {
-  ares__llist_destructor_t destruct;
+  ares_llist_destructor_t destruct;
   void                    *val;
 
   if (node == NULL) {
@@ -319,15 +319,15 @@ void ares__llist_node_destroy(ares__llist_node_t *node)
 
   destruct = node->parent->destruct;
 
-  val = ares__llist_node_claim(node);
+  val = ares_llist_node_claim(node);
   if (val != NULL && destruct != NULL) {
     destruct(val);
   }
 }
 
-void ares__llist_node_replace(ares__llist_node_t *node, void *val)
+void ares_llist_node_replace(ares_llist_node_t *node, void *val)
 {
-  ares__llist_destructor_t destruct;
+  ares_llist_destructor_t destruct;
 
   if (node == NULL) {
     return;
@@ -341,46 +341,46 @@ void ares__llist_node_replace(ares__llist_node_t *node, void *val)
   node->data = val;
 }
 
-void ares__llist_clear(ares__llist_t *list)
+void ares_llist_clear(ares_llist_t *list)
 {
-  ares__llist_node_t *node;
+  ares_llist_node_t *node;
 
   if (list == NULL) {
     return;
   }
 
-  while ((node = ares__llist_node_first(list)) != NULL) {
-    ares__llist_node_destroy(node);
+  while ((node = ares_llist_node_first(list)) != NULL) {
+    ares_llist_node_destroy(node);
   }
 }
 
-void ares__llist_destroy(ares__llist_t *list)
+void ares_llist_destroy(ares_llist_t *list)
 {
   if (list == NULL) {
     return;
   }
-  ares__llist_clear(list);
+  ares_llist_clear(list);
   ares_free(list);
 }
 
-void ares__llist_node_mvparent_last(ares__llist_node_t *node,
-                                    ares__llist_t      *new_parent)
+void ares_llist_node_mvparent_last(ares_llist_node_t *node,
+                                    ares_llist_t      *new_parent)
 {
   if (node == NULL || new_parent == NULL) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  ares__llist_node_detach(node);
-  ares__llist_attach_at(new_parent, ARES__LLIST_INSERT_TAIL, NULL, node);
+  ares_llist_node_detach(node);
+  ares_llist_attach_at(new_parent, ARES__LLIST_INSERT_TAIL, NULL, node);
 }
 
-void ares__llist_node_mvparent_first(ares__llist_node_t *node,
-                                     ares__llist_t      *new_parent)
+void ares_llist_node_mvparent_first(ares_llist_node_t *node,
+                                     ares_llist_t      *new_parent)
 {
   if (node == NULL || new_parent == NULL) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  ares__llist_node_detach(node);
-  ares__llist_attach_at(new_parent, ARES__LLIST_INSERT_HEAD, NULL, node);
+  ares_llist_node_detach(node);
+  ares_llist_attach_at(new_parent, ARES__LLIST_INSERT_HEAD, NULL, node);
 }

--- a/src/lib/dsa/ares_llist.c
+++ b/src/lib/dsa/ares_llist.c
@@ -30,11 +30,11 @@ struct ares_llist {
   ares_llist_node_t      *head;
   ares_llist_node_t      *tail;
   ares_llist_destructor_t destruct;
-  size_t                   cnt;
+  size_t                  cnt;
 };
 
 struct ares_llist_node {
-  void               *data;
+  void              *data;
   ares_llist_node_t *prev;
   ares_llist_node_t *next;
   ares_llist_t      *parent;
@@ -54,7 +54,7 @@ ares_llist_t *ares_llist_create(ares_llist_destructor_t destruct)
 }
 
 void ares_llist_replace_destructor(ares_llist_t           *list,
-                                    ares_llist_destructor_t destruct)
+                                   ares_llist_destructor_t destruct)
 {
   if (list == NULL) {
     return;
@@ -70,9 +70,8 @@ typedef enum {
 } ares_llist_insert_type_t;
 
 static void ares_llist_attach_at(ares_llist_t            *list,
-                                  ares_llist_insert_type_t type,
-                                  ares_llist_node_t       *at,
-                                  ares_llist_node_t       *node)
+                                 ares_llist_insert_type_t type,
+                                 ares_llist_node_t *at, ares_llist_node_t *node)
 {
   if (list == NULL || node == NULL) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
@@ -118,9 +117,8 @@ static void ares_llist_attach_at(ares_llist_t            *list,
 }
 
 static ares_llist_node_t *ares_llist_insert_at(ares_llist_t            *list,
-                                                 ares_llist_insert_type_t type,
-                                                 ares_llist_node_t       *at,
-                                                 void                     *val)
+                                               ares_llist_insert_type_t type,
+                                               ares_llist_node_t *at, void *val)
 {
   ares_llist_node_t *node = NULL;
 
@@ -150,19 +148,17 @@ ares_llist_node_t *ares_llist_insert_last(ares_llist_t *list, void *val)
   return ares_llist_insert_at(list, ARES__LLIST_INSERT_TAIL, NULL, val);
 }
 
-ares_llist_node_t *ares_llist_insert_before(ares_llist_node_t *node,
-                                              void               *val)
+ares_llist_node_t *ares_llist_insert_before(ares_llist_node_t *node, void *val)
 {
   if (node == NULL) {
     return NULL;
   }
 
   return ares_llist_insert_at(node->parent, ARES__LLIST_INSERT_BEFORE, node,
-                               val);
+                              val);
 }
 
-ares_llist_node_t *ares_llist_insert_after(ares_llist_node_t *node,
-                                             void               *val)
+ares_llist_node_t *ares_llist_insert_after(ares_llist_node_t *node, void *val)
 {
   if (node == NULL) {
     return NULL;
@@ -173,7 +169,7 @@ ares_llist_node_t *ares_llist_insert_after(ares_llist_node_t *node,
   }
 
   return ares_llist_insert_at(node->parent, ARES__LLIST_INSERT_BEFORE,
-                               node->next, val);
+                              node->next, val);
 }
 
 ares_llist_node_t *ares_llist_node_first(ares_llist_t *list)
@@ -187,7 +183,7 @@ ares_llist_node_t *ares_llist_node_first(ares_llist_t *list)
 ares_llist_node_t *ares_llist_node_idx(ares_llist_t *list, size_t idx)
 {
   ares_llist_node_t *node;
-  size_t              cnt;
+  size_t             cnt;
 
   if (list == NULL) {
     return NULL;
@@ -311,7 +307,7 @@ void *ares_llist_node_claim(ares_llist_node_t *node)
 void ares_llist_node_destroy(ares_llist_node_t *node)
 {
   ares_llist_destructor_t destruct;
-  void                    *val;
+  void                   *val;
 
   if (node == NULL) {
     return;
@@ -364,7 +360,7 @@ void ares_llist_destroy(ares_llist_t *list)
 }
 
 void ares_llist_node_mvparent_last(ares_llist_node_t *node,
-                                    ares_llist_t      *new_parent)
+                                   ares_llist_t      *new_parent)
 {
   if (node == NULL || new_parent == NULL) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
@@ -375,7 +371,7 @@ void ares_llist_node_mvparent_last(ares_llist_node_t *node,
 }
 
 void ares_llist_node_mvparent_first(ares_llist_node_t *node,
-                                     ares_llist_t      *new_parent)
+                                    ares_llist_t      *new_parent)
 {
   if (node == NULL || new_parent == NULL) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */

--- a/src/lib/dsa/ares_slist.c
+++ b/src/lib/dsa/ares_slist.c
@@ -24,39 +24,39 @@
  * SPDX-License-Identifier: MIT
  */
 #include "ares_private.h"
-#include "ares__slist.h"
+#include "ares_slist.h"
 
 /* SkipList implementation */
 
 #define ARES__SLIST_START_LEVELS 4
 
-struct ares__slist {
+struct ares_slist {
   ares_rand_state         *rand_state;
   unsigned char            rand_data[8];
   size_t                   rand_bits;
 
-  ares__slist_node_t     **head;
+  ares_slist_node_t     **head;
   size_t                   levels;
-  ares__slist_node_t      *tail;
+  ares_slist_node_t      *tail;
 
-  ares__slist_cmp_t        cmp;
-  ares__slist_destructor_t destruct;
+  ares_slist_cmp_t        cmp;
+  ares_slist_destructor_t destruct;
   size_t                   cnt;
 };
 
-struct ares__slist_node {
+struct ares_slist_node {
   void                *data;
-  ares__slist_node_t **prev;
-  ares__slist_node_t **next;
+  ares_slist_node_t **prev;
+  ares_slist_node_t **next;
   size_t               levels;
-  ares__slist_t       *parent;
+  ares_slist_t       *parent;
 };
 
-ares__slist_t *ares__slist_create(ares_rand_state         *rand_state,
-                                  ares__slist_cmp_t        cmp,
-                                  ares__slist_destructor_t destruct)
+ares_slist_t *ares_slist_create(ares_rand_state         *rand_state,
+                                  ares_slist_cmp_t        cmp,
+                                  ares_slist_destructor_t destruct)
 {
-  ares__slist_t *list;
+  ares_slist_t *list;
 
   if (rand_state == NULL || cmp == NULL) {
     return NULL;
@@ -82,17 +82,17 @@ ares__slist_t *ares__slist_create(ares_rand_state         *rand_state,
   return list;
 }
 
-static ares_bool_t ares__slist_coin_flip(ares__slist_t *list)
+static ares_bool_t ares_slist_coin_flip(ares_slist_t *list)
 {
   size_t total_bits = sizeof(list->rand_data) * 8;
   size_t bit;
 
   /* Refill random data used for coin flips.  We pull this in 8 byte chunks.
-   * ares__rand_bytes() has some built-in caching of its own so we don't need
+   * ares_rand_bytes() has some built-in caching of its own so we don't need
    * to be excessive in caching ourselves.  Prefer to require less memory per
    * skiplist */
   if (list->rand_bits == 0) {
-    ares__rand_bytes(list->rand_state, list->rand_data,
+    ares_rand_bytes(list->rand_state, list->rand_data,
                      sizeof(list->rand_data));
     list->rand_bits = total_bits;
   }
@@ -103,8 +103,8 @@ static ares_bool_t ares__slist_coin_flip(ares__slist_t *list)
   return (list->rand_data[bit / 8] & (1 << (bit % 8))) ? ARES_TRUE : ARES_FALSE;
 }
 
-void ares__slist_replace_destructor(ares__slist_t           *list,
-                                    ares__slist_destructor_t destruct)
+void ares_slist_replace_destructor(ares_slist_t           *list,
+                                    ares_slist_destructor_t destruct)
 {
   if (list == NULL) {
     return;
@@ -113,14 +113,14 @@ void ares__slist_replace_destructor(ares__slist_t           *list,
   list->destruct = destruct;
 }
 
-static size_t ares__slist_max_level(const ares__slist_t *list)
+static size_t ares_slist_max_level(const ares_slist_t *list)
 {
   size_t max_level = 0;
 
   if (list->cnt + 1 <= (1 << ARES__SLIST_START_LEVELS)) {
     max_level = ARES__SLIST_START_LEVELS;
   } else {
-    max_level = ares__log2(ares__round_up_pow2(list->cnt + 1));
+    max_level = ares_log2(ares_round_up_pow2(list->cnt + 1));
   }
 
   if (list->levels > max_level) {
@@ -130,21 +130,21 @@ static size_t ares__slist_max_level(const ares__slist_t *list)
   return max_level;
 }
 
-static size_t ares__slist_calc_level(ares__slist_t *list)
+static size_t ares_slist_calc_level(ares_slist_t *list)
 {
-  size_t max_level = ares__slist_max_level(list);
+  size_t max_level = ares_slist_max_level(list);
   size_t level;
 
-  for (level = 1; ares__slist_coin_flip(list) && level < max_level; level++)
+  for (level = 1; ares_slist_coin_flip(list) && level < max_level; level++)
     ;
 
   return level;
 }
 
-static void ares__slist_node_push(ares__slist_t *list, ares__slist_node_t *node)
+static void ares_slist_node_push(ares_slist_t *list, ares_slist_node_t *node)
 {
   size_t              i;
-  ares__slist_node_t *left = NULL;
+  ares_slist_node_t *left = NULL;
 
   /* Scan from highest level in the slist, even if we're not using that number
    * of levels for this entry as this is what makes it O(log n) */
@@ -193,9 +193,9 @@ static void ares__slist_node_push(ares__slist_t *list, ares__slist_node_t *node)
   }
 }
 
-ares__slist_node_t *ares__slist_insert(ares__slist_t *list, void *val)
+ares_slist_node_t *ares_slist_insert(ares_slist_t *list, void *val)
 {
-  ares__slist_node_t *node = NULL;
+  ares_slist_node_t *node = NULL;
 
   if (list == NULL || val == NULL) {
     return NULL;
@@ -211,7 +211,7 @@ ares__slist_node_t *ares__slist_insert(ares__slist_t *list, void *val)
   node->parent = list;
 
   /* Randomly determine the number of levels we want to use */
-  node->levels = ares__slist_calc_level(list);
+  node->levels = ares_slist_calc_level(list);
 
   /* Allocate array of next and prev nodes for linking each level */
   node->next = ares_malloc_zero(sizeof(*node->next) * node->levels);
@@ -238,7 +238,7 @@ ares__slist_node_t *ares__slist_insert(ares__slist_t *list, void *val)
     list->levels = node->levels;
   }
 
-  ares__slist_node_push(list, node);
+  ares_slist_node_push(list, node);
 
   list->cnt++;
 
@@ -255,9 +255,9 @@ fail:
   /* LCOV_EXCL_STOP */
 }
 
-static void ares__slist_node_pop(ares__slist_node_t *node)
+static void ares_slist_node_pop(ares_slist_node_t *node)
 {
-  ares__slist_t *list = node->parent;
+  ares_slist_t *list = node->parent;
   size_t         i;
 
   /* relink each node at each level */
@@ -281,9 +281,9 @@ static void ares__slist_node_pop(ares__slist_node_t *node)
   memset(node->prev, 0, sizeof(*node->prev) * node->levels);
 }
 
-void *ares__slist_node_claim(ares__slist_node_t *node)
+void *ares_slist_node_claim(ares_slist_node_t *node)
 {
-  ares__slist_t *list;
+  ares_slist_t *list;
   void          *val;
 
   if (node == NULL) {
@@ -293,7 +293,7 @@ void *ares__slist_node_claim(ares__slist_node_t *node)
   list = node->parent;
   val  = node->data;
 
-  ares__slist_node_pop(node);
+  ares_slist_node_pop(node);
 
   ares_free(node->next);
   ares_free(node->prev);
@@ -304,9 +304,9 @@ void *ares__slist_node_claim(ares__slist_node_t *node)
   return val;
 }
 
-void ares__slist_node_reinsert(ares__slist_node_t *node)
+void ares_slist_node_reinsert(ares_slist_node_t *node)
 {
-  ares__slist_t *list;
+  ares_slist_t *list;
 
   if (node == NULL) {
     return;
@@ -314,14 +314,14 @@ void ares__slist_node_reinsert(ares__slist_node_t *node)
 
   list = node->parent;
 
-  ares__slist_node_pop(node);
-  ares__slist_node_push(list, node);
+  ares_slist_node_pop(node);
+  ares_slist_node_push(list, node);
 }
 
-ares__slist_node_t *ares__slist_node_find(ares__slist_t *list, const void *val)
+ares_slist_node_t *ares_slist_node_find(ares_slist_t *list, const void *val)
 {
   size_t              i;
-  ares__slist_node_t *node = NULL;
+  ares_slist_node_t *node = NULL;
   int                 rv   = -1;
 
   if (list == NULL || val == NULL) {
@@ -377,7 +377,7 @@ ares__slist_node_t *ares__slist_node_find(ares__slist_t *list, const void *val)
   return node;
 }
 
-ares__slist_node_t *ares__slist_node_first(ares__slist_t *list)
+ares_slist_node_t *ares_slist_node_first(ares_slist_t *list)
 {
   if (list == NULL) {
     return NULL;
@@ -386,7 +386,7 @@ ares__slist_node_t *ares__slist_node_first(ares__slist_t *list)
   return list->head[0];
 }
 
-ares__slist_node_t *ares__slist_node_last(ares__slist_t *list)
+ares_slist_node_t *ares_slist_node_last(ares_slist_t *list)
 {
   if (list == NULL) {
     return NULL;
@@ -394,7 +394,7 @@ ares__slist_node_t *ares__slist_node_last(ares__slist_t *list)
   return list->tail;
 }
 
-ares__slist_node_t *ares__slist_node_next(ares__slist_node_t *node)
+ares_slist_node_t *ares_slist_node_next(ares_slist_node_t *node)
 {
   if (node == NULL) {
     return NULL;
@@ -402,7 +402,7 @@ ares__slist_node_t *ares__slist_node_next(ares__slist_node_t *node)
   return node->next[0];
 }
 
-ares__slist_node_t *ares__slist_node_prev(ares__slist_node_t *node)
+ares_slist_node_t *ares_slist_node_prev(ares_slist_node_t *node)
 {
   if (node == NULL) {
     return NULL;
@@ -410,7 +410,7 @@ ares__slist_node_t *ares__slist_node_prev(ares__slist_node_t *node)
   return node->prev[0];
 }
 
-void *ares__slist_node_val(ares__slist_node_t *node)
+void *ares_slist_node_val(ares_slist_node_t *node)
 {
   if (node == NULL) {
     return NULL;
@@ -419,7 +419,7 @@ void *ares__slist_node_val(ares__slist_node_t *node)
   return node->data;
 }
 
-size_t ares__slist_len(const ares__slist_t *list)
+size_t ares_slist_len(const ares_slist_t *list)
 {
   if (list == NULL) {
     return 0;
@@ -427,7 +427,7 @@ size_t ares__slist_len(const ares__slist_t *list)
   return list->cnt;
 }
 
-ares__slist_t *ares__slist_node_parent(ares__slist_node_t *node)
+ares_slist_t *ares_slist_node_parent(ares_slist_node_t *node)
 {
   if (node == NULL) {
     return NULL;
@@ -435,19 +435,19 @@ ares__slist_t *ares__slist_node_parent(ares__slist_node_t *node)
   return node->parent;
 }
 
-void *ares__slist_first_val(ares__slist_t *list)
+void *ares_slist_first_val(ares_slist_t *list)
 {
-  return ares__slist_node_val(ares__slist_node_first(list));
+  return ares_slist_node_val(ares_slist_node_first(list));
 }
 
-void *ares__slist_last_val(ares__slist_t *list)
+void *ares_slist_last_val(ares_slist_t *list)
 {
-  return ares__slist_node_val(ares__slist_node_last(list));
+  return ares_slist_node_val(ares_slist_node_last(list));
 }
 
-void ares__slist_node_destroy(ares__slist_node_t *node)
+void ares_slist_node_destroy(ares_slist_node_t *node)
 {
-  ares__slist_destructor_t destruct;
+  ares_slist_destructor_t destruct;
   void                    *val;
 
   if (node == NULL) {
@@ -455,23 +455,23 @@ void ares__slist_node_destroy(ares__slist_node_t *node)
   }
 
   destruct = node->parent->destruct;
-  val      = ares__slist_node_claim(node);
+  val      = ares_slist_node_claim(node);
 
   if (val != NULL && destruct != NULL) {
     destruct(val);
   }
 }
 
-void ares__slist_destroy(ares__slist_t *list)
+void ares_slist_destroy(ares_slist_t *list)
 {
-  ares__slist_node_t *node;
+  ares_slist_node_t *node;
 
   if (list == NULL) {
     return;
   }
 
-  while ((node = ares__slist_node_first(list)) != NULL) {
-    ares__slist_node_destroy(node);
+  while ((node = ares_slist_node_first(list)) != NULL) {
+    ares_slist_node_destroy(node);
   }
 
   ares_free(list->head);

--- a/src/lib/dsa/ares_slist.c
+++ b/src/lib/dsa/ares_slist.c
@@ -31,30 +31,30 @@
 #define ARES__SLIST_START_LEVELS 4
 
 struct ares_slist {
-  ares_rand_state         *rand_state;
-  unsigned char            rand_data[8];
-  size_t                   rand_bits;
+  ares_rand_state        *rand_state;
+  unsigned char           rand_data[8];
+  size_t                  rand_bits;
 
   ares_slist_node_t     **head;
-  size_t                   levels;
+  size_t                  levels;
   ares_slist_node_t      *tail;
 
   ares_slist_cmp_t        cmp;
   ares_slist_destructor_t destruct;
-  size_t                   cnt;
+  size_t                  cnt;
 };
 
 struct ares_slist_node {
-  void                *data;
+  void               *data;
   ares_slist_node_t **prev;
   ares_slist_node_t **next;
-  size_t               levels;
+  size_t              levels;
   ares_slist_t       *parent;
 };
 
-ares_slist_t *ares_slist_create(ares_rand_state         *rand_state,
-                                  ares_slist_cmp_t        cmp,
-                                  ares_slist_destructor_t destruct)
+ares_slist_t *ares_slist_create(ares_rand_state        *rand_state,
+                                ares_slist_cmp_t        cmp,
+                                ares_slist_destructor_t destruct)
 {
   ares_slist_t *list;
 
@@ -92,8 +92,7 @@ static ares_bool_t ares_slist_coin_flip(ares_slist_t *list)
    * to be excessive in caching ourselves.  Prefer to require less memory per
    * skiplist */
   if (list->rand_bits == 0) {
-    ares_rand_bytes(list->rand_state, list->rand_data,
-                     sizeof(list->rand_data));
+    ares_rand_bytes(list->rand_state, list->rand_data, sizeof(list->rand_data));
     list->rand_bits = total_bits;
   }
 
@@ -104,7 +103,7 @@ static ares_bool_t ares_slist_coin_flip(ares_slist_t *list)
 }
 
 void ares_slist_replace_destructor(ares_slist_t           *list,
-                                    ares_slist_destructor_t destruct)
+                                   ares_slist_destructor_t destruct)
 {
   if (list == NULL) {
     return;
@@ -143,7 +142,7 @@ static size_t ares_slist_calc_level(ares_slist_t *list)
 
 static void ares_slist_node_push(ares_slist_t *list, ares_slist_node_t *node)
 {
-  size_t              i;
+  size_t             i;
   ares_slist_node_t *left = NULL;
 
   /* Scan from highest level in the slist, even if we're not using that number
@@ -258,7 +257,7 @@ fail:
 static void ares_slist_node_pop(ares_slist_node_t *node)
 {
   ares_slist_t *list = node->parent;
-  size_t         i;
+  size_t        i;
 
   /* relink each node at each level */
   for (i = node->levels; i-- > 0;) {
@@ -284,7 +283,7 @@ static void ares_slist_node_pop(ares_slist_node_t *node)
 void *ares_slist_node_claim(ares_slist_node_t *node)
 {
   ares_slist_t *list;
-  void          *val;
+  void         *val;
 
   if (node == NULL) {
     return NULL;
@@ -320,9 +319,9 @@ void ares_slist_node_reinsert(ares_slist_node_t *node)
 
 ares_slist_node_t *ares_slist_node_find(ares_slist_t *list, const void *val)
 {
-  size_t              i;
+  size_t             i;
   ares_slist_node_t *node = NULL;
-  int                 rv   = -1;
+  int                rv   = -1;
 
   if (list == NULL || val == NULL) {
     return NULL;
@@ -448,7 +447,7 @@ void *ares_slist_last_val(ares_slist_t *list)
 void ares_slist_node_destroy(ares_slist_node_t *node)
 {
   ares_slist_destructor_t destruct;
-  void                    *val;
+  void                   *val;
 
   if (node == NULL) {
     return;

--- a/src/lib/dsa/ares_slist.h
+++ b/src/lib/dsa/ares_slist.h
@@ -27,7 +27,7 @@
 #define __ARES__SLIST_H
 
 
-/*! \addtogroup ares__slist SkipList Data Structure
+/*! \addtogroup ares_slist SkipList Data Structure
  *
  * This data structure is known as a Skip List, which in essence is a sorted
  * linked list with multiple levels of linkage to gain some algorithmic
@@ -49,21 +49,21 @@
  *
  * @{
  */
-struct ares__slist;
+struct ares_slist;
 
 /*! SkipList Object, opaque */
-typedef struct ares__slist ares__slist_t;
+typedef struct ares_slist ares_slist_t;
 
-struct ares__slist_node;
+struct ares_slist_node;
 
 /*! SkipList Node Object, opaque */
-typedef struct ares__slist_node ares__slist_node_t;
+typedef struct ares_slist_node ares_slist_node_t;
 
 /*! SkipList Node Value destructor callback
  *
  *  \param[in] data  User-defined data to destroy
  */
-typedef void (*ares__slist_destructor_t)(void *data);
+typedef void (*ares_slist_destructor_t)(void *data);
 
 /*! SkipList comparison function
  *
@@ -71,7 +71,7 @@ typedef void (*ares__slist_destructor_t)(void *data);
  *  \param[in] data2 Second user-defined data object
  *  \return < 0 if data1 < data1, > 0 if data1 > data2, 0 if data1 == data2
  */
-typedef int (*ares__slist_cmp_t)(const void *data1, const void *data2);
+typedef int (*ares_slist_cmp_t)(const void *data1, const void *data2);
 
 /*! Create SkipList
  *
@@ -80,17 +80,17 @@ typedef int (*ares__slist_cmp_t)(const void *data1, const void *data2);
  *  \param[in] destruct     SkipList Node Value Destructor. Optional, use NULL.
  *  \return Initialized SkipList Object or NULL on misuse or ENOMEM
  */
-ares__slist_t      *ares__slist_create(ares_rand_state         *rand_state,
-                                       ares__slist_cmp_t        cmp,
-                                       ares__slist_destructor_t destruct);
+ares_slist_t      *ares_slist_create(ares_rand_state         *rand_state,
+                                       ares_slist_cmp_t        cmp,
+                                       ares_slist_destructor_t destruct);
 
 /*! Replace SkipList Node Value Destructor
  *
  *  \param[in] list      Initialized SkipList Object
  *  \param[in] destruct  Replacement destructor. May be NULL.
  */
-void                ares__slist_replace_destructor(ares__slist_t           *list,
-                                                   ares__slist_destructor_t destruct);
+void                ares_slist_replace_destructor(ares_slist_t           *list,
+                                                   ares_slist_destructor_t destruct);
 
 /*! Insert Value into SkipList
  *
@@ -99,35 +99,35 @@ void                ares__slist_replace_destructor(ares__slist_t           *list
  *                    and will have destructor called.
  *  \return SkipList Node Object or NULL on misuse or ENOMEM
  */
-ares__slist_node_t *ares__slist_insert(ares__slist_t *list, void *val);
+ares_slist_node_t *ares_slist_insert(ares_slist_t *list, void *val);
 
 /*! Fetch first node in SkipList
  *
  *  \param[in] list  Initialized SkipList Object
  *  \return SkipList Node Object or NULL if none
  */
-ares__slist_node_t *ares__slist_node_first(ares__slist_t *list);
+ares_slist_node_t *ares_slist_node_first(ares_slist_t *list);
 
 /*! Fetch last node in SkipList
  *
  *  \param[in] list  Initialized SkipList Object
  *  \return SkipList Node Object or NULL if none
  */
-ares__slist_node_t *ares__slist_node_last(ares__slist_t *list);
+ares_slist_node_t *ares_slist_node_last(ares_slist_t *list);
 
 /*! Fetch next node in SkipList
  *
  *  \param[in] node  SkipList Node Object
  *  \return SkipList Node Object or NULL if none
  */
-ares__slist_node_t *ares__slist_node_next(ares__slist_node_t *node);
+ares_slist_node_t *ares_slist_node_next(ares_slist_node_t *node);
 
 /*! Fetch previous node in SkipList
  *
  *  \param[in] node  SkipList Node Object
  *  \return SkipList Node Object or NULL if none
  */
-ares__slist_node_t *ares__slist_node_prev(ares__slist_node_t *node);
+ares_slist_node_t *ares_slist_node_prev(ares_slist_node_t *node);
 
 /*! Fetch SkipList Node Object by Value
  *
@@ -135,7 +135,7 @@ ares__slist_node_t *ares__slist_node_prev(ares__slist_node_t *node);
  *  \param[in] val   Object to use for comparison
  *  \return SkipList Node Object or NULL if not found
  */
-ares__slist_node_t *ares__slist_node_find(ares__slist_t *list, const void *val);
+ares_slist_node_t *ares_slist_node_find(ares_slist_t *list, const void *val);
 
 
 /*! Fetch Node Value
@@ -143,42 +143,42 @@ ares__slist_node_t *ares__slist_node_find(ares__slist_t *list, const void *val);
  *  \param[in] node  SkipList Node Object
  *  \return user defined node value
  */
-void               *ares__slist_node_val(ares__slist_node_t *node);
+void               *ares_slist_node_val(ares_slist_node_t *node);
 
 /*! Fetch number of entries in SkipList Object
  *
  *  \param[in] list  Initialized SkipList Object
  *  \return number of entries
  */
-size_t              ares__slist_len(const ares__slist_t *list);
+size_t              ares_slist_len(const ares_slist_t *list);
 
 /*! Fetch SkipList Object from SkipList Node
  *
  *  \param[in] node  SkipList Node Object
  *  \return SkipList Object
  */
-ares__slist_t      *ares__slist_node_parent(ares__slist_node_t *node);
+ares_slist_t      *ares_slist_node_parent(ares_slist_node_t *node);
 
 /*! Fetch first Node Value in SkipList
  *
  *  \param[in] list  Initialized SkipList Object
  *  \return user defined node value or NULL if none
  */
-void               *ares__slist_first_val(ares__slist_t *list);
+void               *ares_slist_first_val(ares_slist_t *list);
 
 /*! Fetch last Node Value in SkipList
  *
  *  \param[in] list  Initialized SkipList Object
  *  \return user defined node value or NULL if none
  */
-void               *ares__slist_last_val(ares__slist_t *list);
+void               *ares_slist_last_val(ares_slist_t *list);
 
 /*! Take back ownership of Node Value in SkipList, remove from SkipList.
  *
  *  \param[in] node  SkipList Node Object
  *  \return user defined node value
  */
-void               *ares__slist_node_claim(ares__slist_node_t *node);
+void               *ares_slist_node_claim(ares_slist_node_t *node);
 
 /*! The internals of the node have changed, thus its position in the sorted
  *  list is no longer valid.  This function will remove it and re-add it to
@@ -187,19 +187,19 @@ void               *ares__slist_node_claim(ares__slist_node_t *node);
  *
  *  \param[in] node  SkipList Node Object
  */
-void                ares__slist_node_reinsert(ares__slist_node_t *node);
+void                ares_slist_node_reinsert(ares_slist_node_t *node);
 
 /*! Remove Node from SkipList, calling destructor for Node Value.
  *
  *  \param[in] node  SkipList Node Object
  */
-void                ares__slist_node_destroy(ares__slist_node_t *node);
+void                ares_slist_node_destroy(ares_slist_node_t *node);
 
 /*! Destroy SkipList Object.  If there are any nodes, they will be destroyed.
  *
  *  \param[in] list  Initialized SkipList Object
  */
-void                ares__slist_destroy(ares__slist_t *list);
+void                ares_slist_destroy(ares_slist_t *list);
 
 /*! @} */
 

--- a/src/lib/dsa/ares_slist.h
+++ b/src/lib/dsa/ares_slist.h
@@ -80,17 +80,17 @@ typedef int (*ares_slist_cmp_t)(const void *data1, const void *data2);
  *  \param[in] destruct     SkipList Node Value Destructor. Optional, use NULL.
  *  \return Initialized SkipList Object or NULL on misuse or ENOMEM
  */
-ares_slist_t      *ares_slist_create(ares_rand_state         *rand_state,
-                                       ares_slist_cmp_t        cmp,
-                                       ares_slist_destructor_t destruct);
+ares_slist_t      *ares_slist_create(ares_rand_state        *rand_state,
+                                     ares_slist_cmp_t        cmp,
+                                     ares_slist_destructor_t destruct);
 
 /*! Replace SkipList Node Value Destructor
  *
  *  \param[in] list      Initialized SkipList Object
  *  \param[in] destruct  Replacement destructor. May be NULL.
  */
-void                ares_slist_replace_destructor(ares_slist_t           *list,
-                                                   ares_slist_destructor_t destruct);
+void               ares_slist_replace_destructor(ares_slist_t           *list,
+                                                 ares_slist_destructor_t destruct);
 
 /*! Insert Value into SkipList
  *
@@ -143,14 +143,14 @@ ares_slist_node_t *ares_slist_node_find(ares_slist_t *list, const void *val);
  *  \param[in] node  SkipList Node Object
  *  \return user defined node value
  */
-void               *ares_slist_node_val(ares_slist_node_t *node);
+void              *ares_slist_node_val(ares_slist_node_t *node);
 
 /*! Fetch number of entries in SkipList Object
  *
  *  \param[in] list  Initialized SkipList Object
  *  \return number of entries
  */
-size_t              ares_slist_len(const ares_slist_t *list);
+size_t             ares_slist_len(const ares_slist_t *list);
 
 /*! Fetch SkipList Object from SkipList Node
  *
@@ -164,21 +164,21 @@ ares_slist_t      *ares_slist_node_parent(ares_slist_node_t *node);
  *  \param[in] list  Initialized SkipList Object
  *  \return user defined node value or NULL if none
  */
-void               *ares_slist_first_val(ares_slist_t *list);
+void              *ares_slist_first_val(ares_slist_t *list);
 
 /*! Fetch last Node Value in SkipList
  *
  *  \param[in] list  Initialized SkipList Object
  *  \return user defined node value or NULL if none
  */
-void               *ares_slist_last_val(ares_slist_t *list);
+void              *ares_slist_last_val(ares_slist_t *list);
 
 /*! Take back ownership of Node Value in SkipList, remove from SkipList.
  *
  *  \param[in] node  SkipList Node Object
  *  \return user defined node value
  */
-void               *ares_slist_node_claim(ares_slist_node_t *node);
+void              *ares_slist_node_claim(ares_slist_node_t *node);
 
 /*! The internals of the node have changed, thus its position in the sorted
  *  list is no longer valid.  This function will remove it and re-add it to
@@ -187,19 +187,19 @@ void               *ares_slist_node_claim(ares_slist_node_t *node);
  *
  *  \param[in] node  SkipList Node Object
  */
-void                ares_slist_node_reinsert(ares_slist_node_t *node);
+void               ares_slist_node_reinsert(ares_slist_node_t *node);
 
 /*! Remove Node from SkipList, calling destructor for Node Value.
  *
  *  \param[in] node  SkipList Node Object
  */
-void                ares_slist_node_destroy(ares_slist_node_t *node);
+void               ares_slist_node_destroy(ares_slist_node_t *node);
 
 /*! Destroy SkipList Object.  If there are any nodes, they will be destroyed.
  *
  *  \param[in] list  Initialized SkipList Object
  */
-void                ares_slist_destroy(ares_slist_t *list);
+void               ares_slist_destroy(ares_slist_t *list);
 
 /*! @} */
 

--- a/src/lib/event/ares_event.h
+++ b/src/lib/event/ares_event.h
@@ -90,9 +90,9 @@ struct ares_event_thread {
    *  event before sleeping. */
   ares_bool_t             isup;
   /*! Handle to the thread for joining during shutdown */
-  ares_thread_t         *thread;
+  ares_thread_t          *thread;
   /*! Lock to protect the data contained within the event thread itself */
-  ares_thread_mutex_t   *mutex;
+  ares_thread_mutex_t    *mutex;
   /*! Reference to the ares channel, for being able to call things like
    *  ares_timeout() and ares_process_fd(). */
   ares_channel_t         *channel;
@@ -101,12 +101,12 @@ struct ares_event_thread {
   /*! Not-yet-processed event handle updates.  These will get enqueued by a
    *  thread other than the event thread itself. The event thread will then
    *  be woken then process these updates itself */
-  ares_llist_t          *ev_updates;
+  ares_llist_t           *ev_updates;
   /*! Registered socket event handles */
-  ares_htable_asvp_t    *ev_sock_handles;
+  ares_htable_asvp_t     *ev_sock_handles;
   /*! Registered custom event handles. Typically used for external triggering.
    */
-  ares_htable_vpvp_t    *ev_cust_handles;
+  ares_htable_vpvp_t     *ev_cust_handles;
   /*! Pointer to the event handle which is used to signal and wake the event
    *  thread itself.  This is needed to be able to do things like update the
    *  file descriptors being waited on and to wake the event subsystem during

--- a/src/lib/event/ares_event.h
+++ b/src/lib/event/ares_event.h
@@ -90,9 +90,9 @@ struct ares_event_thread {
    *  event before sleeping. */
   ares_bool_t             isup;
   /*! Handle to the thread for joining during shutdown */
-  ares__thread_t         *thread;
+  ares_thread_t         *thread;
   /*! Lock to protect the data contained within the event thread itself */
-  ares__thread_mutex_t   *mutex;
+  ares_thread_mutex_t   *mutex;
   /*! Reference to the ares channel, for being able to call things like
    *  ares_timeout() and ares_process_fd(). */
   ares_channel_t         *channel;
@@ -101,12 +101,12 @@ struct ares_event_thread {
   /*! Not-yet-processed event handle updates.  These will get enqueued by a
    *  thread other than the event thread itself. The event thread will then
    *  be woken then process these updates itself */
-  ares__llist_t          *ev_updates;
+  ares_llist_t          *ev_updates;
   /*! Registered socket event handles */
-  ares__htable_asvp_t    *ev_sock_handles;
+  ares_htable_asvp_t    *ev_sock_handles;
   /*! Registered custom event handles. Typically used for external triggering.
    */
-  ares__htable_vpvp_t    *ev_cust_handles;
+  ares_htable_vpvp_t    *ev_cust_handles;
   /*! Pointer to the event handle which is used to signal and wake the event
    *  thread itself.  This is needed to be able to do things like update the
    *  file descriptors being waited on and to wake the event subsystem during

--- a/src/lib/event/ares_event_configchg.c
+++ b/src/lib/event/ares_event_configchg.c
@@ -546,15 +546,15 @@ typedef struct {
 
 struct ares_event_configchg {
   ares_bool_t           isup;
-  ares__thread_t       *thread;
-  ares__htable_strvp_t *filestat;
-  ares__thread_mutex_t *lock;
-  ares__thread_cond_t  *wake;
+  ares_thread_t       *thread;
+  ares_htable_strvp_t *filestat;
+  ares_thread_mutex_t *lock;
+  ares_thread_cond_t  *wake;
   const char           *resolvconf_path;
   ares_event_thread_t  *e;
 };
 
-static ares_status_t config_change_check(ares__htable_strvp_t *filestat,
+static ares_status_t config_change_check(ares_htable_strvp_t *filestat,
                                          const char           *resolvconf_path)
 {
   size_t      i;
@@ -568,7 +568,7 @@ static ares_status_t config_change_check(ares__htable_strvp_t *filestat,
   configfiles[4] = NULL;
 
   for (i = 0; configfiles[i] != NULL; i++) {
-    fileinfo_t *fi = ares__htable_strvp_get_direct(filestat, configfiles[i]);
+    fileinfo_t *fi = ares_htable_strvp_get_direct(filestat, configfiles[i]);
     struct stat st;
 
     if (stat(configfiles[i], &st) == 0) {
@@ -577,7 +577,7 @@ static ares_status_t config_change_check(ares__htable_strvp_t *filestat,
         if (fi == NULL) {
           return ARES_ENOMEM;
         }
-        if (!ares__htable_strvp_insert(filestat, configfiles[i], fi)) {
+        if (!ares_htable_strvp_insert(filestat, configfiles[i], fi)) {
           ares_free(fi);
           return ARES_ENOMEM;
         }
@@ -589,7 +589,7 @@ static ares_status_t config_change_check(ares__htable_strvp_t *filestat,
       fi->mtime = (time_t)st.st_mtime;
     } else if (fi != NULL) {
       /* File no longer exists, remove */
-      ares__htable_strvp_remove(filestat, configfiles[i]);
+      ares_htable_strvp_remove(filestat, configfiles[i]);
       changed = ARES_TRUE;
     }
   }
@@ -604,11 +604,11 @@ static void *ares_event_configchg_thread(void *arg)
 {
   ares_event_configchg_t *c = arg;
 
-  ares__thread_mutex_lock(c->lock);
+  ares_thread_mutex_lock(c->lock);
   while (c->isup) {
     ares_status_t status;
 
-    if (ares__thread_cond_timedwait(c->wake, c->lock, 30000) != ARES_ETIMEOUT) {
+    if (ares_thread_cond_timedwait(c->wake, c->lock, 30000) != ARES_ETIMEOUT) {
       continue;
     }
 
@@ -623,7 +623,7 @@ static void *ares_event_configchg_thread(void *arg)
     }
   }
 
-  ares__thread_mutex_unlock(c->lock);
+  ares_thread_mutex_unlock(c->lock);
   return NULL;
 }
 
@@ -643,13 +643,13 @@ ares_status_t ares_event_configchg_init(ares_event_configchg_t **configchg,
 
   c->e = e;
 
-  c->filestat = ares__htable_strvp_create(ares_free);
+  c->filestat = ares_htable_strvp_create(ares_free);
   if (c->filestat == NULL) {
     status = ARES_ENOMEM;
     goto done;
   }
 
-  c->wake = ares__thread_cond_create();
+  c->wake = ares_thread_cond_create();
   if (c->wake == NULL) {
     status = ARES_ENOMEM;
     goto done;
@@ -666,7 +666,7 @@ ares_status_t ares_event_configchg_init(ares_event_configchg_t **configchg,
   }
 
   c->isup = ARES_TRUE;
-  status  = ares__thread_create(&c->thread, ares_event_configchg_thread, c);
+  status  = ares_thread_create(&c->thread, ares_event_configchg_thread, c);
 
 done:
   if (status != ARES_SUCCESS) {
@@ -684,26 +684,26 @@ void ares_event_configchg_destroy(ares_event_configchg_t *configchg)
   }
 
   if (configchg->lock) {
-    ares__thread_mutex_lock(configchg->lock);
+    ares_thread_mutex_lock(configchg->lock);
   }
 
   configchg->isup = ARES_FALSE;
   if (configchg->wake) {
-    ares__thread_cond_signal(configchg->wake);
+    ares_thread_cond_signal(configchg->wake);
   }
 
   if (configchg->lock) {
-    ares__thread_mutex_unlock(configchg->lock);
+    ares_thread_mutex_unlock(configchg->lock);
   }
 
   if (configchg->thread) {
     void *rv = NULL;
-    ares__thread_join(configchg->thread, &rv);
+    ares_thread_join(configchg->thread, &rv);
   }
 
-  ares__thread_mutex_destroy(configchg->lock);
-  ares__thread_cond_destroy(configchg->wake);
-  ares__htable_strvp_destroy(configchg->filestat);
+  ares_thread_mutex_destroy(configchg->lock);
+  ares_thread_cond_destroy(configchg->wake);
+  ares_htable_strvp_destroy(configchg->filestat);
   ares_free(configchg);
 }
 

--- a/src/lib/event/ares_event_configchg.c
+++ b/src/lib/event/ares_event_configchg.c
@@ -545,17 +545,17 @@ typedef struct {
 } fileinfo_t;
 
 struct ares_event_configchg {
-  ares_bool_t           isup;
+  ares_bool_t          isup;
   ares_thread_t       *thread;
   ares_htable_strvp_t *filestat;
   ares_thread_mutex_t *lock;
   ares_thread_cond_t  *wake;
-  const char           *resolvconf_path;
-  ares_event_thread_t  *e;
+  const char          *resolvconf_path;
+  ares_event_thread_t *e;
 };
 
 static ares_status_t config_change_check(ares_htable_strvp_t *filestat,
-                                         const char           *resolvconf_path)
+                                         const char          *resolvconf_path)
 {
   size_t      i;
   const char *configfiles[5];

--- a/src/lib/event/ares_event_epoll.c
+++ b/src/lib/event/ares_event_epoll.c
@@ -161,7 +161,7 @@ static size_t ares_evsys_epoll_wait(ares_event_thread_t *e,
     ares_event_t      *ev;
     ares_event_flags_t flags = 0;
 
-    ev = ares__htable_asvp_get_direct(e->ev_sock_handles,
+    ev = ares_htable_asvp_get_direct(e->ev_sock_handles,
                                       (ares_socket_t)events[i].data.fd);
     if (ev == NULL || ev->cb == NULL) {
       continue; /* LCOV_EXCL_LINE: DefensiveCoding */

--- a/src/lib/event/ares_event_epoll.c
+++ b/src/lib/event/ares_event_epoll.c
@@ -162,7 +162,7 @@ static size_t ares_evsys_epoll_wait(ares_event_thread_t *e,
     ares_event_flags_t flags = 0;
 
     ev = ares_htable_asvp_get_direct(e->ev_sock_handles,
-                                      (ares_socket_t)events[i].data.fd);
+                                     (ares_socket_t)events[i].data.fd);
     if (ev == NULL || ev->cb == NULL) {
       continue; /* LCOV_EXCL_LINE: DefensiveCoding */
     }

--- a/src/lib/event/ares_event_kqueue.c
+++ b/src/lib/event/ares_event_kqueue.c
@@ -217,7 +217,7 @@ static size_t ares_evsys_kqueue_wait(ares_event_thread_t *e,
     ares_event_t      *ev;
     ares_event_flags_t flags = 0;
 
-    ev = ares__htable_asvp_get_direct(e->ev_sock_handles,
+    ev = ares_htable_asvp_get_direct(e->ev_sock_handles,
                                       (ares_socket_t)events[i].ident);
     if (ev == NULL || ev->cb == NULL) {
       continue;

--- a/src/lib/event/ares_event_kqueue.c
+++ b/src/lib/event/ares_event_kqueue.c
@@ -218,7 +218,7 @@ static size_t ares_evsys_kqueue_wait(ares_event_thread_t *e,
     ares_event_flags_t flags = 0;
 
     ev = ares_htable_asvp_get_direct(e->ev_sock_handles,
-                                      (ares_socket_t)events[i].ident);
+                                     (ares_socket_t)events[i].ident);
     if (ev == NULL || ev->cb == NULL) {
       continue;
     }

--- a/src/lib/event/ares_event_poll.c
+++ b/src/lib/event/ares_event_poll.c
@@ -67,7 +67,7 @@ static size_t ares_evsys_poll_wait(ares_event_thread_t *e,
                                    unsigned long        timeout_ms)
 {
   size_t         num_fds = 0;
-  ares_socket_t *fdlist  = ares__htable_asvp_keys(e->ev_sock_handles, &num_fds);
+  ares_socket_t *fdlist  = ares_htable_asvp_keys(e->ev_sock_handles, &num_fds);
   struct pollfd *pollfd  = NULL;
   int            rv;
   size_t         cnt = 0;
@@ -80,7 +80,7 @@ static size_t ares_evsys_poll_wait(ares_event_thread_t *e,
     }
     for (i = 0; i < num_fds; i++) {
       const ares_event_t *ev =
-        ares__htable_asvp_get_direct(e->ev_sock_handles, fdlist[i]);
+        ares_htable_asvp_get_direct(e->ev_sock_handles, fdlist[i]);
       pollfd[i].fd = ev->fd;
       if (ev->flags & ARES_EVENT_FLAG_READ) {
         pollfd[i].events |= POLLIN;
@@ -107,7 +107,7 @@ static size_t ares_evsys_poll_wait(ares_event_thread_t *e,
 
     cnt++;
 
-    ev = ares__htable_asvp_get_direct(e->ev_sock_handles, pollfd[i].fd);
+    ev = ares_htable_asvp_get_direct(e->ev_sock_handles, pollfd[i].fd);
     if (ev == NULL || ev->cb == NULL) {
       continue; /* LCOV_EXCL_LINE: DefensiveCoding */
     }

--- a/src/lib/event/ares_event_select.c
+++ b/src/lib/event/ares_event_select.c
@@ -75,7 +75,7 @@ static size_t ares_evsys_select_wait(ares_event_thread_t *e,
                                      unsigned long        timeout_ms)
 {
   size_t          num_fds = 0;
-  ares_socket_t  *fdlist = ares__htable_asvp_keys(e->ev_sock_handles, &num_fds);
+  ares_socket_t  *fdlist = ares_htable_asvp_keys(e->ev_sock_handles, &num_fds);
   int             rv;
   size_t          cnt = 0;
   size_t          i;
@@ -92,7 +92,7 @@ static size_t ares_evsys_select_wait(ares_event_thread_t *e,
 
   for (i = 0; i < num_fds; i++) {
     const ares_event_t *ev =
-      ares__htable_asvp_get_direct(e->ev_sock_handles, fdlist[i]);
+      ares_htable_asvp_get_direct(e->ev_sock_handles, fdlist[i]);
     if (ev->flags & ARES_EVENT_FLAG_READ) {
       FD_SET(ev->fd, &read_fds);
     }
@@ -117,7 +117,7 @@ static size_t ares_evsys_select_wait(ares_event_thread_t *e,
       ares_event_t      *ev;
       ares_event_flags_t flags = 0;
 
-      ev = ares__htable_asvp_get_direct(e->ev_sock_handles, fdlist[i]);
+      ev = ares_htable_asvp_get_direct(e->ev_sock_handles, fdlist[i]);
       if (ev == NULL || ev->cb == NULL) {
         continue; /* LCOV_EXCL_LINE: DefensiveCoding */
       }

--- a/src/lib/event/ares_event_select.c
+++ b/src/lib/event/ares_event_select.c
@@ -75,7 +75,7 @@ static size_t ares_evsys_select_wait(ares_event_thread_t *e,
                                      unsigned long        timeout_ms)
 {
   size_t          num_fds = 0;
-  ares_socket_t  *fdlist = ares_htable_asvp_keys(e->ev_sock_handles, &num_fds);
+  ares_socket_t  *fdlist  = ares_htable_asvp_keys(e->ev_sock_handles, &num_fds);
   int             rv;
   size_t          cnt = 0;
   size_t          i;

--- a/src/lib/event/ares_event_win32.c
+++ b/src/lib/event/ares_event_win32.c
@@ -204,14 +204,14 @@ typedef struct {
   NtCancelIoFileEx_t      NtCancelIoFileEx;
 
   /* Implementation details */
-  ares_slist_t          *afd_handles;
+  ares_slist_t           *afd_handles;
   HANDLE                  iocp_handle;
 
   /* IO_STATUS_BLOCK * -> ares_evsys_win32_eventdata_t * mapping.  There is
    * no completion key passed to IOCP with this method so we have to look
    * up based on the lpOverlapped returned (which is mapped to IO_STATUS_BLOCK)
    */
-  ares_htable_vpvp_t    *sockets;
+  ares_htable_vpvp_t     *sockets;
 
   /* Flag about whether or not we are shutting down */
   ares_bool_t             is_shutdown;
@@ -226,19 +226,19 @@ typedef enum {
 
 typedef struct {
   /*! Pointer to parent event container */
-  ares_event_t         *event;
+  ares_event_t        *event;
   /*! Socket passed in to monitor */
-  SOCKET                socket;
+  SOCKET               socket;
   /*! Base socket derived from provided socket */
-  SOCKET                base_socket;
+  SOCKET               base_socket;
   /*! Structure for submitting AFD POLL requests (Internals!) */
-  AFD_POLL_INFO         afd_poll_info;
+  AFD_POLL_INFO        afd_poll_info;
   /*! Status of current polling operation */
-  poll_status_t         poll_status;
+  poll_status_t        poll_status;
   /*! IO Status Block structure submitted with AFD POLL requests and returned
    *  with IOCP results as lpOverlapped (even though its a different structure)
    */
-  IO_STATUS_BLOCK       iosb;
+  IO_STATUS_BLOCK      iosb;
   /*! AFD handle node an outstanding poll request is associated with */
   ares_slist_node_t   *afd_handle_node;
   /* Lock is only for PostQueuedCompletionStatus() to prevent multiple
@@ -379,7 +379,7 @@ static ares_slist_node_t *ares_afd_handle_create(ares_evsys_win32_t *ew)
   OBJECT_ATTRIBUTES  afd_attributes;
   NTSTATUS           status;
   IO_STATUS_BLOCK    iosb;
-  ares_afd_handle_t *afd   = ares_malloc_zero(sizeof(*afd));
+  ares_afd_handle_t *afd  = ares_malloc_zero(sizeof(*afd));
   ares_slist_node_t *node = NULL;
   if (afd == NULL) {
     goto fail;
@@ -425,7 +425,7 @@ fail:
 static ares_slist_node_t *ares_afd_handle_fetch(ares_evsys_win32_t *ew)
 {
   ares_slist_node_t *node = ares_slist_node_first(ew->afd_handles);
-  ares_afd_handle_t  *afd  = ares_slist_node_val(node);
+  ares_afd_handle_t *afd  = ares_slist_node_val(node);
 
   if (afd != NULL && afd->poll_cnt < AFD_POLL_PER_HANDLE) {
     return node;

--- a/src/lib/event/ares_event_win32.c
+++ b/src/lib/event/ares_event_win32.c
@@ -204,14 +204,14 @@ typedef struct {
   NtCancelIoFileEx_t      NtCancelIoFileEx;
 
   /* Implementation details */
-  ares__slist_t          *afd_handles;
+  ares_slist_t          *afd_handles;
   HANDLE                  iocp_handle;
 
   /* IO_STATUS_BLOCK * -> ares_evsys_win32_eventdata_t * mapping.  There is
    * no completion key passed to IOCP with this method so we have to look
    * up based on the lpOverlapped returned (which is mapped to IO_STATUS_BLOCK)
    */
-  ares__htable_vpvp_t    *sockets;
+  ares_htable_vpvp_t    *sockets;
 
   /* Flag about whether or not we are shutting down */
   ares_bool_t             is_shutdown;
@@ -240,10 +240,10 @@ typedef struct {
    */
   IO_STATUS_BLOCK       iosb;
   /*! AFD handle node an outstanding poll request is associated with */
-  ares__slist_node_t   *afd_handle_node;
+  ares_slist_node_t   *afd_handle_node;
   /* Lock is only for PostQueuedCompletionStatus() to prevent multiple
    * signals. Tracking via POLL_STATUS_PENDING/POLL_STATUS_NONE */
-  ares__thread_mutex_t *lock;
+  ares_thread_mutex_t *lock;
 } ares_evsys_win32_eventdata_t;
 
 static size_t ares_evsys_win32_wait(ares_event_thread_t *e,
@@ -256,12 +256,12 @@ static void   ares_iocpevent_signal(const ares_event_t *event)
   ares_evsys_win32_eventdata_t *ed          = event->data;
   ares_bool_t                   queue_event = ARES_FALSE;
 
-  ares__thread_mutex_lock(ed->lock);
+  ares_thread_mutex_lock(ed->lock);
   if (ed->poll_status != POLL_STATUS_PENDING) {
     ed->poll_status = POLL_STATUS_PENDING;
     queue_event     = ARES_TRUE;
   }
-  ares__thread_mutex_unlock(ed->lock);
+  ares_thread_mutex_unlock(ed->lock);
 
   if (!queue_event) {
     return;
@@ -277,9 +277,9 @@ static void ares_iocpevent_cb(ares_event_thread_t *e, ares_socket_t fd,
   (void)e;
   (void)fd;
   (void)flags;
-  ares__thread_mutex_lock(ed->lock);
+  ares_thread_mutex_lock(ed->lock);
   ed->poll_status = POLL_STATUS_NONE;
-  ares__thread_mutex_unlock(ed->lock);
+  ares_thread_mutex_unlock(ed->lock);
 }
 
 static ares_event_t *ares_iocpevent_create(ares_event_thread_t *e)
@@ -314,8 +314,8 @@ static void ares_evsys_win32_destroy(ares_event_thread_t *e)
 
   ew->is_shutdown = ARES_TRUE;
   CARES_DEBUG_LOG("  ** waiting on %lu remaining sockets to be destroyed\n",
-                  (unsigned long)ares__htable_vpvp_num_keys(ew->sockets));
-  while (ares__htable_vpvp_num_keys(ew->sockets)) {
+                  (unsigned long)ares_htable_vpvp_num_keys(ew->sockets));
+  while (ares_htable_vpvp_num_keys(ew->sockets)) {
     ares_evsys_win32_wait(e, 0);
   }
   CARES_DEBUG_LOG("  ** all sockets cleaned up\n");
@@ -325,9 +325,9 @@ static void ares_evsys_win32_destroy(ares_event_thread_t *e)
     CloseHandle(ew->iocp_handle);
   }
 
-  ares__slist_destroy(ew->afd_handles);
+  ares_slist_destroy(ew->afd_handles);
 
-  ares__htable_vpvp_destroy(ew->sockets);
+  ares_htable_vpvp_destroy(ew->sockets);
 
   ares_free(ew);
   e->ev_sys_data = NULL;
@@ -373,14 +373,14 @@ static void fill_object_attributes(OBJECT_ATTRIBUTES *attr,
 #  define UNICODE_STRING_CONSTANT(s) \
     { (sizeof(s) - 1) * sizeof(wchar_t), sizeof(s) * sizeof(wchar_t), L##s }
 
-static ares__slist_node_t *ares_afd_handle_create(ares_evsys_win32_t *ew)
+static ares_slist_node_t *ares_afd_handle_create(ares_evsys_win32_t *ew)
 {
   UNICODE_STRING     afd_device_name = UNICODE_STRING_CONSTANT("\\Device\\Afd");
   OBJECT_ATTRIBUTES  afd_attributes;
   NTSTATUS           status;
   IO_STATUS_BLOCK    iosb;
   ares_afd_handle_t *afd   = ares_malloc_zero(sizeof(*afd));
-  ares__slist_node_t *node = NULL;
+  ares_slist_node_t *node = NULL;
   if (afd == NULL) {
     goto fail;
   }
@@ -407,7 +407,7 @@ static ares__slist_node_t *ares_afd_handle_create(ares_evsys_win32_t *ew)
     goto fail;
   }
 
-  node = ares__slist_insert(ew->afd_handles, afd);
+  node = ares_slist_insert(ew->afd_handles, afd);
   if (node == NULL) {
     goto fail;
   }
@@ -422,10 +422,10 @@ fail:
 
 /* Fetch the lowest poll count entry, but if it exceeds the limit, create a
  * new one and return that */
-static ares__slist_node_t *ares_afd_handle_fetch(ares_evsys_win32_t *ew)
+static ares_slist_node_t *ares_afd_handle_fetch(ares_evsys_win32_t *ew)
 {
-  ares__slist_node_t *node = ares__slist_node_first(ew->afd_handles);
-  ares_afd_handle_t  *afd  = ares__slist_node_val(node);
+  ares_slist_node_t *node = ares_slist_node_first(ew->afd_handles);
+  ares_afd_handle_t  *afd  = ares_slist_node_val(node);
 
   if (afd != NULL && afd->poll_cnt < AFD_POLL_PER_HANDLE) {
     return node;
@@ -488,7 +488,7 @@ static ares_bool_t ares_evsys_win32_init(ares_event_thread_t *e)
     goto fail;
   }
 
-  ew->afd_handles = ares__slist_create(
+  ew->afd_handles = ares_slist_create(
     e->channel->rand_state, ares_afd_handle_cmp, ares_afd_handle_destroy);
   if (ew->afd_handles == NULL) {
     goto fail;
@@ -505,7 +505,7 @@ static ares_bool_t ares_evsys_win32_init(ares_event_thread_t *e)
     goto fail;
   }
 
-  ew->sockets = ares__htable_vpvp_create(NULL, NULL);
+  ew->sockets = ares_htable_vpvp_create(NULL, NULL);
   if (ew->sockets == NULL) {
     goto fail;
   }
@@ -582,7 +582,7 @@ static ares_bool_t ares_evsys_win32_afd_enqueue(ares_event_t      *event,
     return ARES_FALSE;
   }
 
-  afd = ares__slist_node_val(ed->afd_handle_node);
+  afd = ares_slist_node_val(ed->afd_handle_node);
 
   /* Enqueue AFD Poll */
   ed->afd_poll_info.Exclusive         = FALSE;
@@ -621,7 +621,7 @@ static ares_bool_t ares_evsys_win32_afd_enqueue(ares_event_t      *event,
   /* Record that we submitted a poll request to this handle and tell it to
    * re-sort the node since we changed its sort value */
   afd->poll_cnt++;
-  ares__slist_node_reinsert(ed->afd_handle_node);
+  ares_slist_node_reinsert(ed->afd_handle_node);
 
   ed->poll_status = POLL_STATUS_PENDING;
   CARES_DEBUG_LOG("++ afd_enqueue ed=%p flags=%X\n", (void *)ed,
@@ -643,7 +643,7 @@ static ares_bool_t ares_evsys_win32_afd_cancel(ares_evsys_win32_eventdata_t *ed)
     return ARES_FALSE;
   }
 
-  afd = ares__slist_node_val(ed->afd_handle_node);
+  afd = ares_slist_node_val(ed->afd_handle_node);
 
   /* Misuse */
   if (afd == NULL) {
@@ -685,10 +685,10 @@ static void ares_evsys_win32_eventdata_destroy(ares_evsys_win32_t           *ew,
                   (ed->socket == ARES_SOCKET_BAD) ? "data" : "socket");
   /* These type of handles are deferred destroy. Update tracking. */
   if (ed->socket != ARES_SOCKET_BAD) {
-    ares__htable_vpvp_remove(ew->sockets, &ed->iosb);
+    ares_htable_vpvp_remove(ew->sockets, &ed->iosb);
   }
 
-  ares__thread_mutex_destroy(ed->lock);
+  ares_thread_mutex_destroy(ed->lock);
 
   if (ed->event != NULL) {
     ed->event->data = NULL;
@@ -718,7 +718,7 @@ static ares_bool_t ares_evsys_win32_event_add(ares_event_t *event)
    * the ares_evsys_win32_eventdata_t as the placeholder to use as the
    * IOCP Completion Key */
   if (ed->socket == ARES_SOCKET_BAD) {
-    ed->lock = ares__thread_mutex_create();
+    ed->lock = ares_thread_mutex_create();
     if (ed->lock == NULL) {
       goto done;
     }
@@ -731,7 +731,7 @@ static ares_bool_t ares_evsys_win32_event_add(ares_event_t *event)
     goto done;
   }
 
-  if (!ares__htable_vpvp_insert(ew->sockets, &ed->iosb, ed)) {
+  if (!ares_htable_vpvp_insert(ew->sockets, &ed->iosb, ed)) {
     goto done;
   }
 
@@ -859,9 +859,9 @@ static ares_bool_t ares_evsys_win32_process_socket_event(
 
   /* Decrement poll count for AFD handle then resort, also disassociate
    * with socket */
-  afd = ares__slist_node_val(ed->afd_handle_node);
+  afd = ares_slist_node_val(ed->afd_handle_node);
   afd->poll_cnt--;
-  ares__slist_node_reinsert(ed->afd_handle_node);
+  ares_slist_node_reinsert(ed->afd_handle_node);
   ed->afd_handle_node = NULL;
 
   /* Pending destroy, go ahead and kill it */
@@ -946,7 +946,7 @@ static size_t ares_evsys_win32_wait(ares_event_thread_t *e,
         ed = (ares_evsys_win32_eventdata_t *)entries[i].lpCompletionKey;
         rc = ares_evsys_win32_process_other_event(ew, ed, i);
       } else {
-        ed = ares__htable_vpvp_get_direct(ew->sockets, entries[i].lpOverlapped);
+        ed = ares_htable_vpvp_get_direct(ew->sockets, entries[i].lpOverlapped);
         rc = ares_evsys_win32_process_socket_event(ew, ed, i);
       }
 

--- a/src/lib/include/ares_array.h
+++ b/src/lib/include/ares_array.h
@@ -74,8 +74,8 @@ typedef int (*ares_array_cmp_t)(const void *data1, const void *data2);
  *
  *  \return array object or NULL on out of memory
  */
-CARES_EXTERN ares_array_t *
-  ares_array_create(size_t member_size, ares_array_destructor_t destruct);
+CARES_EXTERN ares_array_t *ares_array_create(size_t member_size,
+                                             ares_array_destructor_t destruct);
 
 
 /*! Request the array be at least the requested size.  Useful if the desired
@@ -85,8 +85,7 @@ CARES_EXTERN ares_array_t *
  *  \param[in] size Minimum number of members
  *  \return ARES_SUCCESS on success, ARES_EFORMERR on misuse,
  *    ARES_ENOMEM on out of memory */
-CARES_EXTERN ares_status_t ares_array_set_size(ares_array_t *arr,
-                                                size_t         size);
+CARES_EXTERN ares_status_t ares_array_set_size(ares_array_t *arr, size_t size);
 
 /*! Sort the array using the given comparison function.  This is not
  *  persistent, any future elements inserted will not maintain this sort.
@@ -96,7 +95,7 @@ CARES_EXTERN ares_status_t ares_array_set_size(ares_array_t *arr,
  *  \return ARES_SUCCESS on success
  */
 CARES_EXTERN ares_status_t ares_array_sort(ares_array_t    *arr,
-                                            ares_array_cmp_t cmp);
+                                           ares_array_cmp_t cmp);
 
 /*! Destroy an array object.  If a destructor is set, will be called on each
  *  member of the array.
@@ -131,9 +130,8 @@ CARES_EXTERN size_t ares_array_len(const ares_array_t *arr);
  *  \return ARES_SUCCESS on success, ARES_EFORMERR on bad index,
  *          ARES_ENOMEM on out of memory.
  */
-CARES_EXTERN ares_status_t ares_array_insert_at(void         **elem_ptr,
-                                                 ares_array_t *arr,
-                                                 size_t         idx);
+CARES_EXTERN ares_status_t ares_array_insert_at(void        **elem_ptr,
+                                                ares_array_t *arr, size_t idx);
 
 /*! Insert a new array member at the end of the array
  *
@@ -141,8 +139,8 @@ CARES_EXTERN ares_status_t ares_array_insert_at(void         **elem_ptr,
  *  \param[in]  arr      Initialized array object.
  *  \return ARES_SUCCESS on success, ARES_ENOMEM on out of memory.
  */
-CARES_EXTERN ares_status_t ares_array_insert_last(void         **elem_ptr,
-                                                   ares_array_t *arr);
+CARES_EXTERN ares_status_t ares_array_insert_last(void        **elem_ptr,
+                                                  ares_array_t *arr);
 
 /*! Insert a new array member at the beginning of the array
  *
@@ -150,8 +148,8 @@ CARES_EXTERN ares_status_t ares_array_insert_last(void         **elem_ptr,
  *  \param[in]  arr      Initialized array object.
  *  \return ARES_SUCCESS on success, ARES_ENOMEM on out of memory.
  */
-CARES_EXTERN ares_status_t ares_array_insert_first(void         **elem_ptr,
-                                                    ares_array_t *arr);
+CARES_EXTERN ares_status_t ares_array_insert_first(void        **elem_ptr,
+                                                   ares_array_t *arr);
 
 
 /*! Insert a new array member at the given index and copy the data pointed
@@ -168,8 +166,8 @@ CARES_EXTERN ares_status_t ares_array_insert_first(void         **elem_ptr,
  * ptr, ARES_ENOMEM on out of memory.
  */
 CARES_EXTERN ares_status_t ares_array_insertdata_at(ares_array_t *arr,
-                                                     size_t         idx,
-                                                     const void    *data_ptr);
+                                                    size_t        idx,
+                                                    const void   *data_ptr);
 
 /*! Insert a new array member at the end of the array and copy the data pointed
  *  to by the data pointer into the array.  This will copy member_size bytes
@@ -183,7 +181,7 @@ CARES_EXTERN ares_status_t ares_array_insertdata_at(ares_array_t *arr,
  * ptr, ARES_ENOMEM on out of memory.
  */
 CARES_EXTERN ares_status_t ares_array_insertdata_last(ares_array_t *arr,
-                                                       const void    *data_ptr);
+                                                      const void   *data_ptr);
 
 /*! Insert a new array member at the beginning of the array and copy the data
  * pointed to by the data pointer into the array.  This will copy member_size
@@ -197,7 +195,7 @@ CARES_EXTERN ares_status_t ares_array_insertdata_last(ares_array_t *arr,
  * ptr, ARES_ENOMEM on out of memory.
  */
 CARES_EXTERN ares_status_t ares_array_insertdata_first(ares_array_t *arr,
-                                                        const void *data_ptr);
+                                                       const void   *data_ptr);
 
 /*! Fetch a pointer to the given element in the array
  *  \param[in]  array  Initialized array object
@@ -220,7 +218,7 @@ CARES_EXTERN void         *ares_array_last(ares_array_t *arr);
  *  \param[in]  idx    Index to fetch
  *  \return pointer on success, NULL on failure */
 CARES_EXTERN const void   *ares_array_at_const(const ares_array_t *arr,
-                                                size_t               idx);
+                                               size_t              idx);
 
 /*! Fetch a constant pointer to the first element in the array
  *  \param[in]  array  Initialized array object
@@ -247,7 +245,7 @@ CARES_EXTERN const void   *ares_array_last_const(const ares_array_t *arr);
  *  \return ARES_SUCCESS on success, ARES_EFORMERR on usage failure.
  */
 CARES_EXTERN ares_status_t ares_array_claim_at(void *dest, size_t dest_size,
-                                                ares_array_t *arr, size_t idx);
+                                               ares_array_t *arr, size_t idx);
 
 /*! Remove the member at the specified array index.  The destructor will be
  *  called.
@@ -256,8 +254,7 @@ CARES_EXTERN ares_status_t ares_array_claim_at(void *dest, size_t dest_size,
  *  \param[in] idx  Index to remove
  *  \return ARES_SUCCESS if removed, ARES_EFORMERR on invalid use
  */
-CARES_EXTERN ares_status_t ares_array_remove_at(ares_array_t *arr,
-                                                 size_t         idx);
+CARES_EXTERN ares_status_t ares_array_remove_at(ares_array_t *arr, size_t idx);
 
 /*! Remove the first member of the array.
  *

--- a/src/lib/include/ares_array.h
+++ b/src/lib/include/ares_array.h
@@ -28,7 +28,7 @@
 
 #include "ares.h"
 
-/*! \addtogroup ares__array Array Data Structure
+/*! \addtogroup ares_array Array Data Structure
  *
  * This is an array with helpers.  It is meant to have as little overhead
  * as possible over direct array management by applications but to provide
@@ -38,17 +38,17 @@
  * @{
  */
 
-struct ares__array;
+struct ares_array;
 
 /*! Opaque data structure for array */
-typedef struct ares__array ares__array_t;
+typedef struct ares_array ares_array_t;
 
 /*! Callback to free user-defined member data
  *
  *  \param[in] data  pointer to member of array to be destroyed. The pointer
  *                   itself must not be destroyed, just the data it contains.
  */
-typedef void (*ares__array_destructor_t)(void *data);
+typedef void (*ares_array_destructor_t)(void *data);
 
 /*! Callback to compare two array elements used for sorting
  *
@@ -56,7 +56,7 @@ typedef void (*ares__array_destructor_t)(void *data);
  *  \param[in] data2 array member 2
  *  \return < 0 if data1 < data2, > 0 if data1 > data2, 0 if data1 == data2
  */
-typedef int (*ares__array_cmp_t)(const void *data1, const void *data2);
+typedef int (*ares_array_cmp_t)(const void *data1, const void *data2);
 
 /*! Create an array object
  *
@@ -74,8 +74,8 @@ typedef int (*ares__array_cmp_t)(const void *data1, const void *data2);
  *
  *  \return array object or NULL on out of memory
  */
-CARES_EXTERN ares__array_t *
-  ares__array_create(size_t member_size, ares__array_destructor_t destruct);
+CARES_EXTERN ares_array_t *
+  ares_array_create(size_t member_size, ares_array_destructor_t destruct);
 
 
 /*! Request the array be at least the requested size.  Useful if the desired
@@ -85,7 +85,7 @@ CARES_EXTERN ares__array_t *
  *  \param[in] size Minimum number of members
  *  \return ARES_SUCCESS on success, ARES_EFORMERR on misuse,
  *    ARES_ENOMEM on out of memory */
-CARES_EXTERN ares_status_t ares__array_set_size(ares__array_t *arr,
+CARES_EXTERN ares_status_t ares_array_set_size(ares_array_t *arr,
                                                 size_t         size);
 
 /*! Sort the array using the given comparison function.  This is not
@@ -95,15 +95,15 @@ CARES_EXTERN ares_status_t ares__array_set_size(ares__array_t *arr,
  *  \param[in]  cb       Sort callback
  *  \return ARES_SUCCESS on success
  */
-CARES_EXTERN ares_status_t ares__array_sort(ares__array_t    *arr,
-                                            ares__array_cmp_t cmp);
+CARES_EXTERN ares_status_t ares_array_sort(ares_array_t    *arr,
+                                            ares_array_cmp_t cmp);
 
 /*! Destroy an array object.  If a destructor is set, will be called on each
  *  member of the array.
  *
  *  \param[in] arr     Initialized array object.
  */
-CARES_EXTERN void          ares__array_destroy(ares__array_t *arr);
+CARES_EXTERN void          ares_array_destroy(ares_array_t *arr);
 
 /*! Retrieve the array in the native format.  This will also destroy the
  *  container.  It is the responsibility of the caller to free the returned
@@ -113,14 +113,14 @@ CARES_EXTERN void          ares__array_destroy(ares__array_t *arr);
  *  \param[out] num_members the number of members in the returned array
  *  \return pointer to native array on success, NULL on failure.
  */
-CARES_EXTERN void  *ares__array_finish(ares__array_t *arr, size_t *num_members);
+CARES_EXTERN void  *ares_array_finish(ares_array_t *arr, size_t *num_members);
 
 /*! Retrieve the number of members in the array
  *
  *  \param[in] arr     Initialized array object.
  *  \return numbrer of members
  */
-CARES_EXTERN size_t ares__array_len(const ares__array_t *arr);
+CARES_EXTERN size_t ares_array_len(const ares_array_t *arr);
 
 /*! Insert a new array member at the given index
  *
@@ -131,8 +131,8 @@ CARES_EXTERN size_t ares__array_len(const ares__array_t *arr);
  *  \return ARES_SUCCESS on success, ARES_EFORMERR on bad index,
  *          ARES_ENOMEM on out of memory.
  */
-CARES_EXTERN ares_status_t ares__array_insert_at(void         **elem_ptr,
-                                                 ares__array_t *arr,
+CARES_EXTERN ares_status_t ares_array_insert_at(void         **elem_ptr,
+                                                 ares_array_t *arr,
                                                  size_t         idx);
 
 /*! Insert a new array member at the end of the array
@@ -141,8 +141,8 @@ CARES_EXTERN ares_status_t ares__array_insert_at(void         **elem_ptr,
  *  \param[in]  arr      Initialized array object.
  *  \return ARES_SUCCESS on success, ARES_ENOMEM on out of memory.
  */
-CARES_EXTERN ares_status_t ares__array_insert_last(void         **elem_ptr,
-                                                   ares__array_t *arr);
+CARES_EXTERN ares_status_t ares_array_insert_last(void         **elem_ptr,
+                                                   ares_array_t *arr);
 
 /*! Insert a new array member at the beginning of the array
  *
@@ -150,15 +150,15 @@ CARES_EXTERN ares_status_t ares__array_insert_last(void         **elem_ptr,
  *  \param[in]  arr      Initialized array object.
  *  \return ARES_SUCCESS on success, ARES_ENOMEM on out of memory.
  */
-CARES_EXTERN ares_status_t ares__array_insert_first(void         **elem_ptr,
-                                                    ares__array_t *arr);
+CARES_EXTERN ares_status_t ares_array_insert_first(void         **elem_ptr,
+                                                    ares_array_t *arr);
 
 
 /*! Insert a new array member at the given index and copy the data pointed
  *  to by the data pointer into the array.  This will copy member_size bytes
  *  from the provided pointer, this may not be safe for some data types
  *  that may have a smaller size than the provided member_size which includes
- *  padding as discussed in ares__array_create().
+ *  padding as discussed in ares_array_create().
  *
  *  \param[in]  arr      Initialized array object.
  *  \param[in]  idx      Index in array to place new element, will shift any
@@ -167,7 +167,7 @@ CARES_EXTERN ares_status_t ares__array_insert_first(void         **elem_ptr,
  *  \return ARES_SUCCESS on success, ARES_EFORMERR on bad index or null data
  * ptr, ARES_ENOMEM on out of memory.
  */
-CARES_EXTERN ares_status_t ares__array_insertdata_at(ares__array_t *arr,
+CARES_EXTERN ares_status_t ares_array_insertdata_at(ares_array_t *arr,
                                                      size_t         idx,
                                                      const void    *data_ptr);
 
@@ -175,62 +175,62 @@ CARES_EXTERN ares_status_t ares__array_insertdata_at(ares__array_t *arr,
  *  to by the data pointer into the array.  This will copy member_size bytes
  *  from the provided pointer, this may not be safe for some data types
  *  that may have a smaller size than the provided member_size which includes
- *  padding as discussed in ares__array_create().
+ *  padding as discussed in ares_array_create().
  *
  *  \param[in]  arr      Initialized array object.
  *  \param[in]  data_ptr Pointer to data to copy into array.
  *  \return ARES_SUCCESS on success, ARES_EFORMERR on bad index or null data
  * ptr, ARES_ENOMEM on out of memory.
  */
-CARES_EXTERN ares_status_t ares__array_insertdata_last(ares__array_t *arr,
+CARES_EXTERN ares_status_t ares_array_insertdata_last(ares_array_t *arr,
                                                        const void    *data_ptr);
 
 /*! Insert a new array member at the beginning of the array and copy the data
  * pointed to by the data pointer into the array.  This will copy member_size
  * bytes from the provided pointer, this may not be safe for some data types
  *  that may have a smaller size than the provided member_size which includes
- *  padding as discussed in ares__array_create().
+ *  padding as discussed in ares_array_create().
  *
  *  \param[in]  arr      Initialized array object.
  *  \param[in]  data_ptr Pointer to data to copy into array.
  *  \return ARES_SUCCESS on success, ARES_EFORMERR on bad index or null data
  * ptr, ARES_ENOMEM on out of memory.
  */
-CARES_EXTERN ares_status_t ares__array_insertdata_first(ares__array_t *arr,
+CARES_EXTERN ares_status_t ares_array_insertdata_first(ares_array_t *arr,
                                                         const void *data_ptr);
 
 /*! Fetch a pointer to the given element in the array
  *  \param[in]  array  Initialized array object
  *  \param[in]  idx    Index to fetch
  *  \return pointer on success, NULL on failure */
-CARES_EXTERN void         *ares__array_at(ares__array_t *arr, size_t idx);
+CARES_EXTERN void         *ares_array_at(ares_array_t *arr, size_t idx);
 
 /*! Fetch a pointer to the first element in the array
  *  \param[in]  array  Initialized array object
  *  \return pointer on success, NULL on failure */
-CARES_EXTERN void         *ares__array_first(ares__array_t *arr);
+CARES_EXTERN void         *ares_array_first(ares_array_t *arr);
 
 /*! Fetch a pointer to the last element in the array
  *  \param[in]  array  Initialized array object
  *  \return pointer on success, NULL on failure */
-CARES_EXTERN void         *ares__array_last(ares__array_t *arr);
+CARES_EXTERN void         *ares_array_last(ares_array_t *arr);
 
 /*! Fetch a constant pointer to the given element in the array
  *  \param[in]  array  Initialized array object
  *  \param[in]  idx    Index to fetch
  *  \return pointer on success, NULL on failure */
-CARES_EXTERN const void   *ares__array_at_const(const ares__array_t *arr,
+CARES_EXTERN const void   *ares_array_at_const(const ares_array_t *arr,
                                                 size_t               idx);
 
 /*! Fetch a constant pointer to the first element in the array
  *  \param[in]  array  Initialized array object
  *  \return pointer on success, NULL on failure */
-CARES_EXTERN const void   *ares__array_first_const(const ares__array_t *arr);
+CARES_EXTERN const void   *ares_array_first_const(const ares_array_t *arr);
 
 /*! Fetch a constant pointer to the last element in the array
  *  \param[in]  array  Initialized array object
  *  \return pointer on success, NULL on failure */
-CARES_EXTERN const void   *ares__array_last_const(const ares__array_t *arr);
+CARES_EXTERN const void   *ares_array_last_const(const ares_array_t *arr);
 
 /*! Claim the data from the specified array index, copying it to the buffer
  *  provided by the caller.  The index specified in the array will then be
@@ -241,13 +241,13 @@ CARES_EXTERN const void   *ares__array_last_const(const ares__array_t *arr);
  *                           member needs destructor if not provided.
  *  \param[in]     dest_size Size of buffer provided, used as a sanity check.
  *                           Must match member_size provided to
- *                           ares__array_create() if dest_size specified.
+ *                           ares_array_create() if dest_size specified.
  *  \param[in]     arr       Initialized array object
  *  \param[in]     idx       Index to claim
  *  \return ARES_SUCCESS on success, ARES_EFORMERR on usage failure.
  */
-CARES_EXTERN ares_status_t ares__array_claim_at(void *dest, size_t dest_size,
-                                                ares__array_t *arr, size_t idx);
+CARES_EXTERN ares_status_t ares_array_claim_at(void *dest, size_t dest_size,
+                                                ares_array_t *arr, size_t idx);
 
 /*! Remove the member at the specified array index.  The destructor will be
  *  called.
@@ -256,7 +256,7 @@ CARES_EXTERN ares_status_t ares__array_claim_at(void *dest, size_t dest_size,
  *  \param[in] idx  Index to remove
  *  \return ARES_SUCCESS if removed, ARES_EFORMERR on invalid use
  */
-CARES_EXTERN ares_status_t ares__array_remove_at(ares__array_t *arr,
+CARES_EXTERN ares_status_t ares_array_remove_at(ares_array_t *arr,
                                                  size_t         idx);
 
 /*! Remove the first member of the array.
@@ -264,14 +264,14 @@ CARES_EXTERN ares_status_t ares__array_remove_at(ares__array_t *arr,
  *  \param[in] arr  Initialized array object
  *  \return ARES_SUCCESS if removed, ARES_EFORMERR on invalid use
  */
-CARES_EXTERN ares_status_t ares__array_remove_first(ares__array_t *arr);
+CARES_EXTERN ares_status_t ares_array_remove_first(ares_array_t *arr);
 
 /*! Remove the last member of the array.
  *
  *  \param[in] arr  Initialized array object
  *  \return ARES_SUCCESS if removed, ARES_EFORMERR on invalid use
  */
-CARES_EXTERN ares_status_t ares__array_remove_last(ares__array_t *arr);
+CARES_EXTERN ares_status_t ares_array_remove_last(ares_array_t *arr);
 
 
 /*! @} */

--- a/src/lib/include/ares_buf.h
+++ b/src/lib/include/ares_buf.h
@@ -27,9 +27,9 @@
 #define __ARES__BUF_H
 
 #include "ares.h"
-#include "ares__llist.h"
+#include "ares_llist.h"
 
-/*! \addtogroup ares__buf Safe Data Builder and buffer
+/*! \addtogroup ares_buf Safe Data Builder and buffer
  *
  * This is a buffer building and parsing framework with a focus on security over
  * performance. All data to be read from the buffer will perform explicit length
@@ -45,16 +45,16 @@
  *
  * @{
  */
-struct ares__buf;
+struct ares_buf;
 
 /*! Opaque data type for generic hash table implementation */
-typedef struct ares__buf    ares__buf_t;
+typedef struct ares_buf    ares_buf_t;
 
 /*! Create a new buffer object that dynamically allocates buffers for data.
  *
  *  \return initialized buffer object or NULL if out of memory.
  */
-CARES_EXTERN ares__buf_t   *ares__buf_create(void);
+CARES_EXTERN ares_buf_t   *ares_buf_create(void);
 
 /*! Create a new buffer object that uses a user-provided data pointer.  The
  *  data provided will not be manipulated, and cannot be appended to.  This
@@ -65,7 +65,7 @@ CARES_EXTERN ares__buf_t   *ares__buf_create(void);
  *
  *  \return initialized buffer object or NULL if out of memory or misuse.
  */
-CARES_EXTERN ares__buf_t   *ares__buf_create_const(const unsigned char *data,
+CARES_EXTERN ares_buf_t   *ares_buf_create_const(const unsigned char *data,
                                                    size_t               data_len);
 
 
@@ -73,7 +73,7 @@ CARES_EXTERN ares__buf_t   *ares__buf_create_const(const unsigned char *data,
  *
  *  \param[in] buf  Initialized buf object
  */
-CARES_EXTERN void           ares__buf_destroy(ares__buf_t *buf);
+CARES_EXTERN void           ares_buf_destroy(ares_buf_t *buf);
 
 
 /*! Append multiple bytes to a dynamic buffer object
@@ -83,7 +83,7 @@ CARES_EXTERN void           ares__buf_destroy(ares__buf_t *buf);
  *  \param[in] data_len Length of data to copy to buffer object.
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t  ares__buf_append(ares__buf_t         *buf,
+CARES_EXTERN ares_status_t  ares_buf_append(ares_buf_t         *buf,
                                              const unsigned char *data,
                                              size_t               data_len);
 
@@ -93,7 +93,7 @@ CARES_EXTERN ares_status_t  ares__buf_append(ares__buf_t         *buf,
  *  \param[in] b        Single byte to append to buffer object.
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t  ares__buf_append_byte(ares__buf_t  *buf,
+CARES_EXTERN ares_status_t  ares_buf_append_byte(ares_buf_t  *buf,
                                                   unsigned char b);
 
 /*! Append a null-terminated string to the dynamic buffer object
@@ -102,7 +102,7 @@ CARES_EXTERN ares_status_t  ares__buf_append_byte(ares__buf_t  *buf,
  *  \param[in] str      String to append to buffer object.
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t  ares__buf_append_str(ares__buf_t *buf,
+CARES_EXTERN ares_status_t  ares_buf_append_str(ares_buf_t *buf,
                                                  const char  *str);
 
 /*! Append a 16bit Big Endian number to the buffer.
@@ -111,7 +111,7 @@ CARES_EXTERN ares_status_t  ares__buf_append_str(ares__buf_t *buf,
  *  \param[out] u16     16bit integer
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t  ares__buf_append_be16(ares__buf_t   *buf,
+CARES_EXTERN ares_status_t  ares_buf_append_be16(ares_buf_t   *buf,
                                                   unsigned short u16);
 
 /*! Append a 32bit Big Endian number to the buffer.
@@ -120,7 +120,7 @@ CARES_EXTERN ares_status_t  ares__buf_append_be16(ares__buf_t   *buf,
  *  \param[out] u32     32bit integer
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t  ares__buf_append_be32(ares__buf_t *buf,
+CARES_EXTERN ares_status_t  ares_buf_append_be32(ares_buf_t *buf,
                                                   unsigned int u32);
 
 /*! Append a number in ASCII decimal form.
@@ -130,7 +130,7 @@ CARES_EXTERN ares_status_t  ares__buf_append_be32(ares__buf_t *buf,
  *  \param[in] len  Length to output, use 0 for no padding
  *  \return ARES_SUCCESS on success
  */
-CARES_EXTERN ares_status_t  ares__buf_append_num_dec(ares__buf_t *buf,
+CARES_EXTERN ares_status_t  ares_buf_append_num_dec(ares_buf_t *buf,
                                                      size_t num, size_t len);
 
 /*! Append a number in ASCII hexadecimal form.
@@ -140,7 +140,7 @@ CARES_EXTERN ares_status_t  ares__buf_append_num_dec(ares__buf_t *buf,
  *  \param[in] len  Length to output, use 0 for no padding
  *  \return ARES_SUCCESS on success
  */
-CARES_EXTERN ares_status_t  ares__buf_append_num_hex(ares__buf_t *buf,
+CARES_EXTERN ares_status_t  ares_buf_append_num_hex(ares_buf_t *buf,
                                                      size_t num, size_t len);
 
 /*! Sets the current buffer length.  This *may* be used if there is a need to
@@ -156,13 +156,13 @@ CARES_EXTERN ares_status_t  ares__buf_append_num_hex(ares__buf_t *buf,
  *  \param[in]  len  Length to set
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t  ares__buf_set_length(ares__buf_t *buf, size_t len);
+CARES_EXTERN ares_status_t  ares_buf_set_length(ares_buf_t *buf, size_t len);
 
 
 /*! Start a dynamic append operation that returns a buffer suitable for
  *  writing.  A desired minimum length is passed in, and the actual allocated
  *  buffer size is returned which may be greater than the requested size.
- *  No operation other than ares__buf_append_finish() is allowed on the
+ *  No operation other than ares_buf_append_finish() is allowed on the
  *  buffer after this request.
  *
  *  \param[in]     buf     Initialized buffer object
@@ -170,18 +170,18 @@ CARES_EXTERN ares_status_t  ares__buf_set_length(ares__buf_t *buf, size_t len);
  *                         returned.
  *  \return Pointer to writable buffer or NULL on failure (usage, out of mem)
  */
-CARES_EXTERN unsigned char *ares__buf_append_start(ares__buf_t *buf,
+CARES_EXTERN unsigned char *ares_buf_append_start(ares_buf_t *buf,
                                                    size_t      *len);
 
 /*! Finish a dynamic append operation.  Called after
- *  ares__buf_append_start() once desired data is written.
+ *  ares_buf_append_start() once desired data is written.
  *
  *  \param[in] buf    Initialized buffer object.
  *  \param[in] len    Length of data written.  May be zero to terminate
  *                    operation. Must not be greater than returned from
- *                    ares__buf_append_start().
+ *                    ares_buf_append_start().
  */
-CARES_EXTERN void ares__buf_append_finish(ares__buf_t *buf, size_t len);
+CARES_EXTERN void ares_buf_append_finish(ares_buf_t *buf, size_t len);
 
 /*! Write the data provided to the buffer in a hexdump format.
  *
@@ -190,11 +190,11 @@ CARES_EXTERN void ares__buf_append_finish(ares__buf_t *buf, size_t len);
  *  \param[in] len      Length of data to hexdump
  *  \return ARES_SUCCESS on success.
  */
-CARES_EXTERN ares_status_t  ares__buf_hexdump(ares__buf_t         *buf,
+CARES_EXTERN ares_status_t  ares_buf_hexdump(ares_buf_t         *buf,
                                               const unsigned char *data,
                                               size_t               len);
 
-/*! Clean up ares__buf_t and return allocated pointer to unprocessed data.  It
+/*! Clean up ares_buf_t and return allocated pointer to unprocessed data.  It
  *  is the responsibility of the  caller to ares_free() the returned buffer.
  *  The passed in buf parameter is invalidated by this call.
  *
@@ -202,9 +202,9 @@ CARES_EXTERN ares_status_t  ares__buf_hexdump(ares__buf_t         *buf,
  * \param[out] len    Length of data returned
  * \return pointer to unprocessed data (may be zero length) or NULL on error.
  */
-CARES_EXTERN unsigned char *ares__buf_finish_bin(ares__buf_t *buf, size_t *len);
+CARES_EXTERN unsigned char *ares_buf_finish_bin(ares_buf_t *buf, size_t *len);
 
-/*! Clean up ares__buf_t and return allocated pointer to unprocessed data and
+/*! Clean up ares_buf_t and return allocated pointer to unprocessed data and
  *  return it as a string (null terminated).  It is the responsibility of the
  *  caller to ares_free() the returned buffer. The passed in buf parameter is
  *  invalidated by this call.
@@ -218,7 +218,7 @@ CARES_EXTERN unsigned char *ares__buf_finish_bin(ares__buf_t *buf, size_t *len);
  * \param[out] len    Optional. Length of data returned, or NULL if not needed.
  * \return pointer to unprocessed data or NULL on error.
  */
-CARES_EXTERN char          *ares__buf_finish_str(ares__buf_t *buf, size_t *len);
+CARES_EXTERN char          *ares_buf_finish_str(ares_buf_t *buf, size_t *len);
 
 /*! Tag a position to save in the buffer in case parsing needs to rollback,
  *  such as if insufficient data is available, but more data may be added in
@@ -227,14 +227,14 @@ CARES_EXTERN char          *ares__buf_finish_str(ares__buf_t *buf, size_t *len);
  *
  *  \param[in] buf Initialized buffer object
  */
-CARES_EXTERN void           ares__buf_tag(ares__buf_t *buf);
+CARES_EXTERN void           ares_buf_tag(ares_buf_t *buf);
 
 /*! Rollback to a tagged position.  Will automatically clear the tag.
  *
  *  \param[in] buf Initialized buffer object
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t  ares__buf_tag_rollback(ares__buf_t *buf);
+CARES_EXTERN ares_status_t  ares_buf_tag_rollback(ares_buf_t *buf);
 
 /*! Clear the tagged position without rolling back.  You should do this any
  *  time a tag is no longer needed as future append operations can reclaim
@@ -243,18 +243,18 @@ CARES_EXTERN ares_status_t  ares__buf_tag_rollback(ares__buf_t *buf);
  *  \param[in] buf Initialized buffer object
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t  ares__buf_tag_clear(ares__buf_t *buf);
+CARES_EXTERN ares_status_t  ares_buf_tag_clear(ares_buf_t *buf);
 
 /*! Fetch the buffer and length of data starting from the tagged position up
  *  to the _current_ position.  It will not unset the tagged position.  The
- *  data may be invalidated by any future ares__buf_*() calls.
+ *  data may be invalidated by any future ares_buf_*() calls.
  *
  *  \param[in]  buf    Initialized buffer object
  *  \param[out] len    Length between tag and current offset in buffer
  *  \return NULL on failure (such as no tag), otherwise pointer to start of
  *          buffer
  */
-CARES_EXTERN const unsigned char *ares__buf_tag_fetch(const ares__buf_t *buf,
+CARES_EXTERN const unsigned char *ares_buf_tag_fetch(const ares_buf_t *buf,
                                                       size_t            *len);
 
 /*! Get the length of the current tag offset to the current position.
@@ -262,7 +262,7 @@ CARES_EXTERN const unsigned char *ares__buf_tag_fetch(const ares__buf_t *buf,
  *  \param[in]  buf    Initialized buffer object
  *  \return length
  */
-CARES_EXTERN size_t               ares__buf_tag_length(const ares__buf_t *buf);
+CARES_EXTERN size_t               ares_buf_tag_length(const ares_buf_t *buf);
 
 /*! Fetch the bytes starting from the tagged position up to the _current_
  *  position using the provided buffer.  It will not unset the tagged position.
@@ -273,7 +273,7 @@ CARES_EXTERN size_t               ares__buf_tag_length(const ares__buf_t *buf);
  *                        buffer.
  *  \return ARES_SUCCESS if fetched, ARES_EFORMERR if insufficient buffer size
  */
-CARES_EXTERN ares_status_t ares__buf_tag_fetch_bytes(const ares__buf_t *buf,
+CARES_EXTERN ares_status_t ares_buf_tag_fetch_bytes(const ares_buf_t *buf,
                                                      unsigned char     *bytes,
                                                      size_t            *len);
 
@@ -289,7 +289,7 @@ CARES_EXTERN ares_status_t ares__buf_tag_fetch_bytes(const ares__buf_t *buf,
  *  \return ARES_SUCCESS if fetched, ARES_EFORMERR if insufficient buffer size,
  *          ARES_EBADSTR if not printable ASCII
  */
-CARES_EXTERN ares_status_t ares__buf_tag_fetch_string(const ares__buf_t *buf,
+CARES_EXTERN ares_status_t ares_buf_tag_fetch_string(const ares_buf_t *buf,
                                                       char *str, size_t len);
 
 /*! Consume the given number of bytes without reading them.
@@ -298,7 +298,7 @@ CARES_EXTERN ares_status_t ares__buf_tag_fetch_string(const ares__buf_t *buf,
  *  \param[in] len    Length to consume
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t ares__buf_consume(ares__buf_t *buf, size_t len);
+CARES_EXTERN ares_status_t ares_buf_consume(ares_buf_t *buf, size_t len);
 
 /*! Fetch a 16bit Big Endian number from the buffer.
  *
@@ -306,7 +306,7 @@ CARES_EXTERN ares_status_t ares__buf_consume(ares__buf_t *buf, size_t len);
  *  \param[out] u16     Buffer to hold 16bit integer
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t ares__buf_fetch_be16(ares__buf_t    *buf,
+CARES_EXTERN ares_status_t ares_buf_fetch_be16(ares_buf_t    *buf,
                                                 unsigned short *u16);
 
 /*! Fetch a 32bit Big Endian number from the buffer.
@@ -315,7 +315,7 @@ CARES_EXTERN ares_status_t ares__buf_fetch_be16(ares__buf_t    *buf,
  *  \param[out] u32     Buffer to hold 32bit integer
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t ares__buf_fetch_be32(ares__buf_t  *buf,
+CARES_EXTERN ares_status_t ares_buf_fetch_be32(ares_buf_t  *buf,
                                                 unsigned int *u32);
 
 
@@ -326,7 +326,7 @@ CARES_EXTERN ares_status_t ares__buf_fetch_be32(ares__buf_t  *buf,
  *  \param[in]  len     Requested number of bytes (must be > 0)
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t ares__buf_fetch_bytes(ares__buf_t   *buf,
+CARES_EXTERN ares_status_t ares_buf_fetch_bytes(ares_buf_t   *buf,
                                                  unsigned char *bytes,
                                                  size_t         len);
 
@@ -342,7 +342,7 @@ CARES_EXTERN ares_status_t ares__buf_fetch_bytes(ares__buf_t   *buf,
  *  \param[out] bytes     Pointer passed by reference. Will be allocated.
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t ares__buf_fetch_bytes_dup(ares__buf_t    *buf,
+CARES_EXTERN ares_status_t ares_buf_fetch_bytes_dup(ares_buf_t    *buf,
                                                      size_t          len,
                                                      ares_bool_t     null_term,
                                                      unsigned char **bytes);
@@ -355,8 +355,8 @@ CARES_EXTERN ares_status_t ares__buf_fetch_bytes_dup(ares__buf_t    *buf,
  *  \param[in]  len     Requested number of bytes (must be > 0)
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t ares__buf_fetch_bytes_into_buf(ares__buf_t *buf,
-                                                          ares__buf_t *dest,
+CARES_EXTERN ares_status_t ares_buf_fetch_bytes_into_buf(ares_buf_t *buf,
+                                                          ares_buf_t *dest,
                                                           size_t       len);
 
 /*! Fetch the requested number of bytes and return a new buffer that must be
@@ -368,7 +368,7 @@ CARES_EXTERN ares_status_t ares__buf_fetch_bytes_into_buf(ares__buf_t *buf,
  *  \param[out] str     Pointer passed by reference. Will be allocated.
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t ares__buf_fetch_str_dup(ares__buf_t *buf, size_t len,
+CARES_EXTERN ares_status_t ares_buf_fetch_str_dup(ares_buf_t *buf, size_t len,
                                                    char **str);
 
 /*! Consume whitespace characters (0x09, 0x0B, 0x0C, 0x0D, 0x20, and optionally
@@ -379,7 +379,7 @@ CARES_EXTERN ares_status_t ares__buf_fetch_str_dup(ares__buf_t *buf, size_t len,
  *                                ARES_FALSE otherwise.
  *  \return number of whitespace characters consumed
  */
-CARES_EXTERN size_t        ares__buf_consume_whitespace(ares__buf_t *buf,
+CARES_EXTERN size_t        ares_buf_consume_whitespace(ares_buf_t *buf,
                                                         ares_bool_t  include_linefeed);
 
 
@@ -389,7 +389,7 @@ CARES_EXTERN size_t        ares__buf_consume_whitespace(ares__buf_t *buf,
  *  \param[in]  buf               Initialized buffer object
  *  \return number of characters consumed
  */
-CARES_EXTERN size_t        ares__buf_consume_nonwhitespace(ares__buf_t *buf);
+CARES_EXTERN size_t        ares_buf_consume_nonwhitespace(ares_buf_t *buf);
 
 
 /*! Consume until a character in the character set provided is reached.  Does
@@ -404,8 +404,8 @@ CARES_EXTERN size_t        ares__buf_consume_nonwhitespace(ares__buf_t *buf);
  *                                0 if not found.
  *  \return number of characters consumed
  */
-CARES_EXTERN size_t        ares__buf_consume_until_charset(
-         ares__buf_t *buf, const unsigned char *charset, size_t len,
+CARES_EXTERN size_t        ares_buf_consume_until_charset(
+         ares_buf_t *buf, const unsigned char *charset, size_t len,
          ares_bool_t require_charset);
 
 
@@ -416,7 +416,7 @@ CARES_EXTERN size_t        ares__buf_consume_until_charset(
  *  \param[in] len                length of character set
  *  \return number of characters consumed
  */
-CARES_EXTERN size_t ares__buf_consume_charset(ares__buf_t         *buf,
+CARES_EXTERN size_t ares_buf_consume_charset(ares_buf_t         *buf,
                                               const unsigned char *charset,
                                               size_t               len);
 
@@ -429,7 +429,7 @@ CARES_EXTERN size_t ares__buf_consume_charset(ares__buf_t         *buf,
  *                                ARES_FALSE otherwise.
  *  \return number of characters consumed
  */
-CARES_EXTERN size_t ares__buf_consume_line(ares__buf_t *buf,
+CARES_EXTERN size_t ares_buf_consume_line(ares_buf_t *buf,
                                            ares_bool_t  include_linefeed);
 
 typedef enum {
@@ -455,7 +455,7 @@ typedef enum {
   ARES_BUF_SPLIT_RTRIM = 1 << 5,
   /*! Trim leading and trailing whitespace from buffer */
   ARES_BUF_SPLIT_TRIM = (ARES_BUF_SPLIT_LTRIM | ARES_BUF_SPLIT_RTRIM)
-} ares__buf_split_t;
+} ares_buf_split_t;
 
 /*! Split the provided buffer into multiple sub-buffers stored in the variable
  *  pointed to by the linked list.  The sub buffers are const buffers pointing
@@ -473,14 +473,14 @@ typedef enum {
  *                                ignore the delimiter itself.
  *  \param[out] list              Result. Depending on flags, this may be a
  *                                valid list with no elements.  Use
- *                                ares__llist_destroy() to free the memory which
- *                                will also free the contained ares__buf_t
+ *                                ares_llist_destroy() to free the memory which
+ *                                will also free the contained ares_buf_t
  *                                objects.
  *  \return ARES_SUCCESS on success, or error like ARES_ENOMEM.
  */
-CARES_EXTERN ares_status_t ares__buf_split(
-  ares__buf_t *buf, const unsigned char *delims, size_t delims_len,
-  ares__buf_split_t flags, size_t max_sections, ares__llist_t **list);
+CARES_EXTERN ares_status_t ares_buf_split(
+  ares_buf_t *buf, const unsigned char *delims, size_t delims_len,
+  ares_buf_split_t flags, size_t max_sections, ares_llist_t **list);
 
 /*! Split the provided buffer into a C array of C strings.
  *
@@ -499,9 +499,9 @@ CARES_EXTERN ares_status_t ares__buf_split(
  *  \param[out] nstrs             Number of elements in the array.
  *  \return ARES_SUCCESS on success, or error like ARES_ENOMEM.
  */
-CARES_EXTERN ares_status_t ares__buf_split_str(
-  ares__buf_t *buf, const unsigned char *delims, size_t delims_len,
-  ares__buf_split_t flags, size_t max_sections, char ***strs, size_t *nstrs);
+CARES_EXTERN ares_status_t ares_buf_split_str(
+  ares_buf_t *buf, const unsigned char *delims, size_t delims_len,
+  ares_buf_split_t flags, size_t max_sections, char ***strs, size_t *nstrs);
 
 /*! Check the unprocessed buffer to see if it begins with the sequence of
  *  characters provided.
@@ -511,7 +511,7 @@ CARES_EXTERN ares_status_t ares__buf_split_str(
  *  \param[in] data_len     Length of data to compare.
  *  \return ARES_TRUE on match, ARES_FALSE otherwise.
  */
-CARES_EXTERN ares_bool_t          ares__buf_begins_with(const ares__buf_t   *buf,
+CARES_EXTERN ares_bool_t          ares_buf_begins_with(const ares_buf_t   *buf,
                                                         const unsigned char *data,
                                                         size_t               data_len);
 
@@ -521,17 +521,17 @@ CARES_EXTERN ares_bool_t          ares__buf_begins_with(const ares__buf_t   *buf
  *  \param[in] buf Initialized buffer object
  *  \return length remaining
  */
-CARES_EXTERN size_t               ares__buf_len(const ares__buf_t *buf);
+CARES_EXTERN size_t               ares_buf_len(const ares_buf_t *buf);
 
 /*! Retrieve a pointer to the currently unprocessed data.  Generally this isn't
  *  recommended to be used in practice.  The returned pointer may be invalidated
- *  by any future ares__buf_*() calls.
+ *  by any future ares_buf_*() calls.
  *
  *  \param[in]  buf    Initialized buffer object
  *  \param[out] len    Length of available data
  *  \return Pointer to buffer of unprocessed data
  */
-CARES_EXTERN const unsigned char *ares__buf_peek(const ares__buf_t *buf,
+CARES_EXTERN const unsigned char *ares_buf_peek(const ares_buf_t *buf,
                                                  size_t            *len);
 
 
@@ -546,46 +546,46 @@ CARES_EXTERN const unsigned char *ares__buf_peek(const ares__buf_t *buf,
  *
  *  It may be useful to call in order to ensure the current message being
  *  processed is in the beginning of the buffer if there is an intent to use
- *  ares__buf_set_position() and ares__buf_get_position() as may be necessary
+ *  ares_buf_set_position() and ares_buf_get_position() as may be necessary
  *  when processing DNS compressed names.
  *
  *  If there is an active tag, it will NOT clear the tag, it will use the tag
  *  as the start of the unprocessed data rather than the current offset.  If
- *  a prior tag is no longer needed, may be wise to call ares__buf_tag_clear().
+ *  a prior tag is no longer needed, may be wise to call ares_buf_tag_clear().
  *
  *  \param[in]  buf    Initialized buffer object
  */
-CARES_EXTERN void                 ares__buf_reclaim(ares__buf_t *buf);
+CARES_EXTERN void                 ares_buf_reclaim(ares_buf_t *buf);
 
 /*! Set the current offset within the internal buffer.
  *
- *  Typically this should not be used, if possible, use the ares__buf_tag*()
+ *  Typically this should not be used, if possible, use the ares_buf_tag*()
  *  operations instead.
  *
  *  One exception is DNS name compression which may backwards reference to
  *  an index in the message.  It may be necessary in such a case to call
- *  ares__buf_reclaim() if using a dynamic (non-const) buffer before processing
+ *  ares_buf_reclaim() if using a dynamic (non-const) buffer before processing
  *  such a message.
  *
  *  \param[in] buf  Initialized buffer object
  *  \param[in] idx  Index to set position
  *  \return ARES_SUCCESS if valid index
  */
-CARES_EXTERN ares_status_t ares__buf_set_position(ares__buf_t *buf, size_t idx);
+CARES_EXTERN ares_status_t ares_buf_set_position(ares_buf_t *buf, size_t idx);
 
 /*! Get the current offset within the internal buffer.
  *
- *  Typically this should not be used, if possible, use the ares__buf_tag*()
+ *  Typically this should not be used, if possible, use the ares_buf_tag*()
  *  operations instead.
  *
  *  This can be used to get the current position, useful for saving if a
- *  jump via ares__buf_set_position() is performed and need to restore the
+ *  jump via ares_buf_set_position() is performed and need to restore the
  *  current position for future operations.
  *
  *  \param[in] buf Initialized buffer object
  *  \return index of current position
  */
-CARES_EXTERN size_t        ares__buf_get_position(const ares__buf_t *buf);
+CARES_EXTERN size_t        ares_buf_get_position(const ares_buf_t *buf);
 
 /*! Parse a character-string as defined in RFC1035, as a null-terminated
  *  string.
@@ -599,7 +599,7 @@ CARES_EXTERN size_t        ares__buf_get_position(const ares__buf_t *buf);
  *                             ares_free()'d by the caller.
  *  \return ARES_SUCCESS on success
  */
-CARES_EXTERN ares_status_t ares__buf_parse_dns_str(ares__buf_t *buf,
+CARES_EXTERN ares_status_t ares_buf_parse_dns_str(ares_buf_t *buf,
                                                    size_t       remaining_len,
                                                    char       **name);
 
@@ -617,7 +617,7 @@ CARES_EXTERN ares_status_t ares__buf_parse_dns_str(ares__buf_t *buf,
  *  \param[out] bin_len        Length of returned string.
  *  \return ARES_SUCCESS on success
  */
-CARES_EXTERN ares_status_t ares__buf_parse_dns_binstr(ares__buf_t *buf,
+CARES_EXTERN ares_status_t ares_buf_parse_dns_binstr(ares_buf_t *buf,
                                                       size_t remaining_len,
                                                       unsigned char **bin,
                                                       size_t         *bin_len);
@@ -631,8 +631,8 @@ CARES_EXTERN ares_status_t ares__buf_parse_dns_binstr(ares__buf_t *buf,
  *  \return ARES_ENOTFOUND if file not found, ARES_EFILE if issues reading
  *          file, ARES_ENOMEM if out of memory, ARES_SUCCESS on success.
  */
-CARES_EXTERN ares_status_t ares__buf_load_file(const char  *filename,
-                                               ares__buf_t *buf);
+CARES_EXTERN ares_status_t ares_buf_load_file(const char  *filename,
+                                               ares_buf_t *buf);
 
 /*! @} */
 

--- a/src/lib/include/ares_buf.h
+++ b/src/lib/include/ares_buf.h
@@ -48,13 +48,13 @@
 struct ares_buf;
 
 /*! Opaque data type for generic hash table implementation */
-typedef struct ares_buf    ares_buf_t;
+typedef struct ares_buf     ares_buf_t;
 
 /*! Create a new buffer object that dynamically allocates buffers for data.
  *
  *  \return initialized buffer object or NULL if out of memory.
  */
-CARES_EXTERN ares_buf_t   *ares_buf_create(void);
+CARES_EXTERN ares_buf_t    *ares_buf_create(void);
 
 /*! Create a new buffer object that uses a user-provided data pointer.  The
  *  data provided will not be manipulated, and cannot be appended to.  This
@@ -65,8 +65,8 @@ CARES_EXTERN ares_buf_t   *ares_buf_create(void);
  *
  *  \return initialized buffer object or NULL if out of memory or misuse.
  */
-CARES_EXTERN ares_buf_t   *ares_buf_create_const(const unsigned char *data,
-                                                   size_t               data_len);
+CARES_EXTERN ares_buf_t    *ares_buf_create_const(const unsigned char *data,
+                                                  size_t               data_len);
 
 
 /*! Destroy an initialized buffer object.
@@ -83,9 +83,9 @@ CARES_EXTERN void           ares_buf_destroy(ares_buf_t *buf);
  *  \param[in] data_len Length of data to copy to buffer object.
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t  ares_buf_append(ares_buf_t         *buf,
-                                             const unsigned char *data,
-                                             size_t               data_len);
+CARES_EXTERN ares_status_t  ares_buf_append(ares_buf_t          *buf,
+                                            const unsigned char *data,
+                                            size_t               data_len);
 
 /*! Append a single byte to the dynamic buffer object
  *
@@ -93,8 +93,8 @@ CARES_EXTERN ares_status_t  ares_buf_append(ares_buf_t         *buf,
  *  \param[in] b        Single byte to append to buffer object.
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t  ares_buf_append_byte(ares_buf_t  *buf,
-                                                  unsigned char b);
+CARES_EXTERN ares_status_t  ares_buf_append_byte(ares_buf_t   *buf,
+                                                 unsigned char b);
 
 /*! Append a null-terminated string to the dynamic buffer object
  *
@@ -103,7 +103,7 @@ CARES_EXTERN ares_status_t  ares_buf_append_byte(ares_buf_t  *buf,
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
 CARES_EXTERN ares_status_t  ares_buf_append_str(ares_buf_t *buf,
-                                                 const char  *str);
+                                                const char *str);
 
 /*! Append a 16bit Big Endian number to the buffer.
  *
@@ -111,8 +111,8 @@ CARES_EXTERN ares_status_t  ares_buf_append_str(ares_buf_t *buf,
  *  \param[out] u16     16bit integer
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t  ares_buf_append_be16(ares_buf_t   *buf,
-                                                  unsigned short u16);
+CARES_EXTERN ares_status_t  ares_buf_append_be16(ares_buf_t    *buf,
+                                                 unsigned short u16);
 
 /*! Append a 32bit Big Endian number to the buffer.
  *
@@ -120,8 +120,8 @@ CARES_EXTERN ares_status_t  ares_buf_append_be16(ares_buf_t   *buf,
  *  \param[out] u32     32bit integer
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t  ares_buf_append_be32(ares_buf_t *buf,
-                                                  unsigned int u32);
+CARES_EXTERN ares_status_t  ares_buf_append_be32(ares_buf_t  *buf,
+                                                 unsigned int u32);
 
 /*! Append a number in ASCII decimal form.
  *
@@ -130,8 +130,8 @@ CARES_EXTERN ares_status_t  ares_buf_append_be32(ares_buf_t *buf,
  *  \param[in] len  Length to output, use 0 for no padding
  *  \return ARES_SUCCESS on success
  */
-CARES_EXTERN ares_status_t  ares_buf_append_num_dec(ares_buf_t *buf,
-                                                     size_t num, size_t len);
+CARES_EXTERN ares_status_t  ares_buf_append_num_dec(ares_buf_t *buf, size_t num,
+                                                    size_t len);
 
 /*! Append a number in ASCII hexadecimal form.
  *
@@ -140,8 +140,8 @@ CARES_EXTERN ares_status_t  ares_buf_append_num_dec(ares_buf_t *buf,
  *  \param[in] len  Length to output, use 0 for no padding
  *  \return ARES_SUCCESS on success
  */
-CARES_EXTERN ares_status_t  ares_buf_append_num_hex(ares_buf_t *buf,
-                                                     size_t num, size_t len);
+CARES_EXTERN ares_status_t  ares_buf_append_num_hex(ares_buf_t *buf, size_t num,
+                                                    size_t len);
 
 /*! Sets the current buffer length.  This *may* be used if there is a need to
  *  override a prior position in the buffer, such as if there is a length
@@ -170,8 +170,7 @@ CARES_EXTERN ares_status_t  ares_buf_set_length(ares_buf_t *buf, size_t len);
  *                         returned.
  *  \return Pointer to writable buffer or NULL on failure (usage, out of mem)
  */
-CARES_EXTERN unsigned char *ares_buf_append_start(ares_buf_t *buf,
-                                                   size_t      *len);
+CARES_EXTERN unsigned char *ares_buf_append_start(ares_buf_t *buf, size_t *len);
 
 /*! Finish a dynamic append operation.  Called after
  *  ares_buf_append_start() once desired data is written.
@@ -181,7 +180,7 @@ CARES_EXTERN unsigned char *ares_buf_append_start(ares_buf_t *buf,
  *                    operation. Must not be greater than returned from
  *                    ares_buf_append_start().
  */
-CARES_EXTERN void ares_buf_append_finish(ares_buf_t *buf, size_t len);
+CARES_EXTERN void           ares_buf_append_finish(ares_buf_t *buf, size_t len);
 
 /*! Write the data provided to the buffer in a hexdump format.
  *
@@ -190,9 +189,9 @@ CARES_EXTERN void ares_buf_append_finish(ares_buf_t *buf, size_t len);
  *  \param[in] len      Length of data to hexdump
  *  \return ARES_SUCCESS on success.
  */
-CARES_EXTERN ares_status_t  ares_buf_hexdump(ares_buf_t         *buf,
-                                              const unsigned char *data,
-                                              size_t               len);
+CARES_EXTERN ares_status_t  ares_buf_hexdump(ares_buf_t          *buf,
+                                             const unsigned char *data,
+                                             size_t               len);
 
 /*! Clean up ares_buf_t and return allocated pointer to unprocessed data.  It
  *  is the responsibility of the  caller to ares_free() the returned buffer.
@@ -255,7 +254,7 @@ CARES_EXTERN ares_status_t  ares_buf_tag_clear(ares_buf_t *buf);
  *          buffer
  */
 CARES_EXTERN const unsigned char *ares_buf_tag_fetch(const ares_buf_t *buf,
-                                                      size_t            *len);
+                                                     size_t           *len);
 
 /*! Get the length of the current tag offset to the current position.
  *
@@ -274,8 +273,8 @@ CARES_EXTERN size_t               ares_buf_tag_length(const ares_buf_t *buf);
  *  \return ARES_SUCCESS if fetched, ARES_EFORMERR if insufficient buffer size
  */
 CARES_EXTERN ares_status_t ares_buf_tag_fetch_bytes(const ares_buf_t *buf,
-                                                     unsigned char     *bytes,
-                                                     size_t            *len);
+                                                    unsigned char    *bytes,
+                                                    size_t           *len);
 
 /*! Fetch the bytes starting from the tagged position up to the _current_
  *  position as a NULL-terminated string using the provided buffer.  The data
@@ -290,7 +289,7 @@ CARES_EXTERN ares_status_t ares_buf_tag_fetch_bytes(const ares_buf_t *buf,
  *          ARES_EBADSTR if not printable ASCII
  */
 CARES_EXTERN ares_status_t ares_buf_tag_fetch_string(const ares_buf_t *buf,
-                                                      char *str, size_t len);
+                                                     char *str, size_t len);
 
 /*! Consume the given number of bytes without reading them.
  *
@@ -306,8 +305,8 @@ CARES_EXTERN ares_status_t ares_buf_consume(ares_buf_t *buf, size_t len);
  *  \param[out] u16     Buffer to hold 16bit integer
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t ares_buf_fetch_be16(ares_buf_t    *buf,
-                                                unsigned short *u16);
+CARES_EXTERN ares_status_t ares_buf_fetch_be16(ares_buf_t     *buf,
+                                               unsigned short *u16);
 
 /*! Fetch a 32bit Big Endian number from the buffer.
  *
@@ -315,8 +314,8 @@ CARES_EXTERN ares_status_t ares_buf_fetch_be16(ares_buf_t    *buf,
  *  \param[out] u32     Buffer to hold 32bit integer
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t ares_buf_fetch_be32(ares_buf_t  *buf,
-                                                unsigned int *u32);
+CARES_EXTERN ares_status_t ares_buf_fetch_be32(ares_buf_t   *buf,
+                                               unsigned int *u32);
 
 
 /*! Fetch the requested number of bytes into the provided buffer
@@ -326,9 +325,9 @@ CARES_EXTERN ares_status_t ares_buf_fetch_be32(ares_buf_t  *buf,
  *  \param[in]  len     Requested number of bytes (must be > 0)
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t ares_buf_fetch_bytes(ares_buf_t   *buf,
-                                                 unsigned char *bytes,
-                                                 size_t         len);
+CARES_EXTERN ares_status_t ares_buf_fetch_bytes(ares_buf_t    *buf,
+                                                unsigned char *bytes,
+                                                size_t         len);
 
 
 /*! Fetch the requested number of bytes and return a new buffer that must be
@@ -342,10 +341,9 @@ CARES_EXTERN ares_status_t ares_buf_fetch_bytes(ares_buf_t   *buf,
  *  \param[out] bytes     Pointer passed by reference. Will be allocated.
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
-CARES_EXTERN ares_status_t ares_buf_fetch_bytes_dup(ares_buf_t    *buf,
-                                                     size_t          len,
-                                                     ares_bool_t     null_term,
-                                                     unsigned char **bytes);
+CARES_EXTERN ares_status_t ares_buf_fetch_bytes_dup(ares_buf_t *buf, size_t len,
+                                                    ares_bool_t     null_term,
+                                                    unsigned char **bytes);
 
 /*! Fetch the requested number of bytes and place them into the provided
  *  dest buffer object.
@@ -356,8 +354,8 @@ CARES_EXTERN ares_status_t ares_buf_fetch_bytes_dup(ares_buf_t    *buf,
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
 CARES_EXTERN ares_status_t ares_buf_fetch_bytes_into_buf(ares_buf_t *buf,
-                                                          ares_buf_t *dest,
-                                                          size_t       len);
+                                                         ares_buf_t *dest,
+                                                         size_t      len);
 
 /*! Fetch the requested number of bytes and return a new buffer that must be
  *  ares_free()'d by the caller.  The returned buffer is a null terminated
@@ -369,7 +367,7 @@ CARES_EXTERN ares_status_t ares_buf_fetch_bytes_into_buf(ares_buf_t *buf,
  *  \return ARES_SUCCESS or one of the c-ares error codes
  */
 CARES_EXTERN ares_status_t ares_buf_fetch_str_dup(ares_buf_t *buf, size_t len,
-                                                   char **str);
+                                                  char **str);
 
 /*! Consume whitespace characters (0x09, 0x0B, 0x0C, 0x0D, 0x20, and optionally
  *  0x0A).
@@ -380,7 +378,7 @@ CARES_EXTERN ares_status_t ares_buf_fetch_str_dup(ares_buf_t *buf, size_t len,
  *  \return number of whitespace characters consumed
  */
 CARES_EXTERN size_t        ares_buf_consume_whitespace(ares_buf_t *buf,
-                                                        ares_bool_t  include_linefeed);
+                                                       ares_bool_t include_linefeed);
 
 
 /*! Consume any non-whitespace character (anything other than 0x09, 0x0B, 0x0C,
@@ -404,9 +402,10 @@ CARES_EXTERN size_t        ares_buf_consume_nonwhitespace(ares_buf_t *buf);
  *                                0 if not found.
  *  \return number of characters consumed
  */
-CARES_EXTERN size_t        ares_buf_consume_until_charset(
-         ares_buf_t *buf, const unsigned char *charset, size_t len,
-         ares_bool_t require_charset);
+CARES_EXTERN size_t        ares_buf_consume_until_charset(ares_buf_t          *buf,
+                                                          const unsigned char *charset,
+                                                          size_t               len,
+                                                          ares_bool_t require_charset);
 
 
 /*! Consume while the characters match the characters in the provided set.
@@ -416,9 +415,9 @@ CARES_EXTERN size_t        ares_buf_consume_until_charset(
  *  \param[in] len                length of character set
  *  \return number of characters consumed
  */
-CARES_EXTERN size_t ares_buf_consume_charset(ares_buf_t         *buf,
-                                              const unsigned char *charset,
-                                              size_t               len);
+CARES_EXTERN size_t        ares_buf_consume_charset(ares_buf_t          *buf,
+                                                    const unsigned char *charset,
+                                                    size_t               len);
 
 
 /*! Consume from the current position until the end of the line, and optionally
@@ -429,8 +428,8 @@ CARES_EXTERN size_t ares_buf_consume_charset(ares_buf_t         *buf,
  *                                ARES_FALSE otherwise.
  *  \return number of characters consumed
  */
-CARES_EXTERN size_t ares_buf_consume_line(ares_buf_t *buf,
-                                           ares_bool_t  include_linefeed);
+CARES_EXTERN size_t        ares_buf_consume_line(ares_buf_t *buf,
+                                                 ares_bool_t include_linefeed);
 
 typedef enum {
   /*! No flags */
@@ -511,9 +510,9 @@ CARES_EXTERN ares_status_t ares_buf_split_str(
  *  \param[in] data_len     Length of data to compare.
  *  \return ARES_TRUE on match, ARES_FALSE otherwise.
  */
-CARES_EXTERN ares_bool_t          ares_buf_begins_with(const ares_buf_t   *buf,
-                                                        const unsigned char *data,
-                                                        size_t               data_len);
+CARES_EXTERN ares_bool_t          ares_buf_begins_with(const ares_buf_t    *buf,
+                                                       const unsigned char *data,
+                                                       size_t               data_len);
 
 
 /*! Size of unprocessed remaining data length
@@ -532,7 +531,7 @@ CARES_EXTERN size_t               ares_buf_len(const ares_buf_t *buf);
  *  \return Pointer to buffer of unprocessed data
  */
 CARES_EXTERN const unsigned char *ares_buf_peek(const ares_buf_t *buf,
-                                                 size_t            *len);
+                                                size_t           *len);
 
 
 /*! Wipe any processed data from the beginning of the buffer.  This will
@@ -600,8 +599,8 @@ CARES_EXTERN size_t        ares_buf_get_position(const ares_buf_t *buf);
  *  \return ARES_SUCCESS on success
  */
 CARES_EXTERN ares_status_t ares_buf_parse_dns_str(ares_buf_t *buf,
-                                                   size_t       remaining_len,
-                                                   char       **name);
+                                                  size_t      remaining_len,
+                                                  char      **name);
 
 /*! Parse a character-string as defined in RFC1035, as binary, however for
  *  convenience this does guarantee a NULL terminator (that is not included
@@ -618,9 +617,9 @@ CARES_EXTERN ares_status_t ares_buf_parse_dns_str(ares_buf_t *buf,
  *  \return ARES_SUCCESS on success
  */
 CARES_EXTERN ares_status_t ares_buf_parse_dns_binstr(ares_buf_t *buf,
-                                                      size_t remaining_len,
-                                                      unsigned char **bin,
-                                                      size_t         *bin_len);
+                                                     size_t      remaining_len,
+                                                     unsigned char **bin,
+                                                     size_t         *bin_len);
 
 /*! Load data from specified file path into provided buffer.  The entire file
  *  is loaded into memory.
@@ -631,8 +630,8 @@ CARES_EXTERN ares_status_t ares_buf_parse_dns_binstr(ares_buf_t *buf,
  *  \return ARES_ENOTFOUND if file not found, ARES_EFILE if issues reading
  *          file, ARES_ENOMEM if out of memory, ARES_SUCCESS on success.
  */
-CARES_EXTERN ares_status_t ares_buf_load_file(const char  *filename,
-                                               ares_buf_t *buf);
+CARES_EXTERN ares_status_t ares_buf_load_file(const char *filename,
+                                              ares_buf_t *buf);
 
 /*! @} */
 

--- a/src/lib/include/ares_htable_asvp.h
+++ b/src/lib/include/ares_htable_asvp.h
@@ -23,14 +23,15 @@
  *
  * SPDX-License-Identifier: MIT
  */
-#ifndef __ARES__HTABLE_STVP_H
-#define __ARES__HTABLE_STVP_H
+#ifndef __ARES__HTABLE_ASVP_H
+#define __ARES__HTABLE_ASVP_H
 
-/*! \addtogroup ares__htable_szvp HashTable with size_t Key and void pointer
- * Value
+/*! \addtogroup ares_htable_asvp HashTable with ares_socket_t Key and
+ *                                void pointer Value
  *
- * This data structure wraps the base ares__htable data structure in order to
- * split the key and value data types as size_t and void pointer, respectively.
+ * This data structure wraps the base ares_htable data structure in order to
+ * split the key and value data types as ares_socket_t and void pointer,
+ * respectively.
  *
  * Average time complexity:
  *  - Insert: O(1)
@@ -40,22 +41,23 @@
  * @{
  */
 
-struct ares__htable_szvp;
+struct ares_htable_asvp;
 
-/*! Opaque data type for size_t key, void pointer hash table implementation */
-typedef struct ares__htable_szvp ares__htable_szvp_t;
+/*! Opaque data type for ares_socket_t key, void pointer hash table
+ *  implementation */
+typedef struct ares_htable_asvp ares_htable_asvp_t;
 
 /*! Callback to free value stored in hashtable
  *
  *  \param[in] val  user-supplied value
  */
-typedef void (*ares__htable_szvp_val_free_t)(void *val);
+typedef void (*ares_htable_asvp_val_free_t)(void *val);
 
 /*! Destroy hashtable
  *
  *  \param[in] htable  Initialized hashtable
  */
-CARES_EXTERN void ares__htable_szvp_destroy(ares__htable_szvp_t *htable);
+CARES_EXTERN void ares_htable_asvp_destroy(ares_htable_asvp_t *htable);
 
 /*! Create size_t key, void pointer value hash table
  *
@@ -63,18 +65,28 @@ CARES_EXTERN void ares__htable_szvp_destroy(ares__htable_szvp_t *htable);
  *                       NULL it is expected the caller will clean up any user
  *                       supplied values.
  */
-CARES_EXTERN ares__htable_szvp_t *
-  ares__htable_szvp_create(ares__htable_szvp_val_free_t val_free);
+CARES_EXTERN ares_htable_asvp_t *
+  ares_htable_asvp_create(ares_htable_asvp_val_free_t val_free);
+
+/*! Retrieve an array of keys from the hashtable.
+ *
+ *  \param[in]  htable   Initialized hashtable
+ *  \param[out] num      Count of returned keys
+ *  \return Array of keys in the hashtable. Must be free'd with ares_free().
+ */
+CARES_EXTERN ares_socket_t *
+  ares_htable_asvp_keys(const ares_htable_asvp_t *htable, size_t *num);
+
 
 /*! Insert key/value into hash table
  *
  *  \param[in] htable Initialized hash table
  *  \param[in] key    key to associate with value
  *  \param[in] val    value to store (takes ownership). May be NULL.
- *  \return ARES_TRUE on success, ARES_FALSE on failure or out of memory
+ *  \return ARES_TRUE on success, ARES_FALSE on out of memory or misuse
  */
-CARES_EXTERN ares_bool_t ares__htable_szvp_insert(ares__htable_szvp_t *htable,
-                                                  size_t key, void *val);
+CARES_EXTERN ares_bool_t ares_htable_asvp_insert(ares_htable_asvp_t *htable,
+                                                  ares_socket_t key, void *val);
 
 /*! Retrieve value from hashtable based on key
  *
@@ -83,11 +95,11 @@ CARES_EXTERN ares_bool_t ares__htable_szvp_insert(ares__htable_szvp_t *htable,
  *  \param[out] val     Optional.  Pointer to store value.
  *  \return ARES_TRUE on success, ARES_FALSE on failure
  */
-CARES_EXTERN ares_bool_t ares__htable_szvp_get(
-  const ares__htable_szvp_t *htable, size_t key, void **val);
+CARES_EXTERN ares_bool_t ares_htable_asvp_get(
+  const ares_htable_asvp_t *htable, ares_socket_t key, void **val);
 
 /*! Retrieve value from hashtable directly as return value.  Caveat to this
- *  function over ares__htable_szvp_get() is that if a NULL value is stored
+ *  function over ares_htable_asvp_get() is that if a NULL value is stored
  *  you cannot determine if the key is not found or the value is NULL.
  *
  *  \param[in] htable  Initialized hash table
@@ -95,16 +107,17 @@ CARES_EXTERN ares_bool_t ares__htable_szvp_get(
  *  \return value associated with key in hashtable or NULL
  */
 CARES_EXTERN void *
-  ares__htable_szvp_get_direct(const ares__htable_szvp_t *htable, size_t key);
+  ares_htable_asvp_get_direct(const ares_htable_asvp_t *htable,
+                               ares_socket_t              key);
 
 /*! Remove a value from the hashtable by key
  *
  *  \param[in] htable  Initialized hash table
  *  \param[in] key     key to use to search
- *  \return ARES_TRUE if found, ARES_FALSE if not
+ *  \return ARES_TRUE if found, ARES_FALSE if not found
  */
-CARES_EXTERN ares_bool_t ares__htable_szvp_remove(ares__htable_szvp_t *htable,
-                                                  size_t               key);
+CARES_EXTERN ares_bool_t ares_htable_asvp_remove(ares_htable_asvp_t *htable,
+                                                  ares_socket_t        key);
 
 /*! Retrieve the number of keys stored in the hash table
  *
@@ -112,8 +125,8 @@ CARES_EXTERN ares_bool_t ares__htable_szvp_remove(ares__htable_szvp_t *htable,
  *  \return count
  */
 CARES_EXTERN size_t
-  ares__htable_szvp_num_keys(const ares__htable_szvp_t *htable);
+  ares_htable_asvp_num_keys(const ares_htable_asvp_t *htable);
 
 /*! @} */
 
-#endif /* __ARES__HTABLE_STVP_H */
+#endif /* __ARES__HTABLE_ASVP_H */

--- a/src/lib/include/ares_htable_asvp.h
+++ b/src/lib/include/ares_htable_asvp.h
@@ -86,7 +86,7 @@ CARES_EXTERN ares_socket_t *
  *  \return ARES_TRUE on success, ARES_FALSE on out of memory or misuse
  */
 CARES_EXTERN ares_bool_t ares_htable_asvp_insert(ares_htable_asvp_t *htable,
-                                                  ares_socket_t key, void *val);
+                                                 ares_socket_t key, void *val);
 
 /*! Retrieve value from hashtable based on key
  *
@@ -95,8 +95,8 @@ CARES_EXTERN ares_bool_t ares_htable_asvp_insert(ares_htable_asvp_t *htable,
  *  \param[out] val     Optional.  Pointer to store value.
  *  \return ARES_TRUE on success, ARES_FALSE on failure
  */
-CARES_EXTERN ares_bool_t ares_htable_asvp_get(
-  const ares_htable_asvp_t *htable, ares_socket_t key, void **val);
+CARES_EXTERN ares_bool_t ares_htable_asvp_get(const ares_htable_asvp_t *htable,
+                                              ares_socket_t key, void **val);
 
 /*! Retrieve value from hashtable directly as return value.  Caveat to this
  *  function over ares_htable_asvp_get() is that if a NULL value is stored
@@ -106,9 +106,8 @@ CARES_EXTERN ares_bool_t ares_htable_asvp_get(
  *  \param[in] key     key to use to search
  *  \return value associated with key in hashtable or NULL
  */
-CARES_EXTERN void *
-  ares_htable_asvp_get_direct(const ares_htable_asvp_t *htable,
-                               ares_socket_t              key);
+CARES_EXTERN void *ares_htable_asvp_get_direct(const ares_htable_asvp_t *htable,
+                                               ares_socket_t             key);
 
 /*! Remove a value from the hashtable by key
  *
@@ -117,15 +116,14 @@ CARES_EXTERN void *
  *  \return ARES_TRUE if found, ARES_FALSE if not found
  */
 CARES_EXTERN ares_bool_t ares_htable_asvp_remove(ares_htable_asvp_t *htable,
-                                                  ares_socket_t        key);
+                                                 ares_socket_t       key);
 
 /*! Retrieve the number of keys stored in the hash table
  *
  *  \param[in] htable  Initialized hash table
  *  \return count
  */
-CARES_EXTERN size_t
-  ares_htable_asvp_num_keys(const ares_htable_asvp_t *htable);
+CARES_EXTERN size_t ares_htable_asvp_num_keys(const ares_htable_asvp_t *htable);
 
 /*! @} */
 

--- a/src/lib/include/ares_htable_strvp.h
+++ b/src/lib/include/ares_htable_strvp.h
@@ -26,10 +26,10 @@
 #ifndef __ARES__HTABLE_STRVP_H
 #define __ARES__HTABLE_STRVP_H
 
-/*! \addtogroup ares__htable_strvp HashTable with string Key and void pointer
+/*! \addtogroup ares_htable_strvp HashTable with string Key and void pointer
  * Value
  *
- * This data structure wraps the base ares__htable data structure in order to
+ * This data structure wraps the base ares_htable data structure in order to
  * split the key and value data types as string and void pointer, respectively.
  *
  * Average time complexity:
@@ -40,22 +40,22 @@
  * @{
  */
 
-struct ares__htable_strvp;
+struct ares_htable_strvp;
 
 /*! Opaque data type for size_t key, void pointer hash table implementation */
-typedef struct ares__htable_strvp ares__htable_strvp_t;
+typedef struct ares_htable_strvp ares_htable_strvp_t;
 
 /*! Callback to free value stored in hashtable
  *
  *  \param[in] val  user-supplied value
  */
-typedef void (*ares__htable_strvp_val_free_t)(void *val);
+typedef void (*ares_htable_strvp_val_free_t)(void *val);
 
 /*! Destroy hashtable
  *
  *  \param[in] htable  Initialized hashtable
  */
-CARES_EXTERN void ares__htable_strvp_destroy(ares__htable_strvp_t *htable);
+CARES_EXTERN void ares_htable_strvp_destroy(ares_htable_strvp_t *htable);
 
 /*! Create string, void pointer value hash table
  *
@@ -63,8 +63,8 @@ CARES_EXTERN void ares__htable_strvp_destroy(ares__htable_strvp_t *htable);
  *                       NULL it is expected the caller will clean up any user
  *                       supplied values.
  */
-CARES_EXTERN ares__htable_strvp_t *
-  ares__htable_strvp_create(ares__htable_strvp_val_free_t val_free);
+CARES_EXTERN ares_htable_strvp_t *
+  ares_htable_strvp_create(ares_htable_strvp_val_free_t val_free);
 
 /*! Insert key/value into hash table
  *
@@ -73,7 +73,7 @@ CARES_EXTERN ares__htable_strvp_t *
  *  \param[in] val    value to store (takes ownership). May be NULL.
  *  \return ARES_TRUE on success, ARES_FALSE on failure or out of memory
  */
-CARES_EXTERN ares_bool_t ares__htable_strvp_insert(ares__htable_strvp_t *htable,
+CARES_EXTERN ares_bool_t ares_htable_strvp_insert(ares_htable_strvp_t *htable,
                                                    const char *key, void *val);
 
 /*! Retrieve value from hashtable based on key
@@ -83,11 +83,11 @@ CARES_EXTERN ares_bool_t ares__htable_strvp_insert(ares__htable_strvp_t *htable,
  *  \param[out] val     Optional.  Pointer to store value.
  *  \return ARES_TRUE on success, ARES_FALSE on failure
  */
-CARES_EXTERN ares_bool_t ares__htable_strvp_get(
-  const ares__htable_strvp_t *htable, const char *key, void **val);
+CARES_EXTERN ares_bool_t ares_htable_strvp_get(
+  const ares_htable_strvp_t *htable, const char *key, void **val);
 
 /*! Retrieve value from hashtable directly as return value.  Caveat to this
- *  function over ares__htable_strvp_get() is that if a NULL value is stored
+ *  function over ares_htable_strvp_get() is that if a NULL value is stored
  *  you cannot determine if the key is not found or the value is NULL.
  *
  *  \param[in] htable  Initialized hash table
@@ -95,7 +95,7 @@ CARES_EXTERN ares_bool_t ares__htable_strvp_get(
  *  \return value associated with key in hashtable or NULL
  */
 CARES_EXTERN void *
-  ares__htable_strvp_get_direct(const ares__htable_strvp_t *htable,
+  ares_htable_strvp_get_direct(const ares_htable_strvp_t *htable,
                                 const char                 *key);
 
 /*! Remove a value from the hashtable by key
@@ -104,7 +104,7 @@ CARES_EXTERN void *
  *  \param[in] key     key to use to search
  *  \return ARES_TRUE if found, ARES_FALSE if not
  */
-CARES_EXTERN ares_bool_t ares__htable_strvp_remove(ares__htable_strvp_t *htable,
+CARES_EXTERN ares_bool_t ares_htable_strvp_remove(ares_htable_strvp_t *htable,
                                                    const char           *key);
 
 /*! Retrieve the number of keys stored in the hash table
@@ -113,7 +113,7 @@ CARES_EXTERN ares_bool_t ares__htable_strvp_remove(ares__htable_strvp_t *htable,
  *  \return count
  */
 CARES_EXTERN size_t
-  ares__htable_strvp_num_keys(const ares__htable_strvp_t *htable);
+  ares_htable_strvp_num_keys(const ares_htable_strvp_t *htable);
 
 /*! @} */
 

--- a/src/lib/include/ares_htable_strvp.h
+++ b/src/lib/include/ares_htable_strvp.h
@@ -74,7 +74,7 @@ CARES_EXTERN ares_htable_strvp_t *
  *  \return ARES_TRUE on success, ARES_FALSE on failure or out of memory
  */
 CARES_EXTERN ares_bool_t ares_htable_strvp_insert(ares_htable_strvp_t *htable,
-                                                   const char *key, void *val);
+                                                  const char *key, void *val);
 
 /*! Retrieve value from hashtable based on key
  *
@@ -96,7 +96,7 @@ CARES_EXTERN ares_bool_t ares_htable_strvp_get(
  */
 CARES_EXTERN void *
   ares_htable_strvp_get_direct(const ares_htable_strvp_t *htable,
-                                const char                 *key);
+                               const char                *key);
 
 /*! Remove a value from the hashtable by key
  *
@@ -105,7 +105,7 @@ CARES_EXTERN void *
  *  \return ARES_TRUE if found, ARES_FALSE if not
  */
 CARES_EXTERN ares_bool_t ares_htable_strvp_remove(ares_htable_strvp_t *htable,
-                                                   const char           *key);
+                                                  const char          *key);
 
 /*! Retrieve the number of keys stored in the hash table
  *

--- a/src/lib/include/ares_htable_szvp.h
+++ b/src/lib/include/ares_htable_szvp.h
@@ -23,15 +23,14 @@
  *
  * SPDX-License-Identifier: MIT
  */
-#ifndef __ARES__HTABLE_ASVP_H
-#define __ARES__HTABLE_ASVP_H
+#ifndef __ARES__HTABLE_STVP_H
+#define __ARES__HTABLE_STVP_H
 
-/*! \addtogroup ares__htable_asvp HashTable with ares_socket_t Key and
- *                                void pointer Value
+/*! \addtogroup ares_htable_szvp HashTable with size_t Key and void pointer
+ * Value
  *
- * This data structure wraps the base ares__htable data structure in order to
- * split the key and value data types as ares_socket_t and void pointer,
- * respectively.
+ * This data structure wraps the base ares_htable data structure in order to
+ * split the key and value data types as size_t and void pointer, respectively.
  *
  * Average time complexity:
  *  - Insert: O(1)
@@ -41,23 +40,22 @@
  * @{
  */
 
-struct ares__htable_asvp;
+struct ares_htable_szvp;
 
-/*! Opaque data type for ares_socket_t key, void pointer hash table
- *  implementation */
-typedef struct ares__htable_asvp ares__htable_asvp_t;
+/*! Opaque data type for size_t key, void pointer hash table implementation */
+typedef struct ares_htable_szvp ares_htable_szvp_t;
 
 /*! Callback to free value stored in hashtable
  *
  *  \param[in] val  user-supplied value
  */
-typedef void (*ares__htable_asvp_val_free_t)(void *val);
+typedef void (*ares_htable_szvp_val_free_t)(void *val);
 
 /*! Destroy hashtable
  *
  *  \param[in] htable  Initialized hashtable
  */
-CARES_EXTERN void ares__htable_asvp_destroy(ares__htable_asvp_t *htable);
+CARES_EXTERN void ares_htable_szvp_destroy(ares_htable_szvp_t *htable);
 
 /*! Create size_t key, void pointer value hash table
  *
@@ -65,28 +63,18 @@ CARES_EXTERN void ares__htable_asvp_destroy(ares__htable_asvp_t *htable);
  *                       NULL it is expected the caller will clean up any user
  *                       supplied values.
  */
-CARES_EXTERN ares__htable_asvp_t *
-  ares__htable_asvp_create(ares__htable_asvp_val_free_t val_free);
-
-/*! Retrieve an array of keys from the hashtable.
- *
- *  \param[in]  htable   Initialized hashtable
- *  \param[out] num      Count of returned keys
- *  \return Array of keys in the hashtable. Must be free'd with ares_free().
- */
-CARES_EXTERN ares_socket_t *
-  ares__htable_asvp_keys(const ares__htable_asvp_t *htable, size_t *num);
-
+CARES_EXTERN ares_htable_szvp_t *
+  ares_htable_szvp_create(ares_htable_szvp_val_free_t val_free);
 
 /*! Insert key/value into hash table
  *
  *  \param[in] htable Initialized hash table
  *  \param[in] key    key to associate with value
  *  \param[in] val    value to store (takes ownership). May be NULL.
- *  \return ARES_TRUE on success, ARES_FALSE on out of memory or misuse
+ *  \return ARES_TRUE on success, ARES_FALSE on failure or out of memory
  */
-CARES_EXTERN ares_bool_t ares__htable_asvp_insert(ares__htable_asvp_t *htable,
-                                                  ares_socket_t key, void *val);
+CARES_EXTERN ares_bool_t ares_htable_szvp_insert(ares_htable_szvp_t *htable,
+                                                  size_t key, void *val);
 
 /*! Retrieve value from hashtable based on key
  *
@@ -95,11 +83,11 @@ CARES_EXTERN ares_bool_t ares__htable_asvp_insert(ares__htable_asvp_t *htable,
  *  \param[out] val     Optional.  Pointer to store value.
  *  \return ARES_TRUE on success, ARES_FALSE on failure
  */
-CARES_EXTERN ares_bool_t ares__htable_asvp_get(
-  const ares__htable_asvp_t *htable, ares_socket_t key, void **val);
+CARES_EXTERN ares_bool_t ares_htable_szvp_get(
+  const ares_htable_szvp_t *htable, size_t key, void **val);
 
 /*! Retrieve value from hashtable directly as return value.  Caveat to this
- *  function over ares__htable_asvp_get() is that if a NULL value is stored
+ *  function over ares_htable_szvp_get() is that if a NULL value is stored
  *  you cannot determine if the key is not found or the value is NULL.
  *
  *  \param[in] htable  Initialized hash table
@@ -107,17 +95,16 @@ CARES_EXTERN ares_bool_t ares__htable_asvp_get(
  *  \return value associated with key in hashtable or NULL
  */
 CARES_EXTERN void *
-  ares__htable_asvp_get_direct(const ares__htable_asvp_t *htable,
-                               ares_socket_t              key);
+  ares_htable_szvp_get_direct(const ares_htable_szvp_t *htable, size_t key);
 
 /*! Remove a value from the hashtable by key
  *
  *  \param[in] htable  Initialized hash table
  *  \param[in] key     key to use to search
- *  \return ARES_TRUE if found, ARES_FALSE if not found
+ *  \return ARES_TRUE if found, ARES_FALSE if not
  */
-CARES_EXTERN ares_bool_t ares__htable_asvp_remove(ares__htable_asvp_t *htable,
-                                                  ares_socket_t        key);
+CARES_EXTERN ares_bool_t ares_htable_szvp_remove(ares_htable_szvp_t *htable,
+                                                  size_t               key);
 
 /*! Retrieve the number of keys stored in the hash table
  *
@@ -125,8 +112,8 @@ CARES_EXTERN ares_bool_t ares__htable_asvp_remove(ares__htable_asvp_t *htable,
  *  \return count
  */
 CARES_EXTERN size_t
-  ares__htable_asvp_num_keys(const ares__htable_asvp_t *htable);
+  ares_htable_szvp_num_keys(const ares_htable_szvp_t *htable);
 
 /*! @} */
 
-#endif /* __ARES__HTABLE_ASVP_H */
+#endif /* __ARES__HTABLE_STVP_H */

--- a/src/lib/include/ares_htable_szvp.h
+++ b/src/lib/include/ares_htable_szvp.h
@@ -74,7 +74,7 @@ CARES_EXTERN ares_htable_szvp_t *
  *  \return ARES_TRUE on success, ARES_FALSE on failure or out of memory
  */
 CARES_EXTERN ares_bool_t ares_htable_szvp_insert(ares_htable_szvp_t *htable,
-                                                  size_t key, void *val);
+                                                 size_t key, void *val);
 
 /*! Retrieve value from hashtable based on key
  *
@@ -83,8 +83,8 @@ CARES_EXTERN ares_bool_t ares_htable_szvp_insert(ares_htable_szvp_t *htable,
  *  \param[out] val     Optional.  Pointer to store value.
  *  \return ARES_TRUE on success, ARES_FALSE on failure
  */
-CARES_EXTERN ares_bool_t ares_htable_szvp_get(
-  const ares_htable_szvp_t *htable, size_t key, void **val);
+CARES_EXTERN ares_bool_t ares_htable_szvp_get(const ares_htable_szvp_t *htable,
+                                              size_t key, void **val);
 
 /*! Retrieve value from hashtable directly as return value.  Caveat to this
  *  function over ares_htable_szvp_get() is that if a NULL value is stored
@@ -94,8 +94,8 @@ CARES_EXTERN ares_bool_t ares_htable_szvp_get(
  *  \param[in] key     key to use to search
  *  \return value associated with key in hashtable or NULL
  */
-CARES_EXTERN void *
-  ares_htable_szvp_get_direct(const ares_htable_szvp_t *htable, size_t key);
+CARES_EXTERN void *ares_htable_szvp_get_direct(const ares_htable_szvp_t *htable,
+                                               size_t                    key);
 
 /*! Remove a value from the hashtable by key
  *
@@ -104,15 +104,14 @@ CARES_EXTERN void *
  *  \return ARES_TRUE if found, ARES_FALSE if not
  */
 CARES_EXTERN ares_bool_t ares_htable_szvp_remove(ares_htable_szvp_t *htable,
-                                                  size_t               key);
+                                                 size_t              key);
 
 /*! Retrieve the number of keys stored in the hash table
  *
  *  \param[in] htable  Initialized hash table
  *  \return count
  */
-CARES_EXTERN size_t
-  ares_htable_szvp_num_keys(const ares_htable_szvp_t *htable);
+CARES_EXTERN size_t ares_htable_szvp_num_keys(const ares_htable_szvp_t *htable);
 
 /*! @} */
 

--- a/src/lib/include/ares_htable_vpvp.h
+++ b/src/lib/include/ares_htable_vpvp.h
@@ -26,10 +26,10 @@
 #ifndef __ARES__HTABLE_VPVP_H
 #define __ARES__HTABLE_VPVP_H
 
-/*! \addtogroup ares__htable_vpvp HashTable with void pointer Key and void
+/*! \addtogroup ares_htable_vpvp HashTable with void pointer Key and void
  * pointer Value
  *
- * This data structure wraps the base ares__htable data structure in order to
+ * This data structure wraps the base ares_htable data structure in order to
  * split the key and value data types as size_t and void pointer, respectively.
  *
  * Average time complexity:
@@ -40,28 +40,28 @@
  * @{
  */
 
-struct ares__htable_vpvp;
+struct ares_htable_vpvp;
 
 /*! Opaque data type for size_t key, void pointer hash table implementation */
-typedef struct ares__htable_vpvp ares__htable_vpvp_t;
+typedef struct ares_htable_vpvp ares_htable_vpvp_t;
 
 /*! Callback to free key stored in hashtable
  *
  *  \param[in] key  user-supplied key
  */
-typedef void (*ares__htable_vpvp_key_free_t)(void *key);
+typedef void (*ares_htable_vpvp_key_free_t)(void *key);
 
 /*! Callback to free value stored in hashtable
  *
  *  \param[in] val  user-supplied value
  */
-typedef void (*ares__htable_vpvp_val_free_t)(void *val);
+typedef void (*ares_htable_vpvp_val_free_t)(void *val);
 
 /*! Destroy hashtable
  *
  *  \param[in] htable  Initialized hashtable
  */
-CARES_EXTERN void ares__htable_vpvp_destroy(ares__htable_vpvp_t *htable);
+CARES_EXTERN void ares_htable_vpvp_destroy(ares_htable_vpvp_t *htable);
 
 /*! Create size_t key, void pointer value hash table
  *
@@ -72,9 +72,9 @@ CARES_EXTERN void ares__htable_vpvp_destroy(ares__htable_vpvp_t *htable);
  *                       NULL it is expected the caller will clean up any user
  *                       supplied values.
  */
-CARES_EXTERN ares__htable_vpvp_t *
-  ares__htable_vpvp_create(ares__htable_vpvp_key_free_t key_free,
-                           ares__htable_vpvp_val_free_t val_free);
+CARES_EXTERN ares_htable_vpvp_t *
+  ares_htable_vpvp_create(ares_htable_vpvp_key_free_t key_free,
+                           ares_htable_vpvp_val_free_t val_free);
 
 /*! Insert key/value into hash table
  *
@@ -83,7 +83,7 @@ CARES_EXTERN ares__htable_vpvp_t *
  *  \param[in] val    value to store (takes ownership). May be NULL.
  *  \return ARES_TRUE on success, ARES_FALSE on failure or out of memory
  */
-CARES_EXTERN ares_bool_t ares__htable_vpvp_insert(ares__htable_vpvp_t *htable,
+CARES_EXTERN ares_bool_t ares_htable_vpvp_insert(ares_htable_vpvp_t *htable,
                                                   void *key, void *val);
 
 /*! Retrieve value from hashtable based on key
@@ -93,11 +93,11 @@ CARES_EXTERN ares_bool_t ares__htable_vpvp_insert(ares__htable_vpvp_t *htable,
  *  \param[out] val     Optional.  Pointer to store value.
  *  \return ARES_TRUE on success, ARES_FALSE on failure
  */
-CARES_EXTERN ares_bool_t ares__htable_vpvp_get(
-  const ares__htable_vpvp_t *htable, const void *key, void **val);
+CARES_EXTERN ares_bool_t ares_htable_vpvp_get(
+  const ares_htable_vpvp_t *htable, const void *key, void **val);
 
 /*! Retrieve value from hashtable directly as return value.  Caveat to this
- *  function over ares__htable_vpvp_get() is that if a NULL value is stored
+ *  function over ares_htable_vpvp_get() is that if a NULL value is stored
  *  you cannot determine if the key is not found or the value is NULL.
  *
  *  \param[in] htable  Initialized hash table
@@ -105,7 +105,7 @@ CARES_EXTERN ares_bool_t ares__htable_vpvp_get(
  *  \return value associated with key in hashtable or NULL
  */
 CARES_EXTERN void *
-  ares__htable_vpvp_get_direct(const ares__htable_vpvp_t *htable,
+  ares_htable_vpvp_get_direct(const ares_htable_vpvp_t *htable,
                                const void                *key);
 
 /*! Remove a value from the hashtable by key
@@ -114,7 +114,7 @@ CARES_EXTERN void *
  *  \param[in] key     key to use to search
  *  \return ARES_TRUE if found, ARES_FALSE if not
  */
-CARES_EXTERN ares_bool_t ares__htable_vpvp_remove(ares__htable_vpvp_t *htable,
+CARES_EXTERN ares_bool_t ares_htable_vpvp_remove(ares_htable_vpvp_t *htable,
                                                   const void          *key);
 
 /*! Retrieve the number of keys stored in the hash table
@@ -123,7 +123,7 @@ CARES_EXTERN ares_bool_t ares__htable_vpvp_remove(ares__htable_vpvp_t *htable,
  *  \return count
  */
 CARES_EXTERN size_t
-  ares__htable_vpvp_num_keys(const ares__htable_vpvp_t *htable);
+  ares_htable_vpvp_num_keys(const ares_htable_vpvp_t *htable);
 
 /*! @} */
 

--- a/src/lib/include/ares_htable_vpvp.h
+++ b/src/lib/include/ares_htable_vpvp.h
@@ -74,7 +74,7 @@ CARES_EXTERN void ares_htable_vpvp_destroy(ares_htable_vpvp_t *htable);
  */
 CARES_EXTERN ares_htable_vpvp_t *
   ares_htable_vpvp_create(ares_htable_vpvp_key_free_t key_free,
-                           ares_htable_vpvp_val_free_t val_free);
+                          ares_htable_vpvp_val_free_t val_free);
 
 /*! Insert key/value into hash table
  *
@@ -84,7 +84,7 @@ CARES_EXTERN ares_htable_vpvp_t *
  *  \return ARES_TRUE on success, ARES_FALSE on failure or out of memory
  */
 CARES_EXTERN ares_bool_t ares_htable_vpvp_insert(ares_htable_vpvp_t *htable,
-                                                  void *key, void *val);
+                                                 void *key, void *val);
 
 /*! Retrieve value from hashtable based on key
  *
@@ -93,8 +93,8 @@ CARES_EXTERN ares_bool_t ares_htable_vpvp_insert(ares_htable_vpvp_t *htable,
  *  \param[out] val     Optional.  Pointer to store value.
  *  \return ARES_TRUE on success, ARES_FALSE on failure
  */
-CARES_EXTERN ares_bool_t ares_htable_vpvp_get(
-  const ares_htable_vpvp_t *htable, const void *key, void **val);
+CARES_EXTERN ares_bool_t ares_htable_vpvp_get(const ares_htable_vpvp_t *htable,
+                                              const void *key, void **val);
 
 /*! Retrieve value from hashtable directly as return value.  Caveat to this
  *  function over ares_htable_vpvp_get() is that if a NULL value is stored
@@ -104,9 +104,8 @@ CARES_EXTERN ares_bool_t ares_htable_vpvp_get(
  *  \param[in] key     key to use to search
  *  \return value associated with key in hashtable or NULL
  */
-CARES_EXTERN void *
-  ares_htable_vpvp_get_direct(const ares_htable_vpvp_t *htable,
-                               const void                *key);
+CARES_EXTERN void *ares_htable_vpvp_get_direct(const ares_htable_vpvp_t *htable,
+                                               const void               *key);
 
 /*! Remove a value from the hashtable by key
  *
@@ -115,15 +114,14 @@ CARES_EXTERN void *
  *  \return ARES_TRUE if found, ARES_FALSE if not
  */
 CARES_EXTERN ares_bool_t ares_htable_vpvp_remove(ares_htable_vpvp_t *htable,
-                                                  const void          *key);
+                                                 const void         *key);
 
 /*! Retrieve the number of keys stored in the hash table
  *
  *  \param[in] htable  Initialized hash table
  *  \return count
  */
-CARES_EXTERN size_t
-  ares_htable_vpvp_num_keys(const ares_htable_vpvp_t *htable);
+CARES_EXTERN size_t ares_htable_vpvp_num_keys(const ares_htable_vpvp_t *htable);
 
 /*! @} */
 

--- a/src/lib/include/ares_llist.h
+++ b/src/lib/include/ares_llist.h
@@ -26,7 +26,7 @@
 #ifndef __ARES__LLIST_H
 #define __ARES__LLIST_H
 
-/*! \addtogroup ares__llist LinkedList Data Structure
+/*! \addtogroup ares_llist LinkedList Data Structure
  *
  * This is a doubly-linked list data structure.
  *
@@ -38,29 +38,29 @@
  * @{
  */
 
-struct ares__llist;
+struct ares_llist;
 
 /*! Opaque data structure for linked list */
-typedef struct ares__llist ares__llist_t;
+typedef struct ares_llist ares_llist_t;
 
-struct ares__llist_node;
+struct ares_llist_node;
 
 /*! Opaque data structure for a node in a linked list */
-typedef struct ares__llist_node ares__llist_node_t;
+typedef struct ares_llist_node ares_llist_node_t;
 
 /*! Callback to free user-defined node data
  *
  *  \param[in] data  user supplied data
  */
-typedef void (*ares__llist_destructor_t)(void *data);
+typedef void (*ares_llist_destructor_t)(void *data);
 
 /*! Create a linked list object
  *
  *  \param[in] destruct  Optional. Destructor to call on all removed nodes
  *  \return linked list object or NULL on out of memory
  */
-CARES_EXTERN ares__llist_t *
-  ares__llist_create(ares__llist_destructor_t destruct);
+CARES_EXTERN ares_llist_t *
+  ares_llist_create(ares_llist_destructor_t destruct);
 
 /*! Replace destructor for linked list nodes.  Typically this is used
  *  when wanting to disable the destructor by using NULL.
@@ -69,8 +69,8 @@ CARES_EXTERN ares__llist_t *
  *  \param[in] destruct  replacement destructor, NULL is allowed
  */
 CARES_EXTERN void
-  ares__llist_replace_destructor(ares__llist_t           *list,
-                                 ares__llist_destructor_t destruct);
+  ares_llist_replace_destructor(ares_llist_t           *list,
+                                 ares_llist_destructor_t destruct);
 
 /*! Insert value as the first node in the linked list
  *
@@ -79,7 +79,7 @@ CARES_EXTERN void
  *  \return node object referencing place in list, or null if out of memory or
  *   misuse
  */
-CARES_EXTERN ares__llist_node_t *ares__llist_insert_first(ares__llist_t *list,
+CARES_EXTERN ares_llist_node_t *ares_llist_insert_first(ares_llist_t *list,
                                                           void          *val);
 
 /*! Insert value as the last node in the linked list
@@ -89,7 +89,7 @@ CARES_EXTERN ares__llist_node_t *ares__llist_insert_first(ares__llist_t *list,
  *  \return node object referencing place in list, or null if out of memory or
  *   misuse
  */
-CARES_EXTERN ares__llist_node_t *ares__llist_insert_last(ares__llist_t *list,
+CARES_EXTERN ares_llist_node_t *ares_llist_insert_last(ares_llist_t *list,
                                                          void          *val);
 
 /*! Insert value before specified node in the linked list
@@ -99,8 +99,8 @@ CARES_EXTERN ares__llist_node_t *ares__llist_insert_last(ares__llist_t *list,
  *  \return node object referencing place in list, or null if out of memory or
  *   misuse
  */
-CARES_EXTERN ares__llist_node_t *
-  ares__llist_insert_before(ares__llist_node_t *node, void *val);
+CARES_EXTERN ares_llist_node_t *
+  ares_llist_insert_before(ares_llist_node_t *node, void *val);
 
 /*! Insert value after specified node in the linked list
  *
@@ -109,22 +109,22 @@ CARES_EXTERN ares__llist_node_t *
  *  \return node object referencing place in list, or null if out of memory or
  *   misuse
  */
-CARES_EXTERN ares__llist_node_t *
-  ares__llist_insert_after(ares__llist_node_t *node, void *val);
+CARES_EXTERN ares_llist_node_t *
+  ares_llist_insert_after(ares_llist_node_t *node, void *val);
 
 /*! Obtain first node in list
  *
  *  \param[in] list  Initialized list object
  *  \return first node in list or NULL if none
  */
-CARES_EXTERN ares__llist_node_t *ares__llist_node_first(ares__llist_t *list);
+CARES_EXTERN ares_llist_node_t *ares_llist_node_first(ares_llist_t *list);
 
 /*! Obtain last node in list
  *
  *  \param[in] list  Initialized list object
  *  \return last node in list or NULL if none
  */
-CARES_EXTERN ares__llist_node_t *ares__llist_node_last(ares__llist_t *list);
+CARES_EXTERN ares_llist_node_t *ares_llist_node_last(ares_llist_t *list);
 
 /*! Obtain a node based on its index.  This is an O(n) operation.
  *
@@ -132,7 +132,7 @@ CARES_EXTERN ares__llist_node_t *ares__llist_node_last(ares__llist_t *list);
  *  \param[in] idx  Index of node to retrieve
  *  \return node at index or NULL if invalid index
  */
-CARES_EXTERN ares__llist_node_t *ares__llist_node_idx(ares__llist_t *list,
+CARES_EXTERN ares_llist_node_t *ares_llist_node_idx(ares_llist_t *list,
                                                       size_t         idx);
 
 /*! Obtain next node in respect to specified node
@@ -140,16 +140,16 @@ CARES_EXTERN ares__llist_node_t *ares__llist_node_idx(ares__llist_t *list,
  *  \param[in] node  Node referenced
  *  \return node or NULL if none
  */
-CARES_EXTERN ares__llist_node_t *
-  ares__llist_node_next(ares__llist_node_t *node);
+CARES_EXTERN ares_llist_node_t *
+  ares_llist_node_next(ares_llist_node_t *node);
 
 /*! Obtain previous node in respect to specified node
  *
  *  \param[in] node  Node referenced
  *  \return node or NULL if none
  */
-CARES_EXTERN ares__llist_node_t                           *
-  ares__llist_node_prev(ares__llist_node_t *node);
+CARES_EXTERN ares_llist_node_t                           *
+  ares_llist_node_prev(ares_llist_node_t *node);
 
 
 /*! Obtain value from node
@@ -157,41 +157,41 @@ CARES_EXTERN ares__llist_node_t                           *
  *  \param[in] node  Node referenced
  *  \return user provided value from node
  */
-CARES_EXTERN void          *ares__llist_node_val(ares__llist_node_t *node);
+CARES_EXTERN void          *ares_llist_node_val(ares_llist_node_t *node);
 
 /*! Obtain the number of entries in the list
  *
  *  \param[in] list  Initialized list object
  *  \return count
  */
-CARES_EXTERN size_t         ares__llist_len(const ares__llist_t *list);
+CARES_EXTERN size_t         ares_llist_len(const ares_llist_t *list);
 
 /*! Clear all entries in the list, but don't destroy the list object.
  *
  *  \param[in] list  Initialized list object
  */
-CARES_EXTERN void           ares__llist_clear(ares__llist_t *list);
+CARES_EXTERN void           ares_llist_clear(ares_llist_t *list);
 
 /*! Obtain list object from referenced node
  *
  *  \param[in] node  Node referenced
  *  \return list object node belongs to
  */
-CARES_EXTERN ares__llist_t *ares__llist_node_parent(ares__llist_node_t *node);
+CARES_EXTERN ares_llist_t *ares_llist_node_parent(ares_llist_node_t *node);
 
 /*! Obtain the first user-supplied value in the list
  *
  *  \param[in] list Initialized list object
  *  \return first user supplied value or NULL if none
  */
-CARES_EXTERN void          *ares__llist_first_val(ares__llist_t *list);
+CARES_EXTERN void          *ares_llist_first_val(ares_llist_t *list);
 
 /*! Obtain the last user-supplied value in the list
  *
  *  \param[in] list Initialized list object
  *  \return last user supplied value or NULL if none
  */
-CARES_EXTERN void          *ares__llist_last_val(ares__llist_t *list);
+CARES_EXTERN void          *ares_llist_last_val(ares_llist_t *list);
 
 /*! Take ownership of user-supplied value in list without calling destructor.
  *  Will unchain entry from list.
@@ -199,26 +199,26 @@ CARES_EXTERN void          *ares__llist_last_val(ares__llist_t *list);
  *  \param[in] node Node referenced
  *  \return user supplied value
  */
-CARES_EXTERN void          *ares__llist_node_claim(ares__llist_node_t *node);
+CARES_EXTERN void          *ares_llist_node_claim(ares_llist_node_t *node);
 
 /*! Replace user-supplied value for node
  *
  *  \param[in] node Node referenced
  *  \param[in] val  new user-supplied value
  */
-CARES_EXTERN void ares__llist_node_replace(ares__llist_node_t *node, void *val);
+CARES_EXTERN void ares_llist_node_replace(ares_llist_node_t *node, void *val);
 
 /*! Destroy the node, removing it from the list and calling destructor.
  *
  *  \param[in] node  Node referenced
  */
-CARES_EXTERN void ares__llist_node_destroy(ares__llist_node_t *node);
+CARES_EXTERN void ares_llist_node_destroy(ares_llist_node_t *node);
 
 /*! Destroy the list object and all nodes in the list.
  *
  *  \param[in] list Initialized list object
  */
-CARES_EXTERN void ares__llist_destroy(ares__llist_t *list);
+CARES_EXTERN void ares_llist_destroy(ares_llist_t *list);
 
 /*! Detach node from the current list and re-attach it to the new list as the
  *  last entry.
@@ -226,8 +226,8 @@ CARES_EXTERN void ares__llist_destroy(ares__llist_t *list);
  * \param[in] node       node to move
  * \param[in] new_parent new list
  */
-CARES_EXTERN void ares__llist_node_mvparent_last(ares__llist_node_t *node,
-                                                 ares__llist_t *new_parent);
+CARES_EXTERN void ares_llist_node_mvparent_last(ares_llist_node_t *node,
+                                                 ares_llist_t *new_parent);
 
 /*! Detach node from the current list and re-attach it to the new list as the
  *  first entry.
@@ -235,8 +235,8 @@ CARES_EXTERN void ares__llist_node_mvparent_last(ares__llist_node_t *node,
  * \param[in] node       node to move
  * \param[in] new_parent new list
  */
-CARES_EXTERN void ares__llist_node_mvparent_first(ares__llist_node_t *node,
-                                                  ares__llist_t *new_parent);
+CARES_EXTERN void ares_llist_node_mvparent_first(ares_llist_node_t *node,
+                                                  ares_llist_t *new_parent);
 /*! @} */
 
 #endif /* __ARES__LLIST_H */

--- a/src/lib/include/ares_llist.h
+++ b/src/lib/include/ares_llist.h
@@ -59,8 +59,7 @@ typedef void (*ares_llist_destructor_t)(void *data);
  *  \param[in] destruct  Optional. Destructor to call on all removed nodes
  *  \return linked list object or NULL on out of memory
  */
-CARES_EXTERN ares_llist_t *
-  ares_llist_create(ares_llist_destructor_t destruct);
+CARES_EXTERN ares_llist_t *ares_llist_create(ares_llist_destructor_t destruct);
 
 /*! Replace destructor for linked list nodes.  Typically this is used
  *  when wanting to disable the destructor by using NULL.
@@ -70,7 +69,7 @@ CARES_EXTERN ares_llist_t *
  */
 CARES_EXTERN void
   ares_llist_replace_destructor(ares_llist_t           *list,
-                                 ares_llist_destructor_t destruct);
+                                ares_llist_destructor_t destruct);
 
 /*! Insert value as the first node in the linked list
  *
@@ -80,7 +79,7 @@ CARES_EXTERN void
  *   misuse
  */
 CARES_EXTERN ares_llist_node_t *ares_llist_insert_first(ares_llist_t *list,
-                                                          void          *val);
+                                                        void         *val);
 
 /*! Insert value as the last node in the linked list
  *
@@ -90,7 +89,7 @@ CARES_EXTERN ares_llist_node_t *ares_llist_insert_first(ares_llist_t *list,
  *   misuse
  */
 CARES_EXTERN ares_llist_node_t *ares_llist_insert_last(ares_llist_t *list,
-                                                         void          *val);
+                                                       void         *val);
 
 /*! Insert value before specified node in the linked list
  *
@@ -109,8 +108,8 @@ CARES_EXTERN ares_llist_node_t *
  *  \return node object referencing place in list, or null if out of memory or
  *   misuse
  */
-CARES_EXTERN ares_llist_node_t *
-  ares_llist_insert_after(ares_llist_node_t *node, void *val);
+CARES_EXTERN ares_llist_node_t *ares_llist_insert_after(ares_llist_node_t *node,
+                                                        void              *val);
 
 /*! Obtain first node in list
  *
@@ -133,23 +132,21 @@ CARES_EXTERN ares_llist_node_t *ares_llist_node_last(ares_llist_t *list);
  *  \return node at index or NULL if invalid index
  */
 CARES_EXTERN ares_llist_node_t *ares_llist_node_idx(ares_llist_t *list,
-                                                      size_t         idx);
+                                                    size_t        idx);
 
 /*! Obtain next node in respect to specified node
  *
  *  \param[in] node  Node referenced
  *  \return node or NULL if none
  */
-CARES_EXTERN ares_llist_node_t *
-  ares_llist_node_next(ares_llist_node_t *node);
+CARES_EXTERN ares_llist_node_t *ares_llist_node_next(ares_llist_node_t *node);
 
 /*! Obtain previous node in respect to specified node
  *
  *  \param[in] node  Node referenced
  *  \return node or NULL if none
  */
-CARES_EXTERN ares_llist_node_t                           *
-  ares_llist_node_prev(ares_llist_node_t *node);
+CARES_EXTERN ares_llist_node_t *ares_llist_node_prev(ares_llist_node_t *node);
 
 
 /*! Obtain value from node
@@ -157,41 +154,41 @@ CARES_EXTERN ares_llist_node_t                           *
  *  \param[in] node  Node referenced
  *  \return user provided value from node
  */
-CARES_EXTERN void          *ares_llist_node_val(ares_llist_node_t *node);
+CARES_EXTERN void              *ares_llist_node_val(ares_llist_node_t *node);
 
 /*! Obtain the number of entries in the list
  *
  *  \param[in] list  Initialized list object
  *  \return count
  */
-CARES_EXTERN size_t         ares_llist_len(const ares_llist_t *list);
+CARES_EXTERN size_t             ares_llist_len(const ares_llist_t *list);
 
 /*! Clear all entries in the list, but don't destroy the list object.
  *
  *  \param[in] list  Initialized list object
  */
-CARES_EXTERN void           ares_llist_clear(ares_llist_t *list);
+CARES_EXTERN void               ares_llist_clear(ares_llist_t *list);
 
 /*! Obtain list object from referenced node
  *
  *  \param[in] node  Node referenced
  *  \return list object node belongs to
  */
-CARES_EXTERN ares_llist_t *ares_llist_node_parent(ares_llist_node_t *node);
+CARES_EXTERN ares_llist_t      *ares_llist_node_parent(ares_llist_node_t *node);
 
 /*! Obtain the first user-supplied value in the list
  *
  *  \param[in] list Initialized list object
  *  \return first user supplied value or NULL if none
  */
-CARES_EXTERN void          *ares_llist_first_val(ares_llist_t *list);
+CARES_EXTERN void              *ares_llist_first_val(ares_llist_t *list);
 
 /*! Obtain the last user-supplied value in the list
  *
  *  \param[in] list Initialized list object
  *  \return last user supplied value or NULL if none
  */
-CARES_EXTERN void          *ares_llist_last_val(ares_llist_t *list);
+CARES_EXTERN void              *ares_llist_last_val(ares_llist_t *list);
 
 /*! Take ownership of user-supplied value in list without calling destructor.
  *  Will unchain entry from list.
@@ -199,7 +196,7 @@ CARES_EXTERN void          *ares_llist_last_val(ares_llist_t *list);
  *  \param[in] node Node referenced
  *  \return user supplied value
  */
-CARES_EXTERN void          *ares_llist_node_claim(ares_llist_node_t *node);
+CARES_EXTERN void              *ares_llist_node_claim(ares_llist_node_t *node);
 
 /*! Replace user-supplied value for node
  *
@@ -227,7 +224,7 @@ CARES_EXTERN void ares_llist_destroy(ares_llist_t *list);
  * \param[in] new_parent new list
  */
 CARES_EXTERN void ares_llist_node_mvparent_last(ares_llist_node_t *node,
-                                                 ares_llist_t *new_parent);
+                                                ares_llist_t      *new_parent);
 
 /*! Detach node from the current list and re-attach it to the new list as the
  *  first entry.
@@ -236,7 +233,7 @@ CARES_EXTERN void ares_llist_node_mvparent_last(ares_llist_node_t *node,
  * \param[in] new_parent new list
  */
 CARES_EXTERN void ares_llist_node_mvparent_first(ares_llist_node_t *node,
-                                                  ares_llist_t *new_parent);
+                                                 ares_llist_t      *new_parent);
 /*! @} */
 
 #endif /* __ARES__LLIST_H */

--- a/src/lib/include/ares_str.h
+++ b/src/lib/include/ares_str.h
@@ -45,14 +45,14 @@ CARES_EXTERN size_t ares_strcpy(char *dest, const char *src, size_t dest_size);
 
 CARES_EXTERN ares_bool_t   ares_str_isnum(const char *str);
 
-CARES_EXTERN void          ares__str_ltrim(char *str);
-CARES_EXTERN void          ares__str_rtrim(char *str);
-CARES_EXTERN void          ares__str_trim(char *str);
+CARES_EXTERN void          ares_str_ltrim(char *str);
+CARES_EXTERN void          ares_str_rtrim(char *str);
+CARES_EXTERN void          ares_str_trim(char *str);
 
-CARES_EXTERN unsigned char ares__tolower(unsigned char c);
-CARES_EXTERN ares_bool_t   ares__memeq_ci(const unsigned char *ptr,
+CARES_EXTERN unsigned char ares_tolower(unsigned char c);
+CARES_EXTERN ares_bool_t   ares_memeq_ci(const unsigned char *ptr,
                                           const unsigned char *val, size_t len);
-CARES_EXTERN ares_bool_t   ares__is_hostname(const char *str);
+CARES_EXTERN ares_bool_t   ares_is_hostname(const char *str);
 
 /*! Validate the string provided is printable.  The length specified must be
  *  at least the size of the buffer provided.  If a NULL-terminator is hit
@@ -65,33 +65,33 @@ CARES_EXTERN ares_bool_t   ares__is_hostname(const char *str);
  *                  If 0, will return TRUE since it did not hit an exception.
  *  \return ARES_TRUE if the entire string is printable, ARES_FALSE if not.
  */
-CARES_EXTERN ares_bool_t   ares__str_isprint(const char *str, size_t len);
+CARES_EXTERN ares_bool_t   ares_str_isprint(const char *str, size_t len);
 
 /* We only care about ASCII rules */
-#define ares__isascii(x) (((unsigned char)x) <= 127)
+#define ares_isascii(x) (((unsigned char)x) <= 127)
 
-#define ares__isdigit(x) \
+#define ares_isdigit(x) \
   (((unsigned char)x) >= '0' && ((unsigned char)x) <= '9')
 
-#define ares__isxdigit(x)                                      \
-  (ares__isdigit(x) ||                                         \
+#define ares_isxdigit(x)                                      \
+  (ares_isdigit(x) ||                                         \
    (((unsigned char)x) >= 'a' && ((unsigned char)x) <= 'f') || \
    (((unsigned char)x) >= 'A' && ((unsigned char)x) <= 'F'))
 
-#define ares__isupper(x) \
+#define ares_isupper(x) \
   (((unsigned char)x) >= 'A' && ((unsigned char)x) <= 'Z')
 
-#define ares__islower(x) \
+#define ares_islower(x) \
   (((unsigned char)x) >= 'a' && ((unsigned char)x) <= 'z')
 
-#define ares__isalpha(x) (ares__islower(x) || ares__isupper(x))
+#define ares_isalpha(x) (ares_islower(x) || ares_isupper(x))
 
-#define ares__isspace(x)                                           \
+#define ares_isspace(x)                                           \
   (((unsigned char)(x)) == '\r' || ((unsigned char)(x)) == '\t' || \
    ((unsigned char)(x)) == ' ' || ((unsigned char)(x)) == '\v' ||  \
    ((unsigned char)(x)) == '\f' || ((unsigned char)(x)) == '\n')
 
-#define ares__isprint(x) \
+#define ares_isprint(x) \
   (((unsigned char)(x)) >= 0x20 && ((unsigned char)(x)) <= 0x7E)
 
 /* Character set allowed by hostnames.  This is to include the normal
@@ -108,8 +108,8 @@ CARES_EXTERN ares_bool_t   ares__str_isprint(const char *str, size_t len);
  * anyhow).
  * [A-Za-z0-9-*._/]
  */
-#define ares__is_hostnamech(x)                                            \
-  (ares__isalpha(x) || ares__isdigit(x) || ((unsigned char)(x)) == '-' || \
+#define ares_is_hostnamech(x)                                            \
+  (ares_isalpha(x) || ares_isdigit(x) || ((unsigned char)(x)) == '-' || \
    ((unsigned char)(x)) == '.' || ((unsigned char)(x)) == '_' ||          \
    ((unsigned char)(x)) == '/' || ((unsigned char)(x)) == '*')
 

--- a/src/lib/include/ares_str.h
+++ b/src/lib/include/ares_str.h
@@ -51,7 +51,7 @@ CARES_EXTERN void          ares_str_trim(char *str);
 
 CARES_EXTERN unsigned char ares_tolower(unsigned char c);
 CARES_EXTERN ares_bool_t   ares_memeq_ci(const unsigned char *ptr,
-                                          const unsigned char *val, size_t len);
+                                         const unsigned char *val, size_t len);
 CARES_EXTERN ares_bool_t   ares_is_hostname(const char *str);
 
 /*! Validate the string provided is printable.  The length specified must be
@@ -70,23 +70,20 @@ CARES_EXTERN ares_bool_t   ares_str_isprint(const char *str, size_t len);
 /* We only care about ASCII rules */
 #define ares_isascii(x) (((unsigned char)x) <= 127)
 
-#define ares_isdigit(x) \
-  (((unsigned char)x) >= '0' && ((unsigned char)x) <= '9')
+#define ares_isdigit(x) (((unsigned char)x) >= '0' && ((unsigned char)x) <= '9')
 
-#define ares_isxdigit(x)                                      \
-  (ares_isdigit(x) ||                                         \
+#define ares_isxdigit(x)                                       \
+  (ares_isdigit(x) ||                                          \
    (((unsigned char)x) >= 'a' && ((unsigned char)x) <= 'f') || \
    (((unsigned char)x) >= 'A' && ((unsigned char)x) <= 'F'))
 
-#define ares_isupper(x) \
-  (((unsigned char)x) >= 'A' && ((unsigned char)x) <= 'Z')
+#define ares_isupper(x) (((unsigned char)x) >= 'A' && ((unsigned char)x) <= 'Z')
 
-#define ares_islower(x) \
-  (((unsigned char)x) >= 'a' && ((unsigned char)x) <= 'z')
+#define ares_islower(x) (((unsigned char)x) >= 'a' && ((unsigned char)x) <= 'z')
 
 #define ares_isalpha(x) (ares_islower(x) || ares_isupper(x))
 
-#define ares_isspace(x)                                           \
+#define ares_isspace(x)                                            \
   (((unsigned char)(x)) == '\r' || ((unsigned char)(x)) == '\t' || \
    ((unsigned char)(x)) == ' ' || ((unsigned char)(x)) == '\v' ||  \
    ((unsigned char)(x)) == '\f' || ((unsigned char)(x)) == '\n')
@@ -108,9 +105,9 @@ CARES_EXTERN ares_bool_t   ares_str_isprint(const char *str, size_t len);
  * anyhow).
  * [A-Za-z0-9-*._/]
  */
-#define ares_is_hostnamech(x)                                            \
+#define ares_is_hostnamech(x)                                           \
   (ares_isalpha(x) || ares_isdigit(x) || ((unsigned char)(x)) == '-' || \
-   ((unsigned char)(x)) == '.' || ((unsigned char)(x)) == '_' ||          \
+   ((unsigned char)(x)) == '.' || ((unsigned char)(x)) == '_' ||        \
    ((unsigned char)(x)) == '/' || ((unsigned char)(x)) == '*')
 
 

--- a/src/lib/inet_net_pton.c
+++ b/src/lib/inet_net_pton.c
@@ -147,8 +147,7 @@ static int ares_inet_net_pton_ipv4(const char *src, unsigned char *dst,
   }
 
   bits = -1;
-  if (ch == '/' && ares_isascii(src[0]) && ares_isdigit(src[0]) &&
-      dst > odst) {
+  if (ch == '/' && ares_isascii(src[0]) && ares_isdigit(src[0]) && dst > odst) {
     /* CIDR width specifier.  Nothing can follow it. */
     ch   = *src++; /* Skip over the /. */
     bits = 0;

--- a/src/lib/inet_net_pton.c
+++ b/src/lib/inet_net_pton.c
@@ -83,17 +83,17 @@ static int ares_inet_net_pton_ipv4(const char *src, unsigned char *dst,
   const unsigned char *odst = dst;
 
   ch = *src++;
-  if (ch == '0' && (src[0] == 'x' || src[0] == 'X') && ares__isascii(src[1]) &&
-      ares__isxdigit(src[1])) {
+  if (ch == '0' && (src[0] == 'x' || src[0] == 'X') && ares_isascii(src[1]) &&
+      ares_isxdigit(src[1])) {
     /* Hexadecimal: Eat nybble string. */
     if (!size) {
       goto emsgsize;
     }
     dirty = 0;
     src++; /* skip x or X. */
-    while ((ch = *src++) != '\0' && ares__isascii(ch) && ares__isxdigit(ch)) {
-      if (ares__isupper(ch)) {
-        ch = ares__tolower((unsigned char)ch);
+    while ((ch = *src++) != '\0' && ares_isascii(ch) && ares_isxdigit(ch)) {
+      if (ares_isupper(ch)) {
+        ch = ares_tolower((unsigned char)ch);
       }
       n = (int)(strchr(xdigits, ch) - xdigits);
       if (dirty == 0) {
@@ -115,7 +115,7 @@ static int ares_inet_net_pton_ipv4(const char *src, unsigned char *dst,
       }
       *dst++ = (unsigned char)(tmp << 4);
     }
-  } else if (ares__isascii(ch) && ares__isdigit(ch)) {
+  } else if (ares_isascii(ch) && ares_isdigit(ch)) {
     /* Decimal: eat dotted digit string. */
     for (;;) {
       tmp = 0;
@@ -126,7 +126,7 @@ static int ares_inet_net_pton_ipv4(const char *src, unsigned char *dst,
         if (tmp > 255) {
           goto enoent;
         }
-      } while ((ch = *src++) != '\0' && ares__isascii(ch) && ares__isdigit(ch));
+      } while ((ch = *src++) != '\0' && ares_isascii(ch) && ares_isdigit(ch));
       if (!size--) {
         goto emsgsize;
       }
@@ -138,7 +138,7 @@ static int ares_inet_net_pton_ipv4(const char *src, unsigned char *dst,
         goto enoent;
       }
       ch = *src++;
-      if (!ares__isascii(ch) || !ares__isdigit(ch)) {
+      if (!ares_isascii(ch) || !ares_isdigit(ch)) {
         goto enoent;
       }
     }
@@ -147,7 +147,7 @@ static int ares_inet_net_pton_ipv4(const char *src, unsigned char *dst,
   }
 
   bits = -1;
-  if (ch == '/' && ares__isascii(src[0]) && ares__isdigit(src[0]) &&
+  if (ch == '/' && ares_isascii(src[0]) && ares_isdigit(src[0]) &&
       dst > odst) {
     /* CIDR width specifier.  Nothing can follow it. */
     ch   = *src++; /* Skip over the /. */
@@ -159,7 +159,7 @@ static int ares_inet_net_pton_ipv4(const char *src, unsigned char *dst,
       if (bits > 32) {
         goto enoent;
       }
-    } while ((ch = *src++) != '\0' && ares__isascii(ch) && ares__isdigit(ch));
+    } while ((ch = *src++) != '\0' && ares_isascii(ch) && ares_isdigit(ch));
     if (ch != '\0') {
       goto enoent;
     }

--- a/src/lib/legacy/ares_expand_name.c
+++ b/src/lib/legacy/ares_expand_name.c
@@ -34,12 +34,12 @@
 #include "ares_nameser.h"
 
 ares_status_t ares_expand_name_validated(const unsigned char *encoded,
-                                          const unsigned char *abuf,
-                                          size_t alen, char **s, size_t *enclen,
-                                          ares_bool_t is_hostname)
+                                         const unsigned char *abuf, size_t alen,
+                                         char **s, size_t *enclen,
+                                         ares_bool_t is_hostname)
 {
   ares_status_t status;
-  ares_buf_t  *buf = NULL;
+  ares_buf_t   *buf = NULL;
   size_t        start_len;
 
   if (encoded == NULL || abuf == NULL || alen == 0 || enclen == NULL) {
@@ -93,7 +93,7 @@ int ares_expand_name(const unsigned char *encoded, const unsigned char *abuf,
   }
 
   status  = ares_expand_name_validated(encoded, abuf, (size_t)alen, s,
-                                        &enclen_temp, ARES_FALSE);
+                                       &enclen_temp, ARES_FALSE);
   *enclen = (long)enclen_temp;
   return (int)status;
 }

--- a/src/lib/legacy/ares_expand_name.c
+++ b/src/lib/legacy/ares_expand_name.c
@@ -33,13 +33,13 @@
 
 #include "ares_nameser.h"
 
-ares_status_t ares__expand_name_validated(const unsigned char *encoded,
+ares_status_t ares_expand_name_validated(const unsigned char *encoded,
                                           const unsigned char *abuf,
                                           size_t alen, char **s, size_t *enclen,
                                           ares_bool_t is_hostname)
 {
   ares_status_t status;
-  ares__buf_t  *buf = NULL;
+  ares_buf_t  *buf = NULL;
   size_t        start_len;
 
   if (encoded == NULL || abuf == NULL || alen == 0 || enclen == NULL) {
@@ -57,27 +57,27 @@ ares_status_t ares__expand_name_validated(const unsigned char *encoded,
     *s = NULL;
   }
 
-  buf = ares__buf_create_const(abuf, alen);
+  buf = ares_buf_create_const(abuf, alen);
 
   if (buf == NULL) {
     return ARES_ENOMEM;
   }
 
-  status = ares__buf_set_position(buf, (size_t)(encoded - abuf));
+  status = ares_buf_set_position(buf, (size_t)(encoded - abuf));
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  start_len = ares__buf_len(buf);
-  status    = ares__dns_name_parse(buf, s, is_hostname);
+  start_len = ares_buf_len(buf);
+  status    = ares_dns_name_parse(buf, s, is_hostname);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  *enclen = start_len - ares__buf_len(buf);
+  *enclen = start_len - ares_buf_len(buf);
 
 done:
-  ares__buf_destroy(buf);
+  ares_buf_destroy(buf);
   return status;
 }
 
@@ -92,7 +92,7 @@ int ares_expand_name(const unsigned char *encoded, const unsigned char *abuf,
     return ARES_EBADNAME;
   }
 
-  status  = ares__expand_name_validated(encoded, abuf, (size_t)alen, s,
+  status  = ares_expand_name_validated(encoded, abuf, (size_t)alen, s,
                                         &enclen_temp, ARES_FALSE);
   *enclen = (long)enclen_temp;
   return (int)status;

--- a/src/lib/legacy/ares_expand_string.c
+++ b/src/lib/legacy/ares_expand_string.c
@@ -43,7 +43,7 @@ ares_status_t ares_expand_string_ex(const unsigned char *encoded,
                                     unsigned char **s, size_t *enclen)
 {
   ares_status_t status;
-  ares_buf_t  *buf = NULL;
+  ares_buf_t   *buf = NULL;
   size_t        start_len;
   size_t        len = 0;
 

--- a/src/lib/legacy/ares_expand_string.c
+++ b/src/lib/legacy/ares_expand_string.c
@@ -43,7 +43,7 @@ ares_status_t ares_expand_string_ex(const unsigned char *encoded,
                                     unsigned char **s, size_t *enclen)
 {
   ares_status_t status;
-  ares__buf_t  *buf = NULL;
+  ares_buf_t  *buf = NULL;
   size_t        start_len;
   size_t        len = 0;
 
@@ -62,28 +62,28 @@ ares_status_t ares_expand_string_ex(const unsigned char *encoded,
     *s = NULL;
   }
 
-  buf = ares__buf_create_const(abuf, alen);
+  buf = ares_buf_create_const(abuf, alen);
 
   if (buf == NULL) {
     return ARES_ENOMEM;
   }
 
-  status = ares__buf_set_position(buf, (size_t)(encoded - abuf));
+  status = ares_buf_set_position(buf, (size_t)(encoded - abuf));
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  start_len = ares__buf_len(buf);
-  status    = ares__buf_parse_dns_binstr(buf, ares__buf_len(buf), s, &len);
+  start_len = ares_buf_len(buf);
+  status    = ares_buf_parse_dns_binstr(buf, ares_buf_len(buf), s, &len);
   /* hrm, no way to pass back 'len' with the prototype */
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  *enclen = start_len - ares__buf_len(buf);
+  *enclen = start_len - ares_buf_len(buf);
 
 done:
-  ares__buf_destroy(buf);
+  ares_buf_destroy(buf);
   if (status == ARES_EBADNAME || status == ARES_EBADRESP) {
     status = ARES_EBADSTR;
   }

--- a/src/lib/legacy/ares_fds.c
+++ b/src/lib/legacy/ares_fds.c
@@ -30,7 +30,7 @@
 int ares_fds(const ares_channel_t *channel, fd_set *read_fds, fd_set *write_fds)
 {
   ares_socket_t       nfds;
-  ares__slist_node_t *snode;
+  ares_slist_node_t *snode;
   /* Are there any active queries? */
   size_t              active_queries;
 
@@ -38,19 +38,19 @@ int ares_fds(const ares_channel_t *channel, fd_set *read_fds, fd_set *write_fds)
     return 0;
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
 
-  active_queries = ares__llist_len(channel->all_queries);
+  active_queries = ares_llist_len(channel->all_queries);
 
   nfds = 0;
-  for (snode = ares__slist_node_first(channel->servers); snode != NULL;
-       snode = ares__slist_node_next(snode)) {
-    ares_server_t      *server = ares__slist_node_val(snode);
-    ares__llist_node_t *node;
+  for (snode = ares_slist_node_first(channel->servers); snode != NULL;
+       snode = ares_slist_node_next(snode)) {
+    ares_server_t      *server = ares_slist_node_val(snode);
+    ares_llist_node_t *node;
 
-    for (node = ares__llist_node_first(server->connections); node != NULL;
-         node = ares__llist_node_next(node)) {
-      const ares_conn_t *conn = ares__llist_node_val(node);
+    for (node = ares_llist_node_first(server->connections); node != NULL;
+         node = ares_llist_node_next(node)) {
+      const ares_conn_t *conn = ares_llist_node_val(node);
 
       if (!active_queries && !(conn->flags & ARES_CONN_FLAG_TCP)) {
         continue;
@@ -75,6 +75,6 @@ int ares_fds(const ares_channel_t *channel, fd_set *read_fds, fd_set *write_fds)
     }
   }
 
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
   return (int)nfds;
 }

--- a/src/lib/legacy/ares_fds.c
+++ b/src/lib/legacy/ares_fds.c
@@ -29,10 +29,10 @@
 
 int ares_fds(const ares_channel_t *channel, fd_set *read_fds, fd_set *write_fds)
 {
-  ares_socket_t       nfds;
+  ares_socket_t      nfds;
   ares_slist_node_t *snode;
   /* Are there any active queries? */
-  size_t              active_queries;
+  size_t             active_queries;
 
   if (channel == NULL || read_fds == NULL || write_fds == NULL) {
     return 0;
@@ -45,7 +45,7 @@ int ares_fds(const ares_channel_t *channel, fd_set *read_fds, fd_set *write_fds)
   nfds = 0;
   for (snode = ares_slist_node_first(channel->servers); snode != NULL;
        snode = ares_slist_node_next(snode)) {
-    ares_server_t      *server = ares_slist_node_val(snode);
+    ares_server_t     *server = ares_slist_node_val(snode);
     ares_llist_node_t *node;
 
     for (node = ares_llist_node_first(server->connections); node != NULL;

--- a/src/lib/legacy/ares_getsock.c
+++ b/src/lib/legacy/ares_getsock.c
@@ -30,12 +30,12 @@ int ares_getsock(const ares_channel_t *channel, ares_socket_t *socks,
                  int numsocks) /* size of the 'socks' array */
 {
   ares_slist_node_t *snode;
-  size_t              sockindex = 0;
-  unsigned int        bitmap    = 0;
-  unsigned int        setbits   = 0xffffffff;
+  size_t             sockindex = 0;
+  unsigned int       bitmap    = 0;
+  unsigned int       setbits   = 0xffffffff;
 
   /* Are there any active queries? */
-  size_t              active_queries;
+  size_t             active_queries;
 
   if (channel == NULL || numsocks <= 0) {
     return 0;
@@ -47,7 +47,7 @@ int ares_getsock(const ares_channel_t *channel, ares_socket_t *socks,
 
   for (snode = ares_slist_node_first(channel->servers); snode != NULL;
        snode = ares_slist_node_next(snode)) {
-    ares_server_t      *server = ares_slist_node_val(snode);
+    ares_server_t     *server = ares_slist_node_val(snode);
     ares_llist_node_t *node;
 
     for (node = ares_llist_node_first(server->connections); node != NULL;

--- a/src/lib/legacy/ares_getsock.c
+++ b/src/lib/legacy/ares_getsock.c
@@ -29,7 +29,7 @@
 int ares_getsock(const ares_channel_t *channel, ares_socket_t *socks,
                  int numsocks) /* size of the 'socks' array */
 {
-  ares__slist_node_t *snode;
+  ares_slist_node_t *snode;
   size_t              sockindex = 0;
   unsigned int        bitmap    = 0;
   unsigned int        setbits   = 0xffffffff;
@@ -41,18 +41,18 @@ int ares_getsock(const ares_channel_t *channel, ares_socket_t *socks,
     return 0;
   }
 
-  ares__channel_lock(channel);
+  ares_channel_lock(channel);
 
-  active_queries = ares__llist_len(channel->all_queries);
+  active_queries = ares_llist_len(channel->all_queries);
 
-  for (snode = ares__slist_node_first(channel->servers); snode != NULL;
-       snode = ares__slist_node_next(snode)) {
-    ares_server_t      *server = ares__slist_node_val(snode);
-    ares__llist_node_t *node;
+  for (snode = ares_slist_node_first(channel->servers); snode != NULL;
+       snode = ares_slist_node_next(snode)) {
+    ares_server_t      *server = ares_slist_node_val(snode);
+    ares_llist_node_t *node;
 
-    for (node = ares__llist_node_first(server->connections); node != NULL;
-         node = ares__llist_node_next(node)) {
-      const ares_conn_t *conn = ares__llist_node_val(node);
+    for (node = ares_llist_node_first(server->connections); node != NULL;
+         node = ares_llist_node_next(node)) {
+      const ares_conn_t *conn = ares_llist_node_val(node);
 
       if (sockindex >= (size_t)numsocks || sockindex >= ARES_GETSOCK_MAXNUM) {
         break;
@@ -80,6 +80,6 @@ int ares_getsock(const ares_channel_t *channel, ares_socket_t *socks,
     }
   }
 
-  ares__channel_unlock(channel);
+  ares_channel_unlock(channel);
   return (int)bitmap;
 }

--- a/src/lib/legacy/ares_parse_a_reply.c
+++ b/src/lib/legacy/ares_parse_a_reply.c
@@ -86,7 +86,7 @@ int ares_parse_a_reply(const unsigned char *abuf, int alen,
   if (addrttls != NULL && req_naddrttls) {
     size_t temp_naddrttls = 0;
     ares_addrinfo2addrttl(&ai, AF_INET, req_naddrttls, addrttls, NULL,
-                           &temp_naddrttls);
+                          &temp_naddrttls);
     *naddrttls = (int)temp_naddrttls;
   }
 

--- a/src/lib/legacy/ares_parse_a_reply.c
+++ b/src/lib/legacy/ares_parse_a_reply.c
@@ -71,13 +71,13 @@ int ares_parse_a_reply(const unsigned char *abuf, int alen,
     goto fail;
   }
 
-  status = ares__parse_into_addrinfo(dnsrec, 0, 0, &ai);
+  status = ares_parse_into_addrinfo(dnsrec, 0, 0, &ai);
   if (status != ARES_SUCCESS && status != ARES_ENODATA) {
     goto fail;
   }
 
   if (host != NULL) {
-    status = ares__addrinfo2hostent(&ai, AF_INET, host);
+    status = ares_addrinfo2hostent(&ai, AF_INET, host);
     if (status != ARES_SUCCESS && status != ARES_ENODATA) {
       goto fail; /* LCOV_EXCL_LINE: DefensiveCoding */
     }
@@ -85,15 +85,15 @@ int ares_parse_a_reply(const unsigned char *abuf, int alen,
 
   if (addrttls != NULL && req_naddrttls) {
     size_t temp_naddrttls = 0;
-    ares__addrinfo2addrttl(&ai, AF_INET, req_naddrttls, addrttls, NULL,
+    ares_addrinfo2addrttl(&ai, AF_INET, req_naddrttls, addrttls, NULL,
                            &temp_naddrttls);
     *naddrttls = (int)temp_naddrttls;
   }
 
 
 fail:
-  ares__freeaddrinfo_cnames(ai.cnames);
-  ares__freeaddrinfo_nodes(ai.nodes);
+  ares_freeaddrinfo_cnames(ai.cnames);
+  ares_freeaddrinfo_nodes(ai.nodes);
   ares_free(ai.name);
   ares_free(question_hostname);
   ares_dns_record_destroy(dnsrec);

--- a/src/lib/legacy/ares_parse_aaaa_reply.c
+++ b/src/lib/legacy/ares_parse_aaaa_reply.c
@@ -89,7 +89,7 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
   if (addrttls != NULL && req_naddrttls) {
     size_t temp_naddrttls = 0;
     ares_addrinfo2addrttl(&ai, AF_INET6, req_naddrttls, NULL, addrttls,
-                           &temp_naddrttls);
+                          &temp_naddrttls);
     *naddrttls = (int)temp_naddrttls;
   }
 

--- a/src/lib/legacy/ares_parse_aaaa_reply.c
+++ b/src/lib/legacy/ares_parse_aaaa_reply.c
@@ -74,13 +74,13 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
     goto fail;
   }
 
-  status = ares__parse_into_addrinfo(dnsrec, 0, 0, &ai);
+  status = ares_parse_into_addrinfo(dnsrec, 0, 0, &ai);
   if (status != ARES_SUCCESS && status != ARES_ENODATA) {
     goto fail;
   }
 
   if (host != NULL) {
-    status = ares__addrinfo2hostent(&ai, AF_INET6, host);
+    status = ares_addrinfo2hostent(&ai, AF_INET6, host);
     if (status != ARES_SUCCESS && status != ARES_ENODATA) {
       goto fail; /* LCOV_EXCL_LINE: DefensiveCoding */
     }
@@ -88,14 +88,14 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
 
   if (addrttls != NULL && req_naddrttls) {
     size_t temp_naddrttls = 0;
-    ares__addrinfo2addrttl(&ai, AF_INET6, req_naddrttls, NULL, addrttls,
+    ares_addrinfo2addrttl(&ai, AF_INET6, req_naddrttls, NULL, addrttls,
                            &temp_naddrttls);
     *naddrttls = (int)temp_naddrttls;
   }
 
 fail:
-  ares__freeaddrinfo_cnames(ai.cnames);
-  ares__freeaddrinfo_nodes(ai.nodes);
+  ares_freeaddrinfo_cnames(ai.cnames);
+  ares_freeaddrinfo_nodes(ai.nodes);
   ares_free(question_hostname);
   ares_free(ai.name);
   ares_dns_record_destroy(dnsrec);

--- a/src/lib/legacy/ares_parse_txt_reply.c
+++ b/src/lib/legacy/ares_parse_txt_reply.c
@@ -27,8 +27,8 @@
 #include "ares_private.h"
 #include "ares_data.h"
 
-static int ares__parse_txt_reply(const unsigned char *abuf, size_t alen,
-                                 ares_bool_t ex, void **txt_out)
+static int ares_parse_txt_reply_int(const unsigned char *abuf, size_t alen,
+                                    ares_bool_t ex, void **txt_out)
 {
   ares_status_t        status;
   struct ares_txt_ext *txt_head = NULL;
@@ -129,8 +129,8 @@ int ares_parse_txt_reply(const unsigned char *abuf, int alen,
   if (alen < 0) {
     return ARES_EBADRESP;
   }
-  return ares__parse_txt_reply(abuf, (size_t)alen, ARES_FALSE,
-                               (void **)txt_out);
+  return ares_parse_txt_reply_int(abuf, (size_t)alen, ARES_FALSE,
+                                  (void **)txt_out);
 }
 
 int ares_parse_txt_reply_ext(const unsigned char *abuf, int alen,
@@ -139,5 +139,6 @@ int ares_parse_txt_reply_ext(const unsigned char *abuf, int alen,
   if (alen < 0) {
     return ARES_EBADRESP;
   }
-  return ares__parse_txt_reply(abuf, (size_t)alen, ARES_TRUE, (void **)txt_out);
+  return ares_parse_txt_reply_int(abuf, (size_t)alen, ARES_TRUE,
+                                  (void **)txt_out);
 }

--- a/src/lib/record/ares_dns_multistring.c
+++ b/src/lib/record/ares_dns_multistring.c
@@ -31,7 +31,7 @@ typedef struct {
   size_t         len;
 } multistring_data_t;
 
-struct ares__dns_multistring {
+struct ares_dns_multistring {
   /*! whether or not cached concatenated string is valid */
   ares_bool_t    cache_invalidated;
   /*! combined/concatenated string cache */
@@ -39,10 +39,10 @@ struct ares__dns_multistring {
   /*! length of combined/concatenated string */
   size_t         cache_str_len;
   /*! Data making up strings */
-  ares__array_t *strs; /*!< multistring_data_t type */
+  ares_array_t *strs; /*!< multistring_data_t type */
 };
 
-static void ares__dns_multistring_free_cb(void *arg)
+static void ares_dns_multistring_free_cb(void *arg)
 {
   multistring_data_t *data = arg;
   if (data == NULL) {
@@ -51,15 +51,15 @@ static void ares__dns_multistring_free_cb(void *arg)
   ares_free(data->data);
 }
 
-ares__dns_multistring_t *ares__dns_multistring_create(void)
+ares_dns_multistring_t *ares_dns_multistring_create(void)
 {
-  ares__dns_multistring_t *strs = ares_malloc_zero(sizeof(*strs));
+  ares_dns_multistring_t *strs = ares_malloc_zero(sizeof(*strs));
   if (strs == NULL) {
     return NULL;
   }
 
-  strs->strs = ares__array_create(sizeof(multistring_data_t),
-                                  ares__dns_multistring_free_cb);
+  strs->strs = ares_array_create(sizeof(multistring_data_t),
+                                  ares_dns_multistring_free_cb);
   if (strs->strs == NULL) {
     ares_free(strs);
     return NULL;
@@ -68,29 +68,29 @@ ares__dns_multistring_t *ares__dns_multistring_create(void)
   return strs;
 }
 
-void ares__dns_multistring_clear(ares__dns_multistring_t *strs)
+void ares_dns_multistring_clear(ares_dns_multistring_t *strs)
 {
   if (strs == NULL) {
     return;
   }
 
-  while (ares__array_len(strs->strs)) {
-    ares__array_remove_last(strs->strs);
+  while (ares_array_len(strs->strs)) {
+    ares_array_remove_last(strs->strs);
   }
 }
 
-void ares__dns_multistring_destroy(ares__dns_multistring_t *strs)
+void ares_dns_multistring_destroy(ares_dns_multistring_t *strs)
 {
   if (strs == NULL) {
     return;
   }
-  ares__dns_multistring_clear(strs);
-  ares__array_destroy(strs->strs);
+  ares_dns_multistring_clear(strs);
+  ares_array_destroy(strs->strs);
   ares_free(strs->cache_str);
   ares_free(strs);
 }
 
-ares_status_t ares__dns_multistring_swap_own(ares__dns_multistring_t *strs,
+ares_status_t ares_dns_multistring_swap_own(ares_dns_multistring_t *strs,
                                              size_t idx, unsigned char *str,
                                              size_t len)
 {
@@ -102,7 +102,7 @@ ares_status_t ares__dns_multistring_swap_own(ares__dns_multistring_t *strs,
 
   strs->cache_invalidated = ARES_TRUE;
 
-  data = ares__array_at(strs->strs, idx);
+  data = ares_array_at(strs->strs, idx);
   if (data == NULL) {
     return ARES_EFORMERR;
   }
@@ -113,7 +113,7 @@ ares_status_t ares__dns_multistring_swap_own(ares__dns_multistring_t *strs,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__dns_multistring_del(ares__dns_multistring_t *strs,
+ares_status_t ares_dns_multistring_del(ares_dns_multistring_t *strs,
                                         size_t                   idx)
 {
   if (strs == NULL) {
@@ -122,10 +122,10 @@ ares_status_t ares__dns_multistring_del(ares__dns_multistring_t *strs,
 
   strs->cache_invalidated = ARES_TRUE;
 
-  return ares__array_remove_at(strs->strs, idx);
+  return ares_array_remove_at(strs->strs, idx);
 }
 
-ares_status_t ares__dns_multistring_add_own(ares__dns_multistring_t *strs,
+ares_status_t ares_dns_multistring_add_own(ares_dns_multistring_t *strs,
                                             unsigned char *str, size_t len)
 {
   multistring_data_t *data;
@@ -142,7 +142,7 @@ ares_status_t ares__dns_multistring_add_own(ares__dns_multistring_t *strs,
     return ARES_EFORMERR;
   }
 
-  status = ares__array_insert_last((void **)&data, strs->strs);
+  status = ares_array_insert_last((void **)&data, strs->strs);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -153,16 +153,16 @@ ares_status_t ares__dns_multistring_add_own(ares__dns_multistring_t *strs,
   return ARES_SUCCESS;
 }
 
-size_t ares__dns_multistring_cnt(const ares__dns_multistring_t *strs)
+size_t ares_dns_multistring_cnt(const ares_dns_multistring_t *strs)
 {
   if (strs == NULL) {
     return 0;
   }
-  return ares__array_len(strs->strs);
+  return ares_array_len(strs->strs);
 }
 
 const unsigned char *
-  ares__dns_multistring_get(const ares__dns_multistring_t *strs, size_t idx,
+  ares_dns_multistring_get(const ares_dns_multistring_t *strs, size_t idx,
                             size_t *len)
 {
   const multistring_data_t *data;
@@ -171,7 +171,7 @@ const unsigned char *
     return NULL;
   }
 
-  data = ares__array_at_const(strs->strs, idx);
+  data = ares_array_at_const(strs->strs, idx);
   if (data == NULL) {
     return NULL;
   }
@@ -181,9 +181,9 @@ const unsigned char *
 }
 
 const unsigned char *
-  ares__dns_multistring_combined(ares__dns_multistring_t *strs, size_t *len)
+  ares_dns_multistring_combined(ares_dns_multistring_t *strs, size_t *len)
 {
-  ares__buf_t *buf = NULL;
+  ares_buf_t *buf = NULL;
   size_t       i;
 
   if (strs == NULL || len == NULL) {
@@ -203,19 +203,19 @@ const unsigned char *
   strs->cache_str     = NULL;
   strs->cache_str_len = 0;
 
-  buf = ares__buf_create();
+  buf = ares_buf_create();
 
-  for (i = 0; i < ares__array_len(strs->strs); i++) {
-    const multistring_data_t *data = ares__array_at_const(strs->strs, i);
+  for (i = 0; i < ares_array_len(strs->strs); i++) {
+    const multistring_data_t *data = ares_array_at_const(strs->strs, i);
     if (data == NULL ||
-        ares__buf_append(buf, data->data, data->len) != ARES_SUCCESS) {
-      ares__buf_destroy(buf);
+        ares_buf_append(buf, data->data, data->len) != ARES_SUCCESS) {
+      ares_buf_destroy(buf);
       return NULL;
     }
   }
 
   strs->cache_str =
-    (unsigned char *)ares__buf_finish_str(buf, &strs->cache_str_len);
+    (unsigned char *)ares_buf_finish_str(buf, &strs->cache_str_len);
   if (strs->cache_str != NULL) {
     strs->cache_invalidated = ARES_FALSE;
   }
@@ -223,14 +223,14 @@ const unsigned char *
   return strs->cache_str;
 }
 
-ares_status_t ares__dns_multistring_parse_buf(ares__buf_t *buf,
+ares_status_t ares_dns_multistring_parse_buf(ares_buf_t *buf,
                                               size_t       remaining_len,
-                                              ares__dns_multistring_t **strs,
+                                              ares_dns_multistring_t **strs,
                                               ares_bool_t validate_printable)
 {
   unsigned char len;
   ares_status_t status   = ARES_EBADRESP;
-  size_t        orig_len = ares__buf_len(buf);
+  size_t        orig_len = ares_buf_len(buf);
 
   if (buf == NULL) {
     return ARES_EFORMERR;
@@ -241,14 +241,14 @@ ares_status_t ares__dns_multistring_parse_buf(ares__buf_t *buf,
   }
 
   if (strs != NULL) {
-    *strs = ares__dns_multistring_create();
+    *strs = ares_dns_multistring_create();
     if (*strs == NULL) {
       return ARES_ENOMEM;
     }
   }
 
-  while (orig_len - ares__buf_len(buf) < remaining_len) {
-    status = ares__buf_fetch_bytes(buf, &len, 1);
+  while (orig_len - ares_buf_len(buf) < remaining_len) {
+    status = ares_buf_fetch_bytes(buf, &len, 1);
     if (status != ARES_SUCCESS) {
       break; /* LCOV_EXCL_LINE: DefensiveCoding */
     }
@@ -256,10 +256,10 @@ ares_status_t ares__dns_multistring_parse_buf(ares__buf_t *buf,
     if (len) {
       /* When used by the _str() parser, it really needs to be validated to
        * be a valid printable ascii string.  Do that here */
-      if (validate_printable && ares__buf_len(buf) >= len) {
+      if (validate_printable && ares_buf_len(buf) >= len) {
         size_t      mylen;
-        const char *data = (const char *)ares__buf_peek(buf, &mylen);
-        if (!ares__str_isprint(data, len)) {
+        const char *data = (const char *)ares_buf_peek(buf, &mylen);
+        if (!ares_str_isprint(data, len)) {
           status = ARES_EBADSTR;
           break;
         }
@@ -267,17 +267,17 @@ ares_status_t ares__dns_multistring_parse_buf(ares__buf_t *buf,
 
       if (strs != NULL) {
         unsigned char *data = NULL;
-        status = ares__buf_fetch_bytes_dup(buf, len, ARES_TRUE, &data);
+        status = ares_buf_fetch_bytes_dup(buf, len, ARES_TRUE, &data);
         if (status != ARES_SUCCESS) {
           break;
         }
-        status = ares__dns_multistring_add_own(*strs, data, len);
+        status = ares_dns_multistring_add_own(*strs, data, len);
         if (status != ARES_SUCCESS) {
           ares_free(data);
           break;
         }
       } else {
-        status = ares__buf_consume(buf, len);
+        status = ares_buf_consume(buf, len);
         if (status != ARES_SUCCESS) {
           break;
         }
@@ -286,7 +286,7 @@ ares_status_t ares__dns_multistring_parse_buf(ares__buf_t *buf,
   }
 
   if (status != ARES_SUCCESS && strs != NULL) {
-    ares__dns_multistring_destroy(*strs);
+    ares_dns_multistring_destroy(*strs);
     *strs = NULL;
   }
 

--- a/src/lib/record/ares_dns_multistring.c
+++ b/src/lib/record/ares_dns_multistring.c
@@ -39,7 +39,7 @@ struct ares_dns_multistring {
   /*! length of combined/concatenated string */
   size_t         cache_str_len;
   /*! Data making up strings */
-  ares_array_t *strs; /*!< multistring_data_t type */
+  ares_array_t  *strs; /*!< multistring_data_t type */
 };
 
 static void ares_dns_multistring_free_cb(void *arg)
@@ -58,8 +58,8 @@ ares_dns_multistring_t *ares_dns_multistring_create(void)
     return NULL;
   }
 
-  strs->strs = ares_array_create(sizeof(multistring_data_t),
-                                  ares_dns_multistring_free_cb);
+  strs->strs =
+    ares_array_create(sizeof(multistring_data_t), ares_dns_multistring_free_cb);
   if (strs->strs == NULL) {
     ares_free(strs);
     return NULL;
@@ -91,8 +91,8 @@ void ares_dns_multistring_destroy(ares_dns_multistring_t *strs)
 }
 
 ares_status_t ares_dns_multistring_swap_own(ares_dns_multistring_t *strs,
-                                             size_t idx, unsigned char *str,
-                                             size_t len)
+                                            size_t idx, unsigned char *str,
+                                            size_t len)
 {
   multistring_data_t *data;
 
@@ -113,8 +113,7 @@ ares_status_t ares_dns_multistring_swap_own(ares_dns_multistring_t *strs,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares_dns_multistring_del(ares_dns_multistring_t *strs,
-                                        size_t                   idx)
+ares_status_t ares_dns_multistring_del(ares_dns_multistring_t *strs, size_t idx)
 {
   if (strs == NULL) {
     return ARES_EFORMERR;
@@ -126,7 +125,7 @@ ares_status_t ares_dns_multistring_del(ares_dns_multistring_t *strs,
 }
 
 ares_status_t ares_dns_multistring_add_own(ares_dns_multistring_t *strs,
-                                            unsigned char *str, size_t len)
+                                           unsigned char *str, size_t len)
 {
   multistring_data_t *data;
   ares_status_t       status;
@@ -163,7 +162,7 @@ size_t ares_dns_multistring_cnt(const ares_dns_multistring_t *strs)
 
 const unsigned char *
   ares_dns_multistring_get(const ares_dns_multistring_t *strs, size_t idx,
-                            size_t *len)
+                           size_t *len)
 {
   const multistring_data_t *data;
 
@@ -180,11 +179,11 @@ const unsigned char *
   return data->data;
 }
 
-const unsigned char *
-  ares_dns_multistring_combined(ares_dns_multistring_t *strs, size_t *len)
+const unsigned char *ares_dns_multistring_combined(ares_dns_multistring_t *strs,
+                                                   size_t                 *len)
 {
   ares_buf_t *buf = NULL;
-  size_t       i;
+  size_t      i;
 
   if (strs == NULL || len == NULL) {
     return NULL;
@@ -224,9 +223,9 @@ const unsigned char *
 }
 
 ares_status_t ares_dns_multistring_parse_buf(ares_buf_t *buf,
-                                              size_t       remaining_len,
-                                              ares_dns_multistring_t **strs,
-                                              ares_bool_t validate_printable)
+                                             size_t      remaining_len,
+                                             ares_dns_multistring_t **strs,
+                                             ares_bool_t validate_printable)
 {
   unsigned char len;
   ares_status_t status   = ARES_EBADRESP;

--- a/src/lib/record/ares_dns_multistring.h
+++ b/src/lib/record/ares_dns_multistring.h
@@ -26,27 +26,27 @@
 #ifndef __ARES_DNS_MULTISTRING_H
 #define __ARES_DNS_MULTISTRING_H
 
-#include "ares__buf.h"
+#include "ares_buf.h"
 
-struct ares__dns_multistring;
-typedef struct ares__dns_multistring ares__dns_multistring_t;
+struct ares_dns_multistring;
+typedef struct ares_dns_multistring ares_dns_multistring_t;
 
-ares__dns_multistring_t             *ares__dns_multistring_create(void);
-void          ares__dns_multistring_clear(ares__dns_multistring_t *strs);
-void          ares__dns_multistring_destroy(ares__dns_multistring_t *strs);
-ares_status_t ares__dns_multistring_swap_own(ares__dns_multistring_t *strs,
+ares_dns_multistring_t             *ares_dns_multistring_create(void);
+void          ares_dns_multistring_clear(ares_dns_multistring_t *strs);
+void          ares_dns_multistring_destroy(ares_dns_multistring_t *strs);
+ares_status_t ares_dns_multistring_swap_own(ares_dns_multistring_t *strs,
                                              size_t idx, unsigned char *str,
                                              size_t len);
-ares_status_t ares__dns_multistring_del(ares__dns_multistring_t *strs,
+ares_status_t ares_dns_multistring_del(ares_dns_multistring_t *strs,
                                         size_t                   idx);
-ares_status_t ares__dns_multistring_add_own(ares__dns_multistring_t *strs,
+ares_status_t ares_dns_multistring_add_own(ares_dns_multistring_t *strs,
                                             unsigned char *str, size_t len);
-size_t        ares__dns_multistring_cnt(const ares__dns_multistring_t *strs);
+size_t        ares_dns_multistring_cnt(const ares_dns_multistring_t *strs);
 const unsigned char *
-  ares__dns_multistring_get(const ares__dns_multistring_t *strs, size_t idx,
+  ares_dns_multistring_get(const ares_dns_multistring_t *strs, size_t idx,
                             size_t *len);
 const unsigned char *
-  ares__dns_multistring_combined(ares__dns_multistring_t *strs, size_t *len);
+  ares_dns_multistring_combined(ares_dns_multistring_t *strs, size_t *len);
 
 /*! Parse an array of character strings as defined in RFC1035, as binary,
  *  however, for convenience this does guarantee a NULL terminator (that is
@@ -64,9 +64,9 @@ const unsigned char *
  *                                 data.
  *  \return ARES_SUCCESS on success
  */
-ares_status_t ares__dns_multistring_parse_buf(ares__buf_t *buf,
+ares_status_t ares_dns_multistring_parse_buf(ares_buf_t *buf,
                                               size_t       remaining_len,
-                                              ares__dns_multistring_t **strs,
+                                              ares_dns_multistring_t **strs,
                                               ares_bool_t validate_printable);
 
 #endif

--- a/src/lib/record/ares_dns_multistring.h
+++ b/src/lib/record/ares_dns_multistring.h
@@ -35,18 +35,18 @@ ares_dns_multistring_t             *ares_dns_multistring_create(void);
 void          ares_dns_multistring_clear(ares_dns_multistring_t *strs);
 void          ares_dns_multistring_destroy(ares_dns_multistring_t *strs);
 ares_status_t ares_dns_multistring_swap_own(ares_dns_multistring_t *strs,
-                                             size_t idx, unsigned char *str,
-                                             size_t len);
+                                            size_t idx, unsigned char *str,
+                                            size_t len);
 ares_status_t ares_dns_multistring_del(ares_dns_multistring_t *strs,
-                                        size_t                   idx);
+                                       size_t                  idx);
 ares_status_t ares_dns_multistring_add_own(ares_dns_multistring_t *strs,
-                                            unsigned char *str, size_t len);
+                                           unsigned char *str, size_t len);
 size_t        ares_dns_multistring_cnt(const ares_dns_multistring_t *strs);
 const unsigned char *
   ares_dns_multistring_get(const ares_dns_multistring_t *strs, size_t idx,
-                            size_t *len);
-const unsigned char *
-  ares_dns_multistring_combined(ares_dns_multistring_t *strs, size_t *len);
+                           size_t *len);
+const unsigned char *ares_dns_multistring_combined(ares_dns_multistring_t *strs,
+                                                   size_t                 *len);
 
 /*! Parse an array of character strings as defined in RFC1035, as binary,
  *  however, for convenience this does guarantee a NULL terminator (that is
@@ -64,9 +64,9 @@ const unsigned char *
  *                                 data.
  *  \return ARES_SUCCESS on success
  */
-ares_status_t ares_dns_multistring_parse_buf(ares_buf_t *buf,
-                                              size_t       remaining_len,
-                                              ares_dns_multistring_t **strs,
-                                              ares_bool_t validate_printable);
+ares_status_t        ares_dns_multistring_parse_buf(ares_buf_t *buf,
+                                                    size_t      remaining_len,
+                                                    ares_dns_multistring_t **strs,
+                                                    ares_bool_t validate_printable);
 
 #endif

--- a/src/lib/record/ares_dns_name.c
+++ b/src/lib/record/ares_dns_name.c
@@ -31,7 +31,7 @@ typedef struct {
   size_t idx;
 } ares_nameoffset_t;
 
-static void ares__nameoffset_free(void *arg)
+static void ares_nameoffset_free(void *arg)
 {
   ares_nameoffset_t *off = arg;
   if (off == NULL) {
@@ -41,7 +41,7 @@ static void ares__nameoffset_free(void *arg)
   ares_free(off);
 }
 
-static ares_status_t ares__nameoffset_create(ares__llist_t **list,
+static ares_status_t ares_nameoffset_create(ares_llist_t **list,
                                              const char *name, size_t idx)
 {
   ares_status_t      status;
@@ -53,7 +53,7 @@ static ares_status_t ares__nameoffset_create(ares__llist_t **list,
   }
 
   if (*list == NULL) {
-    *list = ares__llist_create(ares__nameoffset_free);
+    *list = ares_llist_create(ares_nameoffset_free);
   }
   if (*list == NULL) {
     status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
@@ -69,7 +69,7 @@ static ares_status_t ares__nameoffset_create(ares__llist_t **list,
   off->name_len = ares_strlen(off->name);
   off->idx      = idx;
 
-  if (ares__llist_insert_last(*list, off) == NULL) {
+  if (ares_llist_insert_last(*list, off) == NULL) {
     status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
     goto fail;            /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -78,25 +78,25 @@ static ares_status_t ares__nameoffset_create(ares__llist_t **list,
 
 /* LCOV_EXCL_START: OutOfMemory */
 fail:
-  ares__nameoffset_free(off);
+  ares_nameoffset_free(off);
   return status;
   /* LCOV_EXCL_STOP */
 }
 
-static const ares_nameoffset_t *ares__nameoffset_find(ares__llist_t *list,
+static const ares_nameoffset_t *ares_nameoffset_find(ares_llist_t *list,
                                                       const char    *name)
 {
   size_t                   name_len = ares_strlen(name);
-  ares__llist_node_t      *node;
+  ares_llist_node_t      *node;
   const ares_nameoffset_t *longest_match = NULL;
 
   if (list == NULL || name == NULL || name_len == 0) {
     return NULL;
   }
 
-  for (node = ares__llist_node_first(list); node != NULL;
-       node = ares__llist_node_next(node)) {
-    const ares_nameoffset_t *val = ares__llist_node_val(node);
+  for (node = ares_llist_node_first(list); node != NULL;
+       node = ares_llist_node_next(node)) {
+    const ares_nameoffset_t *val = ares_llist_node_val(node);
     size_t                   prefix_len;
 
     /* Can't be a match if the stored name is longer */
@@ -133,38 +133,38 @@ static const ares_nameoffset_t *ares__nameoffset_find(ares__llist_t *list,
 
 static void ares_dns_labels_free_cb(void *arg)
 {
-  ares__buf_t **buf = arg;
+  ares_buf_t **buf = arg;
   if (buf == NULL) {
     return;
   }
 
-  ares__buf_destroy(*buf);
+  ares_buf_destroy(*buf);
 }
 
-static ares__buf_t *ares_dns_labels_add(ares__array_t *labels)
+static ares_buf_t *ares_dns_labels_add(ares_array_t *labels)
 {
-  ares__buf_t **buf;
+  ares_buf_t **buf;
 
   if (labels == NULL) {
     return NULL; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  if (ares__array_insert_last((void **)&buf, labels) != ARES_SUCCESS) {
+  if (ares_array_insert_last((void **)&buf, labels) != ARES_SUCCESS) {
     return NULL;
   }
 
-  *buf = ares__buf_create();
+  *buf = ares_buf_create();
   if (*buf == NULL) {
-    ares__array_remove_last(labels);
+    ares_array_remove_last(labels);
     return NULL;
   }
 
   return *buf;
 }
 
-static ares__buf_t *ares_dns_labels_get_last(ares__array_t *labels)
+static ares_buf_t *ares_dns_labels_get_last(ares_array_t *labels)
 {
-  ares__buf_t **buf = ares__array_last(labels);
+  ares_buf_t **buf = ares_array_last(labels);
 
   if (buf == NULL) {
     return NULL;
@@ -173,9 +173,9 @@ static ares__buf_t *ares_dns_labels_get_last(ares__array_t *labels)
   return *buf;
 }
 
-static ares__buf_t *ares_dns_labels_get_at(ares__array_t *labels, size_t idx)
+static ares_buf_t *ares_dns_labels_get_at(ares_array_t *labels, size_t idx)
 {
-  ares__buf_t **buf = ares__array_at(labels, idx);
+  ares_buf_t **buf = ares_array_at(labels, idx);
 
   if (buf == NULL) {
     return NULL;
@@ -184,37 +184,37 @@ static ares__buf_t *ares_dns_labels_get_at(ares__array_t *labels, size_t idx)
   return *buf;
 }
 
-static void ares_dns_name_labels_del_last(ares__array_t *labels)
+static void ares_dns_name_labels_del_last(ares_array_t *labels)
 {
-  ares__array_remove_last(labels);
+  ares_array_remove_last(labels);
 }
 
-static ares_status_t ares_parse_dns_name_escape(ares__buf_t *namebuf,
-                                                ares__buf_t *label,
+static ares_status_t ares_parse_dns_name_escape(ares_buf_t *namebuf,
+                                                ares_buf_t *label,
                                                 ares_bool_t  validate_hostname)
 {
   ares_status_t status;
   unsigned char c;
 
-  status = ares__buf_fetch_bytes(namebuf, &c, 1);
+  status = ares_buf_fetch_bytes(namebuf, &c, 1);
   if (status != ARES_SUCCESS) {
     return ARES_EBADNAME;
   }
 
   /* If next character is a digit, read 2 more digits */
-  if (ares__isdigit(c)) {
+  if (ares_isdigit(c)) {
     size_t       i;
     unsigned int val = 0;
 
     val = c - '0';
 
     for (i = 0; i < 2; i++) {
-      status = ares__buf_fetch_bytes(namebuf, &c, 1);
+      status = ares_buf_fetch_bytes(namebuf, &c, 1);
       if (status != ARES_SUCCESS) {
         return ARES_EBADNAME;
       }
 
-      if (!ares__isdigit(c)) {
+      if (!ares_isdigit(c)) {
         return ARES_EBADNAME;
       }
       val *= 10;
@@ -226,28 +226,28 @@ static ares_status_t ares_parse_dns_name_escape(ares__buf_t *namebuf,
       return ARES_EBADNAME;
     }
 
-    if (validate_hostname && !ares__is_hostnamech((unsigned char)val)) {
+    if (validate_hostname && !ares_is_hostnamech((unsigned char)val)) {
       return ARES_EBADNAME;
     }
 
-    return ares__buf_append_byte(label, (unsigned char)val);
+    return ares_buf_append_byte(label, (unsigned char)val);
   }
 
   /* We can just output the character */
-  if (validate_hostname && !ares__is_hostnamech(c)) {
+  if (validate_hostname && !ares_is_hostnamech(c)) {
     return ARES_EBADNAME;
   }
 
-  return ares__buf_append_byte(label, c);
+  return ares_buf_append_byte(label, c);
 }
 
-static ares_status_t ares_split_dns_name(ares__array_t *labels,
+static ares_status_t ares_split_dns_name(ares_array_t *labels,
                                          ares_bool_t    validate_hostname,
                                          const char    *name)
 {
   ares_status_t status;
-  ares__buf_t  *label   = NULL;
-  ares__buf_t  *namebuf = NULL;
+  ares_buf_t  *label   = NULL;
+  ares_buf_t  *namebuf = NULL;
   size_t        i;
   size_t        total_len = 0;
   unsigned char c;
@@ -257,7 +257,7 @@ static ares_status_t ares_split_dns_name(ares__array_t *labels,
   }
 
   /* Put name into a buffer for parsing */
-  namebuf = ares__buf_create();
+  namebuf = ares_buf_create();
   if (namebuf == NULL) {
     status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
     goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
@@ -265,7 +265,7 @@ static ares_status_t ares_split_dns_name(ares__array_t *labels,
 
   if (*name != '\0') {
     status =
-      ares__buf_append(namebuf, (const unsigned char *)name, ares_strlen(name));
+      ares_buf_append(namebuf, (const unsigned char *)name, ares_strlen(name));
     if (status != ARES_SUCCESS) {
       goto done; /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -278,7 +278,7 @@ static ares_status_t ares_split_dns_name(ares__array_t *labels,
     goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  while (ares__buf_fetch_bytes(namebuf, &c, 1) == ARES_SUCCESS) {
+  while (ares_buf_fetch_bytes(namebuf, &c, 1) == ARES_SUCCESS) {
     /* New label */
     if (c == '.') {
       label = ares_dns_labels_add(labels);
@@ -299,33 +299,33 @@ static ares_status_t ares_split_dns_name(ares__array_t *labels,
     }
 
     /* Output direct character */
-    if (validate_hostname && !ares__is_hostnamech(c)) {
+    if (validate_hostname && !ares_is_hostnamech(c)) {
       status = ARES_EBADNAME;
       goto done;
     }
 
-    status = ares__buf_append_byte(label, c);
+    status = ares_buf_append_byte(label, c);
     if (status != ARES_SUCCESS) {
       goto done; /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
 
   /* Remove trailing blank label */
-  if (ares__buf_len(ares_dns_labels_get_last(labels)) == 0) {
+  if (ares_buf_len(ares_dns_labels_get_last(labels)) == 0) {
     ares_dns_name_labels_del_last(labels);
   }
 
   /* If someone passed in "." there could have been 2 blank labels, check for
    * that */
-  if (ares__array_len(labels) == 1 &&
-      ares__buf_len(ares_dns_labels_get_last(labels)) == 0) {
+  if (ares_array_len(labels) == 1 &&
+      ares_buf_len(ares_dns_labels_get_last(labels)) == 0) {
     ares_dns_name_labels_del_last(labels);
   }
 
   /* Scan to make sure label lengths are valid */
-  for (i = 0; i < ares__array_len(labels); i++) {
-    const ares__buf_t *buf = ares_dns_labels_get_at(labels, i);
-    size_t             len = ares__buf_len(buf);
+  for (i = 0; i < ares_array_len(labels); i++) {
+    const ares_buf_t *buf = ares_dns_labels_get_at(labels, i);
+    size_t             len = ares_buf_len(buf);
     /* No 0-length labels, and no labels over 63 bytes */
     if (len == 0 || len > 63) {
       status = ARES_EBADNAME;
@@ -335,8 +335,8 @@ static ares_status_t ares_split_dns_name(ares__array_t *labels,
   }
 
   /* Can't exceed maximum (unescaped) length */
-  if (ares__array_len(labels) &&
-      total_len + ares__array_len(labels) - 1 > 255) {
+  if (ares_array_len(labels) &&
+      total_len + ares_array_len(labels) - 1 > 255) {
     status = ARES_EBADNAME;
     goto done;
   }
@@ -344,19 +344,19 @@ static ares_status_t ares_split_dns_name(ares__array_t *labels,
   status = ARES_SUCCESS;
 
 done:
-  ares__buf_destroy(namebuf);
+  ares_buf_destroy(namebuf);
   return status;
 }
 
-ares_status_t ares__dns_name_write(ares__buf_t *buf, ares__llist_t **list,
+ares_status_t ares_dns_name_write(ares_buf_t *buf, ares_llist_t **list,
                                    ares_bool_t validate_hostname,
                                    const char *name)
 {
   const ares_nameoffset_t *off = NULL;
   size_t                   name_len;
   size_t                   orig_name_len;
-  size_t                   pos    = ares__buf_len(buf);
-  ares__array_t           *labels = NULL;
+  size_t                   pos    = ares_buf_len(buf);
+  ares_array_t           *labels = NULL;
   char                     name_copy[512];
   ares_status_t            status;
 
@@ -364,7 +364,7 @@ ares_status_t ares__dns_name_write(ares__buf_t *buf, ares__llist_t **list,
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  labels = ares__array_create(sizeof(ares__buf_t *), ares_dns_labels_free_cb);
+  labels = ares_array_create(sizeof(ares_buf_t *), ares_dns_labels_free_cb);
   if (labels == NULL) {
     return ARES_ENOMEM;
   }
@@ -376,7 +376,7 @@ ares_status_t ares__dns_name_write(ares__buf_t *buf, ares__llist_t **list,
 
   /* Find longest match */
   if (list != NULL) {
-    off = ares__nameoffset_find(*list, name_copy);
+    off = ares_nameoffset_find(*list, name_copy);
     if (off != NULL && off->name_len != name_len) {
       /* truncate */
       name_len            -= (off->name_len + 1);
@@ -393,17 +393,17 @@ ares_status_t ares__dns_name_write(ares__buf_t *buf, ares__llist_t **list,
       goto done;
     }
 
-    for (i = 0; i < ares__array_len(labels); i++) {
+    for (i = 0; i < ares_array_len(labels); i++) {
       size_t               len  = 0;
-      const ares__buf_t   *lbuf = ares_dns_labels_get_at(labels, i);
-      const unsigned char *ptr  = ares__buf_peek(lbuf, &len);
+      const ares_buf_t   *lbuf = ares_dns_labels_get_at(labels, i);
+      const unsigned char *ptr  = ares_buf_peek(lbuf, &len);
 
-      status = ares__buf_append_byte(buf, (unsigned char)(len & 0xFF));
+      status = ares_buf_append_byte(buf, (unsigned char)(len & 0xFF));
       if (status != ARES_SUCCESS) {
         goto done; /* LCOV_EXCL_LINE: OutOfMemory */
       }
 
-      status = ares__buf_append(buf, ptr, len);
+      status = ares_buf_append(buf, ptr, len);
       if (status != ARES_SUCCESS) {
         goto done; /* LCOV_EXCL_LINE: OutOfMemory */
       }
@@ -411,7 +411,7 @@ ares_status_t ares__dns_name_write(ares__buf_t *buf, ares__llist_t **list,
 
     /* If we are NOT jumping to another label, output terminator */
     if (off == NULL) {
-      status = ares__buf_append_byte(buf, 0);
+      status = ares_buf_append_byte(buf, 0);
       if (status != ARES_SUCCESS) {
         goto done; /* LCOV_EXCL_LINE: OutOfMemory */
       }
@@ -422,7 +422,7 @@ ares_status_t ares__dns_name_write(ares__buf_t *buf, ares__llist_t **list,
   if (off != NULL) {
     unsigned short u16 =
       (unsigned short)0xC000 | (unsigned short)(off->idx & 0x3FFF);
-    status = ares__buf_append_be16(buf, u16);
+    status = ares_buf_append_be16(buf, u16);
     if (status != ARES_SUCCESS) {
       goto done; /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -432,7 +432,7 @@ ares_status_t ares__dns_name_write(ares__buf_t *buf, ares__llist_t **list,
    * a prior entry */
   if (list != NULL && (off == NULL || off->name_len != orig_name_len) &&
       name_len > 0) {
-    status = ares__nameoffset_create(list, name /* not truncated copy! */, pos);
+    status = ares_nameoffset_create(list, name /* not truncated copy! */, pos);
     if (status != ARES_SUCCESS) {
       goto done; /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -441,7 +441,7 @@ ares_status_t ares__dns_name_write(ares__buf_t *buf, ares__llist_t **list,
   status = ARES_SUCCESS;
 
 done:
-  ares__array_destroy(labels);
+  ares_array_destroy(labels);
   return status;
 }
 
@@ -465,12 +465,12 @@ static ares_bool_t is_reservedch(int ch)
   return ARES_FALSE;
 }
 
-static ares_status_t ares__fetch_dnsname_into_buf(ares__buf_t *buf,
-                                                  ares__buf_t *dest, size_t len,
+static ares_status_t ares_fetch_dnsname_into_buf(ares_buf_t *buf,
+                                                  ares_buf_t *dest, size_t len,
                                                   ares_bool_t is_hostname)
 {
   size_t               remaining_len;
-  const unsigned char *ptr = ares__buf_peek(buf, &remaining_len);
+  const unsigned char *ptr = ares_buf_peek(buf, &remaining_len);
   ares_status_t        status;
   size_t               i;
 
@@ -483,7 +483,7 @@ static ares_status_t ares__fetch_dnsname_into_buf(ares__buf_t *buf,
 
     /* Hostnames have a very specific allowed character set.  Anything outside
      * of that (non-printable and reserved included) are disallowed */
-    if (is_hostname && !ares__is_hostnamech(c)) {
+    if (is_hostname && !ares_is_hostnamech(c)) {
       status = ARES_EBADRESP;
       goto fail;
     }
@@ -495,7 +495,7 @@ static ares_status_t ares__fetch_dnsname_into_buf(ares__buf_t *buf,
     }
 
     /* Non-printable characters need to be output as \DDD */
-    if (!ares__isprint(c)) {
+    if (!ares_isprint(c)) {
       unsigned char escape[4];
 
       escape[0] = '\\';
@@ -503,7 +503,7 @@ static ares_status_t ares__fetch_dnsname_into_buf(ares__buf_t *buf,
       escape[2] = '0' + ((c % 100) / 10);
       escape[3] = '0' + (c % 10);
 
-      status = ares__buf_append(dest, escape, sizeof(escape));
+      status = ares_buf_append(dest, escape, sizeof(escape));
       if (status != ARES_SUCCESS) {
         goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
       }
@@ -513,39 +513,39 @@ static ares_status_t ares__fetch_dnsname_into_buf(ares__buf_t *buf,
 
     /* Reserved characters need to be escaped, otherwise normal */
     if (is_reservedch(c)) {
-      status = ares__buf_append_byte(dest, '\\');
+      status = ares_buf_append_byte(dest, '\\');
       if (status != ARES_SUCCESS) {
         goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
       }
     }
 
-    status = ares__buf_append_byte(dest, c);
+    status = ares_buf_append_byte(dest, c);
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
 
-  return ares__buf_consume(buf, len);
+  return ares_buf_consume(buf, len);
 
 fail:
   return status;
 }
 
-ares_status_t ares__dns_name_parse(ares__buf_t *buf, char **name,
+ares_status_t ares_dns_name_parse(ares_buf_t *buf, char **name,
                                    ares_bool_t is_hostname)
 {
   size_t        save_offset = 0;
   unsigned char c;
   ares_status_t status;
-  ares__buf_t  *namebuf     = NULL;
-  size_t        label_start = ares__buf_get_position(buf);
+  ares_buf_t  *namebuf     = NULL;
+  size_t        label_start = ares_buf_get_position(buf);
 
   if (buf == NULL) {
     return ARES_EFORMERR;
   }
 
   if (name != NULL) {
-    namebuf = ares__buf_create();
+    namebuf = ares_buf_create();
     if (namebuf == NULL) {
       status = ARES_ENOMEM;
       goto fail;
@@ -562,11 +562,11 @@ ares_status_t ares__dns_name_parse(ares__buf_t *buf, char **name,
   while (1) {
     /* Keep track of the minimum label starting position to prevent forward
      * jumping */
-    if (label_start > ares__buf_get_position(buf)) {
-      label_start = ares__buf_get_position(buf);
+    if (label_start > ares_buf_get_position(buf)) {
+      label_start = ares_buf_get_position(buf);
     }
 
-    status = ares__buf_fetch_bytes(buf, &c, 1);
+    status = ares_buf_fetch_bytes(buf, &c, 1);
     if (status != ARES_SUCCESS) {
       goto fail;
     }
@@ -590,7 +590,7 @@ ares_status_t ares__dns_name_parse(ares__buf_t *buf, char **name,
       size_t offset = (size_t)((c & 0x3F) << 8);
 
       /* Fetch second byte of the redirect length */
-      status = ares__buf_fetch_bytes(buf, &c, 1);
+      status = ares_buf_fetch_bytes(buf, &c, 1);
       if (status != ARES_SUCCESS) {
         goto fail;
       }
@@ -612,10 +612,10 @@ ares_status_t ares__dns_name_parse(ares__buf_t *buf, char **name,
 
       /* First time we make a jump, save the current position */
       if (save_offset == 0) {
-        save_offset = ares__buf_get_position(buf);
+        save_offset = ares_buf_get_position(buf);
       }
 
-      status = ares__buf_set_position(buf, offset);
+      status = ares_buf_set_position(buf, offset);
       if (status != ARES_SUCCESS) {
         status = ARES_EBADNAME;
         goto fail;
@@ -634,14 +634,14 @@ ares_status_t ares__dns_name_parse(ares__buf_t *buf, char **name,
     /* New label */
 
     /* Labels are separated by periods */
-    if (ares__buf_len(namebuf) != 0 && name != NULL) {
-      status = ares__buf_append_byte(namebuf, '.');
+    if (ares_buf_len(namebuf) != 0 && name != NULL) {
+      status = ares_buf_append_byte(namebuf, '.');
       if (status != ARES_SUCCESS) {
         goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
       }
     }
 
-    status = ares__fetch_dnsname_into_buf(buf, namebuf, c, is_hostname);
+    status = ares_fetch_dnsname_into_buf(buf, namebuf, c, is_hostname);
     if (status != ARES_SUCCESS) {
       goto fail;
     }
@@ -650,11 +650,11 @@ ares_status_t ares__dns_name_parse(ares__buf_t *buf, char **name,
   /* Restore offset read after first redirect/pointer as this is where the DNS
    * message continues */
   if (save_offset) {
-    ares__buf_set_position(buf, save_offset);
+    ares_buf_set_position(buf, save_offset);
   }
 
   if (name != NULL) {
-    *name = ares__buf_finish_str(namebuf, NULL);
+    *name = ares_buf_finish_str(namebuf, NULL);
     if (*name == NULL) {
       status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
       goto fail;            /* LCOV_EXCL_LINE: OutOfMemory */
@@ -669,6 +669,6 @@ fail:
     status = ARES_EBADNAME;
   }
 
-  ares__buf_destroy(namebuf);
+  ares_buf_destroy(namebuf);
   return status;
 }

--- a/src/lib/record/ares_dns_name.c
+++ b/src/lib/record/ares_dns_name.c
@@ -42,7 +42,7 @@ static void ares_nameoffset_free(void *arg)
 }
 
 static ares_status_t ares_nameoffset_create(ares_llist_t **list,
-                                             const char *name, size_t idx)
+                                            const char *name, size_t idx)
 {
   ares_status_t      status;
   ares_nameoffset_t *off = NULL;
@@ -84,10 +84,10 @@ fail:
 }
 
 static const ares_nameoffset_t *ares_nameoffset_find(ares_llist_t *list,
-                                                      const char    *name)
+                                                     const char   *name)
 {
   size_t                   name_len = ares_strlen(name);
-  ares_llist_node_t      *node;
+  ares_llist_node_t       *node;
   const ares_nameoffset_t *longest_match = NULL;
 
   if (list == NULL || name == NULL || name_len == 0) {
@@ -191,7 +191,7 @@ static void ares_dns_name_labels_del_last(ares_array_t *labels)
 
 static ares_status_t ares_parse_dns_name_escape(ares_buf_t *namebuf,
                                                 ares_buf_t *label,
-                                                ares_bool_t  validate_hostname)
+                                                ares_bool_t validate_hostname)
 {
   ares_status_t status;
   unsigned char c;
@@ -242,12 +242,12 @@ static ares_status_t ares_parse_dns_name_escape(ares_buf_t *namebuf,
 }
 
 static ares_status_t ares_split_dns_name(ares_array_t *labels,
-                                         ares_bool_t    validate_hostname,
-                                         const char    *name)
+                                         ares_bool_t   validate_hostname,
+                                         const char   *name)
 {
   ares_status_t status;
-  ares_buf_t  *label   = NULL;
-  ares_buf_t  *namebuf = NULL;
+  ares_buf_t   *label   = NULL;
+  ares_buf_t   *namebuf = NULL;
   size_t        i;
   size_t        total_len = 0;
   unsigned char c;
@@ -325,7 +325,7 @@ static ares_status_t ares_split_dns_name(ares_array_t *labels,
   /* Scan to make sure label lengths are valid */
   for (i = 0; i < ares_array_len(labels); i++) {
     const ares_buf_t *buf = ares_dns_labels_get_at(labels, i);
-    size_t             len = ares_buf_len(buf);
+    size_t            len = ares_buf_len(buf);
     /* No 0-length labels, and no labels over 63 bytes */
     if (len == 0 || len > 63) {
       status = ARES_EBADNAME;
@@ -335,8 +335,7 @@ static ares_status_t ares_split_dns_name(ares_array_t *labels,
   }
 
   /* Can't exceed maximum (unescaped) length */
-  if (ares_array_len(labels) &&
-      total_len + ares_array_len(labels) - 1 > 255) {
+  if (ares_array_len(labels) && total_len + ares_array_len(labels) - 1 > 255) {
     status = ARES_EBADNAME;
     goto done;
   }
@@ -349,14 +348,14 @@ done:
 }
 
 ares_status_t ares_dns_name_write(ares_buf_t *buf, ares_llist_t **list,
-                                   ares_bool_t validate_hostname,
-                                   const char *name)
+                                  ares_bool_t validate_hostname,
+                                  const char *name)
 {
   const ares_nameoffset_t *off = NULL;
   size_t                   name_len;
   size_t                   orig_name_len;
   size_t                   pos    = ares_buf_len(buf);
-  ares_array_t           *labels = NULL;
+  ares_array_t            *labels = NULL;
   char                     name_copy[512];
   ares_status_t            status;
 
@@ -395,7 +394,7 @@ ares_status_t ares_dns_name_write(ares_buf_t *buf, ares_llist_t **list,
 
     for (i = 0; i < ares_array_len(labels); i++) {
       size_t               len  = 0;
-      const ares_buf_t   *lbuf = ares_dns_labels_get_at(labels, i);
+      const ares_buf_t    *lbuf = ares_dns_labels_get_at(labels, i);
       const unsigned char *ptr  = ares_buf_peek(lbuf, &len);
 
       status = ares_buf_append_byte(buf, (unsigned char)(len & 0xFF));
@@ -466,8 +465,8 @@ static ares_bool_t is_reservedch(int ch)
 }
 
 static ares_status_t ares_fetch_dnsname_into_buf(ares_buf_t *buf,
-                                                  ares_buf_t *dest, size_t len,
-                                                  ares_bool_t is_hostname)
+                                                 ares_buf_t *dest, size_t len,
+                                                 ares_bool_t is_hostname)
 {
   size_t               remaining_len;
   const unsigned char *ptr = ares_buf_peek(buf, &remaining_len);
@@ -532,12 +531,12 @@ fail:
 }
 
 ares_status_t ares_dns_name_parse(ares_buf_t *buf, char **name,
-                                   ares_bool_t is_hostname)
+                                  ares_bool_t is_hostname)
 {
   size_t        save_offset = 0;
   unsigned char c;
   ares_status_t status;
-  ares_buf_t  *namebuf     = NULL;
+  ares_buf_t   *namebuf     = NULL;
   size_t        label_start = ares_buf_get_position(buf);
 
   if (buf == NULL) {

--- a/src/lib/record/ares_dns_parse.c
+++ b/src/lib/record/ares_dns_parse.c
@@ -29,17 +29,17 @@
 #  include <stdint.h>
 #endif
 
-static size_t ares_dns_rr_remaining_len(const ares__buf_t *buf, size_t orig_len,
+static size_t ares_dns_rr_remaining_len(const ares_buf_t *buf, size_t orig_len,
                                         size_t rdlength)
 {
-  size_t used_len = orig_len - ares__buf_len(buf);
+  size_t used_len = orig_len - ares_buf_len(buf);
   if (used_len >= rdlength) {
     return 0;
   }
   return rdlength - used_len;
 }
 
-static ares_status_t ares_dns_parse_and_set_dns_name(ares__buf_t   *buf,
+static ares_status_t ares_dns_parse_and_set_dns_name(ares_buf_t   *buf,
                                                      ares_bool_t    is_hostname,
                                                      ares_dns_rr_t *rr,
                                                      ares_dns_rr_key_t key)
@@ -47,7 +47,7 @@ static ares_status_t ares_dns_parse_and_set_dns_name(ares__buf_t   *buf,
   ares_status_t status;
   char         *name = NULL;
 
-  status = ares__dns_name_parse(buf, &name, is_hostname);
+  status = ares_dns_name_parse(buf, &name, is_hostname);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -60,7 +60,7 @@ static ares_status_t ares_dns_parse_and_set_dns_name(ares__buf_t   *buf,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_parse_and_set_dns_str(ares__buf_t      *buf,
+static ares_status_t ares_dns_parse_and_set_dns_str(ares_buf_t      *buf,
                                                     size_t            max_len,
                                                     ares_dns_rr_t    *rr,
                                                     ares_dns_rr_key_t key,
@@ -69,7 +69,7 @@ static ares_status_t ares_dns_parse_and_set_dns_str(ares__buf_t      *buf,
   ares_status_t status;
   char         *str = NULL;
 
-  status = ares__buf_parse_dns_str(buf, max_len, &str);
+  status = ares_buf_parse_dns_str(buf, max_len, &str);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -88,35 +88,35 @@ static ares_status_t ares_dns_parse_and_set_dns_str(ares__buf_t      *buf,
 }
 
 static ares_status_t
-  ares_dns_parse_and_set_dns_abin(ares__buf_t *buf, size_t max_len,
+  ares_dns_parse_and_set_dns_abin(ares_buf_t *buf, size_t max_len,
                                   ares_dns_rr_t *rr, ares_dns_rr_key_t key,
                                   ares_bool_t validate_printable)
 {
   ares_status_t            status;
-  ares__dns_multistring_t *strs = NULL;
+  ares_dns_multistring_t *strs = NULL;
 
   status =
-    ares__dns_multistring_parse_buf(buf, max_len, &strs, validate_printable);
+    ares_dns_multistring_parse_buf(buf, max_len, &strs, validate_printable);
   if (status != ARES_SUCCESS) {
     return status;
   }
 
   status = ares_dns_rr_set_abin_own(rr, key, strs);
   if (status != ARES_SUCCESS) {
-    ares__dns_multistring_destroy(strs);
+    ares_dns_multistring_destroy(strs);
     return status;
   }
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_parse_and_set_be32(ares__buf_t      *buf,
+static ares_status_t ares_dns_parse_and_set_be32(ares_buf_t      *buf,
                                                  ares_dns_rr_t    *rr,
                                                  ares_dns_rr_key_t key)
 {
   ares_status_t status;
   unsigned int  u32;
 
-  status = ares__buf_fetch_be32(buf, &u32);
+  status = ares_buf_fetch_be32(buf, &u32);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -124,14 +124,14 @@ static ares_status_t ares_dns_parse_and_set_be32(ares__buf_t      *buf,
   return ares_dns_rr_set_u32(rr, key, u32);
 }
 
-static ares_status_t ares_dns_parse_and_set_be16(ares__buf_t      *buf,
+static ares_status_t ares_dns_parse_and_set_be16(ares_buf_t      *buf,
                                                  ares_dns_rr_t    *rr,
                                                  ares_dns_rr_key_t key)
 {
   ares_status_t  status;
   unsigned short u16;
 
-  status = ares__buf_fetch_be16(buf, &u16);
+  status = ares_buf_fetch_be16(buf, &u16);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -139,14 +139,14 @@ static ares_status_t ares_dns_parse_and_set_be16(ares__buf_t      *buf,
   return ares_dns_rr_set_u16(rr, key, u16);
 }
 
-static ares_status_t ares_dns_parse_and_set_u8(ares__buf_t      *buf,
+static ares_status_t ares_dns_parse_and_set_u8(ares_buf_t      *buf,
                                                ares_dns_rr_t    *rr,
                                                ares_dns_rr_key_t key)
 {
   ares_status_t status;
   unsigned char u8;
 
-  status = ares__buf_fetch_bytes(buf, &u8, 1);
+  status = ares_buf_fetch_bytes(buf, &u8, 1);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -154,7 +154,7 @@ static ares_status_t ares_dns_parse_and_set_u8(ares__buf_t      *buf,
   return ares_dns_rr_set_u8(rr, key, u8);
 }
 
-static ares_status_t ares_dns_parse_rr_a(ares__buf_t *buf, ares_dns_rr_t *rr,
+static ares_status_t ares_dns_parse_rr_a(ares_buf_t *buf, ares_dns_rr_t *rr,
                                          size_t rdlength)
 {
   struct in_addr addr;
@@ -162,7 +162,7 @@ static ares_status_t ares_dns_parse_rr_a(ares__buf_t *buf, ares_dns_rr_t *rr,
 
   (void)rdlength; /* Not needed */
 
-  status = ares__buf_fetch_bytes(buf, (unsigned char *)&addr, sizeof(addr));
+  status = ares_buf_fetch_bytes(buf, (unsigned char *)&addr, sizeof(addr));
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -170,7 +170,7 @@ static ares_status_t ares_dns_parse_rr_a(ares__buf_t *buf, ares_dns_rr_t *rr,
   return ares_dns_rr_set_addr(rr, ARES_RR_A_ADDR, &addr);
 }
 
-static ares_status_t ares_dns_parse_rr_ns(ares__buf_t *buf, ares_dns_rr_t *rr,
+static ares_status_t ares_dns_parse_rr_ns(ares_buf_t *buf, ares_dns_rr_t *rr,
                                           size_t rdlength)
 {
   (void)rdlength; /* Not needed */
@@ -179,7 +179,7 @@ static ares_status_t ares_dns_parse_rr_ns(ares__buf_t *buf, ares_dns_rr_t *rr,
                                          ARES_RR_NS_NSDNAME);
 }
 
-static ares_status_t ares_dns_parse_rr_cname(ares__buf_t   *buf,
+static ares_status_t ares_dns_parse_rr_cname(ares_buf_t   *buf,
                                              ares_dns_rr_t *rr, size_t rdlength)
 {
   (void)rdlength; /* Not needed */
@@ -188,7 +188,7 @@ static ares_status_t ares_dns_parse_rr_cname(ares__buf_t   *buf,
                                          ARES_RR_CNAME_CNAME);
 }
 
-static ares_status_t ares_dns_parse_rr_soa(ares__buf_t *buf, ares_dns_rr_t *rr,
+static ares_status_t ares_dns_parse_rr_soa(ares_buf_t *buf, ares_dns_rr_t *rr,
                                            size_t rdlength)
 {
   ares_status_t status;
@@ -237,7 +237,7 @@ static ares_status_t ares_dns_parse_rr_soa(ares__buf_t *buf, ares_dns_rr_t *rr,
   return ares_dns_parse_and_set_be32(buf, rr, ARES_RR_SOA_MINIMUM);
 }
 
-static ares_status_t ares_dns_parse_rr_ptr(ares__buf_t *buf, ares_dns_rr_t *rr,
+static ares_status_t ares_dns_parse_rr_ptr(ares_buf_t *buf, ares_dns_rr_t *rr,
                                            size_t rdlength)
 {
   (void)rdlength; /* Not needed */
@@ -246,11 +246,11 @@ static ares_status_t ares_dns_parse_rr_ptr(ares__buf_t *buf, ares_dns_rr_t *rr,
                                          ARES_RR_PTR_DNAME);
 }
 
-static ares_status_t ares_dns_parse_rr_hinfo(ares__buf_t   *buf,
+static ares_status_t ares_dns_parse_rr_hinfo(ares_buf_t   *buf,
                                              ares_dns_rr_t *rr, size_t rdlength)
 {
   ares_status_t status;
-  size_t        orig_len = ares__buf_len(buf);
+  size_t        orig_len = ares_buf_len(buf);
 
   (void)rdlength; /* Not needed */
 
@@ -270,7 +270,7 @@ static ares_status_t ares_dns_parse_rr_hinfo(ares__buf_t   *buf,
   return status;
 }
 
-static ares_status_t ares_dns_parse_rr_mx(ares__buf_t *buf, ares_dns_rr_t *rr,
+static ares_status_t ares_dns_parse_rr_mx(ares_buf_t *buf, ares_dns_rr_t *rr,
                                           size_t rdlength)
 {
   ares_status_t status;
@@ -288,18 +288,18 @@ static ares_status_t ares_dns_parse_rr_mx(ares__buf_t *buf, ares_dns_rr_t *rr,
                                          ARES_RR_MX_EXCHANGE);
 }
 
-static ares_status_t ares_dns_parse_rr_txt(ares__buf_t *buf, ares_dns_rr_t *rr,
+static ares_status_t ares_dns_parse_rr_txt(ares_buf_t *buf, ares_dns_rr_t *rr,
                                            size_t rdlength)
 {
   return ares_dns_parse_and_set_dns_abin(buf, rdlength, rr, ARES_RR_TXT_DATA,
                                          ARES_FALSE);
 }
 
-static ares_status_t ares_dns_parse_rr_sig(ares__buf_t *buf, ares_dns_rr_t *rr,
+static ares_status_t ares_dns_parse_rr_sig(ares_buf_t *buf, ares_dns_rr_t *rr,
                                            size_t rdlength)
 {
   ares_status_t  status;
-  size_t         orig_len = ares__buf_len(buf);
+  size_t         orig_len = ares_buf_len(buf);
   size_t         len;
   unsigned char *data;
 
@@ -349,7 +349,7 @@ static ares_status_t ares_dns_parse_rr_sig(ares__buf_t *buf, ares_dns_rr_t *rr,
     return ARES_EBADRESP;
   }
 
-  status = ares__buf_fetch_bytes_dup(buf, len, ARES_FALSE, &data);
+  status = ares_buf_fetch_bytes_dup(buf, len, ARES_FALSE, &data);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -363,7 +363,7 @@ static ares_status_t ares_dns_parse_rr_sig(ares__buf_t *buf, ares_dns_rr_t *rr,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_parse_rr_aaaa(ares__buf_t *buf, ares_dns_rr_t *rr,
+static ares_status_t ares_dns_parse_rr_aaaa(ares_buf_t *buf, ares_dns_rr_t *rr,
                                             size_t rdlength)
 {
   struct ares_in6_addr addr;
@@ -371,7 +371,7 @@ static ares_status_t ares_dns_parse_rr_aaaa(ares__buf_t *buf, ares_dns_rr_t *rr,
 
   (void)rdlength; /* Not needed */
 
-  status = ares__buf_fetch_bytes(buf, (unsigned char *)&addr, sizeof(addr));
+  status = ares_buf_fetch_bytes(buf, (unsigned char *)&addr, sizeof(addr));
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -379,7 +379,7 @@ static ares_status_t ares_dns_parse_rr_aaaa(ares__buf_t *buf, ares_dns_rr_t *rr,
   return ares_dns_rr_set_addr6(rr, ARES_RR_AAAA_ADDR, &addr);
 }
 
-static ares_status_t ares_dns_parse_rr_srv(ares__buf_t *buf, ares_dns_rr_t *rr,
+static ares_status_t ares_dns_parse_rr_srv(ares_buf_t *buf, ares_dns_rr_t *rr,
                                            size_t rdlength)
 {
   ares_status_t status;
@@ -409,11 +409,11 @@ static ares_status_t ares_dns_parse_rr_srv(ares__buf_t *buf, ares_dns_rr_t *rr,
                                          ARES_RR_SRV_TARGET);
 }
 
-static ares_status_t ares_dns_parse_rr_naptr(ares__buf_t   *buf,
+static ares_status_t ares_dns_parse_rr_naptr(ares_buf_t   *buf,
                                              ares_dns_rr_t *rr, size_t rdlength)
 {
   ares_status_t status;
-  size_t        orig_len = ares__buf_len(buf);
+  size_t        orig_len = ares_buf_len(buf);
 
   /* ORDER */
   status = ares_dns_parse_and_set_be16(buf, rr, ARES_RR_NAPTR_ORDER);
@@ -456,13 +456,13 @@ static ares_status_t ares_dns_parse_rr_naptr(ares__buf_t   *buf,
                                          ARES_RR_NAPTR_REPLACEMENT);
 }
 
-static ares_status_t ares_dns_parse_rr_opt(ares__buf_t *buf, ares_dns_rr_t *rr,
+static ares_status_t ares_dns_parse_rr_opt(ares_buf_t *buf, ares_dns_rr_t *rr,
                                            size_t         rdlength,
                                            unsigned short raw_class,
                                            unsigned int   raw_ttl)
 {
   ares_status_t  status;
-  size_t         orig_len = ares__buf_len(buf);
+  size_t         orig_len = ares_buf_len(buf);
   unsigned short rcode_high;
 
   status = ares_dns_rr_set_u16(rr, ARES_RR_OPT_UDP_SIZE, raw_class);
@@ -494,19 +494,19 @@ static ares_status_t ares_dns_parse_rr_opt(ares__buf_t *buf, ares_dns_rr_t *rr,
     unsigned char *val = NULL;
 
     /* Fetch be16 option */
-    status = ares__buf_fetch_be16(buf, &opt);
+    status = ares_buf_fetch_be16(buf, &opt);
     if (status != ARES_SUCCESS) {
       return status;
     }
 
     /* Fetch be16 length */
-    status = ares__buf_fetch_be16(buf, &len);
+    status = ares_buf_fetch_be16(buf, &len);
     if (status != ARES_SUCCESS) {
       return status;
     }
 
     if (len) {
-      status = ares__buf_fetch_bytes_dup(buf, len, ARES_TRUE, &val);
+      status = ares_buf_fetch_bytes_dup(buf, len, ARES_TRUE, &val);
       if (status != ARES_SUCCESS) {
         return status;
       }
@@ -521,11 +521,11 @@ static ares_status_t ares_dns_parse_rr_opt(ares__buf_t *buf, ares_dns_rr_t *rr,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_parse_rr_tlsa(ares__buf_t *buf, ares_dns_rr_t *rr,
+static ares_status_t ares_dns_parse_rr_tlsa(ares_buf_t *buf, ares_dns_rr_t *rr,
                                             size_t rdlength)
 {
   ares_status_t  status;
-  size_t         orig_len = ares__buf_len(buf);
+  size_t         orig_len = ares_buf_len(buf);
   size_t         len;
   unsigned char *data;
 
@@ -549,7 +549,7 @@ static ares_status_t ares_dns_parse_rr_tlsa(ares__buf_t *buf, ares_dns_rr_t *rr,
     return ARES_EBADRESP;
   }
 
-  status = ares__buf_fetch_bytes_dup(buf, len, ARES_FALSE, &data);
+  status = ares_buf_fetch_bytes_dup(buf, len, ARES_FALSE, &data);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -563,11 +563,11 @@ static ares_status_t ares_dns_parse_rr_tlsa(ares__buf_t *buf, ares_dns_rr_t *rr,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_parse_rr_svcb(ares__buf_t *buf, ares_dns_rr_t *rr,
+static ares_status_t ares_dns_parse_rr_svcb(ares_buf_t *buf, ares_dns_rr_t *rr,
                                             size_t rdlength)
 {
   ares_status_t status;
-  size_t        orig_len = ares__buf_len(buf);
+  size_t        orig_len = ares_buf_len(buf);
 
   status = ares_dns_parse_and_set_be16(buf, rr, ARES_RR_SVCB_PRIORITY);
   if (status != ARES_SUCCESS) {
@@ -587,19 +587,19 @@ static ares_status_t ares_dns_parse_rr_svcb(ares__buf_t *buf, ares_dns_rr_t *rr,
     unsigned char *val = NULL;
 
     /* Fetch be16 option */
-    status = ares__buf_fetch_be16(buf, &opt);
+    status = ares_buf_fetch_be16(buf, &opt);
     if (status != ARES_SUCCESS) {
       return status;
     }
 
     /* Fetch be16 length */
-    status = ares__buf_fetch_be16(buf, &len);
+    status = ares_buf_fetch_be16(buf, &len);
     if (status != ARES_SUCCESS) {
       return status;
     }
 
     if (len) {
-      status = ares__buf_fetch_bytes_dup(buf, len, ARES_TRUE, &val);
+      status = ares_buf_fetch_bytes_dup(buf, len, ARES_TRUE, &val);
       if (status != ARES_SUCCESS) {
         return status;
       }
@@ -614,11 +614,11 @@ static ares_status_t ares_dns_parse_rr_svcb(ares__buf_t *buf, ares_dns_rr_t *rr,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_parse_rr_https(ares__buf_t   *buf,
+static ares_status_t ares_dns_parse_rr_https(ares_buf_t   *buf,
                                              ares_dns_rr_t *rr, size_t rdlength)
 {
   ares_status_t status;
-  size_t        orig_len = ares__buf_len(buf);
+  size_t        orig_len = ares_buf_len(buf);
 
   status = ares_dns_parse_and_set_be16(buf, rr, ARES_RR_HTTPS_PRIORITY);
   if (status != ARES_SUCCESS) {
@@ -638,19 +638,19 @@ static ares_status_t ares_dns_parse_rr_https(ares__buf_t   *buf,
     unsigned char *val = NULL;
 
     /* Fetch be16 option */
-    status = ares__buf_fetch_be16(buf, &opt);
+    status = ares_buf_fetch_be16(buf, &opt);
     if (status != ARES_SUCCESS) {
       return status;
     }
 
     /* Fetch be16 length */
-    status = ares__buf_fetch_be16(buf, &len);
+    status = ares_buf_fetch_be16(buf, &len);
     if (status != ARES_SUCCESS) {
       return status;
     }
 
     if (len) {
-      status = ares__buf_fetch_bytes_dup(buf, len, ARES_TRUE, &val);
+      status = ares_buf_fetch_bytes_dup(buf, len, ARES_TRUE, &val);
       if (status != ARES_SUCCESS) {
         return status;
       }
@@ -665,12 +665,12 @@ static ares_status_t ares_dns_parse_rr_https(ares__buf_t   *buf,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_parse_rr_uri(ares__buf_t *buf, ares_dns_rr_t *rr,
+static ares_status_t ares_dns_parse_rr_uri(ares_buf_t *buf, ares_dns_rr_t *rr,
                                            size_t rdlength)
 {
   char         *name = NULL;
   ares_status_t status;
-  size_t        orig_len = ares__buf_len(buf);
+  size_t        orig_len = ares_buf_len(buf);
   size_t        remaining_len;
 
   /* PRIORITY */
@@ -694,12 +694,12 @@ static ares_status_t ares_dns_parse_rr_uri(ares__buf_t *buf, ares_dns_rr_t *rr,
   }
 
   /* NOTE: Not in DNS string format */
-  status = ares__buf_fetch_str_dup(buf, remaining_len, &name);
+  status = ares_buf_fetch_str_dup(buf, remaining_len, &name);
   if (status != ARES_SUCCESS) {
     return status;
   }
 
-  if (!ares__str_isprint(name, remaining_len)) {
+  if (!ares_str_isprint(name, remaining_len)) {
     ares_free(name);
     return ARES_EBADRESP;
   }
@@ -714,13 +714,13 @@ static ares_status_t ares_dns_parse_rr_uri(ares__buf_t *buf, ares_dns_rr_t *rr,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_parse_rr_caa(ares__buf_t *buf, ares_dns_rr_t *rr,
+static ares_status_t ares_dns_parse_rr_caa(ares_buf_t *buf, ares_dns_rr_t *rr,
                                            size_t rdlength)
 {
   unsigned char *data     = NULL;
   size_t         data_len = 0;
   ares_status_t  status;
-  size_t         orig_len = ares__buf_len(buf);
+  size_t         orig_len = ares_buf_len(buf);
 
   /* CRITICAL */
   status = ares_dns_parse_and_set_u8(buf, rr, ARES_RR_CAA_CRITICAL);
@@ -742,7 +742,7 @@ static ares_status_t ares_dns_parse_rr_caa(ares__buf_t *buf, ares_dns_rr_t *rr,
     status = ARES_EBADRESP;
     return status;
   }
-  status = ares__buf_fetch_bytes_dup(buf, data_len, ARES_TRUE, &data);
+  status = ares_buf_fetch_bytes_dup(buf, data_len, ARES_TRUE, &data);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -757,7 +757,7 @@ static ares_status_t ares_dns_parse_rr_caa(ares__buf_t *buf, ares_dns_rr_t *rr,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_parse_rr_raw_rr(ares__buf_t   *buf,
+static ares_status_t ares_dns_parse_rr_raw_rr(ares_buf_t   *buf,
                                               ares_dns_rr_t *rr,
                                               size_t         rdlength,
                                               unsigned short raw_type)
@@ -769,7 +769,7 @@ static ares_status_t ares_dns_parse_rr_raw_rr(ares__buf_t   *buf,
     return ARES_SUCCESS;
   }
 
-  status = ares__buf_fetch_bytes_dup(buf, rdlength, ARES_FALSE, &bytes);
+  status = ares_buf_fetch_bytes_dup(buf, rdlength, ARES_FALSE, &bytes);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -790,7 +790,7 @@ static ares_status_t ares_dns_parse_rr_raw_rr(ares__buf_t   *buf,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_parse_header(ares__buf_t *buf, unsigned int flags,
+static ares_status_t ares_dns_parse_header(ares_buf_t *buf, unsigned int flags,
                                            ares_dns_record_t **dnsrec,
                                            unsigned short     *qdcount,
                                            unsigned short     *ancount,
@@ -834,13 +834,13 @@ static ares_status_t ares_dns_parse_header(ares__buf_t *buf, unsigned int flags,
    */
 
   /* ID */
-  status = ares__buf_fetch_be16(buf, &id);
+  status = ares_buf_fetch_be16(buf, &id);
   if (status != ARES_SUCCESS) {
     goto fail;
   }
 
   /* Flags */
-  status = ares__buf_fetch_be16(buf, &u16);
+  status = ares_buf_fetch_be16(buf, &u16);
   if (status != ARES_SUCCESS) {
     goto fail;
   }
@@ -889,25 +889,25 @@ static ares_status_t ares_dns_parse_header(ares__buf_t *buf, unsigned int flags,
   rcode = u16 & 0xf;
 
   /* QDCOUNT */
-  status = ares__buf_fetch_be16(buf, qdcount);
+  status = ares_buf_fetch_be16(buf, qdcount);
   if (status != ARES_SUCCESS) {
     goto fail;
   }
 
   /* ANCOUNT */
-  status = ares__buf_fetch_be16(buf, ancount);
+  status = ares_buf_fetch_be16(buf, ancount);
   if (status != ARES_SUCCESS) {
     goto fail;
   }
 
   /* NSCOUNT */
-  status = ares__buf_fetch_be16(buf, nscount);
+  status = ares_buf_fetch_be16(buf, nscount);
   if (status != ARES_SUCCESS) {
     goto fail;
   }
 
   /* ARCOUNT */
-  status = ares__buf_fetch_be16(buf, arcount);
+  status = ares_buf_fetch_be16(buf, arcount);
   if (status != ARES_SUCCESS) {
     goto fail;
   }
@@ -958,7 +958,7 @@ fail:
 }
 
 static ares_status_t
-  ares_dns_parse_rr_data(ares__buf_t *buf, size_t rdlength, ares_dns_rr_t *rr,
+  ares_dns_parse_rr_data(ares_buf_t *buf, size_t rdlength, ares_dns_rr_t *rr,
                          ares_dns_rec_type_t type, unsigned short raw_type,
                          unsigned short raw_class, unsigned int raw_ttl)
 {
@@ -1007,7 +1007,7 @@ static ares_status_t
   return ARES_EFORMERR;
 }
 
-static ares_status_t ares_dns_parse_qd(ares__buf_t       *buf,
+static ares_status_t ares_dns_parse_qd(ares_buf_t       *buf,
                                        ares_dns_record_t *dnsrec)
 {
   char               *name = NULL;
@@ -1032,20 +1032,20 @@ static ares_status_t ares_dns_parse_qd(ares__buf_t       *buf,
    */
 
   /* Name */
-  status = ares__dns_name_parse(buf, &name, ARES_FALSE);
+  status = ares_dns_name_parse(buf, &name, ARES_FALSE);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
   /* Type */
-  status = ares__buf_fetch_be16(buf, &u16);
+  status = ares_buf_fetch_be16(buf, &u16);
   if (status != ARES_SUCCESS) {
     goto done;
   }
   type = u16;
 
   /* Class */
-  status = ares__buf_fetch_be16(buf, &u16);
+  status = ares_buf_fetch_be16(buf, &u16);
   if (status != ARES_SUCCESS) {
     goto done;
   }
@@ -1062,7 +1062,7 @@ done:
   return status;
 }
 
-static ares_status_t ares_dns_parse_rr(ares__buf_t *buf, unsigned int flags,
+static ares_status_t ares_dns_parse_rr(ares_buf_t *buf, unsigned int flags,
                                        ares_dns_section_t sect,
                                        ares_dns_record_t *dnsrec)
 {
@@ -1103,13 +1103,13 @@ static ares_status_t ares_dns_parse_rr(ares__buf_t *buf, unsigned int flags,
    */
 
   /* Name */
-  status = ares__dns_name_parse(buf, &name, ARES_FALSE);
+  status = ares_dns_name_parse(buf, &name, ARES_FALSE);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
   /* Type */
-  status = ares__buf_fetch_be16(buf, &u16);
+  status = ares_buf_fetch_be16(buf, &u16);
   if (status != ARES_SUCCESS) {
     goto done;
   }
@@ -1117,20 +1117,20 @@ static ares_status_t ares_dns_parse_rr(ares__buf_t *buf, unsigned int flags,
   raw_type = u16; /* Only used for raw rr data */
 
   /* Class */
-  status = ares__buf_fetch_be16(buf, &u16);
+  status = ares_buf_fetch_be16(buf, &u16);
   if (status != ARES_SUCCESS) {
     goto done;
   }
   qclass = u16;
 
   /* TTL */
-  status = ares__buf_fetch_be32(buf, &ttl);
+  status = ares_buf_fetch_be32(buf, &ttl);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
   /* Length */
-  status = ares__buf_fetch_be16(buf, &u16);
+  status = ares_buf_fetch_be16(buf, &u16);
   if (status != ARES_SUCCESS) {
     goto done;
   }
@@ -1158,7 +1158,7 @@ static ares_status_t ares_dns_parse_rr(ares__buf_t *buf, unsigned int flags,
   }
 
   /* Pull into another buffer for safety */
-  if (rdlength > ares__buf_len(buf)) {
+  if (rdlength > ares_buf_len(buf)) {
     status = ARES_EBADRESP;
     goto done;
   }
@@ -1174,7 +1174,7 @@ static ares_status_t ares_dns_parse_rr(ares__buf_t *buf, unsigned int flags,
 
   /* Record the current remaining length in the buffer so we can tell how
    * much was processed */
-  remaining_len = ares__buf_len(buf);
+  remaining_len = ares_buf_len(buf);
 
   /* Fill in the data for the rr */
   status = ares_dns_parse_rr_data(buf, rdlength, rr, type, raw_type,
@@ -1184,7 +1184,7 @@ static ares_status_t ares_dns_parse_rr(ares__buf_t *buf, unsigned int flags,
   }
 
   /* Determine how many bytes were processed */
-  processed_len = remaining_len - ares__buf_len(buf);
+  processed_len = remaining_len - ares_buf_len(buf);
 
   /* If too many bytes were processed, error! */
   if (processed_len > rdlength) {
@@ -1195,7 +1195,7 @@ static ares_status_t ares_dns_parse_rr(ares__buf_t *buf, unsigned int flags,
   /* If too few bytes were processed, consume the unprocessed data for this
    * record as the parser may not have wanted/needed to use it */
   if (processed_len < rdlength) {
-    ares__buf_consume(buf, rdlength - processed_len);
+    ares_buf_consume(buf, rdlength - processed_len);
   }
 
 
@@ -1204,7 +1204,7 @@ done:
   return status;
 }
 
-static ares_status_t ares_dns_parse_buf(ares__buf_t *buf, unsigned int flags,
+static ares_status_t ares_dns_parse_buf(ares_buf_t *buf, unsigned int flags,
                                         ares_dns_record_t **dnsrec)
 {
   ares_status_t  status;
@@ -1219,7 +1219,7 @@ static ares_status_t ares_dns_parse_buf(ares__buf_t *buf, unsigned int flags,
   }
 
   /* Maximum DNS packet size is 64k, even over TCP */
-  if (ares__buf_len(buf) > 0xFFFF) {
+  if (ares_buf_len(buf) > 0xFFFF) {
     return ARES_EFORMERR;
   }
 
@@ -1310,20 +1310,20 @@ fail:
 ares_status_t ares_dns_parse(const unsigned char *buf, size_t buf_len,
                              unsigned int flags, ares_dns_record_t **dnsrec)
 {
-  ares__buf_t  *parser = NULL;
+  ares_buf_t  *parser = NULL;
   ares_status_t status;
 
   if (buf == NULL || buf_len == 0 || dnsrec == NULL) {
     return ARES_EFORMERR;
   }
 
-  parser = ares__buf_create_const(buf, buf_len);
+  parser = ares_buf_create_const(buf, buf_len);
   if (parser == NULL) {
     return ARES_ENOMEM;
   }
 
   status = ares_dns_parse_buf(parser, flags, dnsrec);
-  ares__buf_destroy(parser);
+  ares_buf_destroy(parser);
 
   return status;
 }

--- a/src/lib/record/ares_dns_parse.c
+++ b/src/lib/record/ares_dns_parse.c
@@ -39,7 +39,7 @@ static size_t ares_dns_rr_remaining_len(const ares_buf_t *buf, size_t orig_len,
   return rdlength - used_len;
 }
 
-static ares_status_t ares_dns_parse_and_set_dns_name(ares_buf_t   *buf,
+static ares_status_t ares_dns_parse_and_set_dns_name(ares_buf_t    *buf,
                                                      ares_bool_t    is_hostname,
                                                      ares_dns_rr_t *rr,
                                                      ares_dns_rr_key_t key)
@@ -60,7 +60,7 @@ static ares_status_t ares_dns_parse_and_set_dns_name(ares_buf_t   *buf,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_parse_and_set_dns_str(ares_buf_t      *buf,
+static ares_status_t ares_dns_parse_and_set_dns_str(ares_buf_t       *buf,
                                                     size_t            max_len,
                                                     ares_dns_rr_t    *rr,
                                                     ares_dns_rr_key_t key,
@@ -92,7 +92,7 @@ static ares_status_t
                                   ares_dns_rr_t *rr, ares_dns_rr_key_t key,
                                   ares_bool_t validate_printable)
 {
-  ares_status_t            status;
+  ares_status_t           status;
   ares_dns_multistring_t *strs = NULL;
 
   status =
@@ -109,7 +109,7 @@ static ares_status_t
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_parse_and_set_be32(ares_buf_t      *buf,
+static ares_status_t ares_dns_parse_and_set_be32(ares_buf_t       *buf,
                                                  ares_dns_rr_t    *rr,
                                                  ares_dns_rr_key_t key)
 {
@@ -124,7 +124,7 @@ static ares_status_t ares_dns_parse_and_set_be32(ares_buf_t      *buf,
   return ares_dns_rr_set_u32(rr, key, u32);
 }
 
-static ares_status_t ares_dns_parse_and_set_be16(ares_buf_t      *buf,
+static ares_status_t ares_dns_parse_and_set_be16(ares_buf_t       *buf,
                                                  ares_dns_rr_t    *rr,
                                                  ares_dns_rr_key_t key)
 {
@@ -139,7 +139,7 @@ static ares_status_t ares_dns_parse_and_set_be16(ares_buf_t      *buf,
   return ares_dns_rr_set_u16(rr, key, u16);
 }
 
-static ares_status_t ares_dns_parse_and_set_u8(ares_buf_t      *buf,
+static ares_status_t ares_dns_parse_and_set_u8(ares_buf_t       *buf,
                                                ares_dns_rr_t    *rr,
                                                ares_dns_rr_key_t key)
 {
@@ -179,8 +179,8 @@ static ares_status_t ares_dns_parse_rr_ns(ares_buf_t *buf, ares_dns_rr_t *rr,
                                          ARES_RR_NS_NSDNAME);
 }
 
-static ares_status_t ares_dns_parse_rr_cname(ares_buf_t   *buf,
-                                             ares_dns_rr_t *rr, size_t rdlength)
+static ares_status_t ares_dns_parse_rr_cname(ares_buf_t *buf, ares_dns_rr_t *rr,
+                                             size_t rdlength)
 {
   (void)rdlength; /* Not needed */
 
@@ -246,8 +246,8 @@ static ares_status_t ares_dns_parse_rr_ptr(ares_buf_t *buf, ares_dns_rr_t *rr,
                                          ARES_RR_PTR_DNAME);
 }
 
-static ares_status_t ares_dns_parse_rr_hinfo(ares_buf_t   *buf,
-                                             ares_dns_rr_t *rr, size_t rdlength)
+static ares_status_t ares_dns_parse_rr_hinfo(ares_buf_t *buf, ares_dns_rr_t *rr,
+                                             size_t rdlength)
 {
   ares_status_t status;
   size_t        orig_len = ares_buf_len(buf);
@@ -409,8 +409,8 @@ static ares_status_t ares_dns_parse_rr_srv(ares_buf_t *buf, ares_dns_rr_t *rr,
                                          ARES_RR_SRV_TARGET);
 }
 
-static ares_status_t ares_dns_parse_rr_naptr(ares_buf_t   *buf,
-                                             ares_dns_rr_t *rr, size_t rdlength)
+static ares_status_t ares_dns_parse_rr_naptr(ares_buf_t *buf, ares_dns_rr_t *rr,
+                                             size_t rdlength)
 {
   ares_status_t status;
   size_t        orig_len = ares_buf_len(buf);
@@ -614,8 +614,8 @@ static ares_status_t ares_dns_parse_rr_svcb(ares_buf_t *buf, ares_dns_rr_t *rr,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_parse_rr_https(ares_buf_t   *buf,
-                                             ares_dns_rr_t *rr, size_t rdlength)
+static ares_status_t ares_dns_parse_rr_https(ares_buf_t *buf, ares_dns_rr_t *rr,
+                                             size_t rdlength)
 {
   ares_status_t status;
   size_t        orig_len = ares_buf_len(buf);
@@ -757,7 +757,7 @@ static ares_status_t ares_dns_parse_rr_caa(ares_buf_t *buf, ares_dns_rr_t *rr,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_parse_rr_raw_rr(ares_buf_t   *buf,
+static ares_status_t ares_dns_parse_rr_raw_rr(ares_buf_t    *buf,
                                               ares_dns_rr_t *rr,
                                               size_t         rdlength,
                                               unsigned short raw_type)
@@ -1007,7 +1007,7 @@ static ares_status_t
   return ARES_EFORMERR;
 }
 
-static ares_status_t ares_dns_parse_qd(ares_buf_t       *buf,
+static ares_status_t ares_dns_parse_qd(ares_buf_t        *buf,
                                        ares_dns_record_t *dnsrec)
 {
   char               *name = NULL;
@@ -1310,7 +1310,7 @@ fail:
 ares_status_t ares_dns_parse(const unsigned char *buf, size_t buf_len,
                              unsigned int flags, ares_dns_record_t **dnsrec)
 {
-  ares_buf_t  *parser = NULL;
+  ares_buf_t   *parser = NULL;
   ares_status_t status;
 
   if (buf == NULL || buf_len == 0 || dnsrec == NULL) {

--- a/src/lib/record/ares_dns_private.h
+++ b/src/lib/record/ares_dns_private.h
@@ -45,7 +45,7 @@ ares_status_t        ares_dns_rr_set_bin_own(ares_dns_rr_t    *dns_rr,
                                              size_t len);
 ares_status_t        ares_dns_rr_set_abin_own(ares_dns_rr_t           *dns_rr,
                                               ares_dns_rr_key_t        key,
-                                              ares__dns_multistring_t *strs);
+                                              ares_dns_multistring_t *strs);
 ares_status_t        ares_dns_rr_set_opt_own(ares_dns_rr_t    *dns_rr,
                                              ares_dns_rr_key_t key, unsigned short opt,
                                              unsigned char *val, size_t val_len);
@@ -58,11 +58,11 @@ void                 ares_dns_record_ttl_decrement(ares_dns_record_t *dnsrec,
 
 /* Same as ares_dns_write() but appends to an existing buffer object */
 ares_status_t        ares_dns_write_buf(const ares_dns_record_t *dnsrec,
-                                        ares__buf_t             *buf);
+                                        ares_buf_t             *buf);
 
 /* Same as ares_dns_write_buf(), but prepends a 16bit length */
 ares_status_t        ares_dns_write_buf_tcp(const ares_dns_record_t *dnsrec,
-                                            ares__buf_t             *buf);
+                                            ares_buf_t             *buf);
 
 /*! Create a DNS record object for a query. The arguments are the same as
  *  those for ares_create_query().
@@ -99,15 +99,15 @@ struct ares_dns_qd {
 
 typedef struct {
   struct in_addr addr;
-} ares__dns_a_t;
+} ares_dns_a_t;
 
 typedef struct {
   char *nsdname;
-} ares__dns_ns_t;
+} ares_dns_ns_t;
 
 typedef struct {
   char *cname;
-} ares__dns_cname_t;
+} ares_dns_cname_t;
 
 typedef struct {
   char        *mname;
@@ -117,25 +117,25 @@ typedef struct {
   unsigned int retry;
   unsigned int expire;
   unsigned int minimum;
-} ares__dns_soa_t;
+} ares_dns_soa_t;
 
 typedef struct {
   char *dname;
-} ares__dns_ptr_t;
+} ares_dns_ptr_t;
 
 typedef struct {
   char *cpu;
   char *os;
-} ares__dns_hinfo_t;
+} ares_dns_hinfo_t;
 
 typedef struct {
   unsigned short preference;
   char          *exchange;
-} ares__dns_mx_t;
+} ares_dns_mx_t;
 
 typedef struct {
-  ares__dns_multistring_t *strs;
-} ares__dns_txt_t;
+  ares_dns_multistring_t *strs;
+} ares_dns_txt_t;
 
 typedef struct {
   unsigned short type_covered;
@@ -148,18 +148,18 @@ typedef struct {
   char          *signers_name;
   unsigned char *signature;
   size_t         signature_len;
-} ares__dns_sig_t;
+} ares_dns_sig_t;
 
 typedef struct {
   struct ares_in6_addr addr;
-} ares__dns_aaaa_t;
+} ares_dns_aaaa_t;
 
 typedef struct {
   unsigned short priority;
   unsigned short weight;
   unsigned short port;
   char          *target;
-} ares__dns_srv_t;
+} ares_dns_srv_t;
 
 typedef struct {
   unsigned short order;
@@ -168,21 +168,21 @@ typedef struct {
   char          *services;
   char          *regexp;
   char          *replacement;
-} ares__dns_naptr_t;
+} ares_dns_naptr_t;
 
 typedef struct {
   unsigned short opt;
   unsigned char *val;
   size_t         val_len;
-} ares__dns_optval_t;
+} ares_dns_optval_t;
 
 typedef struct {
   unsigned short udp_size; /*!< taken from class */
   unsigned char  version;  /*!< taken from bits 8-16 of ttl */
   unsigned short flags;    /*!< Flags, remaining 16 bits, though only
                             *   1 currently defined */
-  ares__array_t *options;  /*!< Type is ares__dns_optval_t */
-} ares__dns_opt_t;
+  ares_array_t *options;  /*!< Type is ares_dns_optval_t */
+} ares_dns_opt_t;
 
 typedef struct {
   unsigned char  cert_usage;
@@ -190,26 +190,26 @@ typedef struct {
   unsigned char  match;
   unsigned char *data;
   size_t         data_len;
-} ares__dns_tlsa_t;
+} ares_dns_tlsa_t;
 
 typedef struct {
   unsigned short priority;
   char          *target;
-  ares__array_t *params; /*!< Type is ares__dns_optval_t */
-} ares__dns_svcb_t;
+  ares_array_t *params; /*!< Type is ares_dns_optval_t */
+} ares_dns_svcb_t;
 
 typedef struct {
   unsigned short priority;
   unsigned short weight;
   char          *target;
-} ares__dns_uri_t;
+} ares_dns_uri_t;
 
 typedef struct {
   unsigned char  critical;
   char          *tag;
   unsigned char *value;
   size_t         value_len;
-} ares__dns_caa_t;
+} ares_dns_caa_t;
 
 /*! Raw, unparsed RR data */
 typedef struct {
@@ -217,7 +217,7 @@ typedef struct {
                           *   of those values since it wasn't parsed */
   unsigned char *data;   /*!< Raw RR data */
   size_t         length; /*!< Length of raw RR data */
-} ares__dns_raw_rr_t;
+} ares_dns_raw_rr_t;
 
 /*! DNS RR data structure */
 struct ares_dns_rr {
@@ -228,25 +228,25 @@ struct ares_dns_rr {
   unsigned int        ttl;
 
   union {
-    ares__dns_a_t      a;
-    ares__dns_ns_t     ns;
-    ares__dns_cname_t  cname;
-    ares__dns_soa_t    soa;
-    ares__dns_ptr_t    ptr;
-    ares__dns_hinfo_t  hinfo;
-    ares__dns_mx_t     mx;
-    ares__dns_txt_t    txt;
-    ares__dns_sig_t    sig;
-    ares__dns_aaaa_t   aaaa;
-    ares__dns_srv_t    srv;
-    ares__dns_naptr_t  naptr;
-    ares__dns_opt_t    opt;
-    ares__dns_tlsa_t   tlsa;
-    ares__dns_svcb_t   svcb;
-    ares__dns_svcb_t   https; /*!< https is a type of svcb, so this is right */
-    ares__dns_uri_t    uri;
-    ares__dns_caa_t    caa;
-    ares__dns_raw_rr_t raw_rr;
+    ares_dns_a_t      a;
+    ares_dns_ns_t     ns;
+    ares_dns_cname_t  cname;
+    ares_dns_soa_t    soa;
+    ares_dns_ptr_t    ptr;
+    ares_dns_hinfo_t  hinfo;
+    ares_dns_mx_t     mx;
+    ares_dns_txt_t    txt;
+    ares_dns_sig_t    sig;
+    ares_dns_aaaa_t   aaaa;
+    ares_dns_srv_t    srv;
+    ares_dns_naptr_t  naptr;
+    ares_dns_opt_t    opt;
+    ares_dns_tlsa_t   tlsa;
+    ares_dns_svcb_t   svcb;
+    ares_dns_svcb_t   https; /*!< https is a type of svcb, so this is right */
+    ares_dns_uri_t    uri;
+    ares_dns_caa_t    caa;
+    ares_dns_raw_rr_t raw_rr;
   } r;
 };
 
@@ -264,10 +264,10 @@ struct ares_dns_record {
                                     *   the ttl of any resource records by
                                     *   this amount.  Used for cache */
 
-  ares__array_t    *qd;            /*!< Type is ares_dns_qd_t */
-  ares__array_t    *an;            /*!< Type is ares_dns_rr_t */
-  ares__array_t    *ns;            /*!< Type is ares_dns_rr_t */
-  ares__array_t    *ar;            /*!< Type is ares_dns_rr_t */
+  ares_array_t    *qd;            /*!< Type is ares_dns_qd_t */
+  ares_array_t    *an;            /*!< Type is ares_dns_rr_t */
+  ares_array_t    *ns;            /*!< Type is ares_dns_rr_t */
+  ares_array_t    *ar;            /*!< Type is ares_dns_rr_t */
 };
 
 #endif

--- a/src/lib/record/ares_dns_private.h
+++ b/src/lib/record/ares_dns_private.h
@@ -43,8 +43,8 @@ ares_status_t        ares_dns_rr_set_str_own(ares_dns_rr_t    *dns_rr,
 ares_status_t        ares_dns_rr_set_bin_own(ares_dns_rr_t    *dns_rr,
                                              ares_dns_rr_key_t key, unsigned char *val,
                                              size_t len);
-ares_status_t        ares_dns_rr_set_abin_own(ares_dns_rr_t           *dns_rr,
-                                              ares_dns_rr_key_t        key,
+ares_status_t        ares_dns_rr_set_abin_own(ares_dns_rr_t          *dns_rr,
+                                              ares_dns_rr_key_t       key,
                                               ares_dns_multistring_t *strs);
 ares_status_t        ares_dns_rr_set_opt_own(ares_dns_rr_t    *dns_rr,
                                              ares_dns_rr_key_t key, unsigned short opt,
@@ -58,11 +58,11 @@ void                 ares_dns_record_ttl_decrement(ares_dns_record_t *dnsrec,
 
 /* Same as ares_dns_write() but appends to an existing buffer object */
 ares_status_t        ares_dns_write_buf(const ares_dns_record_t *dnsrec,
-                                        ares_buf_t             *buf);
+                                        ares_buf_t              *buf);
 
 /* Same as ares_dns_write_buf(), but prepends a 16bit length */
 ares_status_t        ares_dns_write_buf_tcp(const ares_dns_record_t *dnsrec,
-                                            ares_buf_t             *buf);
+                                            ares_buf_t              *buf);
 
 /*! Create a DNS record object for a query. The arguments are the same as
  *  those for ares_create_query().
@@ -181,7 +181,7 @@ typedef struct {
   unsigned char  version;  /*!< taken from bits 8-16 of ttl */
   unsigned short flags;    /*!< Flags, remaining 16 bits, though only
                             *   1 currently defined */
-  ares_array_t *options;  /*!< Type is ares_dns_optval_t */
+  ares_array_t  *options;  /*!< Type is ares_dns_optval_t */
 } ares_dns_opt_t;
 
 typedef struct {
@@ -195,7 +195,7 @@ typedef struct {
 typedef struct {
   unsigned short priority;
   char          *target;
-  ares_array_t *params; /*!< Type is ares_dns_optval_t */
+  ares_array_t  *params; /*!< Type is ares_dns_optval_t */
 } ares_dns_svcb_t;
 
 typedef struct {
@@ -264,10 +264,10 @@ struct ares_dns_record {
                                     *   the ttl of any resource records by
                                     *   this amount.  Used for cache */
 
-  ares_array_t    *qd;            /*!< Type is ares_dns_qd_t */
-  ares_array_t    *an;            /*!< Type is ares_dns_rr_t */
-  ares_array_t    *ns;            /*!< Type is ares_dns_rr_t */
-  ares_array_t    *ar;            /*!< Type is ares_dns_rr_t */
+  ares_array_t     *qd;            /*!< Type is ares_dns_qd_t */
+  ares_array_t     *an;            /*!< Type is ares_dns_rr_t */
+  ares_array_t     *ns;            /*!< Type is ares_dns_rr_t */
+  ares_array_t     *ar;            /*!< Type is ares_dns_rr_t */
 };
 
 #endif

--- a/src/lib/record/ares_dns_record.c
+++ b/src/lib/record/ares_dns_record.c
@@ -29,7 +29,7 @@
 #  include <stdint.h>
 #endif
 
-static void ares__dns_rr_free(ares_dns_rr_t *rr);
+static void ares_dns_rr_free(ares_dns_rr_t *rr);
 
 static void ares_dns_qd_free_cb(void *arg)
 {
@@ -46,7 +46,7 @@ static void ares_dns_rr_free_cb(void *arg)
   if (rr == NULL) {
     return;
   }
-  ares__dns_rr_free(rr);
+  ares_dns_rr_free(rr);
 }
 
 ares_status_t ares_dns_record_create(ares_dns_record_t **dnsrec,
@@ -75,13 +75,13 @@ ares_status_t ares_dns_record_create(ares_dns_record_t **dnsrec,
   (*dnsrec)->opcode = opcode;
   (*dnsrec)->rcode  = rcode;
   (*dnsrec)->qd =
-    ares__array_create(sizeof(ares_dns_qd_t), ares_dns_qd_free_cb);
+    ares_array_create(sizeof(ares_dns_qd_t), ares_dns_qd_free_cb);
   (*dnsrec)->an =
-    ares__array_create(sizeof(ares_dns_rr_t), ares_dns_rr_free_cb);
+    ares_array_create(sizeof(ares_dns_rr_t), ares_dns_rr_free_cb);
   (*dnsrec)->ns =
-    ares__array_create(sizeof(ares_dns_rr_t), ares_dns_rr_free_cb);
+    ares_array_create(sizeof(ares_dns_rr_t), ares_dns_rr_free_cb);
   (*dnsrec)->ar =
-    ares__array_create(sizeof(ares_dns_rr_t), ares_dns_rr_free_cb);
+    ares_array_create(sizeof(ares_dns_rr_t), ares_dns_rr_free_cb);
 
   if ((*dnsrec)->qd == NULL || (*dnsrec)->an == NULL || (*dnsrec)->ns == NULL ||
       (*dnsrec)->ar == NULL) {
@@ -134,7 +134,7 @@ ares_dns_rcode_t ares_dns_record_get_rcode(const ares_dns_record_t *dnsrec)
   return dnsrec->rcode;
 }
 
-static void ares__dns_rr_free(ares_dns_rr_t *rr)
+static void ares_dns_rr_free(ares_dns_rr_t *rr)
 {
   ares_free(rr->name);
 
@@ -172,7 +172,7 @@ static void ares__dns_rr_free(ares_dns_rr_t *rr)
       break;
 
     case ARES_REC_TYPE_TXT:
-      ares__dns_multistring_destroy(rr->r.txt.strs);
+      ares_dns_multistring_destroy(rr->r.txt.strs);
       break;
 
     case ARES_REC_TYPE_SIG:
@@ -192,7 +192,7 @@ static void ares__dns_rr_free(ares_dns_rr_t *rr)
       break;
 
     case ARES_REC_TYPE_OPT:
-      ares__array_destroy(rr->r.opt.options);
+      ares_array_destroy(rr->r.opt.options);
       break;
 
     case ARES_REC_TYPE_TLSA:
@@ -201,12 +201,12 @@ static void ares__dns_rr_free(ares_dns_rr_t *rr)
 
     case ARES_REC_TYPE_SVCB:
       ares_free(rr->r.svcb.target);
-      ares__array_destroy(rr->r.svcb.params);
+      ares_array_destroy(rr->r.svcb.params);
       break;
 
     case ARES_REC_TYPE_HTTPS:
       ares_free(rr->r.https.target);
-      ares__array_destroy(rr->r.https.params);
+      ares_array_destroy(rr->r.https.params);
       break;
 
     case ARES_REC_TYPE_URI:
@@ -231,16 +231,16 @@ void ares_dns_record_destroy(ares_dns_record_t *dnsrec)
   }
 
   /* Free questions */
-  ares__array_destroy(dnsrec->qd);
+  ares_array_destroy(dnsrec->qd);
 
   /* Free answers */
-  ares__array_destroy(dnsrec->an);
+  ares_array_destroy(dnsrec->an);
 
   /* Free authority */
-  ares__array_destroy(dnsrec->ns);
+  ares_array_destroy(dnsrec->ns);
 
   /* Free additional */
-  ares__array_destroy(dnsrec->ar);
+  ares_array_destroy(dnsrec->ar);
 
   ares_free(dnsrec);
 }
@@ -250,7 +250,7 @@ size_t ares_dns_record_query_cnt(const ares_dns_record_t *dnsrec)
   if (dnsrec == NULL) {
     return 0;
   }
-  return ares__array_len(dnsrec->qd);
+  return ares_array_len(dnsrec->qd);
 }
 
 ares_status_t ares_dns_record_query_add(ares_dns_record_t  *dnsrec,
@@ -268,15 +268,15 @@ ares_status_t ares_dns_record_query_add(ares_dns_record_t  *dnsrec,
     return ARES_EFORMERR;
   }
 
-  idx    = ares__array_len(dnsrec->qd);
-  status = ares__array_insert_last((void **)&qd, dnsrec->qd);
+  idx    = ares_array_len(dnsrec->qd);
+  status = ares_array_insert_last((void **)&qd, dnsrec->qd);
   if (status != ARES_SUCCESS) {
     return status;
   }
 
   qd->name = ares_strdup(name);
   if (qd->name == NULL) {
-    ares__array_remove_at(dnsrec->qd, idx);
+    ares_array_remove_at(dnsrec->qd, idx);
     return ARES_ENOMEM;
   }
   qd->qtype  = qtype;
@@ -290,11 +290,11 @@ ares_status_t ares_dns_record_query_set_name(ares_dns_record_t *dnsrec,
   char          *orig_name = NULL;
   ares_dns_qd_t *qd;
 
-  if (dnsrec == NULL || idx >= ares__array_len(dnsrec->qd) || name == NULL) {
+  if (dnsrec == NULL || idx >= ares_array_len(dnsrec->qd) || name == NULL) {
     return ARES_EFORMERR;
   }
 
-  qd = ares__array_at(dnsrec->qd, idx);
+  qd = ares_array_at(dnsrec->qd, idx);
 
   orig_name = qd->name;
   qd->name  = ares_strdup(name);
@@ -313,12 +313,12 @@ ares_status_t ares_dns_record_query_set_type(ares_dns_record_t  *dnsrec,
 {
   ares_dns_qd_t *qd;
 
-  if (dnsrec == NULL || idx >= ares__array_len(dnsrec->qd) ||
+  if (dnsrec == NULL || idx >= ares_array_len(dnsrec->qd) ||
       !ares_dns_rec_type_isvalid(qtype, ARES_TRUE)) {
     return ARES_EFORMERR;
   }
 
-  qd        = ares__array_at(dnsrec->qd, idx);
+  qd        = ares_array_at(dnsrec->qd, idx);
   qd->qtype = qtype;
 
   return ARES_SUCCESS;
@@ -330,11 +330,11 @@ ares_status_t ares_dns_record_query_get(const ares_dns_record_t *dnsrec,
                                         ares_dns_class_t    *qclass)
 {
   const ares_dns_qd_t *qd;
-  if (dnsrec == NULL || idx >= ares__array_len(dnsrec->qd)) {
+  if (dnsrec == NULL || idx >= ares_array_len(dnsrec->qd)) {
     return ARES_EFORMERR;
   }
 
-  qd = ares__array_at(dnsrec->qd, idx);
+  qd = ares_array_at(dnsrec->qd, idx);
   if (name != NULL) {
     *name = qd->name;
   }
@@ -359,11 +359,11 @@ size_t ares_dns_record_rr_cnt(const ares_dns_record_t *dnsrec,
 
   switch (sect) {
     case ARES_SECTION_ANSWER:
-      return ares__array_len(dnsrec->an);
+      return ares_array_len(dnsrec->an);
     case ARES_SECTION_AUTHORITY:
-      return ares__array_len(dnsrec->ns);
+      return ares_array_len(dnsrec->ns);
     case ARES_SECTION_ADDITIONAL:
-      return ares__array_len(dnsrec->ar);
+      return ares_array_len(dnsrec->ar);
   }
 
   return 0; /* LCOV_EXCL_LINE: DefensiveCoding */
@@ -372,7 +372,7 @@ size_t ares_dns_record_rr_cnt(const ares_dns_record_t *dnsrec,
 ares_status_t ares_dns_record_rr_prealloc(ares_dns_record_t *dnsrec,
                                           ares_dns_section_t sect, size_t cnt)
 {
-  ares__array_t *arr = NULL;
+  ares_array_t *arr = NULL;
 
   if (dnsrec == NULL || !ares_dns_section_isvalid(sect)) {
     return ARES_EFORMERR;
@@ -390,11 +390,11 @@ ares_status_t ares_dns_record_rr_prealloc(ares_dns_record_t *dnsrec,
       break;
   }
 
-  if (cnt < ares__array_len(arr)) {
+  if (cnt < ares_array_len(arr)) {
     return ARES_EFORMERR;
   }
 
-  return ares__array_set_size(arr, cnt);
+  return ares_array_set_size(arr, cnt);
 }
 
 ares_status_t ares_dns_record_rr_add(ares_dns_rr_t    **rr_out,
@@ -404,7 +404,7 @@ ares_status_t ares_dns_record_rr_add(ares_dns_rr_t    **rr_out,
                                      ares_dns_class_t rclass, unsigned int ttl)
 {
   ares_dns_rr_t *rr  = NULL;
-  ares__array_t *arr = NULL;
+  ares_array_t *arr = NULL;
   ares_status_t  status;
   size_t         idx;
 
@@ -429,15 +429,15 @@ ares_status_t ares_dns_record_rr_add(ares_dns_rr_t    **rr_out,
       break;
   }
 
-  idx    = ares__array_len(arr);
-  status = ares__array_insert_last((void **)&rr, arr);
+  idx    = ares_array_len(arr);
+  status = ares_array_insert_last((void **)&rr, arr);
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   rr->name = ares_strdup(name);
   if (rr->name == NULL) {
-    ares__array_remove_at(arr, idx);
+    ares_array_remove_at(arr, idx);
     return ARES_ENOMEM;
   }
 
@@ -454,7 +454,7 @@ ares_status_t ares_dns_record_rr_add(ares_dns_rr_t    **rr_out,
 ares_status_t ares_dns_record_rr_del(ares_dns_record_t *dnsrec,
                                      ares_dns_section_t sect, size_t idx)
 {
-  ares__array_t *arr = NULL;
+  ares_array_t *arr = NULL;
 
   if (dnsrec == NULL || !ares_dns_section_isvalid(sect)) {
     return ARES_EFORMERR;
@@ -472,13 +472,13 @@ ares_status_t ares_dns_record_rr_del(ares_dns_record_t *dnsrec,
       break;
   }
 
-  return ares__array_remove_at(arr, idx);
+  return ares_array_remove_at(arr, idx);
 }
 
 ares_dns_rr_t *ares_dns_record_rr_get(ares_dns_record_t *dnsrec,
                                       ares_dns_section_t sect, size_t idx)
 {
-  ares__array_t *arr = NULL;
+  ares_array_t *arr = NULL;
 
   if (dnsrec == NULL || !ares_dns_section_isvalid(sect)) {
     return NULL;
@@ -496,7 +496,7 @@ ares_dns_rr_t *ares_dns_record_rr_get(ares_dns_record_t *dnsrec,
       break;
   }
 
-  return ares__array_at(arr, idx);
+  return ares_array_at(arr, idx);
 }
 
 const ares_dns_rr_t *
@@ -849,14 +849,14 @@ const unsigned char *ares_dns_rr_get_bin(const ares_dns_rr_t *dns_rr,
 
   /* Array of strings, return concatenated version */
   if (ares_dns_rr_key_datatype(key) == ARES_DATATYPE_ABINP) {
-    ares__dns_multistring_t * const *strs =
+    ares_dns_multistring_t * const *strs =
       ares_dns_rr_data_ptr_const(dns_rr, key, NULL);
 
     if (strs == NULL) {
       return NULL;
     }
 
-    return ares__dns_multistring_combined(*strs, len);
+    return ares_dns_multistring_combined(*strs, len);
   }
 
   /* Not a multi-string, just straight binary data */
@@ -877,7 +877,7 @@ const unsigned char *ares_dns_rr_get_bin(const ares_dns_rr_t *dns_rr,
 size_t ares_dns_rr_get_abin_cnt(const ares_dns_rr_t *dns_rr,
                                 ares_dns_rr_key_t    key)
 {
-  ares__dns_multistring_t * const *strs;
+  ares_dns_multistring_t * const *strs;
 
   if (ares_dns_rr_key_datatype(key) != ARES_DATATYPE_ABINP) {
     return 0;
@@ -888,14 +888,14 @@ size_t ares_dns_rr_get_abin_cnt(const ares_dns_rr_t *dns_rr,
     return 0;
   }
 
-  return ares__dns_multistring_cnt(*strs);
+  return ares_dns_multistring_cnt(*strs);
 }
 
 const unsigned char *ares_dns_rr_get_abin(const ares_dns_rr_t *dns_rr,
                                           ares_dns_rr_key_t key, size_t idx,
                                           size_t *len)
 {
-  ares__dns_multistring_t * const *strs;
+  ares_dns_multistring_t * const *strs;
 
   if (ares_dns_rr_key_datatype(key) != ARES_DATATYPE_ABINP) {
     return NULL;
@@ -906,13 +906,13 @@ const unsigned char *ares_dns_rr_get_abin(const ares_dns_rr_t *dns_rr,
     return NULL;
   }
 
-  return ares__dns_multistring_get(*strs, idx, len);
+  return ares_dns_multistring_get(*strs, idx, len);
 }
 
 ares_status_t ares_dns_rr_del_abin(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
                                    size_t idx)
 {
-  ares__dns_multistring_t **strs;
+  ares_dns_multistring_t **strs;
 
   if (ares_dns_rr_key_datatype(key) != ARES_DATATYPE_ABINP) {
     return ARES_EFORMERR;
@@ -923,7 +923,7 @@ ares_status_t ares_dns_rr_del_abin(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
     return ARES_EFORMERR;
   }
 
-  return ares__dns_multistring_del(*strs, idx);
+  return ares_dns_multistring_del(*strs, idx);
 }
 
 ares_status_t ares_dns_rr_add_abin(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
@@ -935,7 +935,7 @@ ares_status_t ares_dns_rr_add_abin(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
     (datatype == ARES_DATATYPE_ABINP) ? ARES_TRUE : ARES_FALSE;
   size_t                    alloclen = is_nullterm ? len + 1 : len;
   unsigned char            *temp;
-  ares__dns_multistring_t **strs;
+  ares_dns_multistring_t **strs;
 
   if (ares_dns_rr_key_datatype(key) != ARES_DATATYPE_ABINP) {
     return ARES_EFORMERR;
@@ -947,7 +947,7 @@ ares_status_t ares_dns_rr_add_abin(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
   }
 
   if (*strs == NULL) {
-    *strs = ares__dns_multistring_create();
+    *strs = ares_dns_multistring_create();
     if (*strs == NULL) {
       return ARES_ENOMEM;
     }
@@ -965,7 +965,7 @@ ares_status_t ares_dns_rr_add_abin(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
     temp[len] = 0;
   }
 
-  status = ares__dns_multistring_add_own(*strs, temp, len);
+  status = ares_dns_multistring_add_own(*strs, temp, len);
   if (status != ARES_SUCCESS) {
     ares_free(temp);
   }
@@ -994,7 +994,7 @@ const char *ares_dns_rr_get_str(const ares_dns_rr_t *dns_rr,
 size_t ares_dns_rr_get_opt_cnt(const ares_dns_rr_t *dns_rr,
                                ares_dns_rr_key_t    key)
 {
-  ares__array_t * const *opts;
+  ares_array_t * const *opts;
 
   if (ares_dns_rr_key_datatype(key) != ARES_DATATYPE_OPT) {
     return 0;
@@ -1005,15 +1005,15 @@ size_t ares_dns_rr_get_opt_cnt(const ares_dns_rr_t *dns_rr,
     return 0;
   }
 
-  return ares__array_len(*opts);
+  return ares_array_len(*opts);
 }
 
 unsigned short ares_dns_rr_get_opt(const ares_dns_rr_t *dns_rr,
                                    ares_dns_rr_key_t key, size_t idx,
                                    const unsigned char **val, size_t *val_len)
 {
-  ares__array_t * const    *opts;
-  const ares__dns_optval_t *opt;
+  ares_array_t * const    *opts;
+  const ares_dns_optval_t *opt;
 
   if (val) {
     *val = NULL;
@@ -1031,7 +1031,7 @@ unsigned short ares_dns_rr_get_opt(const ares_dns_rr_t *dns_rr,
     return 65535;
   }
 
-  opt = ares__array_at(*opts, idx);
+  opt = ares_array_at(*opts, idx);
   if (opt == NULL) {
     return 65535;
   }
@@ -1050,10 +1050,10 @@ ares_bool_t ares_dns_rr_get_opt_byid(const ares_dns_rr_t *dns_rr,
                                      ares_dns_rr_key_t key, unsigned short opt,
                                      const unsigned char **val, size_t *val_len)
 {
-  ares__array_t * const    *opts;
+  ares_array_t * const    *opts;
   size_t                    i;
   size_t                    cnt;
-  const ares__dns_optval_t *optptr = NULL;
+  const ares_dns_optval_t *optptr = NULL;
 
   if (val) {
     *val = NULL;
@@ -1071,9 +1071,9 @@ ares_bool_t ares_dns_rr_get_opt_byid(const ares_dns_rr_t *dns_rr,
     return ARES_FALSE;
   }
 
-  cnt = ares__array_len(*opts);
+  cnt = ares_array_len(*opts);
   for (i = 0; i < cnt; i++) {
-    optptr = ares__array_at(*opts, i);
+    optptr = ares_array_at(*opts, i);
     if (optptr == NULL) {
       return ARES_FALSE;
     }
@@ -1200,22 +1200,22 @@ ares_status_t ares_dns_rr_set_bin_own(ares_dns_rr_t    *dns_rr,
   }
 
   if (ares_dns_rr_key_datatype(key) == ARES_DATATYPE_ABINP) {
-    ares__dns_multistring_t **strs = ares_dns_rr_data_ptr(dns_rr, key, NULL);
+    ares_dns_multistring_t **strs = ares_dns_rr_data_ptr(dns_rr, key, NULL);
     if (strs == NULL) {
       return ARES_EFORMERR;
     }
 
     if (*strs == NULL) {
-      *strs = ares__dns_multistring_create();
+      *strs = ares_dns_multistring_create();
       if (*strs == NULL) {
         return ARES_ENOMEM;
       }
     }
 
     /* Clear all existing entries as this is an override */
-    ares__dns_multistring_clear(*strs);
+    ares_dns_multistring_clear(*strs);
 
-    return ares__dns_multistring_add_own(*strs, val, len);
+    return ares_dns_multistring_add_own(*strs, val, len);
   }
 
   bin = ares_dns_rr_data_ptr(dns_rr, key, &bin_len);
@@ -1309,9 +1309,9 @@ ares_status_t ares_dns_rr_set_str(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
 
 ares_status_t ares_dns_rr_set_abin_own(ares_dns_rr_t           *dns_rr,
                                        ares_dns_rr_key_t        key,
-                                       ares__dns_multistring_t *strs)
+                                       ares_dns_multistring_t *strs)
 {
-  ares__dns_multistring_t **strs_ptr;
+  ares_dns_multistring_t **strs_ptr;
 
   if (ares_dns_rr_key_datatype(key) != ARES_DATATYPE_ABINP) {
     return ARES_EFORMERR;
@@ -1323,16 +1323,16 @@ ares_status_t ares_dns_rr_set_abin_own(ares_dns_rr_t           *dns_rr,
   }
 
   if (*strs_ptr != NULL) {
-    ares__dns_multistring_destroy(*strs_ptr);
+    ares_dns_multistring_destroy(*strs_ptr);
   }
   *strs_ptr = strs;
 
   return ARES_SUCCESS;
 }
 
-static void ares__dns_opt_free_cb(void *arg)
+static void ares_dns_opt_free_cb(void *arg)
 {
-  ares__dns_optval_t *opt = arg;
+  ares_dns_optval_t *opt = arg;
   if (opt == NULL) {
     return;
   }
@@ -1343,8 +1343,8 @@ ares_status_t ares_dns_rr_set_opt_own(ares_dns_rr_t    *dns_rr,
                                       ares_dns_rr_key_t key, unsigned short opt,
                                       unsigned char *val, size_t val_len)
 {
-  ares__array_t     **options;
-  ares__dns_optval_t *optptr = NULL;
+  ares_array_t     **options;
+  ares_dns_optval_t *optptr = NULL;
   size_t              idx;
   size_t              cnt;
   ares_status_t       status;
@@ -1360,15 +1360,15 @@ ares_status_t ares_dns_rr_set_opt_own(ares_dns_rr_t    *dns_rr,
 
   if (*options == NULL) {
     *options =
-      ares__array_create(sizeof(ares__dns_optval_t), ares__dns_opt_free_cb);
+      ares_array_create(sizeof(ares_dns_optval_t), ares_dns_opt_free_cb);
   }
   if (*options == NULL) {
     return ARES_ENOMEM;
   }
 
-  cnt = ares__array_len(*options);
+  cnt = ares_array_len(*options);
   for (idx = 0; idx < cnt; idx++) {
-    optptr = ares__array_at(*options, idx);
+    optptr = ares_array_at(*options, idx);
     if (optptr == NULL) {
       return ARES_EFORMERR;
     }
@@ -1382,7 +1382,7 @@ ares_status_t ares_dns_rr_set_opt_own(ares_dns_rr_t    *dns_rr,
     goto done;
   }
 
-  status = ares__array_insert_last((void **)&optptr, *options);
+  status = ares_array_insert_last((void **)&optptr, *options);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -1424,8 +1424,8 @@ ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t    *dns_rr,
                                        ares_dns_rr_key_t key,
                                        unsigned short    opt)
 {
-  ares__array_t           **options;
-  const ares__dns_optval_t *optptr;
+  ares_array_t           **options;
+  const ares_dns_optval_t *optptr;
   size_t                    idx;
   size_t                    cnt;
 
@@ -1443,14 +1443,14 @@ ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t    *dns_rr,
     return ARES_SUCCESS;
   }
 
-  cnt = ares__array_len(*options);
+  cnt = ares_array_len(*options);
   for (idx = 0; idx < cnt; idx++) {
-    optptr = ares__array_at_const(*options, idx);
+    optptr = ares_array_at_const(*options, idx);
     if (optptr == NULL) {
       return ARES_ENOTFOUND;
     }
     if (optptr->opt == opt) {
-      return ares__array_remove_at(*options, idx);
+      return ares_array_remove_at(*options, idx);
     }
   }
 
@@ -1459,7 +1459,7 @@ ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t    *dns_rr,
 
 char *ares_dns_addr_to_ptr(const struct ares_addr *addr)
 {
-  ares__buf_t               *buf     = NULL;
+  ares_buf_t               *buf     = NULL;
   const unsigned char       *ptr     = NULL;
   size_t                     ptr_len = 0;
   size_t                     i;
@@ -1470,7 +1470,7 @@ char *ares_dns_addr_to_ptr(const struct ares_addr *addr)
     goto fail;
   }
 
-  buf = ares__buf_create();
+  buf = ares_buf_create();
   if (buf == NULL) {
     goto fail;
   }
@@ -1485,47 +1485,47 @@ char *ares_dns_addr_to_ptr(const struct ares_addr *addr)
 
   for (i = ptr_len; i > 0; i--) {
     if (addr->family == AF_INET) {
-      status = ares__buf_append_num_dec(buf, (size_t)ptr[i - 1], 0);
+      status = ares_buf_append_num_dec(buf, (size_t)ptr[i - 1], 0);
     } else {
       unsigned char c;
 
       c      = ptr[i - 1] & 0xF;
-      status = ares__buf_append_byte(buf, hexbytes[c]);
+      status = ares_buf_append_byte(buf, hexbytes[c]);
       if (status != ARES_SUCCESS) {
         goto fail;
       }
 
-      status = ares__buf_append_byte(buf, '.');
+      status = ares_buf_append_byte(buf, '.');
       if (status != ARES_SUCCESS) {
         goto fail;
       }
 
       c      = (ptr[i - 1] >> 4) & 0xF;
-      status = ares__buf_append_byte(buf, hexbytes[c]);
+      status = ares_buf_append_byte(buf, hexbytes[c]);
     }
     if (status != ARES_SUCCESS) {
       goto fail;
     }
 
-    status = ares__buf_append_byte(buf, '.');
+    status = ares_buf_append_byte(buf, '.');
     if (status != ARES_SUCCESS) {
       goto fail;
     }
   }
 
   if (addr->family == AF_INET) {
-    status = ares__buf_append(buf, (const unsigned char *)"in-addr.arpa", 12);
+    status = ares_buf_append(buf, (const unsigned char *)"in-addr.arpa", 12);
   } else {
-    status = ares__buf_append(buf, (const unsigned char *)"ip6.arpa", 8);
+    status = ares_buf_append(buf, (const unsigned char *)"ip6.arpa", 8);
   }
   if (status != ARES_SUCCESS) {
     goto fail;
   }
 
-  return ares__buf_finish_str(buf, NULL);
+  return ares_buf_finish_str(buf, NULL);
 
 fail:
-  ares__buf_destroy(buf);
+  ares_buf_destroy(buf);
   return NULL;
 }
 
@@ -1575,7 +1575,7 @@ ares_status_t
   *dnsrec = NULL;
 
   /* Per RFC 7686, reject queries for ".onion" domain names with NXDOMAIN */
-  if (ares__is_onion_domain(name)) {
+  if (ares_is_onion_domain(name)) {
     status = ARES_ENOTFOUND;
     goto done;
   }

--- a/src/lib/record/ares_dns_record.c
+++ b/src/lib/record/ares_dns_record.c
@@ -74,14 +74,10 @@ ares_status_t ares_dns_record_create(ares_dns_record_t **dnsrec,
   (*dnsrec)->flags  = flags;
   (*dnsrec)->opcode = opcode;
   (*dnsrec)->rcode  = rcode;
-  (*dnsrec)->qd =
-    ares_array_create(sizeof(ares_dns_qd_t), ares_dns_qd_free_cb);
-  (*dnsrec)->an =
-    ares_array_create(sizeof(ares_dns_rr_t), ares_dns_rr_free_cb);
-  (*dnsrec)->ns =
-    ares_array_create(sizeof(ares_dns_rr_t), ares_dns_rr_free_cb);
-  (*dnsrec)->ar =
-    ares_array_create(sizeof(ares_dns_rr_t), ares_dns_rr_free_cb);
+  (*dnsrec)->qd = ares_array_create(sizeof(ares_dns_qd_t), ares_dns_qd_free_cb);
+  (*dnsrec)->an = ares_array_create(sizeof(ares_dns_rr_t), ares_dns_rr_free_cb);
+  (*dnsrec)->ns = ares_array_create(sizeof(ares_dns_rr_t), ares_dns_rr_free_cb);
+  (*dnsrec)->ar = ares_array_create(sizeof(ares_dns_rr_t), ares_dns_rr_free_cb);
 
   if ((*dnsrec)->qd == NULL || (*dnsrec)->an == NULL || (*dnsrec)->ns == NULL ||
       (*dnsrec)->ar == NULL) {
@@ -404,7 +400,7 @@ ares_status_t ares_dns_record_rr_add(ares_dns_rr_t    **rr_out,
                                      ares_dns_class_t rclass, unsigned int ttl)
 {
   ares_dns_rr_t *rr  = NULL;
-  ares_array_t *arr = NULL;
+  ares_array_t  *arr = NULL;
   ares_status_t  status;
   size_t         idx;
 
@@ -933,8 +929,8 @@ ares_status_t ares_dns_rr_add_abin(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
   ares_dns_datatype_t datatype = ares_dns_rr_key_datatype(key);
   ares_bool_t         is_nullterm =
     (datatype == ARES_DATATYPE_ABINP) ? ARES_TRUE : ARES_FALSE;
-  size_t                    alloclen = is_nullterm ? len + 1 : len;
-  unsigned char            *temp;
+  size_t                   alloclen = is_nullterm ? len + 1 : len;
+  unsigned char           *temp;
   ares_dns_multistring_t **strs;
 
   if (ares_dns_rr_key_datatype(key) != ARES_DATATYPE_ABINP) {
@@ -1051,8 +1047,8 @@ ares_bool_t ares_dns_rr_get_opt_byid(const ares_dns_rr_t *dns_rr,
                                      const unsigned char **val, size_t *val_len)
 {
   ares_array_t * const    *opts;
-  size_t                    i;
-  size_t                    cnt;
+  size_t                   i;
+  size_t                   cnt;
   const ares_dns_optval_t *optptr = NULL;
 
   if (val) {
@@ -1307,8 +1303,8 @@ ares_status_t ares_dns_rr_set_str(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
   return status;
 }
 
-ares_status_t ares_dns_rr_set_abin_own(ares_dns_rr_t           *dns_rr,
-                                       ares_dns_rr_key_t        key,
+ares_status_t ares_dns_rr_set_abin_own(ares_dns_rr_t          *dns_rr,
+                                       ares_dns_rr_key_t       key,
                                        ares_dns_multistring_t *strs)
 {
   ares_dns_multistring_t **strs_ptr;
@@ -1345,9 +1341,9 @@ ares_status_t ares_dns_rr_set_opt_own(ares_dns_rr_t    *dns_rr,
 {
   ares_array_t     **options;
   ares_dns_optval_t *optptr = NULL;
-  size_t              idx;
-  size_t              cnt;
-  ares_status_t       status;
+  size_t             idx;
+  size_t             cnt;
+  ares_status_t      status;
 
   if (ares_dns_rr_key_datatype(key) != ARES_DATATYPE_OPT) {
     return ARES_EFORMERR;
@@ -1426,8 +1422,8 @@ ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t    *dns_rr,
 {
   ares_array_t           **options;
   const ares_dns_optval_t *optptr;
-  size_t                    idx;
-  size_t                    cnt;
+  size_t                   idx;
+  size_t                   cnt;
 
   if (ares_dns_rr_key_datatype(key) != ARES_DATATYPE_OPT) {
     return ARES_EFORMERR;
@@ -1459,7 +1455,7 @@ ares_status_t ares_dns_rr_del_opt_byid(ares_dns_rr_t    *dns_rr,
 
 char *ares_dns_addr_to_ptr(const struct ares_addr *addr)
 {
-  ares_buf_t               *buf     = NULL;
+  ares_buf_t                *buf     = NULL;
   const unsigned char       *ptr     = NULL;
   size_t                     ptr_len = 0;
   size_t                     i;

--- a/src/lib/record/ares_dns_write.c
+++ b/src/lib/record/ares_dns_write.c
@@ -31,7 +31,7 @@
 
 
 static ares_status_t ares_dns_write_header(const ares_dns_record_t *dnsrec,
-                                           ares_buf_t             *buf)
+                                           ares_buf_t              *buf)
 {
   unsigned short u16;
   unsigned short opcode;
@@ -120,14 +120,14 @@ static ares_status_t ares_dns_write_header(const ares_dns_record_t *dnsrec,
 
   /* NSCOUNT */
   status = ares_buf_append_be16(buf, (unsigned short)ares_dns_record_rr_cnt(
-                                        dnsrec, ARES_SECTION_AUTHORITY));
+                                       dnsrec, ARES_SECTION_AUTHORITY));
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   /* ARCOUNT */
   status = ares_buf_append_be16(buf, (unsigned short)ares_dns_record_rr_cnt(
-                                        dnsrec, ARES_SECTION_ADDITIONAL));
+                                       dnsrec, ARES_SECTION_ADDITIONAL));
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -136,8 +136,8 @@ static ares_status_t ares_dns_write_header(const ares_dns_record_t *dnsrec,
 }
 
 static ares_status_t ares_dns_write_questions(const ares_dns_record_t *dnsrec,
-                                              ares_llist_t          **namelist,
-                                              ares_buf_t             *buf)
+                                              ares_llist_t           **namelist,
+                                              ares_buf_t              *buf)
 {
   size_t i;
 
@@ -174,9 +174,9 @@ static ares_status_t ares_dns_write_questions(const ares_dns_record_t *dnsrec,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_write_rr_name(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_name(ares_buf_t          *buf,
                                             const ares_dns_rr_t *rr,
-                                            ares_llist_t      **namelist,
+                                            ares_llist_t       **namelist,
                                             ares_bool_t       validate_hostname,
                                             ares_dns_rr_key_t key)
 {
@@ -190,7 +190,7 @@ static ares_status_t ares_dns_write_rr_name(ares_buf_t         *buf,
   return ares_dns_name_write(buf, namelist, validate_hostname, name);
 }
 
-static ares_status_t ares_dns_write_rr_str(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_str(ares_buf_t          *buf,
                                            const ares_dns_rr_t *rr,
                                            ares_dns_rr_key_t    key)
 {
@@ -222,7 +222,7 @@ static ares_status_t ares_dns_write_rr_str(ares_buf_t         *buf,
   return ares_buf_append(buf, (const unsigned char *)str, len);
 }
 
-static ares_status_t ares_dns_write_binstr(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_binstr(ares_buf_t          *buf,
                                            const unsigned char *bin,
                                            size_t               bin_len)
 {
@@ -260,7 +260,7 @@ static ares_status_t ares_dns_write_binstr(ares_buf_t         *buf,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_write_rr_abin(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_abin(ares_buf_t          *buf,
                                             const ares_dns_rr_t *rr,
                                             ares_dns_rr_key_t    key)
 {
@@ -287,7 +287,7 @@ static ares_status_t ares_dns_write_rr_abin(ares_buf_t         *buf,
   return status;
 }
 
-static ares_status_t ares_dns_write_rr_be32(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_be32(ares_buf_t          *buf,
                                             const ares_dns_rr_t *rr,
                                             ares_dns_rr_key_t    key)
 {
@@ -297,7 +297,7 @@ static ares_status_t ares_dns_write_rr_be32(ares_buf_t         *buf,
   return ares_buf_append_be32(buf, ares_dns_rr_get_u32(rr, key));
 }
 
-static ares_status_t ares_dns_write_rr_be16(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_be16(ares_buf_t          *buf,
                                             const ares_dns_rr_t *rr,
                                             ares_dns_rr_key_t    key)
 {
@@ -307,7 +307,7 @@ static ares_status_t ares_dns_write_rr_be16(ares_buf_t         *buf,
   return ares_buf_append_be16(buf, ares_dns_rr_get_u16(rr, key));
 }
 
-static ares_status_t ares_dns_write_rr_u8(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_u8(ares_buf_t          *buf,
                                           const ares_dns_rr_t *rr,
                                           ares_dns_rr_key_t    key)
 {
@@ -317,9 +317,9 @@ static ares_status_t ares_dns_write_rr_u8(ares_buf_t         *buf,
   return ares_buf_append_byte(buf, ares_dns_rr_get_u8(rr, key));
 }
 
-static ares_status_t ares_dns_write_rr_a(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_a(ares_buf_t          *buf,
                                          const ares_dns_rr_t *rr,
-                                         ares_llist_t      **namelist)
+                                         ares_llist_t       **namelist)
 {
   const struct in_addr *addr;
   (void)namelist;
@@ -332,25 +332,25 @@ static ares_status_t ares_dns_write_rr_a(ares_buf_t         *buf,
   return ares_buf_append(buf, (const unsigned char *)addr, sizeof(*addr));
 }
 
-static ares_status_t ares_dns_write_rr_ns(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_ns(ares_buf_t          *buf,
                                           const ares_dns_rr_t *rr,
-                                          ares_llist_t      **namelist)
+                                          ares_llist_t       **namelist)
 {
   return ares_dns_write_rr_name(buf, rr, namelist, ARES_FALSE,
                                 ARES_RR_NS_NSDNAME);
 }
 
-static ares_status_t ares_dns_write_rr_cname(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_cname(ares_buf_t          *buf,
                                              const ares_dns_rr_t *rr,
-                                             ares_llist_t      **namelist)
+                                             ares_llist_t       **namelist)
 {
   return ares_dns_write_rr_name(buf, rr, namelist, ARES_FALSE,
                                 ARES_RR_CNAME_CNAME);
 }
 
-static ares_status_t ares_dns_write_rr_soa(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_soa(ares_buf_t          *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares_llist_t      **namelist)
+                                           ares_llist_t       **namelist)
 {
   ares_status_t status;
 
@@ -396,17 +396,17 @@ static ares_status_t ares_dns_write_rr_soa(ares_buf_t         *buf,
   return ares_dns_write_rr_be32(buf, rr, ARES_RR_SOA_MINIMUM);
 }
 
-static ares_status_t ares_dns_write_rr_ptr(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_ptr(ares_buf_t          *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares_llist_t      **namelist)
+                                           ares_llist_t       **namelist)
 {
   return ares_dns_write_rr_name(buf, rr, namelist, ARES_FALSE,
                                 ARES_RR_PTR_DNAME);
 }
 
-static ares_status_t ares_dns_write_rr_hinfo(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_hinfo(ares_buf_t          *buf,
                                              const ares_dns_rr_t *rr,
-                                             ares_llist_t      **namelist)
+                                             ares_llist_t       **namelist)
 {
   ares_status_t status;
 
@@ -422,9 +422,9 @@ static ares_status_t ares_dns_write_rr_hinfo(ares_buf_t         *buf,
   return ares_dns_write_rr_str(buf, rr, ARES_RR_HINFO_OS);
 }
 
-static ares_status_t ares_dns_write_rr_mx(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_mx(ares_buf_t          *buf,
                                           const ares_dns_rr_t *rr,
-                                          ares_llist_t      **namelist)
+                                          ares_llist_t       **namelist)
 {
   ares_status_t status;
 
@@ -439,17 +439,17 @@ static ares_status_t ares_dns_write_rr_mx(ares_buf_t         *buf,
                                 ARES_RR_MX_EXCHANGE);
 }
 
-static ares_status_t ares_dns_write_rr_txt(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_txt(ares_buf_t          *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares_llist_t      **namelist)
+                                           ares_llist_t       **namelist)
 {
   (void)namelist;
   return ares_dns_write_rr_abin(buf, rr, ARES_RR_TXT_DATA);
 }
 
-static ares_status_t ares_dns_write_rr_sig(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_sig(ares_buf_t          *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares_llist_t      **namelist)
+                                           ares_llist_t       **namelist)
 {
   ares_status_t        status;
   const unsigned char *data;
@@ -515,9 +515,9 @@ static ares_status_t ares_dns_write_rr_sig(ares_buf_t         *buf,
   return ares_buf_append(buf, data, len);
 }
 
-static ares_status_t ares_dns_write_rr_aaaa(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_aaaa(ares_buf_t          *buf,
                                             const ares_dns_rr_t *rr,
-                                            ares_llist_t      **namelist)
+                                            ares_llist_t       **namelist)
 {
   const struct ares_in6_addr *addr;
   (void)namelist;
@@ -530,9 +530,9 @@ static ares_status_t ares_dns_write_rr_aaaa(ares_buf_t         *buf,
   return ares_buf_append(buf, (const unsigned char *)addr, sizeof(*addr));
 }
 
-static ares_status_t ares_dns_write_rr_srv(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_srv(ares_buf_t          *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares_llist_t      **namelist)
+                                           ares_llist_t       **namelist)
 {
   ares_status_t status;
 
@@ -559,9 +559,9 @@ static ares_status_t ares_dns_write_rr_srv(ares_buf_t         *buf,
                                 ARES_RR_SRV_TARGET);
 }
 
-static ares_status_t ares_dns_write_rr_naptr(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_naptr(ares_buf_t          *buf,
                                              const ares_dns_rr_t *rr,
-                                             ares_llist_t      **namelist)
+                                             ares_llist_t       **namelist)
 {
   ares_status_t status;
 
@@ -600,9 +600,9 @@ static ares_status_t ares_dns_write_rr_naptr(ares_buf_t         *buf,
                                 ARES_RR_NAPTR_REPLACEMENT);
 }
 
-static ares_status_t ares_dns_write_rr_opt(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_opt(ares_buf_t          *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares_llist_t      **namelist)
+                                           ares_llist_t       **namelist)
 {
   size_t         len = ares_buf_len(buf);
   ares_status_t  status;
@@ -621,8 +621,8 @@ static ares_status_t ares_dns_write_rr_opt(ares_buf_t         *buf,
   /* We need to go back and overwrite the class and ttl that were emitted as
    * the OPT record overloads them for its own use (yes, very strange!) */
   status = ares_buf_set_length(buf, len - 2 /* RDLENGTH */
-                                       - 4   /* TTL */
-                                       - 2 /* CLASS */);
+                                      - 4   /* TTL */
+                                      - 2 /* CLASS */);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -681,9 +681,9 @@ static ares_status_t ares_dns_write_rr_opt(ares_buf_t         *buf,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_write_rr_tlsa(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_tlsa(ares_buf_t          *buf,
                                             const ares_dns_rr_t *rr,
-                                            ares_llist_t      **namelist)
+                                            ares_llist_t       **namelist)
 {
   ares_status_t        status;
   const unsigned char *data;
@@ -718,9 +718,9 @@ static ares_status_t ares_dns_write_rr_tlsa(ares_buf_t         *buf,
   return ares_buf_append(buf, data, len);
 }
 
-static ares_status_t ares_dns_write_rr_svcb(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_svcb(ares_buf_t          *buf,
                                             const ares_dns_rr_t *rr,
-                                            ares_llist_t      **namelist)
+                                            ares_llist_t       **namelist)
 {
   ares_status_t status;
   size_t        i;
@@ -769,9 +769,9 @@ static ares_status_t ares_dns_write_rr_svcb(ares_buf_t         *buf,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_write_rr_https(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_https(ares_buf_t          *buf,
                                              const ares_dns_rr_t *rr,
-                                             ares_llist_t      **namelist)
+                                             ares_llist_t       **namelist)
 {
   ares_status_t status;
   size_t        i;
@@ -820,9 +820,9 @@ static ares_status_t ares_dns_write_rr_https(ares_buf_t         *buf,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_write_rr_uri(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_uri(ares_buf_t          *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares_llist_t      **namelist)
+                                           ares_llist_t       **namelist)
 {
   ares_status_t status;
   const char   *target;
@@ -849,12 +849,12 @@ static ares_status_t ares_dns_write_rr_uri(ares_buf_t         *buf,
   }
 
   return ares_buf_append(buf, (const unsigned char *)target,
-                          ares_strlen(target));
+                         ares_strlen(target));
 }
 
-static ares_status_t ares_dns_write_rr_caa(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_caa(ares_buf_t          *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares_llist_t      **namelist)
+                                           ares_llist_t       **namelist)
 {
   const unsigned char *data     = NULL;
   size_t               data_len = 0;
@@ -883,9 +883,9 @@ static ares_status_t ares_dns_write_rr_caa(ares_buf_t         *buf,
   return ares_buf_append(buf, data, data_len);
 }
 
-static ares_status_t ares_dns_write_rr_raw_rr(ares_buf_t         *buf,
+static ares_status_t ares_dns_write_rr_raw_rr(ares_buf_t          *buf,
                                               const ares_dns_rr_t *rr,
-                                              ares_llist_t      **namelist)
+                                              ares_llist_t       **namelist)
 {
   size_t               len = ares_buf_len(buf);
   ares_status_t        status;
@@ -903,9 +903,9 @@ static ares_status_t ares_dns_write_rr_raw_rr(ares_buf_t         *buf,
   /* We need to go back and overwrite the type that was emitted by the parent
    * function */
   status = ares_buf_set_length(buf, len - 2 /* RDLENGTH */
-                                       - 4   /* TTL */
-                                       - 2   /* CLASS */
-                                       - 2 /* TYPE */);
+                                      - 4   /* TTL */
+                                      - 2   /* CLASS */
+                                      - 2 /* TYPE */);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -935,9 +935,9 @@ static ares_status_t ares_dns_write_rr_raw_rr(ares_buf_t         *buf,
 }
 
 static ares_status_t ares_dns_write_rr(const ares_dns_record_t *dnsrec,
-                                       ares_llist_t          **namelist,
+                                       ares_llist_t           **namelist,
                                        ares_dns_section_t       section,
-                                       ares_buf_t             *buf)
+                                       ares_buf_t              *buf)
 {
   size_t i;
 
@@ -945,7 +945,7 @@ static ares_status_t ares_dns_write_rr(const ares_dns_record_t *dnsrec,
     const ares_dns_rr_t *rr;
     ares_dns_rec_type_t  type;
     ares_bool_t          allow_compress;
-    ares_llist_t      **namelistptr = NULL;
+    ares_llist_t       **namelistptr = NULL;
     size_t               pos_len;
     ares_status_t        status;
     size_t               rdlength;
@@ -1095,11 +1095,11 @@ static ares_status_t ares_dns_write_rr(const ares_dns_record_t *dnsrec,
 }
 
 ares_status_t ares_dns_write_buf(const ares_dns_record_t *dnsrec,
-                                 ares_buf_t             *buf)
+                                 ares_buf_t              *buf)
 {
   ares_llist_t *namelist = NULL;
-  size_t         orig_len;
-  ares_status_t  status;
+  size_t        orig_len;
+  ares_status_t status;
 
   if (dnsrec == NULL || buf == NULL) {
     return ARES_EFORMERR;
@@ -1142,7 +1142,7 @@ done:
 }
 
 ares_status_t ares_dns_write_buf_tcp(const ares_dns_record_t *dnsrec,
-                                     ares_buf_t             *buf)
+                                     ares_buf_t              *buf)
 {
   ares_status_t status;
   size_t        orig_len;
@@ -1193,7 +1193,7 @@ done:
 ares_status_t ares_dns_write(const ares_dns_record_t *dnsrec,
                              unsigned char **buf, size_t *buf_len)
 {
-  ares_buf_t  *b = NULL;
+  ares_buf_t   *b = NULL;
   ares_status_t status;
 
   if (buf == NULL || buf_len == NULL || dnsrec == NULL) {

--- a/src/lib/record/ares_dns_write.c
+++ b/src/lib/record/ares_dns_write.c
@@ -31,7 +31,7 @@
 
 
 static ares_status_t ares_dns_write_header(const ares_dns_record_t *dnsrec,
-                                           ares__buf_t             *buf)
+                                           ares_buf_t             *buf)
 {
   unsigned short u16;
   unsigned short opcode;
@@ -40,7 +40,7 @@ static ares_status_t ares_dns_write_header(const ares_dns_record_t *dnsrec,
   ares_status_t  status;
 
   /* ID */
-  status = ares__buf_append_be16(buf, dnsrec->id);
+  status = ares_buf_append_be16(buf, dnsrec->id);
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -99,34 +99,34 @@ static ares_status_t ares_dns_write_header(const ares_dns_record_t *dnsrec,
   }
   u16 |= rcode;
 
-  status = ares__buf_append_be16(buf, u16);
+  status = ares_buf_append_be16(buf, u16);
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   /* QDCOUNT */
-  status = ares__buf_append_be16(
+  status = ares_buf_append_be16(
     buf, (unsigned short)ares_dns_record_query_cnt(dnsrec));
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   /* ANCOUNT */
-  status = ares__buf_append_be16(
+  status = ares_buf_append_be16(
     buf, (unsigned short)ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ANSWER));
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   /* NSCOUNT */
-  status = ares__buf_append_be16(buf, (unsigned short)ares_dns_record_rr_cnt(
+  status = ares_buf_append_be16(buf, (unsigned short)ares_dns_record_rr_cnt(
                                         dnsrec, ARES_SECTION_AUTHORITY));
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   /* ARCOUNT */
-  status = ares__buf_append_be16(buf, (unsigned short)ares_dns_record_rr_cnt(
+  status = ares_buf_append_be16(buf, (unsigned short)ares_dns_record_rr_cnt(
                                         dnsrec, ARES_SECTION_ADDITIONAL));
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
@@ -136,8 +136,8 @@ static ares_status_t ares_dns_write_header(const ares_dns_record_t *dnsrec,
 }
 
 static ares_status_t ares_dns_write_questions(const ares_dns_record_t *dnsrec,
-                                              ares__llist_t          **namelist,
-                                              ares__buf_t             *buf)
+                                              ares_llist_t          **namelist,
+                                              ares_buf_t             *buf)
 {
   size_t i;
 
@@ -153,19 +153,19 @@ static ares_status_t ares_dns_write_questions(const ares_dns_record_t *dnsrec,
     }
 
     /* Name */
-    status = ares__dns_name_write(buf, namelist, ARES_TRUE, name);
+    status = ares_dns_name_write(buf, namelist, ARES_TRUE, name);
     if (status != ARES_SUCCESS) {
       return status;
     }
 
     /* Type */
-    status = ares__buf_append_be16(buf, (unsigned short)qtype);
+    status = ares_buf_append_be16(buf, (unsigned short)qtype);
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
     /* Class */
-    status = ares__buf_append_be16(buf, (unsigned short)qclass);
+    status = ares_buf_append_be16(buf, (unsigned short)qclass);
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -174,9 +174,9 @@ static ares_status_t ares_dns_write_questions(const ares_dns_record_t *dnsrec,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_write_rr_name(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_name(ares_buf_t         *buf,
                                             const ares_dns_rr_t *rr,
-                                            ares__llist_t      **namelist,
+                                            ares_llist_t      **namelist,
                                             ares_bool_t       validate_hostname,
                                             ares_dns_rr_key_t key)
 {
@@ -187,10 +187,10 @@ static ares_status_t ares_dns_write_rr_name(ares__buf_t         *buf,
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  return ares__dns_name_write(buf, namelist, validate_hostname, name);
+  return ares_dns_name_write(buf, namelist, validate_hostname, name);
 }
 
-static ares_status_t ares_dns_write_rr_str(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_str(ares_buf_t         *buf,
                                            const ares_dns_rr_t *rr,
                                            ares_dns_rr_key_t    key)
 {
@@ -209,7 +209,7 @@ static ares_status_t ares_dns_write_rr_str(ares__buf_t         *buf,
   }
 
   /* Write 1 byte length */
-  status = ares__buf_append_byte(buf, (unsigned char)(len & 0xFF));
+  status = ares_buf_append_byte(buf, (unsigned char)(len & 0xFF));
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -219,10 +219,10 @@ static ares_status_t ares_dns_write_rr_str(ares__buf_t         *buf,
   }
 
   /* Write string */
-  return ares__buf_append(buf, (const unsigned char *)str, len);
+  return ares_buf_append(buf, (const unsigned char *)str, len);
 }
 
-static ares_status_t ares_dns_write_binstr(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_binstr(ares_buf_t         *buf,
                                            const unsigned char *bin,
                                            size_t               bin_len)
 {
@@ -240,14 +240,14 @@ static ares_status_t ares_dns_write_binstr(ares__buf_t         *buf,
     }
 
     /* Length */
-    status = ares__buf_append_byte(buf, (unsigned char)(len & 0xFF));
+    status = ares_buf_append_byte(buf, (unsigned char)(len & 0xFF));
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
     /* String */
     if (len) {
-      status = ares__buf_append(buf, ptr, len);
+      status = ares_buf_append(buf, ptr, len);
       if (status != ARES_SUCCESS) {
         return status; /* LCOV_EXCL_LINE: OutOfMemory */
       }
@@ -260,7 +260,7 @@ static ares_status_t ares_dns_write_binstr(ares__buf_t         *buf,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_write_rr_abin(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_abin(ares_buf_t         *buf,
                                             const ares_dns_rr_t *rr,
                                             ares_dns_rr_key_t    key)
 {
@@ -287,39 +287,39 @@ static ares_status_t ares_dns_write_rr_abin(ares__buf_t         *buf,
   return status;
 }
 
-static ares_status_t ares_dns_write_rr_be32(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_be32(ares_buf_t         *buf,
                                             const ares_dns_rr_t *rr,
                                             ares_dns_rr_key_t    key)
 {
   if (ares_dns_rr_key_datatype(key) != ARES_DATATYPE_U32) {
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
-  return ares__buf_append_be32(buf, ares_dns_rr_get_u32(rr, key));
+  return ares_buf_append_be32(buf, ares_dns_rr_get_u32(rr, key));
 }
 
-static ares_status_t ares_dns_write_rr_be16(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_be16(ares_buf_t         *buf,
                                             const ares_dns_rr_t *rr,
                                             ares_dns_rr_key_t    key)
 {
   if (ares_dns_rr_key_datatype(key) != ARES_DATATYPE_U16) {
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
-  return ares__buf_append_be16(buf, ares_dns_rr_get_u16(rr, key));
+  return ares_buf_append_be16(buf, ares_dns_rr_get_u16(rr, key));
 }
 
-static ares_status_t ares_dns_write_rr_u8(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_u8(ares_buf_t         *buf,
                                           const ares_dns_rr_t *rr,
                                           ares_dns_rr_key_t    key)
 {
   if (ares_dns_rr_key_datatype(key) != ARES_DATATYPE_U8) {
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
-  return ares__buf_append_byte(buf, ares_dns_rr_get_u8(rr, key));
+  return ares_buf_append_byte(buf, ares_dns_rr_get_u8(rr, key));
 }
 
-static ares_status_t ares_dns_write_rr_a(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_a(ares_buf_t         *buf,
                                          const ares_dns_rr_t *rr,
-                                         ares__llist_t      **namelist)
+                                         ares_llist_t      **namelist)
 {
   const struct in_addr *addr;
   (void)namelist;
@@ -329,28 +329,28 @@ static ares_status_t ares_dns_write_rr_a(ares__buf_t         *buf,
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  return ares__buf_append(buf, (const unsigned char *)addr, sizeof(*addr));
+  return ares_buf_append(buf, (const unsigned char *)addr, sizeof(*addr));
 }
 
-static ares_status_t ares_dns_write_rr_ns(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_ns(ares_buf_t         *buf,
                                           const ares_dns_rr_t *rr,
-                                          ares__llist_t      **namelist)
+                                          ares_llist_t      **namelist)
 {
   return ares_dns_write_rr_name(buf, rr, namelist, ARES_FALSE,
                                 ARES_RR_NS_NSDNAME);
 }
 
-static ares_status_t ares_dns_write_rr_cname(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_cname(ares_buf_t         *buf,
                                              const ares_dns_rr_t *rr,
-                                             ares__llist_t      **namelist)
+                                             ares_llist_t      **namelist)
 {
   return ares_dns_write_rr_name(buf, rr, namelist, ARES_FALSE,
                                 ARES_RR_CNAME_CNAME);
 }
 
-static ares_status_t ares_dns_write_rr_soa(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_soa(ares_buf_t         *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares__llist_t      **namelist)
+                                           ares_llist_t      **namelist)
 {
   ares_status_t status;
 
@@ -396,17 +396,17 @@ static ares_status_t ares_dns_write_rr_soa(ares__buf_t         *buf,
   return ares_dns_write_rr_be32(buf, rr, ARES_RR_SOA_MINIMUM);
 }
 
-static ares_status_t ares_dns_write_rr_ptr(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_ptr(ares_buf_t         *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares__llist_t      **namelist)
+                                           ares_llist_t      **namelist)
 {
   return ares_dns_write_rr_name(buf, rr, namelist, ARES_FALSE,
                                 ARES_RR_PTR_DNAME);
 }
 
-static ares_status_t ares_dns_write_rr_hinfo(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_hinfo(ares_buf_t         *buf,
                                              const ares_dns_rr_t *rr,
-                                             ares__llist_t      **namelist)
+                                             ares_llist_t      **namelist)
 {
   ares_status_t status;
 
@@ -422,9 +422,9 @@ static ares_status_t ares_dns_write_rr_hinfo(ares__buf_t         *buf,
   return ares_dns_write_rr_str(buf, rr, ARES_RR_HINFO_OS);
 }
 
-static ares_status_t ares_dns_write_rr_mx(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_mx(ares_buf_t         *buf,
                                           const ares_dns_rr_t *rr,
-                                          ares__llist_t      **namelist)
+                                          ares_llist_t      **namelist)
 {
   ares_status_t status;
 
@@ -439,17 +439,17 @@ static ares_status_t ares_dns_write_rr_mx(ares__buf_t         *buf,
                                 ARES_RR_MX_EXCHANGE);
 }
 
-static ares_status_t ares_dns_write_rr_txt(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_txt(ares_buf_t         *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares__llist_t      **namelist)
+                                           ares_llist_t      **namelist)
 {
   (void)namelist;
   return ares_dns_write_rr_abin(buf, rr, ARES_RR_TXT_DATA);
 }
 
-static ares_status_t ares_dns_write_rr_sig(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_sig(ares_buf_t         *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares__llist_t      **namelist)
+                                           ares_llist_t      **namelist)
 {
   ares_status_t        status;
   const unsigned char *data;
@@ -512,12 +512,12 @@ static ares_status_t ares_dns_write_rr_sig(ares__buf_t         *buf,
     return ARES_EFORMERR;
   }
 
-  return ares__buf_append(buf, data, len);
+  return ares_buf_append(buf, data, len);
 }
 
-static ares_status_t ares_dns_write_rr_aaaa(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_aaaa(ares_buf_t         *buf,
                                             const ares_dns_rr_t *rr,
-                                            ares__llist_t      **namelist)
+                                            ares_llist_t      **namelist)
 {
   const struct ares_in6_addr *addr;
   (void)namelist;
@@ -527,12 +527,12 @@ static ares_status_t ares_dns_write_rr_aaaa(ares__buf_t         *buf,
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  return ares__buf_append(buf, (const unsigned char *)addr, sizeof(*addr));
+  return ares_buf_append(buf, (const unsigned char *)addr, sizeof(*addr));
 }
 
-static ares_status_t ares_dns_write_rr_srv(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_srv(ares_buf_t         *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares__llist_t      **namelist)
+                                           ares_llist_t      **namelist)
 {
   ares_status_t status;
 
@@ -559,9 +559,9 @@ static ares_status_t ares_dns_write_rr_srv(ares__buf_t         *buf,
                                 ARES_RR_SRV_TARGET);
 }
 
-static ares_status_t ares_dns_write_rr_naptr(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_naptr(ares_buf_t         *buf,
                                              const ares_dns_rr_t *rr,
-                                             ares__llist_t      **namelist)
+                                             ares_llist_t      **namelist)
 {
   ares_status_t status;
 
@@ -600,11 +600,11 @@ static ares_status_t ares_dns_write_rr_naptr(ares__buf_t         *buf,
                                 ARES_RR_NAPTR_REPLACEMENT);
 }
 
-static ares_status_t ares_dns_write_rr_opt(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_opt(ares_buf_t         *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares__llist_t      **namelist)
+                                           ares_llist_t      **namelist)
 {
-  size_t         len = ares__buf_len(buf);
+  size_t         len = ares_buf_len(buf);
   ares_status_t  status;
   unsigned int   ttl = 0;
   size_t         i;
@@ -620,7 +620,7 @@ static ares_status_t ares_dns_write_rr_opt(ares__buf_t         *buf,
 
   /* We need to go back and overwrite the class and ttl that were emitted as
    * the OPT record overloads them for its own use (yes, very strange!) */
-  status = ares__buf_set_length(buf, len - 2 /* RDLENGTH */
+  status = ares_buf_set_length(buf, len - 2 /* RDLENGTH */
                                        - 4   /* TTL */
                                        - 2 /* CLASS */);
   if (status != ARES_SUCCESS) {
@@ -638,13 +638,13 @@ static ares_status_t ares_dns_write_rr_opt(ares__buf_t         *buf,
   ttl |= (unsigned int)ares_dns_rr_get_u8(rr, ARES_RR_OPT_VERSION) << 16;
   ttl |= (unsigned int)ares_dns_rr_get_u16(rr, ARES_RR_OPT_FLAGS);
 
-  status = ares__buf_append_be32(buf, ttl);
+  status = ares_buf_append_be32(buf, ttl);
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   /* Now go back to real end */
-  status = ares__buf_set_length(buf, len);
+  status = ares_buf_set_length(buf, len);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -658,20 +658,20 @@ static ares_status_t ares_dns_write_rr_opt(ares__buf_t         *buf,
     opt = ares_dns_rr_get_opt(rr, ARES_RR_OPT_OPTIONS, i, &val, &val_len);
 
     /* BE16 option */
-    status = ares__buf_append_be16(buf, opt);
+    status = ares_buf_append_be16(buf, opt);
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
     /* BE16 length */
-    status = ares__buf_append_be16(buf, (unsigned short)(val_len & 0xFFFF));
+    status = ares_buf_append_be16(buf, (unsigned short)(val_len & 0xFFFF));
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
     /* Value */
     if (val && val_len) {
-      status = ares__buf_append(buf, val, val_len);
+      status = ares_buf_append(buf, val, val_len);
       if (status != ARES_SUCCESS) {
         return status; /* LCOV_EXCL_LINE: OutOfMemory */
       }
@@ -681,9 +681,9 @@ static ares_status_t ares_dns_write_rr_opt(ares__buf_t         *buf,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_write_rr_tlsa(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_tlsa(ares_buf_t         *buf,
                                             const ares_dns_rr_t *rr,
-                                            ares__llist_t      **namelist)
+                                            ares_llist_t      **namelist)
 {
   ares_status_t        status;
   const unsigned char *data;
@@ -715,12 +715,12 @@ static ares_status_t ares_dns_write_rr_tlsa(ares__buf_t         *buf,
     return ARES_EFORMERR;
   }
 
-  return ares__buf_append(buf, data, len);
+  return ares_buf_append(buf, data, len);
 }
 
-static ares_status_t ares_dns_write_rr_svcb(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_svcb(ares_buf_t         *buf,
                                             const ares_dns_rr_t *rr,
-                                            ares__llist_t      **namelist)
+                                            ares_llist_t      **namelist)
 {
   ares_status_t status;
   size_t        i;
@@ -747,20 +747,20 @@ static ares_status_t ares_dns_write_rr_svcb(ares__buf_t         *buf,
     opt = ares_dns_rr_get_opt(rr, ARES_RR_SVCB_PARAMS, i, &val, &val_len);
 
     /* BE16 option */
-    status = ares__buf_append_be16(buf, opt);
+    status = ares_buf_append_be16(buf, opt);
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
     /* BE16 length */
-    status = ares__buf_append_be16(buf, (unsigned short)(val_len & 0xFFFF));
+    status = ares_buf_append_be16(buf, (unsigned short)(val_len & 0xFFFF));
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
     /* Value */
     if (val && val_len) {
-      status = ares__buf_append(buf, val, val_len);
+      status = ares_buf_append(buf, val, val_len);
       if (status != ARES_SUCCESS) {
         return status; /* LCOV_EXCL_LINE: OutOfMemory */
       }
@@ -769,9 +769,9 @@ static ares_status_t ares_dns_write_rr_svcb(ares__buf_t         *buf,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_write_rr_https(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_https(ares_buf_t         *buf,
                                              const ares_dns_rr_t *rr,
-                                             ares__llist_t      **namelist)
+                                             ares_llist_t      **namelist)
 {
   ares_status_t status;
   size_t        i;
@@ -798,20 +798,20 @@ static ares_status_t ares_dns_write_rr_https(ares__buf_t         *buf,
     opt = ares_dns_rr_get_opt(rr, ARES_RR_HTTPS_PARAMS, i, &val, &val_len);
 
     /* BE16 option */
-    status = ares__buf_append_be16(buf, opt);
+    status = ares_buf_append_be16(buf, opt);
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
     /* BE16 length */
-    status = ares__buf_append_be16(buf, (unsigned short)(val_len & 0xFFFF));
+    status = ares_buf_append_be16(buf, (unsigned short)(val_len & 0xFFFF));
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
     /* Value */
     if (val && val_len) {
-      status = ares__buf_append(buf, val, val_len);
+      status = ares_buf_append(buf, val, val_len);
       if (status != ARES_SUCCESS) {
         return status; /* LCOV_EXCL_LINE: OutOfMemory */
       }
@@ -820,9 +820,9 @@ static ares_status_t ares_dns_write_rr_https(ares__buf_t         *buf,
   return ARES_SUCCESS;
 }
 
-static ares_status_t ares_dns_write_rr_uri(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_uri(ares_buf_t         *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares__llist_t      **namelist)
+                                           ares_llist_t      **namelist)
 {
   ares_status_t status;
   const char   *target;
@@ -848,13 +848,13 @@ static ares_status_t ares_dns_write_rr_uri(ares__buf_t         *buf,
     return ARES_EFORMERR;
   }
 
-  return ares__buf_append(buf, (const unsigned char *)target,
+  return ares_buf_append(buf, (const unsigned char *)target,
                           ares_strlen(target));
 }
 
-static ares_status_t ares_dns_write_rr_caa(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_caa(ares_buf_t         *buf,
                                            const ares_dns_rr_t *rr,
-                                           ares__llist_t      **namelist)
+                                           ares_llist_t      **namelist)
 {
   const unsigned char *data     = NULL;
   size_t               data_len = 0;
@@ -880,14 +880,14 @@ static ares_status_t ares_dns_write_rr_caa(ares__buf_t         *buf,
     return ARES_EFORMERR;
   }
 
-  return ares__buf_append(buf, data, data_len);
+  return ares_buf_append(buf, data, data_len);
 }
 
-static ares_status_t ares_dns_write_rr_raw_rr(ares__buf_t         *buf,
+static ares_status_t ares_dns_write_rr_raw_rr(ares_buf_t         *buf,
                                               const ares_dns_rr_t *rr,
-                                              ares__llist_t      **namelist)
+                                              ares_llist_t      **namelist)
 {
-  size_t               len = ares__buf_len(buf);
+  size_t               len = ares_buf_len(buf);
   ares_status_t        status;
   const unsigned char *data     = NULL;
   size_t               data_len = 0;
@@ -902,7 +902,7 @@ static ares_status_t ares_dns_write_rr_raw_rr(ares__buf_t         *buf,
 
   /* We need to go back and overwrite the type that was emitted by the parent
    * function */
-  status = ares__buf_set_length(buf, len - 2 /* RDLENGTH */
+  status = ares_buf_set_length(buf, len - 2 /* RDLENGTH */
                                        - 4   /* TTL */
                                        - 2   /* CLASS */
                                        - 2 /* TYPE */);
@@ -916,7 +916,7 @@ static ares_status_t ares_dns_write_rr_raw_rr(ares__buf_t         *buf,
   }
 
   /* Now go back to real end */
-  status = ares__buf_set_length(buf, len);
+  status = ares_buf_set_length(buf, len);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -931,13 +931,13 @@ static ares_status_t ares_dns_write_rr_raw_rr(ares__buf_t         *buf,
     return ARES_SUCCESS;
   }
 
-  return ares__buf_append(buf, data, data_len);
+  return ares_buf_append(buf, data, data_len);
 }
 
 static ares_status_t ares_dns_write_rr(const ares_dns_record_t *dnsrec,
-                                       ares__llist_t          **namelist,
+                                       ares_llist_t          **namelist,
                                        ares_dns_section_t       section,
-                                       ares__buf_t             *buf)
+                                       ares_buf_t             *buf)
 {
   size_t i;
 
@@ -945,7 +945,7 @@ static ares_status_t ares_dns_write_rr(const ares_dns_record_t *dnsrec,
     const ares_dns_rr_t *rr;
     ares_dns_rec_type_t  type;
     ares_bool_t          allow_compress;
-    ares__llist_t      **namelistptr = NULL;
+    ares_llist_t      **namelistptr = NULL;
     size_t               pos_len;
     ares_status_t        status;
     size_t               rdlength;
@@ -965,20 +965,20 @@ static ares_status_t ares_dns_write_rr(const ares_dns_record_t *dnsrec,
 
     /* Name */
     status =
-      ares__dns_name_write(buf, namelist, ARES_TRUE, ares_dns_rr_get_name(rr));
+      ares_dns_name_write(buf, namelist, ARES_TRUE, ares_dns_rr_get_name(rr));
     if (status != ARES_SUCCESS) {
       return status;
     }
 
     /* Type */
-    status = ares__buf_append_be16(buf, (unsigned short)type);
+    status = ares_buf_append_be16(buf, (unsigned short)type);
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
     /* Class */
     status =
-      ares__buf_append_be16(buf, (unsigned short)ares_dns_rr_get_class(rr));
+      ares_buf_append_be16(buf, (unsigned short)ares_dns_rr_get_class(rr));
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -990,14 +990,14 @@ static ares_status_t ares_dns_write_rr(const ares_dns_record_t *dnsrec,
     } else {
       ttl -= rr->parent->ttl_decrement;
     }
-    status = ares__buf_append_be32(buf, ttl);
+    status = ares_buf_append_be32(buf, ttl);
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
     /* Length */
-    pos_len = ares__buf_len(buf); /* Save to write real length later */
-    status  = ares__buf_append_be16(buf, 0);
+    pos_len = ares_buf_len(buf); /* Save to write real length later */
+    status  = ares_buf_append_be16(buf, 0);
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -1072,20 +1072,20 @@ static ares_status_t ares_dns_write_rr(const ares_dns_record_t *dnsrec,
 
     /* Back off write pointer, write real length, then go back to proper
      * position */
-    end_length = ares__buf_len(buf);
+    end_length = ares_buf_len(buf);
     rdlength   = end_length - pos_len - 2;
 
-    status = ares__buf_set_length(buf, pos_len);
+    status = ares_buf_set_length(buf, pos_len);
     if (status != ARES_SUCCESS) {
       return status;
     }
 
-    status = ares__buf_append_be16(buf, (unsigned short)(rdlength & 0xFFFF));
+    status = ares_buf_append_be16(buf, (unsigned short)(rdlength & 0xFFFF));
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
-    status = ares__buf_set_length(buf, end_length);
+    status = ares_buf_set_length(buf, end_length);
     if (status != ARES_SUCCESS) {
       return status;
     }
@@ -1095,9 +1095,9 @@ static ares_status_t ares_dns_write_rr(const ares_dns_record_t *dnsrec,
 }
 
 ares_status_t ares_dns_write_buf(const ares_dns_record_t *dnsrec,
-                                 ares__buf_t             *buf)
+                                 ares_buf_t             *buf)
 {
-  ares__llist_t *namelist = NULL;
+  ares_llist_t *namelist = NULL;
   size_t         orig_len;
   ares_status_t  status;
 
@@ -1105,7 +1105,7 @@ ares_status_t ares_dns_write_buf(const ares_dns_record_t *dnsrec,
     return ARES_EFORMERR;
   }
 
-  orig_len = ares__buf_len(buf);
+  orig_len = ares_buf_len(buf);
 
   status = ares_dns_write_header(dnsrec, buf);
   if (status != ARES_SUCCESS) {
@@ -1133,16 +1133,16 @@ ares_status_t ares_dns_write_buf(const ares_dns_record_t *dnsrec,
   }
 
 done:
-  ares__llist_destroy(namelist);
+  ares_llist_destroy(namelist);
   if (status != ARES_SUCCESS) {
-    ares__buf_set_length(buf, orig_len);
+    ares_buf_set_length(buf, orig_len);
   }
 
   return status;
 }
 
 ares_status_t ares_dns_write_buf_tcp(const ares_dns_record_t *dnsrec,
-                                     ares__buf_t             *buf)
+                                     ares_buf_t             *buf)
 {
   ares_status_t status;
   size_t        orig_len;
@@ -1153,10 +1153,10 @@ ares_status_t ares_dns_write_buf_tcp(const ares_dns_record_t *dnsrec,
     return ARES_EFORMERR;
   }
 
-  orig_len = ares__buf_len(buf);
+  orig_len = ares_buf_len(buf);
 
   /* Write placeholder for length */
-  status = ares__buf_append_be16(buf, 0);
+  status = ares_buf_append_be16(buf, 0);
   if (status != ARES_SUCCESS) {
     goto done; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -1167,7 +1167,7 @@ ares_status_t ares_dns_write_buf_tcp(const ares_dns_record_t *dnsrec,
     goto done; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  len     = ares__buf_len(buf);
+  len     = ares_buf_len(buf);
   msg_len = len - orig_len - 2;
   if (msg_len > 65535) {
     status = ARES_EBADQUERY;
@@ -1176,16 +1176,16 @@ ares_status_t ares_dns_write_buf_tcp(const ares_dns_record_t *dnsrec,
 
   /* Now we need to overwrite the length, so we jump back to the original
    * message length, overwrite the section and jump back */
-  ares__buf_set_length(buf, orig_len);
-  status = ares__buf_append_be16(buf, (unsigned short)(msg_len & 0xFFFF));
+  ares_buf_set_length(buf, orig_len);
+  status = ares_buf_append_be16(buf, (unsigned short)(msg_len & 0xFFFF));
   if (status != ARES_SUCCESS) {
     goto done; /* LCOV_EXCL_LINE: UntestablePath */
   }
-  ares__buf_set_length(buf, len);
+  ares_buf_set_length(buf, len);
 
 done:
   if (status != ARES_SUCCESS) {
-    ares__buf_set_length(buf, orig_len);
+    ares_buf_set_length(buf, orig_len);
   }
   return status;
 }
@@ -1193,7 +1193,7 @@ done:
 ares_status_t ares_dns_write(const ares_dns_record_t *dnsrec,
                              unsigned char **buf, size_t *buf_len)
 {
-  ares__buf_t  *b = NULL;
+  ares_buf_t  *b = NULL;
   ares_status_t status;
 
   if (buf == NULL || buf_len == NULL || dnsrec == NULL) {
@@ -1203,7 +1203,7 @@ ares_status_t ares_dns_write(const ares_dns_record_t *dnsrec,
   *buf     = NULL;
   *buf_len = 0;
 
-  b = ares__buf_create();
+  b = ares_buf_create();
   if (b == NULL) {
     return ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -1211,11 +1211,11 @@ ares_status_t ares_dns_write(const ares_dns_record_t *dnsrec,
   status = ares_dns_write_buf(dnsrec, b);
 
   if (status != ARES_SUCCESS) {
-    ares__buf_destroy(b);
+    ares_buf_destroy(b);
     return status;
   }
 
-  *buf = ares__buf_finish_bin(b, buf_len);
+  *buf = ares_buf_finish_bin(b, buf_len);
   return status;
 }
 

--- a/src/lib/str/ares_buf.c
+++ b/src/lib/str/ares_buf.c
@@ -135,8 +135,7 @@ void ares_buf_reclaim(ares_buf_t *buf)
   }
 }
 
-static ares_status_t ares_buf_ensure_space(ares_buf_t *buf,
-                                            size_t       needed_size)
+static ares_status_t ares_buf_ensure_space(ares_buf_t *buf, size_t needed_size)
 {
   size_t         remaining_size;
   size_t         alloc_size;
@@ -209,7 +208,7 @@ ares_status_t ares_buf_set_length(ares_buf_t *buf, size_t len)
 }
 
 ares_status_t ares_buf_append(ares_buf_t *buf, const unsigned char *data,
-                               size_t data_len)
+                              size_t data_len)
 {
   ares_status_t status;
 
@@ -317,8 +316,7 @@ unsigned char *ares_buf_finish_bin(ares_buf_t *buf, size_t *len)
   ares_buf_reclaim(buf);
 
   /* We don't want to return NULL except on failure, may be zero-length */
-  if (buf->alloc_buf == NULL &&
-      ares_buf_ensure_space(buf, 1) != ARES_SUCCESS) {
+  if (buf->alloc_buf == NULL && ares_buf_ensure_space(buf, 1) != ARES_SUCCESS) {
     return NULL; /* LCOV_EXCL_LINE: OutOfMemory */
   }
   ptr  = buf->alloc_buf;
@@ -397,7 +395,7 @@ size_t ares_buf_tag_length(const ares_buf_t *buf)
 }
 
 ares_status_t ares_buf_tag_fetch_bytes(const ares_buf_t *buf,
-                                        unsigned char *bytes, size_t *len)
+                                       unsigned char *bytes, size_t *len)
 {
   size_t               ptr_len = 0;
   const unsigned char *ptr     = ares_buf_tag_fetch(buf, &ptr_len);
@@ -419,7 +417,7 @@ ares_status_t ares_buf_tag_fetch_bytes(const ares_buf_t *buf,
 }
 
 ares_status_t ares_buf_tag_fetch_string(const ares_buf_t *buf, char *str,
-                                         size_t len)
+                                        size_t len)
 {
   size_t        out_len;
   ares_status_t status;
@@ -514,7 +512,7 @@ ares_status_t ares_buf_fetch_be32(ares_buf_t *buf, unsigned int *u32)
 }
 
 ares_status_t ares_buf_fetch_bytes(ares_buf_t *buf, unsigned char *bytes,
-                                    size_t len)
+                                   size_t len)
 {
   size_t               remaining_len;
   const unsigned char *ptr = ares_buf_fetch(buf, &remaining_len);
@@ -528,8 +526,8 @@ ares_status_t ares_buf_fetch_bytes(ares_buf_t *buf, unsigned char *bytes,
 }
 
 ares_status_t ares_buf_fetch_bytes_dup(ares_buf_t *buf, size_t len,
-                                        ares_bool_t     null_term,
-                                        unsigned char **bytes)
+                                       ares_bool_t     null_term,
+                                       unsigned char **bytes)
 {
   size_t               remaining_len;
   const unsigned char *ptr = ares_buf_fetch(buf, &remaining_len);
@@ -578,8 +576,8 @@ ares_status_t ares_buf_fetch_str_dup(ares_buf_t *buf, size_t len, char **str)
   return ares_buf_consume(buf, len);
 }
 
-ares_status_t ares_buf_fetch_bytes_into_buf(ares_buf_t *buf,
-                                             ares_buf_t *dest, size_t len)
+ares_status_t ares_buf_fetch_bytes_into_buf(ares_buf_t *buf, ares_buf_t *dest,
+                                            size_t len)
 {
   size_t               remaining_len;
   const unsigned char *ptr = ares_buf_fetch(buf, &remaining_len);
@@ -598,7 +596,7 @@ ares_status_t ares_buf_fetch_bytes_into_buf(ares_buf_t *buf,
 }
 
 static ares_bool_t ares_is_whitespace(unsigned char c,
-                                       ares_bool_t   include_linefeed)
+                                      ares_bool_t   include_linefeed)
 {
   switch (c) {
     case '\r':
@@ -616,7 +614,7 @@ static ares_bool_t ares_is_whitespace(unsigned char c,
 }
 
 size_t ares_buf_consume_whitespace(ares_buf_t *buf,
-                                    ares_bool_t  include_linefeed)
+                                   ares_bool_t include_linefeed)
 {
   size_t               remaining_len = 0;
   const unsigned char *ptr           = ares_buf_fetch(buf, &remaining_len);
@@ -687,9 +685,9 @@ done:
   return i;
 }
 
-size_t ares_buf_consume_until_charset(ares_buf_t         *buf,
-                                       const unsigned char *charset, size_t len,
-                                       ares_bool_t require_charset)
+size_t ares_buf_consume_until_charset(ares_buf_t          *buf,
+                                      const unsigned char *charset, size_t len,
+                                      ares_bool_t require_charset)
 {
   size_t               remaining_len = 0;
   const unsigned char *ptr           = ares_buf_fetch(buf, &remaining_len);
@@ -722,7 +720,7 @@ done:
 }
 
 size_t ares_buf_consume_charset(ares_buf_t *buf, const unsigned char *charset,
-                                 size_t len)
+                                size_t len)
 {
   size_t               remaining_len = 0;
   const unsigned char *ptr           = ares_buf_fetch(buf, &remaining_len);
@@ -756,16 +754,16 @@ static void ares_buf_destroy_cb(void *arg)
   ares_buf_destroy(arg);
 }
 
-static ares_bool_t ares_buf_split_isduplicate(ares_llist_t       *list,
-                                               const unsigned char *val,
-                                               size_t               len,
-                                               ares_buf_split_t    flags)
+static ares_bool_t ares_buf_split_isduplicate(ares_llist_t        *list,
+                                              const unsigned char *val,
+                                              size_t               len,
+                                              ares_buf_split_t     flags)
 {
   ares_llist_node_t *node;
 
   for (node = ares_llist_node_first(list); node != NULL;
        node = ares_llist_node_next(node)) {
-    const ares_buf_t   *buf  = ares_llist_node_val(node);
+    const ares_buf_t    *buf  = ares_llist_node_val(node);
     size_t               plen = 0;
     const unsigned char *ptr  = ares_buf_peek(buf, &plen);
 
@@ -788,8 +786,8 @@ static ares_bool_t ares_buf_split_isduplicate(ares_llist_t       *list,
 }
 
 ares_status_t ares_buf_split(ares_buf_t *buf, const unsigned char *delims,
-                              size_t delims_len, ares_buf_split_t flags,
-                              size_t max_sections, ares_llist_t **list)
+                             size_t delims_len, ares_buf_split_t flags,
+                             size_t max_sections, ares_llist_t **list)
 {
   ares_status_t status = ARES_SUCCESS;
   ares_bool_t   first  = ARES_TRUE;
@@ -899,11 +897,11 @@ static void ares_free_split_array(void *arg)
 }
 
 ares_status_t ares_buf_split_str(ares_buf_t *buf, const unsigned char *delims,
-                                  size_t delims_len, ares_buf_split_t flags,
-                                  size_t max_sections, char ***strs,
-                                  size_t *nstrs)
+                                 size_t delims_len, ares_buf_split_t flags,
+                                 size_t max_sections, char ***strs,
+                                 size_t *nstrs)
 {
-  ares_status_t       status;
+  ares_status_t      status;
   ares_llist_t      *list = NULL;
   ares_llist_node_t *node;
   ares_array_t      *arr = NULL;
@@ -929,7 +927,7 @@ ares_status_t ares_buf_split_str(ares_buf_t *buf, const unsigned char *delims,
   for (node = ares_llist_node_first(list); node != NULL;
        node = ares_llist_node_next(node)) {
     ares_buf_t *lbuf = ares_llist_node_val(node);
-    char        *str  = NULL;
+    char       *str  = NULL;
 
     status = ares_buf_fetch_str_dup(lbuf, ares_buf_len(lbuf), &str);
     if (status != ARES_SUCCESS) {
@@ -953,8 +951,8 @@ done:
   return status;
 }
 
-ares_bool_t ares_buf_begins_with(const ares_buf_t   *buf,
-                                  const unsigned char *data, size_t data_len)
+ares_bool_t ares_buf_begins_with(const ares_buf_t    *buf,
+                                 const unsigned char *data, size_t data_len)
 {
   size_t               remaining_len = 0;
   const unsigned char *ptr           = ares_buf_fetch(buf, &remaining_len);
@@ -1012,12 +1010,12 @@ ares_status_t ares_buf_set_position(ares_buf_t *buf, size_t idx)
 
 static ares_status_t
   ares_buf_parse_dns_binstr_int(ares_buf_t *buf, size_t remaining_len,
-                                 unsigned char **bin, size_t *bin_len,
-                                 ares_bool_t validate_printable)
+                                unsigned char **bin, size_t *bin_len,
+                                ares_bool_t validate_printable)
 {
   unsigned char len;
   ares_status_t status = ARES_EBADRESP;
-  ares_buf_t  *binbuf = NULL;
+  ares_buf_t   *binbuf = NULL;
 
   if (buf == NULL) {
     return ARES_EFORMERR;
@@ -1081,19 +1079,19 @@ done:
 }
 
 ares_status_t ares_buf_parse_dns_binstr(ares_buf_t *buf, size_t remaining_len,
-                                         unsigned char **bin, size_t *bin_len)
+                                        unsigned char **bin, size_t *bin_len)
 {
   return ares_buf_parse_dns_binstr_int(buf, remaining_len, bin, bin_len,
-                                        ARES_FALSE);
+                                       ARES_FALSE);
 }
 
 ares_status_t ares_buf_parse_dns_str(ares_buf_t *buf, size_t remaining_len,
-                                      char **str)
+                                     char **str)
 {
   size_t len;
 
   return ares_buf_parse_dns_binstr_int(buf, remaining_len,
-                                        (unsigned char **)str, &len, ARES_TRUE);
+                                       (unsigned char **)str, &len, ARES_TRUE);
 }
 
 ares_status_t ares_buf_append_num_dec(ares_buf_t *buf, size_t num, size_t len)
@@ -1152,8 +1150,8 @@ ares_status_t ares_buf_append_str(ares_buf_t *buf, const char *str)
 }
 
 static ares_status_t ares_buf_hexdump_line(ares_buf_t *buf, size_t idx,
-                                            const unsigned char *data,
-                                            size_t               len)
+                                           const unsigned char *data,
+                                           size_t               len)
 {
   size_t        i;
   ares_status_t status;
@@ -1206,7 +1204,7 @@ static ares_status_t ares_buf_hexdump_line(ares_buf_t *buf, size_t idx,
 }
 
 ares_status_t ares_buf_hexdump(ares_buf_t *buf, const unsigned char *data,
-                                size_t len)
+                               size_t len)
 {
   size_t i;
 

--- a/src/lib/str/ares_buf.c
+++ b/src/lib/str/ares_buf.c
@@ -24,13 +24,13 @@
  * SPDX-License-Identifier: MIT
  */
 #include "ares_private.h"
-#include "ares__buf.h"
+#include "ares_buf.h"
 #include <limits.h>
 #ifdef HAVE_STDINT_H
 #  include <stdint.h>
 #endif
 
-struct ares__buf {
+struct ares_buf {
   const unsigned char *data;          /*!< pointer to start of data buffer */
   size_t               data_len;      /*!< total size of data in buffer */
 
@@ -43,9 +43,9 @@ struct ares__buf {
                                        *   SIZE_MAX if not set. */
 };
 
-ares__buf_t *ares__buf_create(void)
+ares_buf_t *ares_buf_create(void)
 {
-  ares__buf_t *buf = ares_malloc_zero(sizeof(*buf));
+  ares_buf_t *buf = ares_malloc_zero(sizeof(*buf));
   if (buf == NULL) {
     return NULL;
   }
@@ -54,15 +54,15 @@ ares__buf_t *ares__buf_create(void)
   return buf;
 }
 
-ares__buf_t *ares__buf_create_const(const unsigned char *data, size_t data_len)
+ares_buf_t *ares_buf_create_const(const unsigned char *data, size_t data_len)
 {
-  ares__buf_t *buf;
+  ares_buf_t *buf;
 
   if (data == NULL || data_len == 0) {
     return NULL;
   }
 
-  buf = ares__buf_create();
+  buf = ares_buf_create();
   if (buf == NULL) {
     return NULL;
   }
@@ -73,7 +73,7 @@ ares__buf_t *ares__buf_create_const(const unsigned char *data, size_t data_len)
   return buf;
 }
 
-void ares__buf_destroy(ares__buf_t *buf)
+void ares_buf_destroy(ares_buf_t *buf)
 {
   if (buf == NULL) {
     return;
@@ -82,7 +82,7 @@ void ares__buf_destroy(ares__buf_t *buf)
   ares_free(buf);
 }
 
-static ares_bool_t ares__buf_is_const(const ares__buf_t *buf)
+static ares_bool_t ares_buf_is_const(const ares_buf_t *buf)
 {
   if (buf == NULL) {
     return ARES_FALSE; /* LCOV_EXCL_LINE: DefensiveCoding */
@@ -95,7 +95,7 @@ static ares_bool_t ares__buf_is_const(const ares__buf_t *buf)
   return ARES_FALSE;
 }
 
-void ares__buf_reclaim(ares__buf_t *buf)
+void ares_buf_reclaim(ares_buf_t *buf)
 {
   size_t prefix_size;
   size_t data_size;
@@ -104,7 +104,7 @@ void ares__buf_reclaim(ares__buf_t *buf)
     return;
   }
 
-  if (ares__buf_is_const(buf)) {
+  if (ares_buf_is_const(buf)) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
@@ -135,7 +135,7 @@ void ares__buf_reclaim(ares__buf_t *buf)
   }
 }
 
-static ares_status_t ares__buf_ensure_space(ares__buf_t *buf,
+static ares_status_t ares_buf_ensure_space(ares_buf_t *buf,
                                             size_t       needed_size)
 {
   size_t         remaining_size;
@@ -146,11 +146,11 @@ static ares_status_t ares__buf_ensure_space(ares__buf_t *buf,
     return ARES_EFORMERR;
   }
 
-  if (ares__buf_is_const(buf)) {
+  if (ares_buf_is_const(buf)) {
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  /* When calling ares__buf_finish_str() we end up adding a null terminator,
+  /* When calling ares_buf_finish_str() we end up adding a null terminator,
    * so we want to ensure the size is always sufficient for this as we don't
    * want an ARES_ENOMEM at that point */
   needed_size++;
@@ -162,7 +162,7 @@ static ares_status_t ares__buf_ensure_space(ares__buf_t *buf,
   }
 
   /* See if just moving consumed data frees up enough space */
-  ares__buf_reclaim(buf);
+  ares_buf_reclaim(buf);
 
   remaining_size = buf->alloc_buf_len - buf->data_len;
   if (remaining_size >= needed_size) {
@@ -194,9 +194,9 @@ static ares_status_t ares__buf_ensure_space(ares__buf_t *buf,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__buf_set_length(ares__buf_t *buf, size_t len)
+ares_status_t ares_buf_set_length(ares_buf_t *buf, size_t len)
 {
-  if (buf == NULL || ares__buf_is_const(buf)) {
+  if (buf == NULL || ares_buf_is_const(buf)) {
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
@@ -208,7 +208,7 @@ ares_status_t ares__buf_set_length(ares__buf_t *buf, size_t len)
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__buf_append(ares__buf_t *buf, const unsigned char *data,
+ares_status_t ares_buf_append(ares_buf_t *buf, const unsigned char *data,
                                size_t data_len)
 {
   ares_status_t status;
@@ -221,7 +221,7 @@ ares_status_t ares__buf_append(ares__buf_t *buf, const unsigned char *data,
     return ARES_SUCCESS;
   }
 
-  status = ares__buf_ensure_space(buf, data_len);
+  status = ares_buf_ensure_space(buf, data_len);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -231,21 +231,21 @@ ares_status_t ares__buf_append(ares__buf_t *buf, const unsigned char *data,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__buf_append_byte(ares__buf_t *buf, unsigned char b)
+ares_status_t ares_buf_append_byte(ares_buf_t *buf, unsigned char b)
 {
-  return ares__buf_append(buf, &b, 1);
+  return ares_buf_append(buf, &b, 1);
 }
 
-ares_status_t ares__buf_append_be16(ares__buf_t *buf, unsigned short u16)
+ares_status_t ares_buf_append_be16(ares_buf_t *buf, unsigned short u16)
 {
   ares_status_t status;
 
-  status = ares__buf_append_byte(buf, (unsigned char)((u16 >> 8) & 0xff));
+  status = ares_buf_append_byte(buf, (unsigned char)((u16 >> 8) & 0xff));
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  status = ares__buf_append_byte(buf, (unsigned char)(u16 & 0xff));
+  status = ares_buf_append_byte(buf, (unsigned char)(u16 & 0xff));
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -253,26 +253,26 @@ ares_status_t ares__buf_append_be16(ares__buf_t *buf, unsigned short u16)
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__buf_append_be32(ares__buf_t *buf, unsigned int u32)
+ares_status_t ares_buf_append_be32(ares_buf_t *buf, unsigned int u32)
 {
   ares_status_t status;
 
-  status = ares__buf_append_byte(buf, ((unsigned char)(u32 >> 24) & 0xff));
+  status = ares_buf_append_byte(buf, ((unsigned char)(u32 >> 24) & 0xff));
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  status = ares__buf_append_byte(buf, ((unsigned char)(u32 >> 16) & 0xff));
+  status = ares_buf_append_byte(buf, ((unsigned char)(u32 >> 16) & 0xff));
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  status = ares__buf_append_byte(buf, ((unsigned char)(u32 >> 8) & 0xff));
+  status = ares_buf_append_byte(buf, ((unsigned char)(u32 >> 8) & 0xff));
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  status = ares__buf_append_byte(buf, ((unsigned char)u32 & 0xff));
+  status = ares_buf_append_byte(buf, ((unsigned char)u32 & 0xff));
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -280,7 +280,7 @@ ares_status_t ares__buf_append_be32(ares__buf_t *buf, unsigned int u32)
   return ARES_SUCCESS;
 }
 
-unsigned char *ares__buf_append_start(ares__buf_t *buf, size_t *len)
+unsigned char *ares_buf_append_start(ares_buf_t *buf, size_t *len)
 {
   ares_status_t status;
 
@@ -288,17 +288,17 @@ unsigned char *ares__buf_append_start(ares__buf_t *buf, size_t *len)
     return NULL;
   }
 
-  status = ares__buf_ensure_space(buf, *len);
+  status = ares_buf_ensure_space(buf, *len);
   if (status != ARES_SUCCESS) {
     return NULL;
   }
 
-  /* -1 for possible null terminator for ares__buf_finish_str() */
+  /* -1 for possible null terminator for ares_buf_finish_str() */
   *len = buf->alloc_buf_len - buf->data_len - 1;
   return buf->alloc_buf + buf->data_len;
 }
 
-void ares__buf_append_finish(ares__buf_t *buf, size_t len)
+void ares_buf_append_finish(ares_buf_t *buf, size_t len)
 {
   if (buf == NULL) {
     return;
@@ -307,18 +307,18 @@ void ares__buf_append_finish(ares__buf_t *buf, size_t len)
   buf->data_len += len;
 }
 
-unsigned char *ares__buf_finish_bin(ares__buf_t *buf, size_t *len)
+unsigned char *ares_buf_finish_bin(ares_buf_t *buf, size_t *len)
 {
   unsigned char *ptr = NULL;
-  if (buf == NULL || len == NULL || ares__buf_is_const(buf)) {
+  if (buf == NULL || len == NULL || ares_buf_is_const(buf)) {
     return NULL;
   }
 
-  ares__buf_reclaim(buf);
+  ares_buf_reclaim(buf);
 
   /* We don't want to return NULL except on failure, may be zero-length */
   if (buf->alloc_buf == NULL &&
-      ares__buf_ensure_space(buf, 1) != ARES_SUCCESS) {
+      ares_buf_ensure_space(buf, 1) != ARES_SUCCESS) {
     return NULL; /* LCOV_EXCL_LINE: OutOfMemory */
   }
   ptr  = buf->alloc_buf;
@@ -327,12 +327,12 @@ unsigned char *ares__buf_finish_bin(ares__buf_t *buf, size_t *len)
   return ptr;
 }
 
-char *ares__buf_finish_str(ares__buf_t *buf, size_t *len)
+char *ares_buf_finish_str(ares_buf_t *buf, size_t *len)
 {
   char  *ptr;
   size_t mylen;
 
-  ptr = (char *)ares__buf_finish_bin(buf, &mylen);
+  ptr = (char *)ares_buf_finish_bin(buf, &mylen);
   if (ptr == NULL) {
     return NULL;
   }
@@ -341,14 +341,14 @@ char *ares__buf_finish_str(ares__buf_t *buf, size_t *len)
     *len = mylen;
   }
 
-  /* NOTE: ensured via ares__buf_ensure_space() that there is always at least
+  /* NOTE: ensured via ares_buf_ensure_space() that there is always at least
    *       1 extra byte available for this specific use-case */
   ptr[mylen] = 0;
 
   return ptr;
 }
 
-void ares__buf_tag(ares__buf_t *buf)
+void ares_buf_tag(ares_buf_t *buf)
 {
   if (buf == NULL) {
     return;
@@ -357,7 +357,7 @@ void ares__buf_tag(ares__buf_t *buf)
   buf->tag_offset = buf->offset;
 }
 
-ares_status_t ares__buf_tag_rollback(ares__buf_t *buf)
+ares_status_t ares_buf_tag_rollback(ares_buf_t *buf)
 {
   if (buf == NULL || buf->tag_offset == SIZE_MAX) {
     return ARES_EFORMERR;
@@ -368,7 +368,7 @@ ares_status_t ares__buf_tag_rollback(ares__buf_t *buf)
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__buf_tag_clear(ares__buf_t *buf)
+ares_status_t ares_buf_tag_clear(ares_buf_t *buf)
 {
   if (buf == NULL || buf->tag_offset == SIZE_MAX) {
     return ARES_EFORMERR;
@@ -378,7 +378,7 @@ ares_status_t ares__buf_tag_clear(ares__buf_t *buf)
   return ARES_SUCCESS;
 }
 
-const unsigned char *ares__buf_tag_fetch(const ares__buf_t *buf, size_t *len)
+const unsigned char *ares_buf_tag_fetch(const ares_buf_t *buf, size_t *len)
 {
   if (buf == NULL || buf->tag_offset == SIZE_MAX || len == NULL) {
     return NULL;
@@ -388,7 +388,7 @@ const unsigned char *ares__buf_tag_fetch(const ares__buf_t *buf, size_t *len)
   return buf->data + buf->tag_offset;
 }
 
-size_t ares__buf_tag_length(const ares__buf_t *buf)
+size_t ares_buf_tag_length(const ares_buf_t *buf)
 {
   if (buf == NULL || buf->tag_offset == SIZE_MAX) {
     return 0;
@@ -396,11 +396,11 @@ size_t ares__buf_tag_length(const ares__buf_t *buf)
   return buf->offset - buf->tag_offset;
 }
 
-ares_status_t ares__buf_tag_fetch_bytes(const ares__buf_t *buf,
+ares_status_t ares_buf_tag_fetch_bytes(const ares_buf_t *buf,
                                         unsigned char *bytes, size_t *len)
 {
   size_t               ptr_len = 0;
-  const unsigned char *ptr     = ares__buf_tag_fetch(buf, &ptr_len);
+  const unsigned char *ptr     = ares_buf_tag_fetch(buf, &ptr_len);
 
   if (ptr == NULL || bytes == NULL || len == NULL) {
     return ARES_EFORMERR;
@@ -418,7 +418,7 @@ ares_status_t ares__buf_tag_fetch_bytes(const ares__buf_t *buf,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__buf_tag_fetch_string(const ares__buf_t *buf, char *str,
+ares_status_t ares_buf_tag_fetch_string(const ares_buf_t *buf, char *str,
                                          size_t len)
 {
   size_t        out_len;
@@ -432,7 +432,7 @@ ares_status_t ares__buf_tag_fetch_string(const ares__buf_t *buf, char *str,
   /* Space for NULL terminator */
   out_len = len - 1;
 
-  status = ares__buf_tag_fetch_bytes(buf, (unsigned char *)str, &out_len);
+  status = ares_buf_tag_fetch_bytes(buf, (unsigned char *)str, &out_len);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -442,7 +442,7 @@ ares_status_t ares__buf_tag_fetch_string(const ares__buf_t *buf, char *str,
 
   /* Validate string is printable */
   for (i = 0; i < out_len; i++) {
-    if (!ares__isprint(str[i])) {
+    if (!ares_isprint(str[i])) {
       return ARES_EBADSTR;
     }
   }
@@ -450,7 +450,7 @@ ares_status_t ares__buf_tag_fetch_string(const ares__buf_t *buf, char *str,
   return ARES_SUCCESS;
 }
 
-static const unsigned char *ares__buf_fetch(const ares__buf_t *buf, size_t *len)
+static const unsigned char *ares_buf_fetch(const ares_buf_t *buf, size_t *len)
 {
   if (len != NULL) {
     *len = 0;
@@ -468,9 +468,9 @@ static const unsigned char *ares__buf_fetch(const ares__buf_t *buf, size_t *len)
   return buf->data + buf->offset;
 }
 
-ares_status_t ares__buf_consume(ares__buf_t *buf, size_t len)
+ares_status_t ares_buf_consume(ares_buf_t *buf, size_t len)
 {
-  size_t remaining_len = ares__buf_len(buf);
+  size_t remaining_len = ares_buf_len(buf);
 
   if (remaining_len < len) {
     return ARES_EBADRESP;
@@ -480,10 +480,10 @@ ares_status_t ares__buf_consume(ares__buf_t *buf, size_t len)
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__buf_fetch_be16(ares__buf_t *buf, unsigned short *u16)
+ares_status_t ares_buf_fetch_be16(ares_buf_t *buf, unsigned short *u16)
 {
   size_t               remaining_len;
-  const unsigned char *ptr = ares__buf_fetch(buf, &remaining_len);
+  const unsigned char *ptr = ares_buf_fetch(buf, &remaining_len);
   unsigned int         u32;
 
   if (buf == NULL || u16 == NULL || remaining_len < sizeof(*u16)) {
@@ -495,13 +495,13 @@ ares_status_t ares__buf_fetch_be16(ares__buf_t *buf, unsigned short *u16)
   u32  = ((unsigned int)(ptr[0]) << 8 | (unsigned int)ptr[1]);
   *u16 = (unsigned short)(u32 & 0xFFFF);
 
-  return ares__buf_consume(buf, sizeof(*u16));
+  return ares_buf_consume(buf, sizeof(*u16));
 }
 
-ares_status_t ares__buf_fetch_be32(ares__buf_t *buf, unsigned int *u32)
+ares_status_t ares_buf_fetch_be32(ares_buf_t *buf, unsigned int *u32)
 {
   size_t               remaining_len;
-  const unsigned char *ptr = ares__buf_fetch(buf, &remaining_len);
+  const unsigned char *ptr = ares_buf_fetch(buf, &remaining_len);
 
   if (buf == NULL || u32 == NULL || remaining_len < sizeof(*u32)) {
     return ARES_EBADRESP;
@@ -510,29 +510,29 @@ ares_status_t ares__buf_fetch_be32(ares__buf_t *buf, unsigned int *u32)
   *u32 = ((unsigned int)(ptr[0]) << 24 | (unsigned int)(ptr[1]) << 16 |
           (unsigned int)(ptr[2]) << 8 | (unsigned int)(ptr[3]));
 
-  return ares__buf_consume(buf, sizeof(*u32));
+  return ares_buf_consume(buf, sizeof(*u32));
 }
 
-ares_status_t ares__buf_fetch_bytes(ares__buf_t *buf, unsigned char *bytes,
+ares_status_t ares_buf_fetch_bytes(ares_buf_t *buf, unsigned char *bytes,
                                     size_t len)
 {
   size_t               remaining_len;
-  const unsigned char *ptr = ares__buf_fetch(buf, &remaining_len);
+  const unsigned char *ptr = ares_buf_fetch(buf, &remaining_len);
 
   if (buf == NULL || bytes == NULL || len == 0 || remaining_len < len) {
     return ARES_EBADRESP;
   }
 
   memcpy(bytes, ptr, len);
-  return ares__buf_consume(buf, len);
+  return ares_buf_consume(buf, len);
 }
 
-ares_status_t ares__buf_fetch_bytes_dup(ares__buf_t *buf, size_t len,
+ares_status_t ares_buf_fetch_bytes_dup(ares_buf_t *buf, size_t len,
                                         ares_bool_t     null_term,
                                         unsigned char **bytes)
 {
   size_t               remaining_len;
-  const unsigned char *ptr = ares__buf_fetch(buf, &remaining_len);
+  const unsigned char *ptr = ares_buf_fetch(buf, &remaining_len);
 
   if (buf == NULL || bytes == NULL || len == 0 || remaining_len < len) {
     return ARES_EBADRESP;
@@ -547,14 +547,14 @@ ares_status_t ares__buf_fetch_bytes_dup(ares__buf_t *buf, size_t len,
   if (null_term) {
     (*bytes)[len] = 0;
   }
-  return ares__buf_consume(buf, len);
+  return ares_buf_consume(buf, len);
 }
 
-ares_status_t ares__buf_fetch_str_dup(ares__buf_t *buf, size_t len, char **str)
+ares_status_t ares_buf_fetch_str_dup(ares_buf_t *buf, size_t len, char **str)
 {
   size_t               remaining_len;
   size_t               i;
-  const unsigned char *ptr = ares__buf_fetch(buf, &remaining_len);
+  const unsigned char *ptr = ares_buf_fetch(buf, &remaining_len);
 
   if (buf == NULL || str == NULL || len == 0 || remaining_len < len) {
     return ARES_EBADRESP;
@@ -562,7 +562,7 @@ ares_status_t ares__buf_fetch_str_dup(ares__buf_t *buf, size_t len, char **str)
 
   /* Validate string is printable */
   for (i = 0; i < len; i++) {
-    if (!ares__isprint(ptr[i])) {
+    if (!ares_isprint(ptr[i])) {
       return ARES_EBADSTR;
     }
   }
@@ -575,29 +575,29 @@ ares_status_t ares__buf_fetch_str_dup(ares__buf_t *buf, size_t len, char **str)
   memcpy(*str, ptr, len);
   (*str)[len] = 0;
 
-  return ares__buf_consume(buf, len);
+  return ares_buf_consume(buf, len);
 }
 
-ares_status_t ares__buf_fetch_bytes_into_buf(ares__buf_t *buf,
-                                             ares__buf_t *dest, size_t len)
+ares_status_t ares_buf_fetch_bytes_into_buf(ares_buf_t *buf,
+                                             ares_buf_t *dest, size_t len)
 {
   size_t               remaining_len;
-  const unsigned char *ptr = ares__buf_fetch(buf, &remaining_len);
+  const unsigned char *ptr = ares_buf_fetch(buf, &remaining_len);
   ares_status_t        status;
 
   if (buf == NULL || dest == NULL || len == 0 || remaining_len < len) {
     return ARES_EBADRESP;
   }
 
-  status = ares__buf_append(dest, ptr, len);
+  status = ares_buf_append(dest, ptr, len);
   if (status != ARES_SUCCESS) {
     return status;
   }
 
-  return ares__buf_consume(buf, len);
+  return ares_buf_consume(buf, len);
 }
 
-static ares_bool_t ares__is_whitespace(unsigned char c,
+static ares_bool_t ares_is_whitespace(unsigned char c,
                                        ares_bool_t   include_linefeed)
 {
   switch (c) {
@@ -615,11 +615,11 @@ static ares_bool_t ares__is_whitespace(unsigned char c,
   return ARES_FALSE;
 }
 
-size_t ares__buf_consume_whitespace(ares__buf_t *buf,
+size_t ares_buf_consume_whitespace(ares_buf_t *buf,
                                     ares_bool_t  include_linefeed)
 {
   size_t               remaining_len = 0;
-  const unsigned char *ptr           = ares__buf_fetch(buf, &remaining_len);
+  const unsigned char *ptr           = ares_buf_fetch(buf, &remaining_len);
   size_t               i;
 
   if (ptr == NULL) {
@@ -627,21 +627,21 @@ size_t ares__buf_consume_whitespace(ares__buf_t *buf,
   }
 
   for (i = 0; i < remaining_len; i++) {
-    if (!ares__is_whitespace(ptr[i], include_linefeed)) {
+    if (!ares_is_whitespace(ptr[i], include_linefeed)) {
       break;
     }
   }
 
   if (i > 0) {
-    ares__buf_consume(buf, i);
+    ares_buf_consume(buf, i);
   }
   return i;
 }
 
-size_t ares__buf_consume_nonwhitespace(ares__buf_t *buf)
+size_t ares_buf_consume_nonwhitespace(ares_buf_t *buf)
 {
   size_t               remaining_len = 0;
-  const unsigned char *ptr           = ares__buf_fetch(buf, &remaining_len);
+  const unsigned char *ptr           = ares_buf_fetch(buf, &remaining_len);
   size_t               i;
 
   if (ptr == NULL) {
@@ -649,21 +649,21 @@ size_t ares__buf_consume_nonwhitespace(ares__buf_t *buf)
   }
 
   for (i = 0; i < remaining_len; i++) {
-    if (ares__is_whitespace(ptr[i], ARES_TRUE)) {
+    if (ares_is_whitespace(ptr[i], ARES_TRUE)) {
       break;
     }
   }
 
   if (i > 0) {
-    ares__buf_consume(buf, i);
+    ares_buf_consume(buf, i);
   }
   return i;
 }
 
-size_t ares__buf_consume_line(ares__buf_t *buf, ares_bool_t include_linefeed)
+size_t ares_buf_consume_line(ares_buf_t *buf, ares_bool_t include_linefeed)
 {
   size_t               remaining_len = 0;
-  const unsigned char *ptr           = ares__buf_fetch(buf, &remaining_len);
+  const unsigned char *ptr           = ares_buf_fetch(buf, &remaining_len);
   size_t               i;
 
   if (ptr == NULL) {
@@ -682,17 +682,17 @@ done:
   }
 
   if (i > 0) {
-    ares__buf_consume(buf, i);
+    ares_buf_consume(buf, i);
   }
   return i;
 }
 
-size_t ares__buf_consume_until_charset(ares__buf_t         *buf,
+size_t ares_buf_consume_until_charset(ares_buf_t         *buf,
                                        const unsigned char *charset, size_t len,
                                        ares_bool_t require_charset)
 {
   size_t               remaining_len = 0;
-  const unsigned char *ptr           = ares__buf_fetch(buf, &remaining_len);
+  const unsigned char *ptr           = ares_buf_fetch(buf, &remaining_len);
   size_t               i;
   ares_bool_t          found = ARES_FALSE;
 
@@ -716,16 +716,16 @@ done:
   }
 
   if (i > 0) {
-    ares__buf_consume(buf, i);
+    ares_buf_consume(buf, i);
   }
   return i;
 }
 
-size_t ares__buf_consume_charset(ares__buf_t *buf, const unsigned char *charset,
+size_t ares_buf_consume_charset(ares_buf_t *buf, const unsigned char *charset,
                                  size_t len)
 {
   size_t               remaining_len = 0;
-  const unsigned char *ptr           = ares__buf_fetch(buf, &remaining_len);
+  const unsigned char *ptr           = ares_buf_fetch(buf, &remaining_len);
   size_t               i;
 
   if (ptr == NULL || charset == NULL || len == 0) {
@@ -746,28 +746,28 @@ size_t ares__buf_consume_charset(ares__buf_t *buf, const unsigned char *charset,
   }
 
   if (i > 0) {
-    ares__buf_consume(buf, i);
+    ares_buf_consume(buf, i);
   }
   return i;
 }
 
-static void ares__buf_destroy_cb(void *arg)
+static void ares_buf_destroy_cb(void *arg)
 {
-  ares__buf_destroy(arg);
+  ares_buf_destroy(arg);
 }
 
-static ares_bool_t ares__buf_split_isduplicate(ares__llist_t       *list,
+static ares_bool_t ares_buf_split_isduplicate(ares_llist_t       *list,
                                                const unsigned char *val,
                                                size_t               len,
-                                               ares__buf_split_t    flags)
+                                               ares_buf_split_t    flags)
 {
-  ares__llist_node_t *node;
+  ares_llist_node_t *node;
 
-  for (node = ares__llist_node_first(list); node != NULL;
-       node = ares__llist_node_next(node)) {
-    const ares__buf_t   *buf  = ares__llist_node_val(node);
+  for (node = ares_llist_node_first(list); node != NULL;
+       node = ares_llist_node_next(node)) {
+    const ares_buf_t   *buf  = ares_llist_node_val(node);
     size_t               plen = 0;
-    const unsigned char *ptr  = ares__buf_peek(buf, &plen);
+    const unsigned char *ptr  = ares_buf_peek(buf, &plen);
 
     /* Can't be duplicate if lengths mismatch */
     if (plen != len) {
@@ -775,7 +775,7 @@ static ares_bool_t ares__buf_split_isduplicate(ares__llist_t       *list,
     }
 
     if (flags & ARES_BUF_SPLIT_CASE_INSENSITIVE) {
-      if (ares__memeq_ci(ptr, val, len)) {
+      if (ares_memeq_ci(ptr, val, len)) {
         return ARES_TRUE;
       }
     } else {
@@ -787,9 +787,9 @@ static ares_bool_t ares__buf_split_isduplicate(ares__llist_t       *list,
   return ARES_FALSE;
 }
 
-ares_status_t ares__buf_split(ares__buf_t *buf, const unsigned char *delims,
-                              size_t delims_len, ares__buf_split_t flags,
-                              size_t max_sections, ares__llist_t **list)
+ares_status_t ares_buf_split(ares_buf_t *buf, const unsigned char *delims,
+                              size_t delims_len, ares_buf_split_t flags,
+                              size_t max_sections, ares_llist_t **list)
 {
   ares_status_t status = ARES_SUCCESS;
   ares_bool_t   first  = ARES_TRUE;
@@ -798,38 +798,38 @@ ares_status_t ares__buf_split(ares__buf_t *buf, const unsigned char *delims,
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  *list = ares__llist_create(ares__buf_destroy_cb);
+  *list = ares_llist_create(ares_buf_destroy_cb);
   if (*list == NULL) {
     status = ARES_ENOMEM;
     goto done;
   }
 
-  while (ares__buf_len(buf)) {
+  while (ares_buf_len(buf)) {
     size_t               len = 0;
     const unsigned char *ptr;
 
     if (first) {
       /* No delimiter yet, just tag the start */
-      ares__buf_tag(buf);
+      ares_buf_tag(buf);
     } else {
       if (flags & ARES_BUF_SPLIT_KEEP_DELIMS) {
         /* tag then eat delimiter so its first byte in buffer */
-        ares__buf_tag(buf);
-        ares__buf_consume(buf, 1);
+        ares_buf_tag(buf);
+        ares_buf_consume(buf, 1);
       } else {
         /* throw away delimiter */
-        ares__buf_consume(buf, 1);
-        ares__buf_tag(buf);
+        ares_buf_consume(buf, 1);
+        ares_buf_tag(buf);
       }
     }
 
-    if (max_sections && ares__llist_len(*list) >= max_sections - 1) {
-      ares__buf_consume(buf, ares__buf_len(buf));
+    if (max_sections && ares_llist_len(*list) >= max_sections - 1) {
+      ares_buf_consume(buf, ares_buf_len(buf));
     } else {
-      ares__buf_consume_until_charset(buf, delims, delims_len, ARES_FALSE);
+      ares_buf_consume_until_charset(buf, delims, delims_len, ARES_FALSE);
     }
 
-    ptr = ares__buf_tag_fetch(buf, &len);
+    ptr = ares_buf_tag_fetch(buf, &len);
 
     /* Shouldn't be possible */
     if (ptr == NULL) {
@@ -840,7 +840,7 @@ ares_status_t ares__buf_split(ares__buf_t *buf, const unsigned char *delims,
     if (flags & ARES_BUF_SPLIT_LTRIM) {
       size_t i;
       for (i = 0; i < len; i++) {
-        if (!ares__is_whitespace(ptr[i], ARES_TRUE)) {
+        if (!ares_is_whitespace(ptr[i], ARES_TRUE)) {
           break;
         }
       }
@@ -849,22 +849,22 @@ ares_status_t ares__buf_split(ares__buf_t *buf, const unsigned char *delims,
     }
 
     if (flags & ARES_BUF_SPLIT_RTRIM) {
-      while (len > 0 && ares__is_whitespace(ptr[len - 1], ARES_TRUE)) {
+      while (len > 0 && ares_is_whitespace(ptr[len - 1], ARES_TRUE)) {
         len--;
       }
     }
 
     if (len != 0 || flags & ARES_BUF_SPLIT_ALLOW_BLANK) {
-      ares__buf_t *data;
+      ares_buf_t *data;
 
       if (!(flags & ARES_BUF_SPLIT_NO_DUPLICATES) ||
-          !ares__buf_split_isduplicate(*list, ptr, len, flags)) {
+          !ares_buf_split_isduplicate(*list, ptr, len, flags)) {
         /* Since we don't allow const buffers of 0 length, and user wants
          * 0-length buffers, swap what we do here */
         if (len) {
-          data = ares__buf_create_const(ptr, len);
+          data = ares_buf_create_const(ptr, len);
         } else {
-          data = ares__buf_create();
+          data = ares_buf_create();
         }
 
         if (data == NULL) {
@@ -872,8 +872,8 @@ ares_status_t ares__buf_split(ares__buf_t *buf, const unsigned char *delims,
           goto done;
         }
 
-        if (ares__llist_insert_last(*list, data) == NULL) {
-          ares__buf_destroy(data);
+        if (ares_llist_insert_last(*list, data) == NULL) {
+          ares_buf_destroy(data);
           status = ARES_ENOMEM;
           goto done;
         }
@@ -885,28 +885,28 @@ ares_status_t ares__buf_split(ares__buf_t *buf, const unsigned char *delims,
 
 done:
   if (status != ARES_SUCCESS) {
-    ares__llist_destroy(*list);
+    ares_llist_destroy(*list);
     *list = NULL;
   }
 
   return status;
 }
 
-static void ares__free_split_array(void *arg)
+static void ares_free_split_array(void *arg)
 {
   void **ptr = arg;
   ares_free(*ptr);
 }
 
-ares_status_t ares__buf_split_str(ares__buf_t *buf, const unsigned char *delims,
-                                  size_t delims_len, ares__buf_split_t flags,
+ares_status_t ares_buf_split_str(ares_buf_t *buf, const unsigned char *delims,
+                                  size_t delims_len, ares_buf_split_t flags,
                                   size_t max_sections, char ***strs,
                                   size_t *nstrs)
 {
   ares_status_t       status;
-  ares__llist_t      *list = NULL;
-  ares__llist_node_t *node;
-  ares__array_t      *arr = NULL;
+  ares_llist_t      *list = NULL;
+  ares_llist_node_t *node;
+  ares_array_t      *arr = NULL;
 
   if (strs == NULL || nstrs == NULL) {
     return ARES_EFORMERR;
@@ -915,28 +915,28 @@ ares_status_t ares__buf_split_str(ares__buf_t *buf, const unsigned char *delims,
   *strs  = NULL;
   *nstrs = 0;
 
-  status = ares__buf_split(buf, delims, delims_len, flags, max_sections, &list);
+  status = ares_buf_split(buf, delims, delims_len, flags, max_sections, &list);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  arr = ares__array_create(sizeof(char *), ares__free_split_array);
+  arr = ares_array_create(sizeof(char *), ares_free_split_array);
   if (arr == NULL) {
     status = ARES_ENOMEM;
     goto done;
   }
 
-  for (node = ares__llist_node_first(list); node != NULL;
-       node = ares__llist_node_next(node)) {
-    ares__buf_t *lbuf = ares__llist_node_val(node);
+  for (node = ares_llist_node_first(list); node != NULL;
+       node = ares_llist_node_next(node)) {
+    ares_buf_t *lbuf = ares_llist_node_val(node);
     char        *str  = NULL;
 
-    status = ares__buf_fetch_str_dup(lbuf, ares__buf_len(lbuf), &str);
+    status = ares_buf_fetch_str_dup(lbuf, ares_buf_len(lbuf), &str);
     if (status != ARES_SUCCESS) {
       goto done;
     }
 
-    status = ares__array_insertdata_last(arr, &str);
+    status = ares_array_insertdata_last(arr, &str);
     if (status != ARES_SUCCESS) {
       ares_free(str);
       goto done;
@@ -944,20 +944,20 @@ ares_status_t ares__buf_split_str(ares__buf_t *buf, const unsigned char *delims,
   }
 
 done:
-  ares__llist_destroy(list);
+  ares_llist_destroy(list);
   if (status == ARES_SUCCESS) {
-    *strs = ares__array_finish(arr, nstrs);
+    *strs = ares_array_finish(arr, nstrs);
   } else {
-    ares__array_destroy(arr);
+    ares_array_destroy(arr);
   }
   return status;
 }
 
-ares_bool_t ares__buf_begins_with(const ares__buf_t   *buf,
+ares_bool_t ares_buf_begins_with(const ares_buf_t   *buf,
                                   const unsigned char *data, size_t data_len)
 {
   size_t               remaining_len = 0;
-  const unsigned char *ptr           = ares__buf_fetch(buf, &remaining_len);
+  const unsigned char *ptr           = ares_buf_fetch(buf, &remaining_len);
 
   if (ptr == NULL || data == NULL || data_len == 0) {
     return ARES_FALSE;
@@ -974,7 +974,7 @@ ares_bool_t ares__buf_begins_with(const ares__buf_t   *buf,
   return ARES_TRUE;
 }
 
-size_t ares__buf_len(const ares__buf_t *buf)
+size_t ares_buf_len(const ares_buf_t *buf)
 {
   if (buf == NULL) {
     return 0;
@@ -983,12 +983,12 @@ size_t ares__buf_len(const ares__buf_t *buf)
   return buf->data_len - buf->offset;
 }
 
-const unsigned char *ares__buf_peek(const ares__buf_t *buf, size_t *len)
+const unsigned char *ares_buf_peek(const ares_buf_t *buf, size_t *len)
 {
-  return ares__buf_fetch(buf, len);
+  return ares_buf_fetch(buf, len);
 }
 
-size_t ares__buf_get_position(const ares__buf_t *buf)
+size_t ares_buf_get_position(const ares_buf_t *buf)
 {
   if (buf == NULL) {
     return 0;
@@ -996,7 +996,7 @@ size_t ares__buf_get_position(const ares__buf_t *buf)
   return buf->offset;
 }
 
-ares_status_t ares__buf_set_position(ares__buf_t *buf, size_t idx)
+ares_status_t ares_buf_set_position(ares_buf_t *buf, size_t idx)
 {
   if (buf == NULL) {
     return ARES_EFORMERR;
@@ -1011,13 +1011,13 @@ ares_status_t ares__buf_set_position(ares__buf_t *buf, size_t idx)
 }
 
 static ares_status_t
-  ares__buf_parse_dns_binstr_int(ares__buf_t *buf, size_t remaining_len,
+  ares_buf_parse_dns_binstr_int(ares_buf_t *buf, size_t remaining_len,
                                  unsigned char **bin, size_t *bin_len,
                                  ares_bool_t validate_printable)
 {
   unsigned char len;
   ares_status_t status = ARES_EBADRESP;
-  ares__buf_t  *binbuf = NULL;
+  ares_buf_t  *binbuf = NULL;
 
   if (buf == NULL) {
     return ARES_EFORMERR;
@@ -1027,12 +1027,12 @@ static ares_status_t
     return ARES_EBADRESP;
   }
 
-  binbuf = ares__buf_create();
+  binbuf = ares_buf_create();
   if (binbuf == NULL) {
     return ARES_ENOMEM;
   }
 
-  status = ares__buf_fetch_bytes(buf, &len, 1);
+  status = ares_buf_fetch_bytes(buf, &len, 1);
   if (status != ARES_SUCCESS) {
     goto done; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
@@ -1047,32 +1047,32 @@ static ares_status_t
   if (len) {
     /* When used by the _str() parser, it really needs to be validated to
      * be a valid printable ascii string.  Do that here */
-    if (validate_printable && ares__buf_len(buf) >= len) {
+    if (validate_printable && ares_buf_len(buf) >= len) {
       size_t      mylen;
-      const char *data = (const char *)ares__buf_peek(buf, &mylen);
-      if (!ares__str_isprint(data, len)) {
+      const char *data = (const char *)ares_buf_peek(buf, &mylen);
+      if (!ares_str_isprint(data, len)) {
         status = ARES_EBADSTR;
         goto done;
       }
     }
 
     if (bin != NULL) {
-      status = ares__buf_fetch_bytes_into_buf(buf, binbuf, len);
+      status = ares_buf_fetch_bytes_into_buf(buf, binbuf, len);
     } else {
-      status = ares__buf_consume(buf, len);
+      status = ares_buf_consume(buf, len);
     }
   }
 
 done:
   if (status != ARES_SUCCESS) {
-    ares__buf_destroy(binbuf);
+    ares_buf_destroy(binbuf);
   } else {
     if (bin != NULL) {
       size_t mylen = 0;
-      /* NOTE: we use ares__buf_finish_str() here as we guarantee NULL
+      /* NOTE: we use ares_buf_finish_str() here as we guarantee NULL
        *       Termination even though we are technically returning binary data.
        */
-      *bin     = (unsigned char *)ares__buf_finish_str(binbuf, &mylen);
+      *bin     = (unsigned char *)ares_buf_finish_str(binbuf, &mylen);
       *bin_len = mylen;
     }
   }
@@ -1080,32 +1080,32 @@ done:
   return status;
 }
 
-ares_status_t ares__buf_parse_dns_binstr(ares__buf_t *buf, size_t remaining_len,
+ares_status_t ares_buf_parse_dns_binstr(ares_buf_t *buf, size_t remaining_len,
                                          unsigned char **bin, size_t *bin_len)
 {
-  return ares__buf_parse_dns_binstr_int(buf, remaining_len, bin, bin_len,
+  return ares_buf_parse_dns_binstr_int(buf, remaining_len, bin, bin_len,
                                         ARES_FALSE);
 }
 
-ares_status_t ares__buf_parse_dns_str(ares__buf_t *buf, size_t remaining_len,
+ares_status_t ares_buf_parse_dns_str(ares_buf_t *buf, size_t remaining_len,
                                       char **str)
 {
   size_t len;
 
-  return ares__buf_parse_dns_binstr_int(buf, remaining_len,
+  return ares_buf_parse_dns_binstr_int(buf, remaining_len,
                                         (unsigned char **)str, &len, ARES_TRUE);
 }
 
-ares_status_t ares__buf_append_num_dec(ares__buf_t *buf, size_t num, size_t len)
+ares_status_t ares_buf_append_num_dec(ares_buf_t *buf, size_t num, size_t len)
 {
   size_t i;
   size_t mod;
 
   if (len == 0) {
-    len = ares__count_digits(num);
+    len = ares_count_digits(num);
   }
 
-  mod = ares__pow(10, len);
+  mod = ares_pow(10, len);
 
   for (i = len; i > 0; i--) {
     size_t        digit = (num % mod);
@@ -1119,7 +1119,7 @@ ares_status_t ares__buf_append_num_dec(ares__buf_t *buf, size_t num, size_t len)
     }
 
     digit  /= mod;
-    status  = ares__buf_append_byte(buf, '0' + (unsigned char)(digit & 0xFF));
+    status  = ares_buf_append_byte(buf, '0' + (unsigned char)(digit & 0xFF));
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -1127,18 +1127,18 @@ ares_status_t ares__buf_append_num_dec(ares__buf_t *buf, size_t num, size_t len)
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__buf_append_num_hex(ares__buf_t *buf, size_t num, size_t len)
+ares_status_t ares_buf_append_num_hex(ares_buf_t *buf, size_t num, size_t len)
 {
   size_t                     i;
   static const unsigned char hexbytes[] = "0123456789ABCDEF";
 
   if (len == 0) {
-    len = ares__count_hexdigits(num);
+    len = ares_count_hexdigits(num);
   }
 
   for (i = len; i > 0; i--) {
     ares_status_t status;
-    status = ares__buf_append_byte(buf, hexbytes[(num >> ((i - 1) * 4)) & 0xF]);
+    status = ares_buf_append_byte(buf, hexbytes[(num >> ((i - 1) * 4)) & 0xF]);
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -1146,12 +1146,12 @@ ares_status_t ares__buf_append_num_hex(ares__buf_t *buf, size_t num, size_t len)
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__buf_append_str(ares__buf_t *buf, const char *str)
+ares_status_t ares_buf_append_str(ares_buf_t *buf, const char *str)
 {
-  return ares__buf_append(buf, (const unsigned char *)str, ares_strlen(str));
+  return ares_buf_append(buf, (const unsigned char *)str, ares_strlen(str));
 }
 
-static ares_status_t ares__buf_hexdump_line(ares__buf_t *buf, size_t idx,
+static ares_status_t ares_buf_hexdump_line(ares_buf_t *buf, size_t idx,
                                             const unsigned char *data,
                                             size_t               len)
 {
@@ -1159,35 +1159,35 @@ static ares_status_t ares__buf_hexdump_line(ares__buf_t *buf, size_t idx,
   ares_status_t status;
 
   /* Address */
-  status = ares__buf_append_num_hex(buf, idx, 6);
+  status = ares_buf_append_num_hex(buf, idx, 6);
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   /* | */
-  status = ares__buf_append_str(buf, " | ");
+  status = ares_buf_append_str(buf, " | ");
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   for (i = 0; i < 16; i++) {
     if (i >= len) {
-      status = ares__buf_append_str(buf, "  ");
+      status = ares_buf_append_str(buf, "  ");
     } else {
-      status = ares__buf_append_num_hex(buf, data[i], 2);
+      status = ares_buf_append_num_hex(buf, data[i], 2);
     }
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
 
-    status = ares__buf_append_byte(buf, ' ');
+    status = ares_buf_append_byte(buf, ' ');
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
 
   /* | */
-  status = ares__buf_append_str(buf, " | ");
+  status = ares_buf_append_str(buf, " | ");
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }
@@ -1196,16 +1196,16 @@ static ares_status_t ares__buf_hexdump_line(ares__buf_t *buf, size_t idx,
     if (i >= len) {
       break;
     }
-    status = ares__buf_append_byte(buf, ares__isprint(data[i]) ? data[i] : '.');
+    status = ares_buf_append_byte(buf, ares_isprint(data[i]) ? data[i] : '.');
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
 
-  return ares__buf_append_byte(buf, '\n');
+  return ares_buf_append_byte(buf, '\n');
 }
 
-ares_status_t ares__buf_hexdump(ares__buf_t *buf, const unsigned char *data,
+ares_status_t ares_buf_hexdump(ares_buf_t *buf, const unsigned char *data,
                                 size_t len)
 {
   size_t i;
@@ -1213,7 +1213,7 @@ ares_status_t ares__buf_hexdump(ares__buf_t *buf, const unsigned char *data,
   /* Each line is 16 bytes */
   for (i = 0; i < len; i += 16) {
     ares_status_t status;
-    status = ares__buf_hexdump_line(buf, i, data + i, len - i);
+    status = ares_buf_hexdump_line(buf, i, data + i, len - i);
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -1222,7 +1222,7 @@ ares_status_t ares__buf_hexdump(ares__buf_t *buf, const unsigned char *data,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__buf_load_file(const char *filename, ares__buf_t *buf)
+ares_status_t ares_buf_load_file(const char *filename, ares_buf_t *buf)
 {
   FILE          *fp        = NULL;
   unsigned char *ptr       = NULL;
@@ -1277,7 +1277,7 @@ ares_status_t ares__buf_load_file(const char *filename, ares__buf_t *buf)
 
   /* Read entire data into buffer */
   ptr_len = len;
-  ptr     = ares__buf_append_start(buf, &ptr_len);
+  ptr     = ares_buf_append_start(buf, &ptr_len);
   if (ptr == NULL) {
     status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
     goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
@@ -1289,7 +1289,7 @@ ares_status_t ares__buf_load_file(const char *filename, ares__buf_t *buf)
     goto done;           /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  ares__buf_append_finish(buf, len);
+  ares_buf_append_finish(buf, len);
   status = ARES_SUCCESS;
 
 done:

--- a/src/lib/str/ares_str.c
+++ b/src/lib/str/ares_str.c
@@ -187,7 +187,7 @@ unsigned char ares_tolower(unsigned char c)
 }
 
 ares_bool_t ares_memeq_ci(const unsigned char *ptr, const unsigned char *val,
-                           size_t len)
+                          size_t len)
 {
   size_t i;
   for (i = 0; i < len; i++) {

--- a/src/lib/str/ares_str.c
+++ b/src/lib/str/ares_str.c
@@ -108,7 +108,7 @@ ares_bool_t ares_str_isnum(const char *str)
   return ARES_TRUE;
 }
 
-void ares__str_rtrim(char *str)
+void ares_str_rtrim(char *str)
 {
   size_t len;
   size_t i;
@@ -119,14 +119,14 @@ void ares__str_rtrim(char *str)
 
   len = ares_strlen(str);
   for (i = len; i > 0; i--) {
-    if (!ares__isspace(str[i - 1])) {
+    if (!ares_isspace(str[i - 1])) {
       break;
     }
   }
   str[i] = 0;
 }
 
-void ares__str_ltrim(char *str)
+void ares_str_ltrim(char *str)
 {
   size_t i;
   size_t len;
@@ -135,7 +135,7 @@ void ares__str_ltrim(char *str)
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  for (i = 0; str[i] != 0 && ares__isspace(str[i]); i++) {
+  for (i = 0; str[i] != 0 && ares_isspace(str[i]); i++) {
     /* Do nothing */
   }
 
@@ -150,15 +150,15 @@ void ares__str_ltrim(char *str)
   str[len - i] = 0;
 }
 
-void ares__str_trim(char *str)
+void ares_str_trim(char *str)
 {
-  ares__str_ltrim(str);
-  ares__str_rtrim(str);
+  ares_str_ltrim(str);
+  ares_str_rtrim(str);
 }
 
 /* tolower() is locale-specific.  Use a lookup table fast conversion that only
  * operates on ASCII */
-static const unsigned char ares__tolower_lookup[] = {
+static const unsigned char ares_tolower_lookup[] = {
   0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C,
   0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
   0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26,
@@ -181,24 +181,24 @@ static const unsigned char ares__tolower_lookup[] = {
   0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF
 };
 
-unsigned char ares__tolower(unsigned char c)
+unsigned char ares_tolower(unsigned char c)
 {
-  return ares__tolower_lookup[c];
+  return ares_tolower_lookup[c];
 }
 
-ares_bool_t ares__memeq_ci(const unsigned char *ptr, const unsigned char *val,
+ares_bool_t ares_memeq_ci(const unsigned char *ptr, const unsigned char *val,
                            size_t len)
 {
   size_t i;
   for (i = 0; i < len; i++) {
-    if (ares__tolower_lookup[ptr[i]] != ares__tolower_lookup[val[i]]) {
+    if (ares_tolower_lookup[ptr[i]] != ares_tolower_lookup[val[i]]) {
       return ARES_FALSE;
     }
   }
   return ARES_TRUE;
 }
 
-ares_bool_t ares__is_hostname(const char *str)
+ares_bool_t ares_is_hostname(const char *str)
 {
   size_t i;
 
@@ -207,14 +207,14 @@ ares_bool_t ares__is_hostname(const char *str)
   }
 
   for (i = 0; str[i] != 0; i++) {
-    if (!ares__is_hostnamech(str[i])) {
+    if (!ares_is_hostnamech(str[i])) {
       return ARES_FALSE;
     }
   }
   return ARES_TRUE;
 }
 
-ares_bool_t ares__str_isprint(const char *str, size_t len)
+ares_bool_t ares_str_isprint(const char *str, size_t len)
 {
   size_t i;
 
@@ -223,7 +223,7 @@ ares_bool_t ares__str_isprint(const char *str, size_t len)
   }
 
   for (i = 0; i < len; i++) {
-    if (!ares__isprint(str[i])) {
+    if (!ares_isprint(str[i])) {
       return ARES_FALSE;
     }
   }
@@ -311,8 +311,8 @@ int ares_strcasecmp(const char *a, const char *b)
     size_t i;
 
     for (i = 0; i < (size_t)-1; i++) {
-      int c1 = ares__tolower(a[i]);
-      int c2 = ares__tolower(b[i]);
+      int c1 = ares_tolower(a[i]);
+      int c2 = ares_tolower(b[i]);
       if (c1 != c2) {
         return c1 - c2;
       }
@@ -360,8 +360,8 @@ int ares_strncasecmp(const char *a, const char *b, size_t n)
     size_t i;
 
     for (i = 0; i < n; i++) {
-      int c1 = ares__tolower(a[i]);
-      int c2 = ares__tolower(b[i]);
+      int c1 = ares_tolower(a[i]);
+      int c2 = ares_tolower(b[i]);
       if (c1 != c2) {
         return c1 - c2;
       }

--- a/src/lib/str/ares_strsplit.c
+++ b/src/lib/str/ares_strsplit.c
@@ -48,7 +48,7 @@ char **ares_strsplit_duplicate(char **elms, size_t num_elm)
     out[i] = ares_strdup(elms[i]);
     if (out[i] == NULL) {
       ares_strsplit_free(out, num_elm); /* LCOV_EXCL_LINE: OutOfMemory */
-      return NULL;                       /* LCOV_EXCL_LINE: OutOfMemory */
+      return NULL;                      /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
 
@@ -57,13 +57,13 @@ char **ares_strsplit_duplicate(char **elms, size_t num_elm)
 
 char **ares_strsplit(const char *in, const char *delms, size_t *num_elm)
 {
-  ares_status_t       status;
+  ares_status_t      status;
   ares_buf_t        *buf   = NULL;
   ares_llist_t      *llist = NULL;
   ares_llist_node_t *node;
-  char              **out = NULL;
-  size_t              cnt = 0;
-  size_t              idx = 0;
+  char             **out = NULL;
+  size_t             cnt = 0;
+  size_t             idx = 0;
 
   if (in == NULL || delms == NULL || num_elm == NULL) {
     return NULL; /* LCOV_EXCL_LINE: DefensiveCoding */
@@ -99,7 +99,7 @@ char **ares_strsplit(const char *in, const char *delms, size_t *num_elm)
   for (node = ares_llist_node_first(llist); node != NULL;
        node = ares_llist_node_next(node)) {
     ares_buf_t *val  = ares_llist_node_val(node);
-    char        *temp = NULL;
+    char       *temp = NULL;
 
     status = ares_buf_fetch_str_dup(val, ares_buf_len(val), &temp);
     if (status != ARES_SUCCESS) {

--- a/src/lib/str/ares_strsplit.c
+++ b/src/lib/str/ares_strsplit.c
@@ -25,12 +25,12 @@
  */
 #include "ares_private.h"
 
-void ares__strsplit_free(char **elms, size_t num_elm)
+void ares_strsplit_free(char **elms, size_t num_elm)
 {
   ares_free_array(elms, num_elm, ares_free);
 }
 
-char **ares__strsplit_duplicate(char **elms, size_t num_elm)
+char **ares_strsplit_duplicate(char **elms, size_t num_elm)
 {
   size_t i;
   char **out;
@@ -47,7 +47,7 @@ char **ares__strsplit_duplicate(char **elms, size_t num_elm)
   for (i = 0; i < num_elm; i++) {
     out[i] = ares_strdup(elms[i]);
     if (out[i] == NULL) {
-      ares__strsplit_free(out, num_elm); /* LCOV_EXCL_LINE: OutOfMemory */
+      ares_strsplit_free(out, num_elm); /* LCOV_EXCL_LINE: OutOfMemory */
       return NULL;                       /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
@@ -55,12 +55,12 @@ char **ares__strsplit_duplicate(char **elms, size_t num_elm)
   return out;
 }
 
-char **ares__strsplit(const char *in, const char *delms, size_t *num_elm)
+char **ares_strsplit(const char *in, const char *delms, size_t *num_elm)
 {
   ares_status_t       status;
-  ares__buf_t        *buf   = NULL;
-  ares__llist_t      *llist = NULL;
-  ares__llist_node_t *node;
+  ares_buf_t        *buf   = NULL;
+  ares_llist_t      *llist = NULL;
+  ares_llist_node_t *node;
   char              **out = NULL;
   size_t              cnt = 0;
   size_t              idx = 0;
@@ -71,19 +71,19 @@ char **ares__strsplit(const char *in, const char *delms, size_t *num_elm)
 
   *num_elm = 0;
 
-  buf = ares__buf_create_const((const unsigned char *)in, ares_strlen(in));
+  buf = ares_buf_create_const((const unsigned char *)in, ares_strlen(in));
   if (buf == NULL) {
     return NULL;
   }
 
-  status = ares__buf_split(
+  status = ares_buf_split(
     buf, (const unsigned char *)delms, ares_strlen(delms),
     ARES_BUF_SPLIT_NO_DUPLICATES | ARES_BUF_SPLIT_CASE_INSENSITIVE, 0, &llist);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  cnt = ares__llist_len(llist);
+  cnt = ares_llist_len(llist);
   if (cnt == 0) {
     status = ARES_EFORMERR;
     goto done;
@@ -96,12 +96,12 @@ char **ares__strsplit(const char *in, const char *delms, size_t *num_elm)
     goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  for (node = ares__llist_node_first(llist); node != NULL;
-       node = ares__llist_node_next(node)) {
-    ares__buf_t *val  = ares__llist_node_val(node);
+  for (node = ares_llist_node_first(llist); node != NULL;
+       node = ares_llist_node_next(node)) {
+    ares_buf_t *val  = ares_llist_node_val(node);
     char        *temp = NULL;
 
-    status = ares__buf_fetch_str_dup(val, ares__buf_len(val), &temp);
+    status = ares_buf_fetch_str_dup(val, ares_buf_len(val), &temp);
     if (status != ARES_SUCCESS) {
       goto done;
     }
@@ -113,10 +113,10 @@ char **ares__strsplit(const char *in, const char *delms, size_t *num_elm)
   status   = ARES_SUCCESS;
 
 done:
-  ares__llist_destroy(llist);
-  ares__buf_destroy(buf);
+  ares_llist_destroy(llist);
+  ares_buf_destroy(buf);
   if (status != ARES_SUCCESS) {
-    ares__strsplit_free(out, cnt);
+    ares_strsplit_free(out, cnt);
     out = NULL;
   }
 

--- a/src/lib/str/ares_strsplit.h
+++ b/src/lib/str/ares_strsplit.h
@@ -40,12 +40,12 @@
  * returns an allocated array of allocated string elements.
  *
  */
-char **ares__strsplit(const char *in, const char *delms, size_t *num_elm);
+char **ares_strsplit(const char *in, const char *delms, size_t *num_elm);
 
-/* Frees the result returned from ares__strsplit(). */
-void   ares__strsplit_free(char **elms, size_t num_elm);
+/* Frees the result returned from ares_strsplit(). */
+void   ares_strsplit_free(char **elms, size_t num_elm);
 
 /* Duplicate the array */
-char **ares__strsplit_duplicate(char **elms, size_t num_elm);
+char **ares_strsplit_duplicate(char **elms, size_t num_elm);
 
 #endif /* HEADER_CARES_STRSPLIT_H */

--- a/src/lib/util/ares_iface_ips.c
+++ b/src/lib/util/ares_iface_ips.c
@@ -60,13 +60,13 @@
 
 
 static ares_status_t ares_iface_ips_enumerate(ares_iface_ips_t *ips,
-                                               const char        *name);
+                                              const char       *name);
 
 typedef struct {
-  char                  *name;
-  struct ares_addr       addr;
-  unsigned char          netmask;
-  unsigned int           ll_scope;
+  char                 *name;
+  struct ares_addr      addr;
+  unsigned char         netmask;
+  unsigned int          ll_scope;
   ares_iface_ip_flags_t flags;
 } ares_iface_ip_t;
 
@@ -92,8 +92,7 @@ static ares_iface_ips_t *ares_iface_ips_alloc(ares_iface_ip_flags_t flags)
   }
 
   ips->enum_flags = flags;
-  ips->ips =
-    ares_array_create(sizeof(ares_iface_ip_t), ares_iface_ip_free_cb);
+  ips->ips = ares_array_create(sizeof(ares_iface_ip_t), ares_iface_ip_free_cb);
   if (ips->ips == NULL) {
     ares_free(ips); /* LCOV_EXCL_LINE: OutOfMemory */
     return NULL;    /* LCOV_EXCL_LINE: OutOfMemory */
@@ -112,7 +111,7 @@ void ares_iface_ips_destroy(ares_iface_ips_t *ips)
 }
 
 ares_status_t ares_iface_ips(ares_iface_ips_t    **ips,
-                              ares_iface_ip_flags_t flags, const char *name)
+                             ares_iface_ip_flags_t flags, const char *name)
 {
   ares_status_t status;
 
@@ -139,11 +138,11 @@ ares_status_t ares_iface_ips(ares_iface_ips_t    **ips,
 
 static ares_status_t
   ares_iface_ips_add(ares_iface_ips_t *ips, ares_iface_ip_flags_t flags,
-                      const char *name, const struct ares_addr *addr,
-                      unsigned char netmask, unsigned int ll_scope)
+                     const char *name, const struct ares_addr *addr,
+                     unsigned char netmask, unsigned int ll_scope)
 {
   ares_iface_ip_t *ip;
-  ares_status_t     status;
+  ares_status_t    status;
 
   if (ips == NULL || name == NULL || addr == NULL) {
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
@@ -235,7 +234,7 @@ const char *ares_iface_ips_get_name(const ares_iface_ips_t *ips, size_t idx)
 }
 
 const struct ares_addr *ares_iface_ips_get_addr(const ares_iface_ips_t *ips,
-                                                 size_t                   idx)
+                                                size_t                  idx)
 {
   const ares_iface_ip_t *ip;
 
@@ -252,7 +251,7 @@ const struct ares_addr *ares_iface_ips_get_addr(const ares_iface_ips_t *ips,
 }
 
 ares_iface_ip_flags_t ares_iface_ips_get_flags(const ares_iface_ips_t *ips,
-                                                 size_t                   idx)
+                                               size_t                  idx)
 {
   const ares_iface_ip_t *ip;
 
@@ -269,7 +268,7 @@ ares_iface_ip_flags_t ares_iface_ips_get_flags(const ares_iface_ips_t *ips,
 }
 
 unsigned char ares_iface_ips_get_netmask(const ares_iface_ips_t *ips,
-                                          size_t                   idx)
+                                         size_t                  idx)
 {
   const ares_iface_ip_t *ip;
 
@@ -286,7 +285,7 @@ unsigned char ares_iface_ips_get_netmask(const ares_iface_ips_t *ips,
 }
 
 unsigned int ares_iface_ips_get_ll_scope(const ares_iface_ips_t *ips,
-                                          size_t                   idx)
+                                         size_t                  idx)
 {
   const ares_iface_ip_t *ip;
 
@@ -346,7 +345,7 @@ static ares_bool_t name_match(const char *name, const char *adapter_name,
 }
 
 static ares_status_t ares_iface_ips_enumerate(ares_iface_ips_t *ips,
-                                               const char        *name)
+                                              const char       *name)
 {
   ULONG myflags = GAA_FLAG_INCLUDE_PREFIX /*|GAA_FLAG_INCLUDE_ALL_INTERFACES */;
   ULONG outBufLen = 0;
@@ -377,7 +376,7 @@ static ares_status_t ares_iface_ips_enumerate(ares_iface_ips_t *ips,
 
   for (address = addresses; address != NULL; address = address->Next) {
     IP_ADAPTER_UNICAST_ADDRESS *ipaddr     = NULL;
-    ares_iface_ip_flags_t      addrflag   = 0;
+    ares_iface_ip_flags_t       addrflag   = 0;
     char                        ifname[64] = "";
 
 #  if defined(HAVE_CONVERTINTERFACEINDEXTOLUID) && \
@@ -432,8 +431,8 @@ static ares_status_t ares_iface_ips_enumerate(ares_iface_ips_t *ips,
       }
 
       status = ares_iface_ips_add(ips, addrflag, ifname, &addr,
-                                   ipaddr->OnLinkPrefixLength /* netmask */,
-                                   address->Ipv6IfIndex /* ll_scope */);
+                                  ipaddr->OnLinkPrefixLength /* netmask */,
+                                  address->Ipv6IfIndex /* ll_scope */);
 
       if (status != ARES_SUCCESS) {
         goto done;
@@ -460,7 +459,7 @@ static unsigned char count_addr_bits(const unsigned char *addr, size_t addr_len)
 }
 
 static ares_status_t ares_iface_ips_enumerate(ares_iface_ips_t *ips,
-                                               const char        *name)
+                                              const char       *name)
 {
   struct ifaddrs *ifap   = NULL;
   struct ifaddrs *ifa    = NULL;
@@ -473,9 +472,9 @@ static ares_status_t ares_iface_ips_enumerate(ares_iface_ips_t *ips,
 
   for (ifa = ifap; ifa != NULL; ifa = ifa->ifa_next) {
     ares_iface_ip_flags_t addrflag = 0;
-    struct ares_addr       addr;
-    unsigned char          netmask  = 0;
-    unsigned int           ll_scope = 0;
+    struct ares_addr      addr;
+    unsigned char         netmask  = 0;
+    unsigned int          ll_scope = 0;
 
     if (ifa->ifa_addr == NULL) {
       continue;
@@ -520,7 +519,7 @@ static ares_status_t ares_iface_ips_enumerate(ares_iface_ips_t *ips,
     }
 
     status = ares_iface_ips_add(ips, addrflag, ifa->ifa_name, &addr, netmask,
-                                 ll_scope);
+                                ll_scope);
     if (status != ARES_SUCCESS) {
       goto done;
     }
@@ -534,7 +533,7 @@ done:
 #else
 
 static ares_status_t ares_iface_ips_enumerate(ares_iface_ips_t *ips,
-                                               const char        *name)
+                                              const char       *name)
 {
   (void)ips;
   (void)name;
@@ -552,10 +551,10 @@ unsigned int ares_if_nametoindex(const char *name)
   }
   return if_nametoindex(name);
 #else
-  ares_status_t      status;
+  ares_status_t     status;
   ares_iface_ips_t *ips = NULL;
-  size_t             i;
-  unsigned int       index = 0;
+  size_t            i;
+  unsigned int      index = 0;
 
   if (name == NULL) {
     return 0;
@@ -580,8 +579,7 @@ done:
 #endif
 }
 
-const char *ares_if_indextoname(unsigned int index, char *name,
-                                 size_t name_len)
+const char *ares_if_indextoname(unsigned int index, char *name, size_t name_len)
 {
 #ifdef HAVE_IF_INDEXTONAME
   if (name_len < IF_NAMESIZE) {
@@ -589,10 +587,10 @@ const char *ares_if_indextoname(unsigned int index, char *name,
   }
   return if_indextoname(index, name);
 #else
-  ares_status_t      status;
+  ares_status_t     status;
   ares_iface_ips_t *ips = NULL;
-  size_t             i;
-  const char        *ptr = NULL;
+  size_t            i;
+  const char       *ptr = NULL;
 
   if (name == NULL || name_len < IF_NAMESIZE) {
     goto done;

--- a/src/lib/util/ares_iface_ips.c
+++ b/src/lib/util/ares_iface_ips.c
@@ -59,7 +59,7 @@
 #endif
 
 
-static ares_status_t ares__iface_ips_enumerate(ares__iface_ips_t *ips,
+static ares_status_t ares_iface_ips_enumerate(ares_iface_ips_t *ips,
                                                const char        *name);
 
 typedef struct {
@@ -67,33 +67,33 @@ typedef struct {
   struct ares_addr       addr;
   unsigned char          netmask;
   unsigned int           ll_scope;
-  ares__iface_ip_flags_t flags;
-} ares__iface_ip_t;
+  ares_iface_ip_flags_t flags;
+} ares_iface_ip_t;
 
-struct ares__iface_ips {
-  ares__array_t         *ips; /*!< Type is ares__iface_ip_t */
-  ares__iface_ip_flags_t enum_flags;
+struct ares_iface_ips {
+  ares_array_t         *ips; /*!< Type is ares_iface_ip_t */
+  ares_iface_ip_flags_t enum_flags;
 };
 
-static void ares__iface_ip_free_cb(void *arg)
+static void ares_iface_ip_free_cb(void *arg)
 {
-  ares__iface_ip_t *ip = arg;
+  ares_iface_ip_t *ip = arg;
   if (ip == NULL) {
     return;
   }
   ares_free(ip->name);
 }
 
-static ares__iface_ips_t *ares__iface_ips_alloc(ares__iface_ip_flags_t flags)
+static ares_iface_ips_t *ares_iface_ips_alloc(ares_iface_ip_flags_t flags)
 {
-  ares__iface_ips_t *ips = ares_malloc_zero(sizeof(*ips));
+  ares_iface_ips_t *ips = ares_malloc_zero(sizeof(*ips));
   if (ips == NULL) {
     return NULL; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   ips->enum_flags = flags;
   ips->ips =
-    ares__array_create(sizeof(ares__iface_ip_t), ares__iface_ip_free_cb);
+    ares_array_create(sizeof(ares_iface_ip_t), ares_iface_ip_free_cb);
   if (ips->ips == NULL) {
     ares_free(ips); /* LCOV_EXCL_LINE: OutOfMemory */
     return NULL;    /* LCOV_EXCL_LINE: OutOfMemory */
@@ -101,18 +101,18 @@ static ares__iface_ips_t *ares__iface_ips_alloc(ares__iface_ip_flags_t flags)
   return ips;
 }
 
-void ares__iface_ips_destroy(ares__iface_ips_t *ips)
+void ares_iface_ips_destroy(ares_iface_ips_t *ips)
 {
   if (ips == NULL) {
     return;
   }
 
-  ares__array_destroy(ips->ips);
+  ares_array_destroy(ips->ips);
   ares_free(ips);
 }
 
-ares_status_t ares__iface_ips(ares__iface_ips_t    **ips,
-                              ares__iface_ip_flags_t flags, const char *name)
+ares_status_t ares_iface_ips(ares_iface_ips_t    **ips,
+                              ares_iface_ip_flags_t flags, const char *name)
 {
   ares_status_t status;
 
@@ -120,15 +120,15 @@ ares_status_t ares__iface_ips(ares__iface_ips_t    **ips,
     return ARES_EFORMERR;
   }
 
-  *ips = ares__iface_ips_alloc(flags);
+  *ips = ares_iface_ips_alloc(flags);
   if (*ips == NULL) {
     return ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  status = ares__iface_ips_enumerate(*ips, name);
+  status = ares_iface_ips_enumerate(*ips, name);
   if (status != ARES_SUCCESS) {
     /* LCOV_EXCL_START: UntestablePath */
-    ares__iface_ips_destroy(*ips);
+    ares_iface_ips_destroy(*ips);
     *ips = NULL;
     return status;
     /* LCOV_EXCL_STOP */
@@ -138,11 +138,11 @@ ares_status_t ares__iface_ips(ares__iface_ips_t    **ips,
 }
 
 static ares_status_t
-  ares__iface_ips_add(ares__iface_ips_t *ips, ares__iface_ip_flags_t flags,
+  ares_iface_ips_add(ares_iface_ips_t *ips, ares_iface_ip_flags_t flags,
                       const char *name, const struct ares_addr *addr,
                       unsigned char netmask, unsigned int ll_scope)
 {
-  ares__iface_ip_t *ip;
+  ares_iface_ip_t *ip;
   ares_status_t     status;
 
   if (ips == NULL || name == NULL || addr == NULL) {
@@ -162,7 +162,7 @@ static ares_status_t
   }
 
   /* Check for link-local */
-  if (ares__addr_is_linklocal(addr)) {
+  if (ares_addr_is_linklocal(addr)) {
     flags |= ARES_IFACE_IP_LINKLOCAL;
   }
   if (flags & ARES_IFACE_IP_LINKLOCAL &&
@@ -190,7 +190,7 @@ static ares_status_t
     }
   }
 
-  status = ares__array_insert_last((void **)&ip, ips->ips);
+  status = ares_array_insert_last((void **)&ip, ips->ips);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -203,30 +203,30 @@ static ares_status_t
   memcpy(&ip->addr, addr, sizeof(*addr));
   ip->name = ares_strdup(name);
   if (ip->name == NULL) {
-    ares__array_remove_last(ips->ips);
+    ares_array_remove_last(ips->ips);
     return ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   return ARES_SUCCESS;
 }
 
-size_t ares__iface_ips_cnt(const ares__iface_ips_t *ips)
+size_t ares_iface_ips_cnt(const ares_iface_ips_t *ips)
 {
   if (ips == NULL) {
     return 0;
   }
-  return ares__array_len(ips->ips);
+  return ares_array_len(ips->ips);
 }
 
-const char *ares__iface_ips_get_name(const ares__iface_ips_t *ips, size_t idx)
+const char *ares_iface_ips_get_name(const ares_iface_ips_t *ips, size_t idx)
 {
-  const ares__iface_ip_t *ip;
+  const ares_iface_ip_t *ip;
 
   if (ips == NULL) {
     return NULL;
   }
 
-  ip = ares__array_at_const(ips->ips, idx);
+  ip = ares_array_at_const(ips->ips, idx);
   if (ip == NULL) {
     return NULL;
   }
@@ -234,16 +234,16 @@ const char *ares__iface_ips_get_name(const ares__iface_ips_t *ips, size_t idx)
   return ip->name;
 }
 
-const struct ares_addr *ares__iface_ips_get_addr(const ares__iface_ips_t *ips,
+const struct ares_addr *ares_iface_ips_get_addr(const ares_iface_ips_t *ips,
                                                  size_t                   idx)
 {
-  const ares__iface_ip_t *ip;
+  const ares_iface_ip_t *ip;
 
   if (ips == NULL) {
     return NULL;
   }
 
-  ip = ares__array_at_const(ips->ips, idx);
+  ip = ares_array_at_const(ips->ips, idx);
   if (ip == NULL) {
     return NULL;
   }
@@ -251,16 +251,16 @@ const struct ares_addr *ares__iface_ips_get_addr(const ares__iface_ips_t *ips,
   return &ip->addr;
 }
 
-ares__iface_ip_flags_t ares__iface_ips_get_flags(const ares__iface_ips_t *ips,
+ares_iface_ip_flags_t ares_iface_ips_get_flags(const ares_iface_ips_t *ips,
                                                  size_t                   idx)
 {
-  const ares__iface_ip_t *ip;
+  const ares_iface_ip_t *ip;
 
   if (ips == NULL) {
     return 0;
   }
 
-  ip = ares__array_at_const(ips->ips, idx);
+  ip = ares_array_at_const(ips->ips, idx);
   if (ip == NULL) {
     return 0;
   }
@@ -268,16 +268,16 @@ ares__iface_ip_flags_t ares__iface_ips_get_flags(const ares__iface_ips_t *ips,
   return ip->flags;
 }
 
-unsigned char ares__iface_ips_get_netmask(const ares__iface_ips_t *ips,
+unsigned char ares_iface_ips_get_netmask(const ares_iface_ips_t *ips,
                                           size_t                   idx)
 {
-  const ares__iface_ip_t *ip;
+  const ares_iface_ip_t *ip;
 
   if (ips == NULL) {
     return 0;
   }
 
-  ip = ares__array_at_const(ips->ips, idx);
+  ip = ares_array_at_const(ips->ips, idx);
   if (ip == NULL) {
     return 0;
   }
@@ -285,16 +285,16 @@ unsigned char ares__iface_ips_get_netmask(const ares__iface_ips_t *ips,
   return ip->netmask;
 }
 
-unsigned int ares__iface_ips_get_ll_scope(const ares__iface_ips_t *ips,
+unsigned int ares_iface_ips_get_ll_scope(const ares_iface_ips_t *ips,
                                           size_t                   idx)
 {
-  const ares__iface_ip_t *ip;
+  const ares_iface_ip_t *ip;
 
   if (ips == NULL) {
     return 0;
   }
 
-  ip = ares__array_at_const(ips->ips, idx);
+  ip = ares_array_at_const(ips->ips, idx);
   if (ip == NULL) {
     return 0;
   }
@@ -345,7 +345,7 @@ static ares_bool_t name_match(const char *name, const char *adapter_name,
   return ARES_FALSE;
 }
 
-static ares_status_t ares__iface_ips_enumerate(ares__iface_ips_t *ips,
+static ares_status_t ares_iface_ips_enumerate(ares_iface_ips_t *ips,
                                                const char        *name)
 {
   ULONG myflags = GAA_FLAG_INCLUDE_PREFIX /*|GAA_FLAG_INCLUDE_ALL_INTERFACES */;
@@ -377,7 +377,7 @@ static ares_status_t ares__iface_ips_enumerate(ares__iface_ips_t *ips,
 
   for (address = addresses; address != NULL; address = address->Next) {
     IP_ADAPTER_UNICAST_ADDRESS *ipaddr     = NULL;
-    ares__iface_ip_flags_t      addrflag   = 0;
+    ares_iface_ip_flags_t      addrflag   = 0;
     char                        ifname[64] = "";
 
 #  if defined(HAVE_CONVERTINTERFACEINDEXTOLUID) && \
@@ -431,7 +431,7 @@ static ares_status_t ares__iface_ips_enumerate(ares__iface_ips_t *ips,
         continue;
       }
 
-      status = ares__iface_ips_add(ips, addrflag, ifname, &addr,
+      status = ares_iface_ips_add(ips, addrflag, ifname, &addr,
                                    ipaddr->OnLinkPrefixLength /* netmask */,
                                    address->Ipv6IfIndex /* ll_scope */);
 
@@ -454,12 +454,12 @@ static unsigned char count_addr_bits(const unsigned char *addr, size_t addr_len)
   unsigned char count = 0;
 
   for (i = 0; i < addr_len; i++) {
-    count += ares__count_bits_u8(addr[i]);
+    count += ares_count_bits_u8(addr[i]);
   }
   return count;
 }
 
-static ares_status_t ares__iface_ips_enumerate(ares__iface_ips_t *ips,
+static ares_status_t ares_iface_ips_enumerate(ares_iface_ips_t *ips,
                                                const char        *name)
 {
   struct ifaddrs *ifap   = NULL;
@@ -472,7 +472,7 @@ static ares_status_t ares__iface_ips_enumerate(ares__iface_ips_t *ips,
   }
 
   for (ifa = ifap; ifa != NULL; ifa = ifa->ifa_next) {
-    ares__iface_ip_flags_t addrflag = 0;
+    ares_iface_ip_flags_t addrflag = 0;
     struct ares_addr       addr;
     unsigned char          netmask  = 0;
     unsigned int           ll_scope = 0;
@@ -519,7 +519,7 @@ static ares_status_t ares__iface_ips_enumerate(ares__iface_ips_t *ips,
       continue;
     }
 
-    status = ares__iface_ips_add(ips, addrflag, ifa->ifa_name, &addr, netmask,
+    status = ares_iface_ips_add(ips, addrflag, ifa->ifa_name, &addr, netmask,
                                  ll_scope);
     if (status != ARES_SUCCESS) {
       goto done;
@@ -533,7 +533,7 @@ done:
 
 #else
 
-static ares_status_t ares__iface_ips_enumerate(ares__iface_ips_t *ips,
+static ares_status_t ares_iface_ips_enumerate(ares_iface_ips_t *ips,
                                                const char        *name)
 {
   (void)ips;
@@ -544,7 +544,7 @@ static ares_status_t ares__iface_ips_enumerate(ares__iface_ips_t *ips,
 #endif
 
 
-unsigned int ares__if_nametoindex(const char *name)
+unsigned int ares_if_nametoindex(const char *name)
 {
 #ifdef HAVE_IF_NAMETOINDEX
   if (name == NULL) {
@@ -553,7 +553,7 @@ unsigned int ares__if_nametoindex(const char *name)
   return if_nametoindex(name);
 #else
   ares_status_t      status;
-  ares__iface_ips_t *ips = NULL;
+  ares_iface_ips_t *ips = NULL;
   size_t             i;
   unsigned int       index = 0;
 
@@ -562,25 +562,25 @@ unsigned int ares__if_nametoindex(const char *name)
   }
 
   status =
-    ares__iface_ips(&ips, ARES_IFACE_IP_V6 | ARES_IFACE_IP_LINKLOCAL, name);
+    ares_iface_ips(&ips, ARES_IFACE_IP_V6 | ARES_IFACE_IP_LINKLOCAL, name);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  for (i = 0; i < ares__iface_ips_cnt(ips); i++) {
-    if (ares__iface_ips_get_flags(ips, i) & ARES_IFACE_IP_LINKLOCAL) {
-      index = ares__iface_ips_get_ll_scope(ips, i);
+  for (i = 0; i < ares_iface_ips_cnt(ips); i++) {
+    if (ares_iface_ips_get_flags(ips, i) & ARES_IFACE_IP_LINKLOCAL) {
+      index = ares_iface_ips_get_ll_scope(ips, i);
       goto done;
     }
   }
 
 done:
-  ares__iface_ips_destroy(ips);
+  ares_iface_ips_destroy(ips);
   return index;
 #endif
 }
 
-const char *ares__if_indextoname(unsigned int index, char *name,
+const char *ares_if_indextoname(unsigned int index, char *name,
                                  size_t name_len)
 {
 #ifdef HAVE_IF_INDEXTONAME
@@ -590,7 +590,7 @@ const char *ares__if_indextoname(unsigned int index, char *name,
   return if_indextoname(index, name);
 #else
   ares_status_t      status;
-  ares__iface_ips_t *ips = NULL;
+  ares_iface_ips_t *ips = NULL;
   size_t             i;
   const char        *ptr = NULL;
 
@@ -603,22 +603,22 @@ const char *ares__if_indextoname(unsigned int index, char *name,
   }
 
   status =
-    ares__iface_ips(&ips, ARES_IFACE_IP_V6 | ARES_IFACE_IP_LINKLOCAL, NULL);
+    ares_iface_ips(&ips, ARES_IFACE_IP_V6 | ARES_IFACE_IP_LINKLOCAL, NULL);
   if (status != ARES_SUCCESS) {
     goto done;
   }
 
-  for (i = 0; i < ares__iface_ips_cnt(ips); i++) {
-    if (ares__iface_ips_get_flags(ips, i) & ARES_IFACE_IP_LINKLOCAL &&
-        ares__iface_ips_get_ll_scope(ips, i) == index) {
-      ares_strcpy(name, ares__iface_ips_get_name(ips, i), name_len);
+  for (i = 0; i < ares_iface_ips_cnt(ips); i++) {
+    if (ares_iface_ips_get_flags(ips, i) & ARES_IFACE_IP_LINKLOCAL &&
+        ares_iface_ips_get_ll_scope(ips, i) == index) {
+      ares_strcpy(name, ares_iface_ips_get_name(ips, i), name_len);
       ptr = name;
       goto done;
     }
   }
 
 done:
-  ares__iface_ips_destroy(ips);
+  ares_iface_ips_destroy(ips);
   return ptr;
 #endif
 }

--- a/src/lib/util/ares_iface_ips.h
+++ b/src/lib/util/ares_iface_ips.h
@@ -53,7 +53,7 @@ typedef struct ares_iface_ips ares_iface_ips_t;
  *
  *  \param[in]  ips   Initialized IP address enumeration structure
  */
-void                           ares_iface_ips_destroy(ares_iface_ips_t *ips);
+void                          ares_iface_ips_destroy(ares_iface_ips_t *ips);
 
 /*! Enumerate ip addresses on interfaces
  *
@@ -63,15 +63,15 @@ void                           ares_iface_ips_destroy(ares_iface_ips_t *ips);
  *  \return ARES_ENOMEM on out of memory, ARES_ENOTIMP if not supported on
  *          the system, ARES_SUCCESS on success
  */
-ares_status_t                  ares_iface_ips(ares_iface_ips_t    **ips,
-                                               ares_iface_ip_flags_t flags, const char *name);
+ares_status_t                 ares_iface_ips(ares_iface_ips_t    **ips,
+                                             ares_iface_ip_flags_t flags, const char *name);
 
 /*! Count of ips enumerated
  *
  * \param[in]  ips   Initialized IP address enumeration structure
  * \return count
  */
-size_t      ares_iface_ips_cnt(const ares_iface_ips_t *ips);
+size_t                        ares_iface_ips_cnt(const ares_iface_ips_t *ips);
 
 /*! Retrieve interface name
  *
@@ -88,7 +88,7 @@ const char *ares_iface_ips_get_name(const ares_iface_ips_t *ips, size_t idx);
  * \return interface address
  */
 const struct ares_addr *ares_iface_ips_get_addr(const ares_iface_ips_t *ips,
-                                                 size_t                   idx);
+                                                size_t                  idx);
 
 /*! Retrieve interface address flags
  *
@@ -96,8 +96,8 @@ const struct ares_addr *ares_iface_ips_get_addr(const ares_iface_ips_t *ips,
  * \param[in]  idx   Index of entry to pull
  * \return interface address flags
  */
-ares_iface_ip_flags_t  ares_iface_ips_get_flags(const ares_iface_ips_t *ips,
-                                                  size_t                   idx);
+ares_iface_ip_flags_t   ares_iface_ips_get_flags(const ares_iface_ips_t *ips,
+                                                 size_t                  idx);
 
 /*! Retrieve interface address netmask
  *
@@ -105,8 +105,8 @@ ares_iface_ip_flags_t  ares_iface_ips_get_flags(const ares_iface_ips_t *ips,
  * \param[in]  idx   Index of entry to pull
  * \return interface address netmask
  */
-unsigned char ares_iface_ips_get_netmask(const ares_iface_ips_t *ips,
-                                          size_t                   idx);
+unsigned char           ares_iface_ips_get_netmask(const ares_iface_ips_t *ips,
+                                                   size_t                  idx);
 
 /*! Retrieve interface ipv6 link local scope
  *
@@ -114,8 +114,8 @@ unsigned char ares_iface_ips_get_netmask(const ares_iface_ips_t *ips,
  * \param[in]  idx   Index of entry to pull
  * \return interface ipv6 link local scope
  */
-unsigned int  ares_iface_ips_get_ll_scope(const ares_iface_ips_t *ips,
-                                           size_t                   idx);
+unsigned int            ares_iface_ips_get_ll_scope(const ares_iface_ips_t *ips,
+                                                    size_t                  idx);
 
 
 /*! Retrieve the interface index (aka link local scope) from the interface
@@ -124,7 +124,7 @@ unsigned int  ares_iface_ips_get_ll_scope(const ares_iface_ips_t *ips,
  * \param[in] name  Interface name
  * \return 0 on failure, index otherwise
  */
-unsigned int  ares_if_nametoindex(const char *name);
+unsigned int            ares_if_nametoindex(const char *name);
 
 /*! Retrieves the interface name from the index (aka link local scope)
  *
@@ -133,7 +133,7 @@ unsigned int  ares_if_nametoindex(const char *name);
  * \param[in] name_len Length of provided buffer, must be at least IF_NAMESIZE
  * \return NULL on failure, or pointer to name on success
  */
-const char   *ares_if_indextoname(unsigned int index, char *name,
-                                   size_t name_len);
+const char             *ares_if_indextoname(unsigned int index, char *name,
+                                            size_t name_len);
 
 #endif

--- a/src/lib/util/ares_iface_ips.h
+++ b/src/lib/util/ares_iface_ips.h
@@ -42,18 +42,18 @@ typedef enum {
   /*! Default, enumerate all ips for online interfaces, including loopback */
   ARES_IFACE_IP_DEFAULT = (ARES_IFACE_IP_V4 | ARES_IFACE_IP_V6 |
                            ARES_IFACE_IP_LOOPBACK | ARES_IFACE_IP_LINKLOCAL)
-} ares__iface_ip_flags_t;
+} ares_iface_ip_flags_t;
 
-struct ares__iface_ips;
+struct ares_iface_ips;
 
 /*! Opaque pointer for holding enumerated interface ip addresses */
-typedef struct ares__iface_ips ares__iface_ips_t;
+typedef struct ares_iface_ips ares_iface_ips_t;
 
-/*! Destroy ip address enumeration created by ares__iface_ips().
+/*! Destroy ip address enumeration created by ares_iface_ips().
  *
  *  \param[in]  ips   Initialized IP address enumeration structure
  */
-void                           ares__iface_ips_destroy(ares__iface_ips_t *ips);
+void                           ares_iface_ips_destroy(ares_iface_ips_t *ips);
 
 /*! Enumerate ip addresses on interfaces
  *
@@ -63,15 +63,15 @@ void                           ares__iface_ips_destroy(ares__iface_ips_t *ips);
  *  \return ARES_ENOMEM on out of memory, ARES_ENOTIMP if not supported on
  *          the system, ARES_SUCCESS on success
  */
-ares_status_t                  ares__iface_ips(ares__iface_ips_t    **ips,
-                                               ares__iface_ip_flags_t flags, const char *name);
+ares_status_t                  ares_iface_ips(ares_iface_ips_t    **ips,
+                                               ares_iface_ip_flags_t flags, const char *name);
 
 /*! Count of ips enumerated
  *
  * \param[in]  ips   Initialized IP address enumeration structure
  * \return count
  */
-size_t      ares__iface_ips_cnt(const ares__iface_ips_t *ips);
+size_t      ares_iface_ips_cnt(const ares_iface_ips_t *ips);
 
 /*! Retrieve interface name
  *
@@ -79,7 +79,7 @@ size_t      ares__iface_ips_cnt(const ares__iface_ips_t *ips);
  * \param[in]  idx   Index of entry to pull
  * \return interface name
  */
-const char *ares__iface_ips_get_name(const ares__iface_ips_t *ips, size_t idx);
+const char *ares_iface_ips_get_name(const ares_iface_ips_t *ips, size_t idx);
 
 /*! Retrieve interface address
  *
@@ -87,7 +87,7 @@ const char *ares__iface_ips_get_name(const ares__iface_ips_t *ips, size_t idx);
  * \param[in]  idx   Index of entry to pull
  * \return interface address
  */
-const struct ares_addr *ares__iface_ips_get_addr(const ares__iface_ips_t *ips,
+const struct ares_addr *ares_iface_ips_get_addr(const ares_iface_ips_t *ips,
                                                  size_t                   idx);
 
 /*! Retrieve interface address flags
@@ -96,7 +96,7 @@ const struct ares_addr *ares__iface_ips_get_addr(const ares__iface_ips_t *ips,
  * \param[in]  idx   Index of entry to pull
  * \return interface address flags
  */
-ares__iface_ip_flags_t  ares__iface_ips_get_flags(const ares__iface_ips_t *ips,
+ares_iface_ip_flags_t  ares_iface_ips_get_flags(const ares_iface_ips_t *ips,
                                                   size_t                   idx);
 
 /*! Retrieve interface address netmask
@@ -105,7 +105,7 @@ ares__iface_ip_flags_t  ares__iface_ips_get_flags(const ares__iface_ips_t *ips,
  * \param[in]  idx   Index of entry to pull
  * \return interface address netmask
  */
-unsigned char ares__iface_ips_get_netmask(const ares__iface_ips_t *ips,
+unsigned char ares_iface_ips_get_netmask(const ares_iface_ips_t *ips,
                                           size_t                   idx);
 
 /*! Retrieve interface ipv6 link local scope
@@ -114,7 +114,7 @@ unsigned char ares__iface_ips_get_netmask(const ares__iface_ips_t *ips,
  * \param[in]  idx   Index of entry to pull
  * \return interface ipv6 link local scope
  */
-unsigned int  ares__iface_ips_get_ll_scope(const ares__iface_ips_t *ips,
+unsigned int  ares_iface_ips_get_ll_scope(const ares_iface_ips_t *ips,
                                            size_t                   idx);
 
 
@@ -124,7 +124,7 @@ unsigned int  ares__iface_ips_get_ll_scope(const ares__iface_ips_t *ips,
  * \param[in] name  Interface name
  * \return 0 on failure, index otherwise
  */
-unsigned int  ares__if_nametoindex(const char *name);
+unsigned int  ares_if_nametoindex(const char *name);
 
 /*! Retrieves the interface name from the index (aka link local scope)
  *
@@ -133,7 +133,7 @@ unsigned int  ares__if_nametoindex(const char *name);
  * \param[in] name_len Length of provided buffer, must be at least IF_NAMESIZE
  * \return NULL on failure, or pointer to name on success
  */
-const char   *ares__if_indextoname(unsigned int index, char *name,
+const char   *ares_if_indextoname(unsigned int index, char *name,
                                    size_t name_len);
 
 #endif

--- a/src/lib/util/ares_math.c
+++ b/src/lib/util/ares_math.c
@@ -29,7 +29,7 @@
 /* Uses public domain code snippets from
  * http://graphics.stanford.edu/~seander/bithacks.html */
 
-static unsigned int ares__round_up_pow2_u32(unsigned int n)
+static unsigned int ares_round_up_pow2_u32(unsigned int n)
 {
   /* NOTE: if already a power of 2, will return itself, not the next */
   n--;
@@ -42,7 +42,7 @@ static unsigned int ares__round_up_pow2_u32(unsigned int n)
   return n;
 }
 
-static ares_int64_t ares__round_up_pow2_u64(ares_int64_t n)
+static ares_int64_t ares_round_up_pow2_u64(ares_int64_t n)
 {
   /* NOTE: if already a power of 2, will return itself, not the next */
   n--;
@@ -56,7 +56,7 @@ static ares_int64_t ares__round_up_pow2_u64(ares_int64_t n)
   return n;
 }
 
-ares_bool_t ares__is_64bit(void)
+ares_bool_t ares_is_64bit(void)
 {
 #ifdef _MSC_VER
 #  pragma warning(push)
@@ -70,16 +70,16 @@ ares_bool_t ares__is_64bit(void)
 #endif
 }
 
-size_t ares__round_up_pow2(size_t n)
+size_t ares_round_up_pow2(size_t n)
 {
-  if (ares__is_64bit()) {
-    return (size_t)ares__round_up_pow2_u64((ares_int64_t)n);
+  if (ares_is_64bit()) {
+    return (size_t)ares_round_up_pow2_u64((ares_int64_t)n);
   }
 
-  return (size_t)ares__round_up_pow2_u32((unsigned int)n);
+  return (size_t)ares_round_up_pow2_u32((unsigned int)n);
 }
 
-size_t ares__log2(size_t n)
+size_t ares_log2(size_t n)
 {
   static const unsigned char tab32[32] = { 0,  1,  28, 2,  29, 14, 24, 3,
                                            30, 22, 20, 15, 25, 17, 4,  8,
@@ -92,7 +92,7 @@ size_t ares__log2(size_t n)
     56, 45, 25, 31, 35, 16, 9,  12, 44, 24, 15, 8,  23, 7,  6,  5
   };
 
-  if (!ares__is_64bit()) {
+  if (!ares_is_64bit()) {
     return tab32[(n * 0x077CB531) >> 27];
   }
 
@@ -100,7 +100,7 @@ size_t ares__log2(size_t n)
 }
 
 /* x^y */
-size_t ares__pow(size_t x, size_t y)
+size_t ares_pow(size_t x, size_t y)
 {
   size_t res = 1;
 
@@ -118,7 +118,7 @@ size_t ares__pow(size_t x, size_t y)
   return res;
 }
 
-size_t ares__count_digits(size_t n)
+size_t ares_count_digits(size_t n)
 {
   size_t digits;
 
@@ -132,7 +132,7 @@ size_t ares__count_digits(size_t n)
   return digits;
 }
 
-size_t ares__count_hexdigits(size_t n)
+size_t ares_count_hexdigits(size_t n)
 {
   size_t digits;
 
@@ -146,7 +146,7 @@ size_t ares__count_hexdigits(size_t n)
   return digits;
 }
 
-unsigned char ares__count_bits_u8(unsigned char x)
+unsigned char ares_count_bits_u8(unsigned char x)
 {
   /* Implementation obtained from:
    * http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetTable */

--- a/src/lib/util/ares_math.h
+++ b/src/lib/util/ares_math.h
@@ -34,12 +34,12 @@ typedef long long          ares_int64_t;
 typedef unsigned long long ares_uint64_t;
 #endif
 
-ares_bool_t   ares__is_64bit(void);
-size_t        ares__round_up_pow2(size_t n);
-size_t        ares__log2(size_t n);
-size_t        ares__pow(size_t x, size_t y);
-size_t        ares__count_digits(size_t n);
-size_t        ares__count_hexdigits(size_t n);
-unsigned char ares__count_bits_u8(unsigned char x);
+ares_bool_t   ares_is_64bit(void);
+size_t        ares_round_up_pow2(size_t n);
+size_t        ares_log2(size_t n);
+size_t        ares_pow(size_t x, size_t y);
+size_t        ares_count_digits(size_t n);
+size_t        ares_count_hexdigits(size_t n);
+unsigned char ares_count_bits_u8(unsigned char x);
 
 #endif

--- a/src/lib/util/ares_rand.c
+++ b/src/lib/util/ares_rand.c
@@ -288,7 +288,7 @@ void ares_destroy_rand_state(ares_rand_state *state)
 }
 
 static void ares_rand_bytes_fetch(ares_rand_state *state, unsigned char *buf,
-                                   size_t len)
+                                  size_t len)
 {
   while (1) {
     size_t bytes_read = 0;

--- a/src/lib/util/ares_rand.c
+++ b/src/lib/util/ares_rand.c
@@ -55,7 +55,7 @@ typedef struct ares_rand_rc4 {
 static unsigned int ares_u32_from_ptr(void *addr)
 {
   /* LCOV_EXCL_START: FallbackCode */
-  if (ares__is_64bit()) {
+  if (ares_is_64bit()) {
     return (unsigned int)((((ares_uint64_t)addr >> 32) & 0xFFFFFFFF) |
                           ((ares_uint64_t)addr & 0xFFFFFFFF));
   }
@@ -83,7 +83,7 @@ static void ares_rc4_generate_key(ares_rand_rc4 *rc4_state, unsigned char *key,
 #else
   /* Randomness is hard to come by.  Maybe the system randomizes heap and stack
    * addresses. Maybe the current timestamp give us some randomness. Use
-   * rc4_state (heap), &i (stack), and ares__tvnow()
+   * rc4_state (heap), &i (stack), and ares_tvnow()
    */
   data = ares_u32_from_ptr(rc4_state);
   memcpy(key + len, &data, sizeof(data));
@@ -93,7 +93,7 @@ static void ares_rc4_generate_key(ares_rand_rc4 *rc4_state, unsigned char *key,
   memcpy(key + len, &data, sizeof(data));
   len += sizeof(data);
 
-  ares__tvnow(&tv);
+  ares_tvnow(&tv);
   data = (unsigned int)((tv.sec | tv.usec) & 0xFFFFFFFF);
   memcpy(key + len, &data, sizeof(data));
   len += sizeof(data);
@@ -193,7 +193,7 @@ BOOLEAN WINAPI SystemFunction036(PVOID RandomBuffer, ULONG RandomBufferLength);
 #endif
 
 
-static ares_bool_t ares__init_rand_engine(ares_rand_state *state)
+static ares_bool_t ares_init_rand_engine(ares_rand_state *state)
 {
   state->cache_remaining = 0;
 
@@ -233,7 +233,7 @@ static ares_bool_t ares__init_rand_engine(ares_rand_state *state)
   return ARES_TRUE; /* LCOV_EXCL_LINE: UntestablePath */
 }
 
-ares_rand_state *ares__init_rand_state(void)
+ares_rand_state *ares_init_rand_state(void)
 {
   ares_rand_state *state = NULL;
 
@@ -242,7 +242,7 @@ ares_rand_state *ares__init_rand_state(void)
     return NULL;
   }
 
-  if (!ares__init_rand_engine(state)) {
+  if (!ares_init_rand_engine(state)) {
     ares_free(state); /* LCOV_EXCL_LINE: UntestablePath */
     return NULL;      /* LCOV_EXCL_LINE: UntestablePath */
   }
@@ -250,7 +250,7 @@ ares_rand_state *ares__init_rand_state(void)
   return state;
 }
 
-static void ares__clear_rand_state(ares_rand_state *state)
+static void ares_clear_rand_state(ares_rand_state *state)
 {
   if (!state) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
@@ -269,25 +269,25 @@ static void ares__clear_rand_state(ares_rand_state *state)
   }
 }
 
-static void ares__reinit_rand(ares_rand_state *state)
+static void ares_reinit_rand(ares_rand_state *state)
 {
   /* LCOV_EXCL_START: UntestablePath */
-  ares__clear_rand_state(state);
-  ares__init_rand_engine(state);
+  ares_clear_rand_state(state);
+  ares_init_rand_engine(state);
   /* LCOV_EXCL_STOP */
 }
 
-void ares__destroy_rand_state(ares_rand_state *state)
+void ares_destroy_rand_state(ares_rand_state *state)
 {
   if (!state) {
     return;
   }
 
-  ares__clear_rand_state(state);
+  ares_clear_rand_state(state);
   ares_free(state);
 }
 
-static void ares__rand_bytes_fetch(ares_rand_state *state, unsigned char *buf,
+static void ares_rand_bytes_fetch(ares_rand_state *state, unsigned char *buf,
                                    size_t len)
 {
   while (1) {
@@ -354,17 +354,17 @@ static void ares__rand_bytes_fetch(ares_rand_state *state, unsigned char *buf,
 
     /* If we didn't return before we got here, that means we had a critical rand
      * failure and need to reinitialized */
-    ares__reinit_rand(state); /* LCOV_EXCL_LINE: UntestablePath */
+    ares_reinit_rand(state); /* LCOV_EXCL_LINE: UntestablePath */
   }
 }
 
-void ares__rand_bytes(ares_rand_state *state, unsigned char *buf, size_t len)
+void ares_rand_bytes(ares_rand_state *state, unsigned char *buf, size_t len)
 {
   /* See if we need to refill the cache to serve the request, but if len is
    * excessive, we're not going to update our cache or serve from cache */
   if (len > state->cache_remaining && len < sizeof(state->cache)) {
     size_t fetch_size = sizeof(state->cache) - state->cache_remaining;
-    ares__rand_bytes_fetch(state, state->cache, fetch_size);
+    ares_rand_bytes_fetch(state, state->cache, fetch_size);
     state->cache_remaining = sizeof(state->cache);
   }
 
@@ -377,13 +377,13 @@ void ares__rand_bytes(ares_rand_state *state, unsigned char *buf, size_t len)
   }
 
   /* Serve direct due to excess size of request */
-  ares__rand_bytes_fetch(state, buf, len);
+  ares_rand_bytes_fetch(state, buf, len);
 }
 
-unsigned short ares__generate_new_id(ares_rand_state *state)
+unsigned short ares_generate_new_id(ares_rand_state *state)
 {
   unsigned short r = 0;
 
-  ares__rand_bytes(state, (unsigned char *)&r, sizeof(r));
+  ares_rand_bytes(state, (unsigned char *)&r, sizeof(r));
   return r;
 }

--- a/src/lib/util/ares_rand.h
+++ b/src/lib/util/ares_rand.h
@@ -29,8 +29,8 @@
 struct ares_rand_state;
 typedef struct ares_rand_state ares_rand_state;
 
-ares_rand_state               *ares__init_rand_state(void);
-void                           ares__destroy_rand_state(ares_rand_state *state);
-void ares__rand_bytes(ares_rand_state *state, unsigned char *buf, size_t len);
+ares_rand_state               *ares_init_rand_state(void);
+void                           ares_destroy_rand_state(ares_rand_state *state);
+void ares_rand_bytes(ares_rand_state *state, unsigned char *buf, size_t len);
 
 #endif

--- a/src/lib/util/ares_threads.c
+++ b/src/lib/util/ares_threads.c
@@ -28,13 +28,13 @@
 #ifdef CARES_THREADS
 #  ifdef _WIN32
 
-struct ares__thread_mutex {
+struct ares_thread_mutex {
   CRITICAL_SECTION mutex;
 };
 
-ares__thread_mutex_t *ares__thread_mutex_create(void)
+ares_thread_mutex_t *ares_thread_mutex_create(void)
 {
-  ares__thread_mutex_t *mut = ares_malloc_zero(sizeof(*mut));
+  ares_thread_mutex_t *mut = ares_malloc_zero(sizeof(*mut));
   if (mut == NULL) {
     return NULL;
   }
@@ -43,7 +43,7 @@ ares__thread_mutex_t *ares__thread_mutex_create(void)
   return mut;
 }
 
-void ares__thread_mutex_destroy(ares__thread_mutex_t *mut)
+void ares_thread_mutex_destroy(ares_thread_mutex_t *mut)
 {
   if (mut == NULL) {
     return;
@@ -52,7 +52,7 @@ void ares__thread_mutex_destroy(ares__thread_mutex_t *mut)
   ares_free(mut);
 }
 
-void ares__thread_mutex_lock(ares__thread_mutex_t *mut)
+void ares_thread_mutex_lock(ares_thread_mutex_t *mut)
 {
   if (mut == NULL) {
     return;
@@ -60,7 +60,7 @@ void ares__thread_mutex_lock(ares__thread_mutex_t *mut)
   EnterCriticalSection(&mut->mutex);
 }
 
-void ares__thread_mutex_unlock(ares__thread_mutex_t *mut)
+void ares_thread_mutex_unlock(ares_thread_mutex_t *mut)
 {
   if (mut == NULL) {
     return;
@@ -68,13 +68,13 @@ void ares__thread_mutex_unlock(ares__thread_mutex_t *mut)
   LeaveCriticalSection(&mut->mutex);
 }
 
-struct ares__thread_cond {
+struct ares_thread_cond {
   CONDITION_VARIABLE cond;
 };
 
-ares__thread_cond_t *ares__thread_cond_create(void)
+ares_thread_cond_t *ares_thread_cond_create(void)
 {
-  ares__thread_cond_t *cond = ares_malloc_zero(sizeof(*cond));
+  ares_thread_cond_t *cond = ares_malloc_zero(sizeof(*cond));
   if (cond == NULL) {
     return NULL;
   }
@@ -82,7 +82,7 @@ ares__thread_cond_t *ares__thread_cond_create(void)
   return cond;
 }
 
-void ares__thread_cond_destroy(ares__thread_cond_t *cond)
+void ares_thread_cond_destroy(ares_thread_cond_t *cond)
 {
   if (cond == NULL) {
     return;
@@ -90,7 +90,7 @@ void ares__thread_cond_destroy(ares__thread_cond_t *cond)
   ares_free(cond);
 }
 
-void ares__thread_cond_signal(ares__thread_cond_t *cond)
+void ares_thread_cond_signal(ares_thread_cond_t *cond)
 {
   if (cond == NULL) {
     return;
@@ -98,7 +98,7 @@ void ares__thread_cond_signal(ares__thread_cond_t *cond)
   WakeConditionVariable(&cond->cond);
 }
 
-void ares__thread_cond_broadcast(ares__thread_cond_t *cond)
+void ares_thread_cond_broadcast(ares_thread_cond_t *cond)
 {
   if (cond == NULL) {
     return;
@@ -106,8 +106,8 @@ void ares__thread_cond_broadcast(ares__thread_cond_t *cond)
   WakeAllConditionVariable(&cond->cond);
 }
 
-ares_status_t ares__thread_cond_wait(ares__thread_cond_t  *cond,
-                                     ares__thread_mutex_t *mut)
+ares_status_t ares_thread_cond_wait(ares_thread_cond_t  *cond,
+                                     ares_thread_mutex_t *mut)
 {
   if (cond == NULL || mut == NULL) {
     return ARES_EFORMERR;
@@ -117,8 +117,8 @@ ares_status_t ares__thread_cond_wait(ares__thread_cond_t  *cond,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t  *cond,
-                                          ares__thread_mutex_t *mut,
+ares_status_t ares_thread_cond_timedwait(ares_thread_cond_t  *cond,
+                                          ares_thread_mutex_t *mut,
                                           unsigned long         timeout_ms)
 {
   if (cond == NULL || mut == NULL) {
@@ -132,7 +132,7 @@ ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t  *cond,
   return ARES_SUCCESS;
 }
 
-struct ares__thread {
+struct ares_thread {
   HANDLE thread;
   DWORD  id;
 
@@ -142,18 +142,18 @@ struct ares__thread {
 };
 
 /* Wrap for pthread compatibility */
-static DWORD WINAPI ares__thread_func(LPVOID lpParameter)
+static DWORD WINAPI ares_thread_func(LPVOID lpParameter)
 {
-  ares__thread_t *thread = lpParameter;
+  ares_thread_t *thread = lpParameter;
 
   thread->rv = thread->func(thread->arg);
   return 0;
 }
 
-ares_status_t ares__thread_create(ares__thread_t    **thread,
-                                  ares__thread_func_t func, void *arg)
+ares_status_t ares_thread_create(ares_thread_t    **thread,
+                                  ares_thread_func_t func, void *arg)
 {
-  ares__thread_t *thr = NULL;
+  ares_thread_t *thr = NULL;
 
   if (func == NULL || thread == NULL) {
     return ARES_EFORMERR;
@@ -166,7 +166,7 @@ ares_status_t ares__thread_create(ares__thread_t    **thread,
 
   thr->func   = func;
   thr->arg    = arg;
-  thr->thread = CreateThread(NULL, 0, ares__thread_func, thr, 0, &thr->id);
+  thr->thread = CreateThread(NULL, 0, ares_thread_func, thr, 0, &thr->id);
   if (thr->thread == NULL) {
     ares_free(thr);
     return ARES_ESERVFAIL;
@@ -176,7 +176,7 @@ ares_status_t ares__thread_create(ares__thread_t    **thread,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__thread_join(ares__thread_t *thread, void **rv)
+ares_status_t ares_thread_join(ares_thread_t *thread, void **rv)
 {
   ares_status_t status = ARES_SUCCESS;
 
@@ -211,14 +211,14 @@ ares_status_t ares__thread_join(ares__thread_t *thread, void **rv)
 #      include <sys/time.h>
 #    endif
 
-struct ares__thread_mutex {
+struct ares_thread_mutex {
   pthread_mutex_t mutex;
 };
 
-ares__thread_mutex_t *ares__thread_mutex_create(void)
+ares_thread_mutex_t *ares_thread_mutex_create(void)
 {
   pthread_mutexattr_t   attr;
-  ares__thread_mutex_t *mut = ares_malloc_zero(sizeof(*mut));
+  ares_thread_mutex_t *mut = ares_malloc_zero(sizeof(*mut));
   if (mut == NULL) {
     return NULL;
   }
@@ -247,7 +247,7 @@ fail:
   /* LCOV_EXCL_STOP */
 }
 
-void ares__thread_mutex_destroy(ares__thread_mutex_t *mut)
+void ares_thread_mutex_destroy(ares_thread_mutex_t *mut)
 {
   if (mut == NULL) {
     return;
@@ -256,7 +256,7 @@ void ares__thread_mutex_destroy(ares__thread_mutex_t *mut)
   ares_free(mut);
 }
 
-void ares__thread_mutex_lock(ares__thread_mutex_t *mut)
+void ares_thread_mutex_lock(ares_thread_mutex_t *mut)
 {
   if (mut == NULL) {
     return;
@@ -264,7 +264,7 @@ void ares__thread_mutex_lock(ares__thread_mutex_t *mut)
   pthread_mutex_lock(&mut->mutex);
 }
 
-void ares__thread_mutex_unlock(ares__thread_mutex_t *mut)
+void ares_thread_mutex_unlock(ares_thread_mutex_t *mut)
 {
   if (mut == NULL) {
     return;
@@ -272,13 +272,13 @@ void ares__thread_mutex_unlock(ares__thread_mutex_t *mut)
   pthread_mutex_unlock(&mut->mutex);
 }
 
-struct ares__thread_cond {
+struct ares_thread_cond {
   pthread_cond_t cond;
 };
 
-ares__thread_cond_t *ares__thread_cond_create(void)
+ares_thread_cond_t *ares_thread_cond_create(void)
 {
-  ares__thread_cond_t *cond = ares_malloc_zero(sizeof(*cond));
+  ares_thread_cond_t *cond = ares_malloc_zero(sizeof(*cond));
   if (cond == NULL) {
     return NULL;
   }
@@ -286,7 +286,7 @@ ares__thread_cond_t *ares__thread_cond_create(void)
   return cond;
 }
 
-void ares__thread_cond_destroy(ares__thread_cond_t *cond)
+void ares_thread_cond_destroy(ares_thread_cond_t *cond)
 {
   if (cond == NULL) {
     return;
@@ -295,7 +295,7 @@ void ares__thread_cond_destroy(ares__thread_cond_t *cond)
   ares_free(cond);
 }
 
-void ares__thread_cond_signal(ares__thread_cond_t *cond)
+void ares_thread_cond_signal(ares_thread_cond_t *cond)
 {
   if (cond == NULL) {
     return;
@@ -303,7 +303,7 @@ void ares__thread_cond_signal(ares__thread_cond_t *cond)
   pthread_cond_signal(&cond->cond);
 }
 
-void ares__thread_cond_broadcast(ares__thread_cond_t *cond)
+void ares_thread_cond_broadcast(ares_thread_cond_t *cond)
 {
   if (cond == NULL) {
     return;
@@ -311,8 +311,8 @@ void ares__thread_cond_broadcast(ares__thread_cond_t *cond)
   pthread_cond_broadcast(&cond->cond);
 }
 
-ares_status_t ares__thread_cond_wait(ares__thread_cond_t  *cond,
-                                     ares__thread_mutex_t *mut)
+ares_status_t ares_thread_cond_wait(ares_thread_cond_t  *cond,
+                                     ares_thread_mutex_t *mut)
 {
   if (cond == NULL || mut == NULL) {
     return ARES_EFORMERR;
@@ -322,7 +322,7 @@ ares_status_t ares__thread_cond_wait(ares__thread_cond_t  *cond,
   return ARES_SUCCESS;
 }
 
-static void ares__timespec_timeout(struct timespec *ts, unsigned long add_ms)
+static void ares_timespec_timeout(struct timespec *ts, unsigned long add_ms)
 {
 #    if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_REALTIME)
   clock_gettime(CLOCK_REALTIME, ts);
@@ -345,8 +345,8 @@ static void ares__timespec_timeout(struct timespec *ts, unsigned long add_ms)
   }
 }
 
-ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t  *cond,
-                                          ares__thread_mutex_t *mut,
+ares_status_t ares_thread_cond_timedwait(ares_thread_cond_t  *cond,
+                                          ares_thread_mutex_t *mut,
                                           unsigned long         timeout_ms)
 {
   struct timespec ts;
@@ -355,7 +355,7 @@ ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t  *cond,
     return ARES_EFORMERR;
   }
 
-  ares__timespec_timeout(&ts, timeout_ms);
+  ares_timespec_timeout(&ts, timeout_ms);
 
   if (pthread_cond_timedwait(&cond->cond, &mut->mutex, &ts) != 0) {
     return ARES_ETIMEOUT;
@@ -364,14 +364,14 @@ ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t  *cond,
   return ARES_SUCCESS;
 }
 
-struct ares__thread {
+struct ares_thread {
   pthread_t thread;
 };
 
-ares_status_t ares__thread_create(ares__thread_t    **thread,
-                                  ares__thread_func_t func, void *arg)
+ares_status_t ares_thread_create(ares_thread_t    **thread,
+                                  ares_thread_func_t func, void *arg)
 {
-  ares__thread_t *thr = NULL;
+  ares_thread_t *thr = NULL;
 
   if (func == NULL || thread == NULL) {
     return ARES_EFORMERR;
@@ -390,7 +390,7 @@ ares_status_t ares__thread_create(ares__thread_t    **thread,
   return ARES_SUCCESS;
 }
 
-ares_status_t ares__thread_join(ares__thread_t *thread, void **rv)
+ares_status_t ares_thread_join(ares_thread_t *thread, void **rv)
 {
   void         *ret    = NULL;
   ares_status_t status = ARES_SUCCESS;
@@ -420,56 +420,56 @@ ares_bool_t ares_threadsafety(void)
 #else /* !CARES_THREADS */
 
 /* NoOp */
-ares__thread_mutex_t *ares__thread_mutex_create(void)
+ares_thread_mutex_t *ares_thread_mutex_create(void)
 {
   return NULL;
 }
 
-void ares__thread_mutex_destroy(ares__thread_mutex_t *mut)
+void ares_thread_mutex_destroy(ares_thread_mutex_t *mut)
 {
   (void)mut;
 }
 
-void ares__thread_mutex_lock(ares__thread_mutex_t *mut)
+void ares_thread_mutex_lock(ares_thread_mutex_t *mut)
 {
   (void)mut;
 }
 
-void ares__thread_mutex_unlock(ares__thread_mutex_t *mut)
+void ares_thread_mutex_unlock(ares_thread_mutex_t *mut)
 {
   (void)mut;
 }
 
-ares__thread_cond_t *ares__thread_cond_create(void)
+ares_thread_cond_t *ares_thread_cond_create(void)
 {
   return NULL;
 }
 
-void ares__thread_cond_destroy(ares__thread_cond_t *cond)
+void ares_thread_cond_destroy(ares_thread_cond_t *cond)
 {
   (void)cond;
 }
 
-void ares__thread_cond_signal(ares__thread_cond_t *cond)
+void ares_thread_cond_signal(ares_thread_cond_t *cond)
 {
   (void)cond;
 }
 
-void ares__thread_cond_broadcast(ares__thread_cond_t *cond)
+void ares_thread_cond_broadcast(ares_thread_cond_t *cond)
 {
   (void)cond;
 }
 
-ares_status_t ares__thread_cond_wait(ares__thread_cond_t  *cond,
-                                     ares__thread_mutex_t *mut)
+ares_status_t ares_thread_cond_wait(ares_thread_cond_t  *cond,
+                                     ares_thread_mutex_t *mut)
 {
   (void)cond;
   (void)mut;
   return ARES_ENOTIMP;
 }
 
-ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t  *cond,
-                                          ares__thread_mutex_t *mut,
+ares_status_t ares_thread_cond_timedwait(ares_thread_cond_t  *cond,
+                                          ares_thread_mutex_t *mut,
                                           unsigned long         timeout_ms)
 {
   (void)cond;
@@ -478,8 +478,8 @@ ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t  *cond,
   return ARES_ENOTIMP;
 }
 
-ares_status_t ares__thread_create(ares__thread_t    **thread,
-                                  ares__thread_func_t func, void *arg)
+ares_status_t ares_thread_create(ares_thread_t    **thread,
+                                  ares_thread_func_t func, void *arg)
 {
   (void)thread;
   (void)func;
@@ -487,7 +487,7 @@ ares_status_t ares__thread_create(ares__thread_t    **thread,
   return ARES_ENOTIMP;
 }
 
-ares_status_t ares__thread_join(ares__thread_t *thread, void **rv)
+ares_status_t ares_thread_join(ares_thread_t *thread, void **rv)
 {
   (void)thread;
   (void)rv;
@@ -501,7 +501,7 @@ ares_bool_t ares_threadsafety(void)
 #endif
 
 
-ares_status_t ares__channel_threading_init(ares_channel_t *channel)
+ares_status_t ares_channel_threading_init(ares_channel_t *channel)
 {
   ares_status_t status = ARES_SUCCESS;
 
@@ -510,13 +510,13 @@ ares_status_t ares__channel_threading_init(ares_channel_t *channel)
     return ARES_SUCCESS;
   }
 
-  channel->lock = ares__thread_mutex_create();
+  channel->lock = ares_thread_mutex_create();
   if (channel->lock == NULL) {
     status = ARES_ENOMEM;
     goto done;
   }
 
-  channel->cond_empty = ares__thread_cond_create();
+  channel->cond_empty = ares_thread_cond_create();
   if (channel->cond_empty == NULL) {
     status = ARES_ENOMEM;
     goto done;
@@ -524,27 +524,27 @@ ares_status_t ares__channel_threading_init(ares_channel_t *channel)
 
 done:
   if (status != ARES_SUCCESS) {
-    ares__channel_threading_destroy(channel);
+    ares_channel_threading_destroy(channel);
   }
   return status;
 }
 
-void ares__channel_threading_destroy(ares_channel_t *channel)
+void ares_channel_threading_destroy(ares_channel_t *channel)
 {
-  ares__thread_mutex_destroy(channel->lock);
+  ares_thread_mutex_destroy(channel->lock);
   channel->lock = NULL;
-  ares__thread_cond_destroy(channel->cond_empty);
+  ares_thread_cond_destroy(channel->cond_empty);
   channel->cond_empty = NULL;
 }
 
-void ares__channel_lock(const ares_channel_t *channel)
+void ares_channel_lock(const ares_channel_t *channel)
 {
-  ares__thread_mutex_lock(channel->lock);
+  ares_thread_mutex_lock(channel->lock);
 }
 
-void ares__channel_unlock(const ares_channel_t *channel)
+void ares_channel_unlock(const ares_channel_t *channel)
 {
-  ares__thread_mutex_unlock(channel->lock);
+  ares_thread_mutex_unlock(channel->lock);
 }
 
 /* Must not be holding a channel lock already, public function only */
@@ -562,29 +562,29 @@ ares_status_t ares_queue_wait_empty(ares_channel_t *channel, int timeout_ms)
   }
 
   if (timeout_ms >= 0) {
-    ares__tvnow(&tout);
+    ares_tvnow(&tout);
     tout.sec  += (ares_int64_t)(timeout_ms / 1000);
     tout.usec += (unsigned int)(timeout_ms % 1000) * 1000;
   }
 
-  ares__thread_mutex_lock(channel->lock);
-  while (ares__llist_len(channel->all_queries)) {
+  ares_thread_mutex_lock(channel->lock);
+  while (ares_llist_len(channel->all_queries)) {
     if (timeout_ms < 0) {
-      ares__thread_cond_wait(channel->cond_empty, channel->lock);
+      ares_thread_cond_wait(channel->cond_empty, channel->lock);
     } else {
       ares_timeval_t tv_remaining;
       ares_timeval_t tv_now;
       unsigned long  tms;
 
-      ares__tvnow(&tv_now);
-      ares__timeval_remaining(&tv_remaining, &tv_now, &tout);
+      ares_tvnow(&tv_now);
+      ares_timeval_remaining(&tv_remaining, &tv_now, &tout);
       tms =
         (unsigned long)((tv_remaining.sec * 1000) + (tv_remaining.usec / 1000));
       if (tms == 0) {
         status = ARES_ETIMEOUT;
       } else {
         status =
-          ares__thread_cond_timedwait(channel->cond_empty, channel->lock, tms);
+          ares_thread_cond_timedwait(channel->cond_empty, channel->lock, tms);
       }
 
       /* If there was a timeout, don't loop.  Otherwise, make sure this wasn't
@@ -594,7 +594,7 @@ ares_status_t ares_queue_wait_empty(ares_channel_t *channel, int timeout_ms)
       }
     }
   }
-  ares__thread_mutex_unlock(channel->lock);
+  ares_thread_mutex_unlock(channel->lock);
   return status;
 }
 
@@ -605,10 +605,10 @@ void ares_queue_notify_empty(ares_channel_t *channel)
   }
 
   /* We are guaranteed to be holding a channel lock already */
-  if (ares__llist_len(channel->all_queries)) {
+  if (ares_llist_len(channel->all_queries)) {
     return;
   }
 
   /* Notify all waiters of the conditional */
-  ares__thread_cond_broadcast(channel->cond_empty);
+  ares_thread_cond_broadcast(channel->cond_empty);
 }

--- a/src/lib/util/ares_threads.c
+++ b/src/lib/util/ares_threads.c
@@ -107,7 +107,7 @@ void ares_thread_cond_broadcast(ares_thread_cond_t *cond)
 }
 
 ares_status_t ares_thread_cond_wait(ares_thread_cond_t  *cond,
-                                     ares_thread_mutex_t *mut)
+                                    ares_thread_mutex_t *mut)
 {
   if (cond == NULL || mut == NULL) {
     return ARES_EFORMERR;
@@ -118,8 +118,8 @@ ares_status_t ares_thread_cond_wait(ares_thread_cond_t  *cond,
 }
 
 ares_status_t ares_thread_cond_timedwait(ares_thread_cond_t  *cond,
-                                          ares_thread_mutex_t *mut,
-                                          unsigned long         timeout_ms)
+                                         ares_thread_mutex_t *mut,
+                                         unsigned long        timeout_ms)
 {
   if (cond == NULL || mut == NULL) {
     return ARES_EFORMERR;
@@ -151,7 +151,7 @@ static DWORD WINAPI ares_thread_func(LPVOID lpParameter)
 }
 
 ares_status_t ares_thread_create(ares_thread_t    **thread,
-                                  ares_thread_func_t func, void *arg)
+                                 ares_thread_func_t func, void *arg)
 {
   ares_thread_t *thr = NULL;
 
@@ -217,7 +217,7 @@ struct ares_thread_mutex {
 
 ares_thread_mutex_t *ares_thread_mutex_create(void)
 {
-  pthread_mutexattr_t   attr;
+  pthread_mutexattr_t  attr;
   ares_thread_mutex_t *mut = ares_malloc_zero(sizeof(*mut));
   if (mut == NULL) {
     return NULL;
@@ -312,7 +312,7 @@ void ares_thread_cond_broadcast(ares_thread_cond_t *cond)
 }
 
 ares_status_t ares_thread_cond_wait(ares_thread_cond_t  *cond,
-                                     ares_thread_mutex_t *mut)
+                                    ares_thread_mutex_t *mut)
 {
   if (cond == NULL || mut == NULL) {
     return ARES_EFORMERR;
@@ -346,8 +346,8 @@ static void ares_timespec_timeout(struct timespec *ts, unsigned long add_ms)
 }
 
 ares_status_t ares_thread_cond_timedwait(ares_thread_cond_t  *cond,
-                                          ares_thread_mutex_t *mut,
-                                          unsigned long         timeout_ms)
+                                         ares_thread_mutex_t *mut,
+                                         unsigned long        timeout_ms)
 {
   struct timespec ts;
 
@@ -369,7 +369,7 @@ struct ares_thread {
 };
 
 ares_status_t ares_thread_create(ares_thread_t    **thread,
-                                  ares_thread_func_t func, void *arg)
+                                 ares_thread_func_t func, void *arg)
 {
   ares_thread_t *thr = NULL;
 
@@ -461,7 +461,7 @@ void ares_thread_cond_broadcast(ares_thread_cond_t *cond)
 }
 
 ares_status_t ares_thread_cond_wait(ares_thread_cond_t  *cond,
-                                     ares_thread_mutex_t *mut)
+                                    ares_thread_mutex_t *mut)
 {
   (void)cond;
   (void)mut;
@@ -469,8 +469,8 @@ ares_status_t ares_thread_cond_wait(ares_thread_cond_t  *cond,
 }
 
 ares_status_t ares_thread_cond_timedwait(ares_thread_cond_t  *cond,
-                                          ares_thread_mutex_t *mut,
-                                          unsigned long         timeout_ms)
+                                         ares_thread_mutex_t *mut,
+                                         unsigned long        timeout_ms)
 {
   (void)cond;
   (void)mut;
@@ -479,7 +479,7 @@ ares_status_t ares_thread_cond_timedwait(ares_thread_cond_t  *cond,
 }
 
 ares_status_t ares_thread_create(ares_thread_t    **thread,
-                                  ares_thread_func_t func, void *arg)
+                                 ares_thread_func_t func, void *arg)
 {
   (void)thread;
   (void)func;

--- a/src/lib/util/ares_threads.h
+++ b/src/lib/util/ares_threads.h
@@ -26,35 +26,35 @@
 #ifndef __ARES__THREADS_H
 #define __ARES__THREADS_H
 
-struct ares__thread_mutex;
-typedef struct ares__thread_mutex ares__thread_mutex_t;
+struct ares_thread_mutex;
+typedef struct ares_thread_mutex ares_thread_mutex_t;
 
-ares__thread_mutex_t             *ares__thread_mutex_create(void);
-void ares__thread_mutex_destroy(ares__thread_mutex_t *mut);
-void ares__thread_mutex_lock(ares__thread_mutex_t *mut);
-void ares__thread_mutex_unlock(ares__thread_mutex_t *mut);
+ares_thread_mutex_t             *ares_thread_mutex_create(void);
+void ares_thread_mutex_destroy(ares_thread_mutex_t *mut);
+void ares_thread_mutex_lock(ares_thread_mutex_t *mut);
+void ares_thread_mutex_unlock(ares_thread_mutex_t *mut);
 
 
-struct ares__thread_cond;
-typedef struct ares__thread_cond ares__thread_cond_t;
+struct ares_thread_cond;
+typedef struct ares_thread_cond ares_thread_cond_t;
 
-ares__thread_cond_t             *ares__thread_cond_create(void);
-void          ares__thread_cond_destroy(ares__thread_cond_t *cond);
-void          ares__thread_cond_signal(ares__thread_cond_t *cond);
-void          ares__thread_cond_broadcast(ares__thread_cond_t *cond);
-ares_status_t ares__thread_cond_wait(ares__thread_cond_t  *cond,
-                                     ares__thread_mutex_t *mut);
-ares_status_t ares__thread_cond_timedwait(ares__thread_cond_t  *cond,
-                                          ares__thread_mutex_t *mut,
+ares_thread_cond_t             *ares_thread_cond_create(void);
+void          ares_thread_cond_destroy(ares_thread_cond_t *cond);
+void          ares_thread_cond_signal(ares_thread_cond_t *cond);
+void          ares_thread_cond_broadcast(ares_thread_cond_t *cond);
+ares_status_t ares_thread_cond_wait(ares_thread_cond_t  *cond,
+                                     ares_thread_mutex_t *mut);
+ares_status_t ares_thread_cond_timedwait(ares_thread_cond_t  *cond,
+                                          ares_thread_mutex_t *mut,
                                           unsigned long         timeout_ms);
 
 
-struct ares__thread;
-typedef struct ares__thread ares__thread_t;
+struct ares_thread;
+typedef struct ares_thread ares_thread_t;
 
-typedef void *(*ares__thread_func_t)(void *arg);
-ares_status_t ares__thread_create(ares__thread_t    **thread,
-                                  ares__thread_func_t func, void *arg);
-ares_status_t ares__thread_join(ares__thread_t *thread, void **rv);
+typedef void *(*ares_thread_func_t)(void *arg);
+ares_status_t ares_thread_create(ares_thread_t    **thread,
+                                  ares_thread_func_t func, void *arg);
+ares_status_t ares_thread_join(ares_thread_t *thread, void **rv);
 
 #endif

--- a/src/lib/util/ares_threads.h
+++ b/src/lib/util/ares_threads.h
@@ -43,10 +43,10 @@ void          ares_thread_cond_destroy(ares_thread_cond_t *cond);
 void          ares_thread_cond_signal(ares_thread_cond_t *cond);
 void          ares_thread_cond_broadcast(ares_thread_cond_t *cond);
 ares_status_t ares_thread_cond_wait(ares_thread_cond_t  *cond,
-                                     ares_thread_mutex_t *mut);
+                                    ares_thread_mutex_t *mut);
 ares_status_t ares_thread_cond_timedwait(ares_thread_cond_t  *cond,
-                                          ares_thread_mutex_t *mut,
-                                          unsigned long         timeout_ms);
+                                         ares_thread_mutex_t *mut,
+                                         unsigned long        timeout_ms);
 
 
 struct ares_thread;
@@ -54,7 +54,7 @@ typedef struct ares_thread ares_thread_t;
 
 typedef void *(*ares_thread_func_t)(void *arg);
 ares_status_t ares_thread_create(ares_thread_t    **thread,
-                                  ares_thread_func_t func, void *arg);
+                                 ares_thread_func_t func, void *arg);
 ares_status_t ares_thread_join(ares_thread_t *thread, void **rv);
 
 #endif

--- a/src/lib/util/ares_time.h
+++ b/src/lib/util/ares_time.h
@@ -35,14 +35,14 @@ typedef struct {
 } ares_timeval_t;
 
 /* return true if now is exactly check time or later */
-ares_bool_t ares__timedout(const ares_timeval_t *now,
+ares_bool_t ares_timedout(const ares_timeval_t *now,
                            const ares_timeval_t *check);
 
-void        ares__tvnow(ares_timeval_t *now);
-void        ares__timeval_remaining(ares_timeval_t       *remaining,
+void        ares_tvnow(ares_timeval_t *now);
+void        ares_timeval_remaining(ares_timeval_t       *remaining,
                                     const ares_timeval_t *now,
                                     const ares_timeval_t *tout);
-void ares__timeval_diff(ares_timeval_t *tvdiff, const ares_timeval_t *tvstart,
+void ares_timeval_diff(ares_timeval_t *tvdiff, const ares_timeval_t *tvstart,
                         const ares_timeval_t *tvstop);
 
 #endif

--- a/src/lib/util/ares_time.h
+++ b/src/lib/util/ares_time.h
@@ -36,13 +36,13 @@ typedef struct {
 
 /* return true if now is exactly check time or later */
 ares_bool_t ares_timedout(const ares_timeval_t *now,
-                           const ares_timeval_t *check);
+                          const ares_timeval_t *check);
 
 void        ares_tvnow(ares_timeval_t *now);
 void        ares_timeval_remaining(ares_timeval_t       *remaining,
-                                    const ares_timeval_t *now,
-                                    const ares_timeval_t *tout);
+                                   const ares_timeval_t *now,
+                                   const ares_timeval_t *tout);
 void ares_timeval_diff(ares_timeval_t *tvdiff, const ares_timeval_t *tvstart,
-                        const ares_timeval_t *tvstop);
+                       const ares_timeval_t *tvstop);
 
 #endif

--- a/src/lib/util/ares_timeval.c
+++ b/src/lib/util/ares_timeval.c
@@ -28,7 +28,7 @@
 
 #if defined(_WIN32) && !defined(MSDOS)
 
-void ares__tvnow(ares_timeval_t *now)
+void ares_tvnow(ares_timeval_t *now)
 {
   /* QueryPerformanceCounters() has been around since Windows 2000, though
    * significant fixes were made in later versions.  Documentation states
@@ -52,7 +52,7 @@ void ares__tvnow(ares_timeval_t *now)
 
 #elif defined(HAVE_CLOCK_GETTIME_MONOTONIC)
 
-void ares__tvnow(ares_timeval_t *now)
+void ares_tvnow(ares_timeval_t *now)
 {
   /* clock_gettime() is guaranteed to be increased monotonically when the
    * monotonic clock is queried. Time starting point is unspecified, it
@@ -76,7 +76,7 @@ void ares__tvnow(ares_timeval_t *now)
 
 #elif defined(HAVE_GETTIMEOFDAY)
 
-void ares__tvnow(ares_timeval_t *now)
+void ares_tvnow(ares_timeval_t *now)
 {
   /* gettimeofday() is not granted to be increased monotonically, due to
    * clock drifting and external source time synchronization it can jump

--- a/src/tools/adig.c
+++ b/src/tools/adig.c
@@ -289,7 +289,7 @@ static ares_bool_t read_rcfile(adig_config_t *config)
 
   size_t        rcargc;
   char        **rcargv;
-  ares_buf_t  *rcbuf;
+  ares_buf_t   *rcbuf;
   ares_status_t rcstatus;
 
 #if defined(WIN32)
@@ -339,7 +339,7 @@ static ares_bool_t read_rcfile(adig_config_t *config)
   rcbuf = ares_buf_create();
   if (ares_buf_load_file(rcfile, rcbuf) == ARES_SUCCESS) {
     rcstatus = ares_buf_split_str(rcbuf, (const unsigned char *)"\n ", 2,
-                                   ARES_BUF_SPLIT_TRIM, 0, &rcargv, &rcargc);
+                                  ARES_BUF_SPLIT_TRIM, 0, &rcargv, &rcargc);
 
     if (rcstatus == ARES_SUCCESS) {
       read_cmdline((int)rcargc, (const char * const *)rcargv, config,

--- a/src/tools/adig.c
+++ b/src/tools/adig.c
@@ -43,8 +43,8 @@
 #endif
 
 #include "ares.h"
-#include "ares__array.h"
-#include "ares__buf.h"
+#include "ares_array.h"
+#include "ares_buf.h"
 #include "ares_dns.h"
 #include "ares_getopt.h"
 #include "ares_mem.h"
@@ -289,7 +289,7 @@ static ares_bool_t read_rcfile(adig_config_t *config)
 
   size_t        rcargc;
   char        **rcargv;
-  ares__buf_t  *rcbuf;
+  ares_buf_t  *rcbuf;
   ares_status_t rcstatus;
 
 #if defined(WIN32)
@@ -336,9 +336,9 @@ static ares_bool_t read_rcfile(adig_config_t *config)
     return ARES_TRUE;
   }
 
-  rcbuf = ares__buf_create();
-  if (ares__buf_load_file(rcfile, rcbuf) == ARES_SUCCESS) {
-    rcstatus = ares__buf_split_str(rcbuf, (const unsigned char *)"\n ", 2,
+  rcbuf = ares_buf_create();
+  if (ares_buf_load_file(rcfile, rcbuf) == ARES_SUCCESS) {
+    rcstatus = ares_buf_split_str(rcbuf, (const unsigned char *)"\n ", 2,
                                    ARES_BUF_SPLIT_TRIM, 0, &rcargv, &rcargc);
 
     if (rcstatus == ARES_SUCCESS) {
@@ -353,14 +353,14 @@ static ares_bool_t read_rcfile(adig_config_t *config)
     ares_free_array(rcargv, rcargc, ares_free);
 
     if (rcstatus != ARES_SUCCESS) {
-      ares__buf_destroy(rcbuf);
+      ares_buf_destroy(rcbuf);
       return ARES_FALSE;
     }
 
   } else {
     DEBUGF(fprintf(stderr, "read_cmdline() failed to load rcfile"));
   }
-  ares__buf_destroy(rcbuf);
+  ares_buf_destroy(rcbuf);
 
   return ARES_TRUE;
 }

--- a/test/ares-test-fuzz.c
+++ b/test/ares-test-fuzz.c
@@ -26,7 +26,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include "ares.h"
-#include "include/ares__buf.h"
+#include "include/ares_buf.h"
 #include "include/ares_mem.h"
 
 int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size);
@@ -130,7 +130,7 @@ int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
 {
   ares_dns_record_t *dnsrec      = NULL;
   char              *printdata   = NULL;
-  ares__buf_t       *printmsg    = NULL;
+  ares_buf_t       *printmsg    = NULL;
   size_t             i;
   unsigned char     *datadup     = NULL;
   size_t             datadup_len = 0;
@@ -146,29 +146,29 @@ int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
   }
 
   /* Lets test the message fetchers */
-  printmsg = ares__buf_create();
+  printmsg = ares_buf_create();
   if (printmsg == NULL) {
     goto done;
   }
 
-  ares__buf_append_str(printmsg, ";; ->>HEADER<<- opcode: ");
-  ares__buf_append_str(printmsg, ares_dns_opcode_tostr(ares_dns_record_get_opcode(dnsrec)));
-  ares__buf_append_str(printmsg, ", status: ");
-  ares__buf_append_str(printmsg, ares_dns_rcode_tostr(ares_dns_record_get_rcode(dnsrec)));
-  ares__buf_append_str(printmsg, ", id: ");
-  ares__buf_append_num_dec(printmsg, (size_t)ares_dns_record_get_id(dnsrec), 0);
-  ares__buf_append_str(printmsg, "\n;; flags: ");
-  ares__buf_append_num_hex(printmsg, (size_t)ares_dns_record_get_flags(dnsrec), 0);
-  ares__buf_append_str(printmsg, "; QUERY: ");
-  ares__buf_append_num_dec(printmsg, ares_dns_record_query_cnt(dnsrec), 0);
-  ares__buf_append_str(printmsg, ", ANSWER: ");
-  ares__buf_append_num_dec(printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ANSWER), 0);
-  ares__buf_append_str(printmsg, ", AUTHORITY: ");
-  ares__buf_append_num_dec(printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_AUTHORITY), 0);
-  ares__buf_append_str(printmsg, ", ADDITIONAL: ");
-  ares__buf_append_num_dec(printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ADDITIONAL), 0);
-  ares__buf_append_str(printmsg, "\n\n");
-  ares__buf_append_str(printmsg, ";; QUESTION SECTION:\n");
+  ares_buf_append_str(printmsg, ";; ->>HEADER<<- opcode: ");
+  ares_buf_append_str(printmsg, ares_dns_opcode_tostr(ares_dns_record_get_opcode(dnsrec)));
+  ares_buf_append_str(printmsg, ", status: ");
+  ares_buf_append_str(printmsg, ares_dns_rcode_tostr(ares_dns_record_get_rcode(dnsrec)));
+  ares_buf_append_str(printmsg, ", id: ");
+  ares_buf_append_num_dec(printmsg, (size_t)ares_dns_record_get_id(dnsrec), 0);
+  ares_buf_append_str(printmsg, "\n;; flags: ");
+  ares_buf_append_num_hex(printmsg, (size_t)ares_dns_record_get_flags(dnsrec), 0);
+  ares_buf_append_str(printmsg, "; QUERY: ");
+  ares_buf_append_num_dec(printmsg, ares_dns_record_query_cnt(dnsrec), 0);
+  ares_buf_append_str(printmsg, ", ANSWER: ");
+  ares_buf_append_num_dec(printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ANSWER), 0);
+  ares_buf_append_str(printmsg, ", AUTHORITY: ");
+  ares_buf_append_num_dec(printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_AUTHORITY), 0);
+  ares_buf_append_str(printmsg, ", ADDITIONAL: ");
+  ares_buf_append_num_dec(printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ADDITIONAL), 0);
+  ares_buf_append_str(printmsg, "\n\n");
+  ares_buf_append_str(printmsg, ";; QUESTION SECTION:\n");
   for (i = 0; i < ares_dns_record_query_cnt(dnsrec); i++) {
     const char         *name;
     ares_dns_rec_type_t qtype;
@@ -178,21 +178,21 @@ int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
       goto done;
     }
 
-    ares__buf_append_str(printmsg, ";");
-    ares__buf_append_str(printmsg, name);
-    ares__buf_append_str(printmsg, ".\t\t\t");
-    ares__buf_append_str(printmsg, ares_dns_class_tostr(qclass));
-    ares__buf_append_str(printmsg, "\t");
-    ares__buf_append_str(printmsg, ares_dns_rec_type_tostr(qtype));
-    ares__buf_append_str(printmsg, "\n");
+    ares_buf_append_str(printmsg, ";");
+    ares_buf_append_str(printmsg, name);
+    ares_buf_append_str(printmsg, ".\t\t\t");
+    ares_buf_append_str(printmsg, ares_dns_class_tostr(qclass));
+    ares_buf_append_str(printmsg, "\t");
+    ares_buf_append_str(printmsg, ares_dns_rec_type_tostr(qtype));
+    ares_buf_append_str(printmsg, "\n");
   }
-  ares__buf_append_str(printmsg, "\n");
+  ares_buf_append_str(printmsg, "\n");
   for (i = ARES_SECTION_ANSWER; i < ARES_SECTION_ADDITIONAL + 1; i++) {
     size_t j;
 
-    ares__buf_append_str(printmsg, ";; ");
-    ares__buf_append_str(printmsg, ares_dns_section_tostr((ares_dns_section_t)i));
-    ares__buf_append_str(printmsg, " SECTION:\n");
+    ares_buf_append_str(printmsg, ";; ");
+    ares_buf_append_str(printmsg, ares_dns_section_tostr((ares_dns_section_t)i));
+    ares_buf_append_str(printmsg, " SECTION:\n");
     for (j = 0; j < ares_dns_record_rr_cnt(dnsrec, (ares_dns_section_t)i); j++) {
       size_t                   keys_cnt = 0;
       const ares_dns_rr_key_t *keys     = NULL;
@@ -200,44 +200,44 @@ int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
       size_t                   k;
 
       rr = ares_dns_record_rr_get(dnsrec, (ares_dns_section_t)i, j);
-      ares__buf_append_str(printmsg, ares_dns_rr_get_name(rr));
-      ares__buf_append_str(printmsg, ".\t\t\t");
-      ares__buf_append_str(printmsg, ares_dns_class_tostr(ares_dns_rr_get_class(rr)));
-      ares__buf_append_str(printmsg, "\t");
-      ares__buf_append_str(printmsg, ares_dns_rec_type_tostr(ares_dns_rr_get_type(rr)));
-      ares__buf_append_str(printmsg, "\t");
-      ares__buf_append_num_dec(printmsg, ares_dns_rr_get_ttl(rr), 0);
-      ares__buf_append_str(printmsg, "\t");
+      ares_buf_append_str(printmsg, ares_dns_rr_get_name(rr));
+      ares_buf_append_str(printmsg, ".\t\t\t");
+      ares_buf_append_str(printmsg, ares_dns_class_tostr(ares_dns_rr_get_class(rr)));
+      ares_buf_append_str(printmsg, "\t");
+      ares_buf_append_str(printmsg, ares_dns_rec_type_tostr(ares_dns_rr_get_type(rr)));
+      ares_buf_append_str(printmsg, "\t");
+      ares_buf_append_num_dec(printmsg, ares_dns_rr_get_ttl(rr), 0);
+      ares_buf_append_str(printmsg, "\t");
 
       keys = ares_dns_rr_get_keys(ares_dns_rr_get_type(rr), &keys_cnt);
       for (k = 0; k<keys_cnt; k++) {
         char buf[256] = "";
 
-        ares__buf_append_str(printmsg, ares_dns_rr_key_tostr(keys[k]));
-        ares__buf_append_str(printmsg, "=");
+        ares_buf_append_str(printmsg, ares_dns_rr_key_tostr(keys[k]));
+        ares_buf_append_str(printmsg, "=");
         switch (ares_dns_rr_key_datatype(keys[k])) {
           case ARES_DATATYPE_INADDR:
             ares_inet_ntop(AF_INET, ares_dns_rr_get_addr(rr, keys[k]), buf, sizeof(buf));
-            ares__buf_append_str(printmsg, buf);
+            ares_buf_append_str(printmsg, buf);
             break;
           case ARES_DATATYPE_INADDR6:
             ares_inet_ntop(AF_INET6, ares_dns_rr_get_addr6(rr, keys[k]), buf, sizeof(buf));
-            ares__buf_append_str(printmsg, buf);
+            ares_buf_append_str(printmsg, buf);
             break;
           case ARES_DATATYPE_U8:
-            ares__buf_append_num_dec(printmsg, ares_dns_rr_get_u8(rr, keys[k]), 0);
+            ares_buf_append_num_dec(printmsg, ares_dns_rr_get_u8(rr, keys[k]), 0);
             break;
           case ARES_DATATYPE_U16:
-            ares__buf_append_num_dec(printmsg, ares_dns_rr_get_u16(rr, keys[k]), 0);
+            ares_buf_append_num_dec(printmsg, ares_dns_rr_get_u16(rr, keys[k]), 0);
             break;
           case ARES_DATATYPE_U32:
-            ares__buf_append_num_dec(printmsg, ares_dns_rr_get_u32(rr, keys[k]), 0);
+            ares_buf_append_num_dec(printmsg, ares_dns_rr_get_u32(rr, keys[k]), 0);
             break;
           case ARES_DATATYPE_NAME:
           case ARES_DATATYPE_STR:
-            ares__buf_append_byte(printmsg, '"');
-            ares__buf_append_str(printmsg, ares_dns_rr_get_str(rr, keys[k]));
-            ares__buf_append_byte(printmsg, '"');
+            ares_buf_append_byte(printmsg, '"');
+            ares_buf_append_str(printmsg, ares_dns_rr_get_str(rr, keys[k]));
+            ares_buf_append_byte(printmsg, '"');
             break;
           case ARES_DATATYPE_BIN:
             /* TODO */
@@ -245,9 +245,9 @@ int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
           case ARES_DATATYPE_BINP:
             {
               size_t templen;
-              ares__buf_append_byte(printmsg, '"');
-              ares__buf_append_str(printmsg, (const char *)ares_dns_rr_get_bin(rr, keys[k], &templen));
-              ares__buf_append_byte(printmsg, '"');
+              ares_buf_append_byte(printmsg, '"');
+              ares_buf_append_str(printmsg, (const char *)ares_dns_rr_get_bin(rr, keys[k], &templen));
+              ares_buf_append_byte(printmsg, '"');
             }
             break;
           case ARES_DATATYPE_ABINP:
@@ -257,11 +257,11 @@ int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
                 size_t templen;
 
                 if (a != 0) {
-                  ares__buf_append_byte(printmsg, ' ');
+                  ares_buf_append_byte(printmsg, ' ');
                 }
-                ares__buf_append_byte(printmsg, '"');
-                ares__buf_append_str(printmsg, (const char *)ares_dns_rr_get_abin(rr, keys[k], a, &templen));
-                ares__buf_append_byte(printmsg, '"');
+                ares_buf_append_byte(printmsg, '"');
+                ares_buf_append_str(printmsg, (const char *)ares_dns_rr_get_abin(rr, keys[k], a, &templen));
+                ares_buf_append_byte(printmsg, '"');
               }
             }
             break;
@@ -269,16 +269,16 @@ int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
             /* TODO */
             break;
         }
-        ares__buf_append_str(printmsg, " ");
+        ares_buf_append_str(printmsg, " ");
       }
-      ares__buf_append_str(printmsg, "\n");
+      ares_buf_append_str(printmsg, "\n");
     }
   }
-  ares__buf_append_str(printmsg, ";; SIZE: ");
-  ares__buf_append_num_dec(printmsg, size, 0);
-  ares__buf_append_str(printmsg, "\n\n");
+  ares_buf_append_str(printmsg, ";; SIZE: ");
+  ares_buf_append_num_dec(printmsg, size, 0);
+  ares_buf_append_str(printmsg, "\n\n");
 
-  printdata = ares__buf_finish_str(printmsg, NULL);
+  printdata = ares_buf_finish_str(printmsg, NULL);
   printmsg  = NULL;
 
   /* Write it back out as a dns message to test writer */
@@ -288,7 +288,7 @@ int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
 
 done:
   ares_dns_record_destroy(dnsrec);
-  ares__buf_destroy(printmsg);
+  ares_buf_destroy(printmsg);
   ares_free(printdata);
   ares_free(datadup);
   return 0;

--- a/test/ares-test-fuzz.c
+++ b/test/ares-test-fuzz.c
@@ -128,9 +128,9 @@ int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
 
 int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
 {
-  ares_dns_record_t *dnsrec      = NULL;
-  char              *printdata   = NULL;
-  ares_buf_t       *printmsg    = NULL;
+  ares_dns_record_t *dnsrec    = NULL;
+  char              *printdata = NULL;
+  ares_buf_t        *printmsg  = NULL;
   size_t             i;
   unsigned char     *datadup     = NULL;
   size_t             datadup_len = 0;
@@ -152,21 +152,27 @@ int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
   }
 
   ares_buf_append_str(printmsg, ";; ->>HEADER<<- opcode: ");
-  ares_buf_append_str(printmsg, ares_dns_opcode_tostr(ares_dns_record_get_opcode(dnsrec)));
+  ares_buf_append_str(
+    printmsg, ares_dns_opcode_tostr(ares_dns_record_get_opcode(dnsrec)));
   ares_buf_append_str(printmsg, ", status: ");
-  ares_buf_append_str(printmsg, ares_dns_rcode_tostr(ares_dns_record_get_rcode(dnsrec)));
+  ares_buf_append_str(printmsg,
+                      ares_dns_rcode_tostr(ares_dns_record_get_rcode(dnsrec)));
   ares_buf_append_str(printmsg, ", id: ");
   ares_buf_append_num_dec(printmsg, (size_t)ares_dns_record_get_id(dnsrec), 0);
   ares_buf_append_str(printmsg, "\n;; flags: ");
-  ares_buf_append_num_hex(printmsg, (size_t)ares_dns_record_get_flags(dnsrec), 0);
+  ares_buf_append_num_hex(printmsg, (size_t)ares_dns_record_get_flags(dnsrec),
+                          0);
   ares_buf_append_str(printmsg, "; QUERY: ");
   ares_buf_append_num_dec(printmsg, ares_dns_record_query_cnt(dnsrec), 0);
   ares_buf_append_str(printmsg, ", ANSWER: ");
-  ares_buf_append_num_dec(printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ANSWER), 0);
+  ares_buf_append_num_dec(
+    printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ANSWER), 0);
   ares_buf_append_str(printmsg, ", AUTHORITY: ");
-  ares_buf_append_num_dec(printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_AUTHORITY), 0);
+  ares_buf_append_num_dec(
+    printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_AUTHORITY), 0);
   ares_buf_append_str(printmsg, ", ADDITIONAL: ");
-  ares_buf_append_num_dec(printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ADDITIONAL), 0);
+  ares_buf_append_num_dec(
+    printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ADDITIONAL), 0);
   ares_buf_append_str(printmsg, "\n\n");
   ares_buf_append_str(printmsg, ";; QUESTION SECTION:\n");
   for (i = 0; i < ares_dns_record_query_cnt(dnsrec); i++) {
@@ -174,7 +180,8 @@ int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
     ares_dns_rec_type_t qtype;
     ares_dns_class_t    qclass;
 
-    if (ares_dns_record_query_get(dnsrec, i, &name, &qtype, &qclass) != ARES_SUCCESS) {
+    if (ares_dns_record_query_get(dnsrec, i, &name, &qtype, &qclass) !=
+        ARES_SUCCESS) {
       goto done;
     }
 
@@ -191,9 +198,11 @@ int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
     size_t j;
 
     ares_buf_append_str(printmsg, ";; ");
-    ares_buf_append_str(printmsg, ares_dns_section_tostr((ares_dns_section_t)i));
+    ares_buf_append_str(printmsg,
+                        ares_dns_section_tostr((ares_dns_section_t)i));
     ares_buf_append_str(printmsg, " SECTION:\n");
-    for (j = 0; j < ares_dns_record_rr_cnt(dnsrec, (ares_dns_section_t)i); j++) {
+    for (j = 0; j < ares_dns_record_rr_cnt(dnsrec, (ares_dns_section_t)i);
+         j++) {
       size_t                   keys_cnt = 0;
       const ares_dns_rr_key_t *keys     = NULL;
       ares_dns_rr_t           *rr       = NULL;
@@ -202,36 +211,43 @@ int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
       rr = ares_dns_record_rr_get(dnsrec, (ares_dns_section_t)i, j);
       ares_buf_append_str(printmsg, ares_dns_rr_get_name(rr));
       ares_buf_append_str(printmsg, ".\t\t\t");
-      ares_buf_append_str(printmsg, ares_dns_class_tostr(ares_dns_rr_get_class(rr)));
+      ares_buf_append_str(printmsg,
+                          ares_dns_class_tostr(ares_dns_rr_get_class(rr)));
       ares_buf_append_str(printmsg, "\t");
-      ares_buf_append_str(printmsg, ares_dns_rec_type_tostr(ares_dns_rr_get_type(rr)));
+      ares_buf_append_str(printmsg,
+                          ares_dns_rec_type_tostr(ares_dns_rr_get_type(rr)));
       ares_buf_append_str(printmsg, "\t");
       ares_buf_append_num_dec(printmsg, ares_dns_rr_get_ttl(rr), 0);
       ares_buf_append_str(printmsg, "\t");
 
       keys = ares_dns_rr_get_keys(ares_dns_rr_get_type(rr), &keys_cnt);
-      for (k = 0; k<keys_cnt; k++) {
+      for (k = 0; k < keys_cnt; k++) {
         char buf[256] = "";
 
         ares_buf_append_str(printmsg, ares_dns_rr_key_tostr(keys[k]));
         ares_buf_append_str(printmsg, "=");
         switch (ares_dns_rr_key_datatype(keys[k])) {
           case ARES_DATATYPE_INADDR:
-            ares_inet_ntop(AF_INET, ares_dns_rr_get_addr(rr, keys[k]), buf, sizeof(buf));
+            ares_inet_ntop(AF_INET, ares_dns_rr_get_addr(rr, keys[k]), buf,
+                           sizeof(buf));
             ares_buf_append_str(printmsg, buf);
             break;
           case ARES_DATATYPE_INADDR6:
-            ares_inet_ntop(AF_INET6, ares_dns_rr_get_addr6(rr, keys[k]), buf, sizeof(buf));
+            ares_inet_ntop(AF_INET6, ares_dns_rr_get_addr6(rr, keys[k]), buf,
+                           sizeof(buf));
             ares_buf_append_str(printmsg, buf);
             break;
           case ARES_DATATYPE_U8:
-            ares_buf_append_num_dec(printmsg, ares_dns_rr_get_u8(rr, keys[k]), 0);
+            ares_buf_append_num_dec(printmsg, ares_dns_rr_get_u8(rr, keys[k]),
+                                    0);
             break;
           case ARES_DATATYPE_U16:
-            ares_buf_append_num_dec(printmsg, ares_dns_rr_get_u16(rr, keys[k]), 0);
+            ares_buf_append_num_dec(printmsg, ares_dns_rr_get_u16(rr, keys[k]),
+                                    0);
             break;
           case ARES_DATATYPE_U32:
-            ares_buf_append_num_dec(printmsg, ares_dns_rr_get_u32(rr, keys[k]), 0);
+            ares_buf_append_num_dec(printmsg, ares_dns_rr_get_u32(rr, keys[k]),
+                                    0);
             break;
           case ARES_DATATYPE_NAME:
           case ARES_DATATYPE_STR:
@@ -246,21 +262,24 @@ int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
             {
               size_t templen;
               ares_buf_append_byte(printmsg, '"');
-              ares_buf_append_str(printmsg, (const char *)ares_dns_rr_get_bin(rr, keys[k], &templen));
+              ares_buf_append_str(printmsg, (const char *)ares_dns_rr_get_bin(
+                                              rr, keys[k], &templen));
               ares_buf_append_byte(printmsg, '"');
             }
             break;
           case ARES_DATATYPE_ABINP:
             {
               size_t a;
-              for (a=0; a<ares_dns_rr_get_abin_cnt(rr, keys[k]); a++) {
+              for (a = 0; a < ares_dns_rr_get_abin_cnt(rr, keys[k]); a++) {
                 size_t templen;
 
                 if (a != 0) {
                   ares_buf_append_byte(printmsg, ' ');
                 }
                 ares_buf_append_byte(printmsg, '"');
-                ares_buf_append_str(printmsg, (const char *)ares_dns_rr_get_abin(rr, keys[k], a, &templen));
+                ares_buf_append_str(
+                  printmsg,
+                  (const char *)ares_dns_rr_get_abin(rr, keys[k], a, &templen));
                 ares_buf_append_byte(printmsg, '"');
               }
             }

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -46,7 +46,7 @@ extern "C" {
 #include "ares_inet_net_pton.h"
 #include "ares_data.h"
 #include "str/ares_strsplit.h"
-#include "dsa/ares__htable.h"
+#include "dsa/ares_htable.h"
 
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
@@ -96,7 +96,7 @@ TEST_F(LibraryTest, Strsplit) {
     },
   };
   for(size_t i = 0; i < data.inputs.size(); i++) {
-    char **out = ares__strsplit(data.inputs.at(i).c_str(),
+    char **out = ares_strsplit(data.inputs.at(i).c_str(),
                                data.delimiters.at(i).c_str(), &n);
     if(data.expected.at(i).size() == 0) {
       EXPECT_EQ(out, nullptr);
@@ -107,7 +107,7 @@ TEST_F(LibraryTest, Strsplit) {
         EXPECT_STREQ(out[j], data.expected.at(i).at(j).c_str());
       }
     }
-    ares__strsplit_free(out, n);
+    ares_strsplit_free(out, n);
   }
 }
 
@@ -234,55 +234,55 @@ TEST_F(LibraryTest, MallocDataFail) {
 }
 
 TEST(Misc, OnionDomain) {
-  EXPECT_EQ(0, ares__is_onion_domain("onion.no"));
-  EXPECT_EQ(0, ares__is_onion_domain(".onion.no"));
-  EXPECT_EQ(1, ares__is_onion_domain(".onion"));
-  EXPECT_EQ(1, ares__is_onion_domain(".onion."));
-  EXPECT_EQ(1, ares__is_onion_domain("yes.onion"));
-  EXPECT_EQ(1, ares__is_onion_domain("yes.onion."));
-  EXPECT_EQ(1, ares__is_onion_domain("YES.ONION"));
-  EXPECT_EQ(1, ares__is_onion_domain("YES.ONION."));
+  EXPECT_EQ(0, ares_is_onion_domain("onion.no"));
+  EXPECT_EQ(0, ares_is_onion_domain(".onion.no"));
+  EXPECT_EQ(1, ares_is_onion_domain(".onion"));
+  EXPECT_EQ(1, ares_is_onion_domain(".onion."));
+  EXPECT_EQ(1, ares_is_onion_domain("yes.onion"));
+  EXPECT_EQ(1, ares_is_onion_domain("yes.onion."));
+  EXPECT_EQ(1, ares_is_onion_domain("YES.ONION"));
+  EXPECT_EQ(1, ares_is_onion_domain("YES.ONION."));
 }
 
 TEST_F(LibraryTest, CatDomain) {
   char *s;
 
-  ares__cat_domain("foo", "example.net", &s);
+  ares_cat_domain("foo", "example.net", &s);
   EXPECT_STREQ("foo.example.net", s);
   ares_free(s);
 
-  ares__cat_domain("foo", ".", &s);
+  ares_cat_domain("foo", ".", &s);
   EXPECT_STREQ("foo.", s);
   ares_free(s);
 
-  ares__cat_domain("foo", "example.net.", &s);
+  ares_cat_domain("foo", "example.net.", &s);
   EXPECT_STREQ("foo.example.net.", s);
   ares_free(s);
 }
 
 TEST_F(LibraryTest, SlistMisuse) {
-  EXPECT_EQ(NULL, ares__slist_create(NULL, NULL, NULL));
-  ares__slist_replace_destructor(NULL, NULL);
-  EXPECT_EQ(NULL, ares__slist_insert(NULL, NULL));
-  EXPECT_EQ(NULL, ares__slist_node_find(NULL, NULL));
-  EXPECT_EQ(NULL, ares__slist_node_first(NULL));
-  EXPECT_EQ(NULL, ares__slist_node_last(NULL));
-  EXPECT_EQ(NULL, ares__slist_node_next(NULL));
-  EXPECT_EQ(NULL, ares__slist_node_prev(NULL));
-  EXPECT_EQ(NULL, ares__slist_node_val(NULL));
-  EXPECT_EQ((size_t)0, ares__slist_len(NULL));
-  EXPECT_EQ(NULL, ares__slist_node_parent(NULL));
-  EXPECT_EQ(NULL, ares__slist_first_val(NULL));
-  EXPECT_EQ(NULL, ares__slist_last_val(NULL));
-  EXPECT_EQ(NULL, ares__slist_node_claim(NULL));
+  EXPECT_EQ(NULL, ares_slist_create(NULL, NULL, NULL));
+  ares_slist_replace_destructor(NULL, NULL);
+  EXPECT_EQ(NULL, ares_slist_insert(NULL, NULL));
+  EXPECT_EQ(NULL, ares_slist_node_find(NULL, NULL));
+  EXPECT_EQ(NULL, ares_slist_node_first(NULL));
+  EXPECT_EQ(NULL, ares_slist_node_last(NULL));
+  EXPECT_EQ(NULL, ares_slist_node_next(NULL));
+  EXPECT_EQ(NULL, ares_slist_node_prev(NULL));
+  EXPECT_EQ(NULL, ares_slist_node_val(NULL));
+  EXPECT_EQ((size_t)0, ares_slist_len(NULL));
+  EXPECT_EQ(NULL, ares_slist_node_parent(NULL));
+  EXPECT_EQ(NULL, ares_slist_first_val(NULL));
+  EXPECT_EQ(NULL, ares_slist_last_val(NULL));
+  EXPECT_EQ(NULL, ares_slist_node_claim(NULL));
 }
 
 TEST_F(LibraryTest, IfaceIPs) {
   ares_status_t      status;
-  ares__iface_ips_t *ips = NULL;
+  ares_iface_ips_t *ips = NULL;
   size_t             i;
 
-  status = ares__iface_ips(&ips, ARES_IFACE_IP_DEFAULT, NULL);
+  status = ares_iface_ips(&ips, ARES_IFACE_IP_DEFAULT, NULL);
   EXPECT_TRUE(status == ARES_SUCCESS || status == ARES_ENOTIMP);
 
   /* Not implemented, can't run tests */
@@ -291,54 +291,54 @@ TEST_F(LibraryTest, IfaceIPs) {
 
   EXPECT_NE(nullptr, ips);
 
-  for (i=0; i<ares__iface_ips_cnt(ips); i++) {
-    const char *name = ares__iface_ips_get_name(ips, i);
+  for (i=0; i<ares_iface_ips_cnt(ips); i++) {
+    const char *name = ares_iface_ips_get_name(ips, i);
     EXPECT_NE(nullptr, name);
-    int flags = (int)ares__iface_ips_get_flags(ips, i);
+    int flags = (int)ares_iface_ips_get_flags(ips, i);
     EXPECT_NE(0, (int)flags);
-    EXPECT_NE(nullptr, ares__iface_ips_get_addr(ips, i));
-    EXPECT_NE(0, ares__iface_ips_get_netmask(ips, i));
+    EXPECT_NE(nullptr, ares_iface_ips_get_addr(ips, i));
+    EXPECT_NE(0, ares_iface_ips_get_netmask(ips, i));
     if (flags & ARES_IFACE_IP_LINKLOCAL && flags & ARES_IFACE_IP_V6) {
       /* Hmm, seems not to work at least on MacOS
-       * EXPECT_NE(0, ares__iface_ips_get_ll_scope(ips, i));
+       * EXPECT_NE(0, ares_iface_ips_get_ll_scope(ips, i));
        */
     } else {
-      EXPECT_EQ(0, ares__iface_ips_get_ll_scope(ips, i));
+      EXPECT_EQ(0, ares_iface_ips_get_ll_scope(ips, i));
     }
-    unsigned int idx = ares__if_nametoindex(name);
+    unsigned int idx = ares_if_nametoindex(name);
     EXPECT_NE(0, idx);
     char namebuf[256];
-    EXPECT_EQ(std::string(ares__if_indextoname(idx, namebuf, sizeof(namebuf))), std::string(name));
+    EXPECT_EQ(std::string(ares_if_indextoname(idx, namebuf, sizeof(namebuf))), std::string(name));
   }
 
 
   /* Negative checking */
-  ares__iface_ips_get_name(ips, ares__iface_ips_cnt(ips));
-  ares__iface_ips_get_flags(ips, ares__iface_ips_cnt(ips));
-  ares__iface_ips_get_addr(ips, ares__iface_ips_cnt(ips));
-  ares__iface_ips_get_netmask(ips, ares__iface_ips_cnt(ips));
-  ares__iface_ips_get_ll_scope(ips, ares__iface_ips_cnt(ips));
+  ares_iface_ips_get_name(ips, ares_iface_ips_cnt(ips));
+  ares_iface_ips_get_flags(ips, ares_iface_ips_cnt(ips));
+  ares_iface_ips_get_addr(ips, ares_iface_ips_cnt(ips));
+  ares_iface_ips_get_netmask(ips, ares_iface_ips_cnt(ips));
+  ares_iface_ips_get_ll_scope(ips, ares_iface_ips_cnt(ips));
 
-  ares__iface_ips(NULL, ARES_IFACE_IP_DEFAULT, NULL);
-  ares__iface_ips_cnt(NULL);
-  ares__iface_ips_get_name(NULL, 0);
-  ares__iface_ips_get_flags(NULL, 0);
-  ares__iface_ips_get_addr(NULL, 0);
-  ares__iface_ips_get_netmask(NULL, 0);
-  ares__iface_ips_get_ll_scope(NULL, 0);
-  ares__iface_ips_destroy(NULL);
-  ares__if_nametoindex(NULL);
-  ares__if_indextoname(0, NULL, 0);
+  ares_iface_ips(NULL, ARES_IFACE_IP_DEFAULT, NULL);
+  ares_iface_ips_cnt(NULL);
+  ares_iface_ips_get_name(NULL, 0);
+  ares_iface_ips_get_flags(NULL, 0);
+  ares_iface_ips_get_addr(NULL, 0);
+  ares_iface_ips_get_netmask(NULL, 0);
+  ares_iface_ips_get_ll_scope(NULL, 0);
+  ares_iface_ips_destroy(NULL);
+  ares_if_nametoindex(NULL);
+  ares_if_indextoname(0, NULL, 0);
 
-  ares__iface_ips_destroy(ips);
+  ares_iface_ips_destroy(ips);
 }
 
 TEST_F(LibraryTest, HtableMisuse) {
-  EXPECT_EQ(NULL, ares__htable_create(NULL, NULL, NULL, NULL));
-  EXPECT_EQ(ARES_FALSE, ares__htable_insert(NULL, NULL));
-  EXPECT_EQ(NULL, ares__htable_get(NULL, NULL));
-  EXPECT_EQ(ARES_FALSE, ares__htable_remove(NULL, NULL));
-  EXPECT_EQ((size_t)0, ares__htable_num_keys(NULL));
+  EXPECT_EQ(NULL, ares_htable_create(NULL, NULL, NULL, NULL));
+  EXPECT_EQ(ARES_FALSE, ares_htable_insert(NULL, NULL));
+  EXPECT_EQ(NULL, ares_htable_get(NULL, NULL));
+  EXPECT_EQ(ARES_FALSE, ares_htable_remove(NULL, NULL));
+  EXPECT_EQ((size_t)0, ares_htable_num_keys(NULL));
 }
 #endif /* !CARES_SYMBOL_HIDING */
 
@@ -769,9 +769,9 @@ TEST_F(LibraryTest, DNSRecord) {
   /* Write */
   EXPECT_EQ(ARES_SUCCESS, ares_dns_write(dnsrec, &msg, &msglen));
 
-  ares__buf_t *hexdump = ares__buf_create();
-  EXPECT_EQ(ARES_SUCCESS, ares__buf_hexdump(hexdump, msg, msglen));
-  char *hexdata = ares__buf_finish_str(hexdump, NULL);
+  ares_buf_t *hexdump = ares_buf_create();
+  EXPECT_EQ(ARES_SUCCESS, ares_buf_hexdump(hexdump, msg, msglen));
+  char *hexdata = ares_buf_finish_str(hexdump, NULL);
   //printf("HEXDUMP\n%s", hexdata);
   ares_free(hexdata);
 
@@ -790,120 +790,120 @@ TEST_F(LibraryTest, DNSRecord) {
   EXPECT_EQ(arcount, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ADDITIONAL));
 
   /* Iterate and print */
-  ares__buf_t *printmsg = ares__buf_create();
-  ares__buf_append_str(printmsg, ";; ->>HEADER<<- opcode: ");
-  ares__buf_append_str(printmsg, ares_dns_opcode_tostr(ares_dns_record_get_opcode(dnsrec)));
-  ares__buf_append_str(printmsg, ", status: ");
-  ares__buf_append_str(printmsg, ares_dns_rcode_tostr(ares_dns_record_get_rcode(dnsrec)));
-  ares__buf_append_str(printmsg, ", id: ");
-  ares__buf_append_num_dec(printmsg, (size_t)ares_dns_record_get_id(dnsrec), 0);
-  ares__buf_append_str(printmsg, "\n;; flags: ");
-  ares__buf_append_num_hex(printmsg, (size_t)ares_dns_record_get_flags(dnsrec), 0);
-  ares__buf_append_str(printmsg, "; QUERY: ");
-  ares__buf_append_num_dec(printmsg, ares_dns_record_query_cnt(dnsrec), 0);
-  ares__buf_append_str(printmsg, ", ANSWER: ");
-  ares__buf_append_num_dec(printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ANSWER), 0);
-  ares__buf_append_str(printmsg, ", AUTHORITY: ");
-  ares__buf_append_num_dec(printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_AUTHORITY), 0);
-  ares__buf_append_str(printmsg, ", ADDITIONAL: ");
-  ares__buf_append_num_dec(printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ADDITIONAL), 0);
-  ares__buf_append_str(printmsg, "\n\n");
-  ares__buf_append_str(printmsg, ";; QUESTION SECTION:\n");
+  ares_buf_t *printmsg = ares_buf_create();
+  ares_buf_append_str(printmsg, ";; ->>HEADER<<- opcode: ");
+  ares_buf_append_str(printmsg, ares_dns_opcode_tostr(ares_dns_record_get_opcode(dnsrec)));
+  ares_buf_append_str(printmsg, ", status: ");
+  ares_buf_append_str(printmsg, ares_dns_rcode_tostr(ares_dns_record_get_rcode(dnsrec)));
+  ares_buf_append_str(printmsg, ", id: ");
+  ares_buf_append_num_dec(printmsg, (size_t)ares_dns_record_get_id(dnsrec), 0);
+  ares_buf_append_str(printmsg, "\n;; flags: ");
+  ares_buf_append_num_hex(printmsg, (size_t)ares_dns_record_get_flags(dnsrec), 0);
+  ares_buf_append_str(printmsg, "; QUERY: ");
+  ares_buf_append_num_dec(printmsg, ares_dns_record_query_cnt(dnsrec), 0);
+  ares_buf_append_str(printmsg, ", ANSWER: ");
+  ares_buf_append_num_dec(printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ANSWER), 0);
+  ares_buf_append_str(printmsg, ", AUTHORITY: ");
+  ares_buf_append_num_dec(printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_AUTHORITY), 0);
+  ares_buf_append_str(printmsg, ", ADDITIONAL: ");
+  ares_buf_append_num_dec(printmsg, ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ADDITIONAL), 0);
+  ares_buf_append_str(printmsg, "\n\n");
+  ares_buf_append_str(printmsg, ";; QUESTION SECTION:\n");
   for (size_t i = 0; i < ares_dns_record_query_cnt(dnsrec); i++) {
     const char         *name;
     ares_dns_rec_type_t qtype;
     ares_dns_class_t    qclass;
     ares_dns_record_query_get(dnsrec, i, &name, &qtype, &qclass);
-    ares__buf_append_str(printmsg, ";");
-    ares__buf_append_str(printmsg, name);
-    ares__buf_append_str(printmsg, ".\t\t\t");
-    ares__buf_append_str(printmsg, ares_dns_class_tostr(qclass));
-    ares__buf_append_str(printmsg, "\t");
-    ares__buf_append_str(printmsg, ares_dns_rec_type_tostr(qtype));
-    ares__buf_append_str(printmsg, "\n");
+    ares_buf_append_str(printmsg, ";");
+    ares_buf_append_str(printmsg, name);
+    ares_buf_append_str(printmsg, ".\t\t\t");
+    ares_buf_append_str(printmsg, ares_dns_class_tostr(qclass));
+    ares_buf_append_str(printmsg, "\t");
+    ares_buf_append_str(printmsg, ares_dns_rec_type_tostr(qtype));
+    ares_buf_append_str(printmsg, "\n");
   }
-  ares__buf_append_str(printmsg, "\n");
+  ares_buf_append_str(printmsg, "\n");
   for (size_t i = ARES_SECTION_ANSWER; i < ARES_SECTION_ADDITIONAL + 1; i++) {
-    ares__buf_append_str(printmsg, ";; ");
-    ares__buf_append_str(printmsg, ares_dns_section_tostr((ares_dns_section_t)i));
-    ares__buf_append_str(printmsg, " SECTION:\n");
+    ares_buf_append_str(printmsg, ";; ");
+    ares_buf_append_str(printmsg, ares_dns_section_tostr((ares_dns_section_t)i));
+    ares_buf_append_str(printmsg, " SECTION:\n");
     for (size_t j = 0; j < ares_dns_record_rr_cnt(dnsrec, (ares_dns_section_t)i); j++) {
       rr = ares_dns_record_rr_get(dnsrec, (ares_dns_section_t)i, j);
-      ares__buf_append_str(printmsg, ares_dns_rr_get_name(rr));
-      ares__buf_append_str(printmsg, ".\t\t\t");
-      ares__buf_append_str(printmsg, ares_dns_class_tostr(ares_dns_rr_get_class(rr)));
-      ares__buf_append_str(printmsg, "\t");
-      ares__buf_append_str(printmsg, ares_dns_rec_type_tostr(ares_dns_rr_get_type(rr)));
-      ares__buf_append_str(printmsg, "\t");
-      ares__buf_append_num_dec(printmsg, ares_dns_rr_get_ttl(rr), 0);
-      ares__buf_append_str(printmsg, "\t");
+      ares_buf_append_str(printmsg, ares_dns_rr_get_name(rr));
+      ares_buf_append_str(printmsg, ".\t\t\t");
+      ares_buf_append_str(printmsg, ares_dns_class_tostr(ares_dns_rr_get_class(rr)));
+      ares_buf_append_str(printmsg, "\t");
+      ares_buf_append_str(printmsg, ares_dns_rec_type_tostr(ares_dns_rr_get_type(rr)));
+      ares_buf_append_str(printmsg, "\t");
+      ares_buf_append_num_dec(printmsg, ares_dns_rr_get_ttl(rr), 0);
+      ares_buf_append_str(printmsg, "\t");
 
       size_t keys_cnt;
       const ares_dns_rr_key_t *keys = ares_dns_rr_get_keys(ares_dns_rr_get_type(rr), &keys_cnt);
       for (size_t k = 0; k<keys_cnt; k++) {
         char buf[256] = "";
-        ares__buf_append_str(printmsg, ares_dns_rr_key_tostr(keys[k]));
-        ares__buf_append_str(printmsg, "=");
+        ares_buf_append_str(printmsg, ares_dns_rr_key_tostr(keys[k]));
+        ares_buf_append_str(printmsg, "=");
         switch (ares_dns_rr_key_datatype(keys[k])) {
           case ARES_DATATYPE_INADDR:
             ares_inet_ntop(AF_INET, ares_dns_rr_get_addr(rr, keys[k]), buf, sizeof(buf));
-            ares__buf_append_str(printmsg, buf);
+            ares_buf_append_str(printmsg, buf);
             break;
           case ARES_DATATYPE_INADDR6:
             ares_inet_ntop(AF_INET6, ares_dns_rr_get_addr6(rr, keys[k]), buf, sizeof(buf));
-            ares__buf_append_str(printmsg, buf);
+            ares_buf_append_str(printmsg, buf);
             break;
           case ARES_DATATYPE_U8:
-            ares__buf_append_num_dec(printmsg, ares_dns_rr_get_u8(rr, keys[k]), 0);
+            ares_buf_append_num_dec(printmsg, ares_dns_rr_get_u8(rr, keys[k]), 0);
             break;
           case ARES_DATATYPE_U16:
-            ares__buf_append_num_dec(printmsg, ares_dns_rr_get_u16(rr, keys[k]), 0);
+            ares_buf_append_num_dec(printmsg, ares_dns_rr_get_u16(rr, keys[k]), 0);
             break;
           case ARES_DATATYPE_U32:
-            ares__buf_append_num_dec(printmsg, ares_dns_rr_get_u32(rr, keys[k]), 0);
+            ares_buf_append_num_dec(printmsg, ares_dns_rr_get_u32(rr, keys[k]), 0);
             break;
           case ARES_DATATYPE_NAME:
           case ARES_DATATYPE_STR:
-            ares__buf_append_byte(printmsg, '"');
-            ares__buf_append_str(printmsg, ares_dns_rr_get_str(rr, keys[k]));
-            ares__buf_append_byte(printmsg, '"');
+            ares_buf_append_byte(printmsg, '"');
+            ares_buf_append_str(printmsg, ares_dns_rr_get_str(rr, keys[k]));
+            ares_buf_append_byte(printmsg, '"');
             break;
           case ARES_DATATYPE_BIN:
             /* TODO */
             break;
           case ARES_DATATYPE_BINP:
             {
-              ares__buf_append_byte(printmsg, '"');
+              ares_buf_append_byte(printmsg, '"');
               size_t templen;
-              ares__buf_append_str(printmsg, (const char *)ares_dns_rr_get_bin(rr, keys[k], &templen));
-              ares__buf_append_byte(printmsg, '"');
+              ares_buf_append_str(printmsg, (const char *)ares_dns_rr_get_bin(rr, keys[k], &templen));
+              ares_buf_append_byte(printmsg, '"');
             }
             break;
           case ARES_DATATYPE_ABINP:
             for (size_t a=0; a<ares_dns_rr_get_abin_cnt(rr, keys[k]); a++) {
               if (a != 0) {
-                ares__buf_append_byte(printmsg, ' ');
+                ares_buf_append_byte(printmsg, ' ');
               }
-              ares__buf_append_byte(printmsg, '"');
+              ares_buf_append_byte(printmsg, '"');
               size_t templen;
-              ares__buf_append_str(printmsg, (const char *)ares_dns_rr_get_abin(rr, keys[k], a, &templen));
-              ares__buf_append_byte(printmsg, '"');
+              ares_buf_append_str(printmsg, (const char *)ares_dns_rr_get_abin(rr, keys[k], a, &templen));
+              ares_buf_append_byte(printmsg, '"');
             }
             break;
           case ARES_DATATYPE_OPT:
             /* TODO */
             break;
         }
-        ares__buf_append_str(printmsg, " ");
+        ares_buf_append_str(printmsg, " ");
       }
-      ares__buf_append_str(printmsg, "\n");
+      ares_buf_append_str(printmsg, "\n");
     }
   }
-  ares__buf_append_str(printmsg, ";; SIZE: ");
-  ares__buf_append_num_dec(printmsg, msglen, 0);
-  ares__buf_append_str(printmsg, "\n\n");
+  ares_buf_append_str(printmsg, ";; SIZE: ");
+  ares_buf_append_num_dec(printmsg, msglen, 0);
+  ares_buf_append_str(printmsg, "\n\n");
 
-  char *printdata = ares__buf_finish_str(printmsg, NULL);
+  char *printdata = ares_buf_finish_str(printmsg, NULL);
   //printf("%s", printdata);
   ares_free(printdata);
 
@@ -1072,108 +1072,108 @@ TEST_F(LibraryTest, DNSParseFlags) {
 }
 
 TEST_F(LibraryTest, ArrayMisuse) {
-  EXPECT_EQ(NULL, ares__array_create(0, NULL));
-  ares__array_destroy(NULL);
-  EXPECT_EQ(NULL, ares__array_finish(NULL, NULL));
-  EXPECT_EQ(0, ares__array_len(NULL));
-  EXPECT_NE(ARES_SUCCESS, ares__array_insert_at(NULL, NULL, 0));
-  EXPECT_NE(ARES_SUCCESS, ares__array_insert_last(NULL, NULL));
-  EXPECT_NE(ARES_SUCCESS, ares__array_insert_first(NULL, NULL));
-  EXPECT_EQ(NULL, ares__array_at(NULL, 0));
-  EXPECT_EQ(NULL, ares__array_first(NULL));
-  EXPECT_EQ(NULL, ares__array_last(NULL));
-  EXPECT_NE(ARES_SUCCESS, ares__array_claim_at(NULL, 0, NULL, 0));
-  EXPECT_NE(ARES_SUCCESS, ares__array_remove_at(NULL, 0));
-  EXPECT_NE(ARES_SUCCESS, ares__array_remove_first(NULL));
-  EXPECT_NE(ARES_SUCCESS, ares__array_remove_last(NULL));
+  EXPECT_EQ(NULL, ares_array_create(0, NULL));
+  ares_array_destroy(NULL);
+  EXPECT_EQ(NULL, ares_array_finish(NULL, NULL));
+  EXPECT_EQ(0, ares_array_len(NULL));
+  EXPECT_NE(ARES_SUCCESS, ares_array_insert_at(NULL, NULL, 0));
+  EXPECT_NE(ARES_SUCCESS, ares_array_insert_last(NULL, NULL));
+  EXPECT_NE(ARES_SUCCESS, ares_array_insert_first(NULL, NULL));
+  EXPECT_EQ(NULL, ares_array_at(NULL, 0));
+  EXPECT_EQ(NULL, ares_array_first(NULL));
+  EXPECT_EQ(NULL, ares_array_last(NULL));
+  EXPECT_NE(ARES_SUCCESS, ares_array_claim_at(NULL, 0, NULL, 0));
+  EXPECT_NE(ARES_SUCCESS, ares_array_remove_at(NULL, 0));
+  EXPECT_NE(ARES_SUCCESS, ares_array_remove_first(NULL));
+  EXPECT_NE(ARES_SUCCESS, ares_array_remove_last(NULL));
 }
 
 TEST_F(LibraryTest, BufMisuse) {
-  EXPECT_EQ(NULL, ares__buf_create_const(NULL, 0));
-  ares__buf_reclaim(NULL);
-  EXPECT_NE(ARES_SUCCESS, ares__buf_append(NULL, NULL, 55));
+  EXPECT_EQ(NULL, ares_buf_create_const(NULL, 0));
+  ares_buf_reclaim(NULL);
+  EXPECT_NE(ARES_SUCCESS, ares_buf_append(NULL, NULL, 55));
   size_t len = 10;
-  EXPECT_EQ(NULL, ares__buf_append_start(NULL, &len));
-  EXPECT_EQ(NULL, ares__buf_append_start(NULL, NULL));
-  ares__buf_append_finish(NULL, 0);
-  EXPECT_EQ(NULL, ares__buf_finish_bin(NULL, NULL));
-  EXPECT_EQ(NULL, ares__buf_finish_str(NULL, NULL));
-  ares__buf_tag(NULL);
-  EXPECT_NE(ARES_SUCCESS, ares__buf_tag_rollback(NULL));
-  EXPECT_NE(ARES_SUCCESS, ares__buf_tag_clear(NULL));
-  EXPECT_EQ(NULL, ares__buf_tag_fetch(NULL, NULL));
-  EXPECT_EQ((size_t)0, ares__buf_tag_length(NULL));
-  EXPECT_NE(ARES_SUCCESS, ares__buf_tag_fetch_bytes(NULL, NULL, NULL));
-  EXPECT_NE(ARES_SUCCESS, ares__buf_tag_fetch_string(NULL, NULL, 0));
-  EXPECT_NE(ARES_SUCCESS, ares__buf_fetch_bytes_dup(NULL, 0, ARES_FALSE, NULL));
-  EXPECT_NE(ARES_SUCCESS, ares__buf_fetch_str_dup(NULL, 0, NULL));
-  EXPECT_EQ((size_t)0, ares__buf_consume_whitespace(NULL, ARES_FALSE));
-  EXPECT_EQ((size_t)0, ares__buf_consume_nonwhitespace(NULL));
-  EXPECT_EQ((size_t)0, ares__buf_consume_line(NULL, ARES_FALSE));
-  EXPECT_EQ(ARES_FALSE, ares__buf_begins_with(NULL, NULL, 0));
-  EXPECT_EQ((size_t)0, ares__buf_get_position(NULL));
-  EXPECT_NE(ARES_SUCCESS, ares__buf_set_position(NULL, 0));
-  EXPECT_NE(ARES_SUCCESS, ares__buf_parse_dns_binstr(NULL, 0, NULL, NULL));
+  EXPECT_EQ(NULL, ares_buf_append_start(NULL, &len));
+  EXPECT_EQ(NULL, ares_buf_append_start(NULL, NULL));
+  ares_buf_append_finish(NULL, 0);
+  EXPECT_EQ(NULL, ares_buf_finish_bin(NULL, NULL));
+  EXPECT_EQ(NULL, ares_buf_finish_str(NULL, NULL));
+  ares_buf_tag(NULL);
+  EXPECT_NE(ARES_SUCCESS, ares_buf_tag_rollback(NULL));
+  EXPECT_NE(ARES_SUCCESS, ares_buf_tag_clear(NULL));
+  EXPECT_EQ(NULL, ares_buf_tag_fetch(NULL, NULL));
+  EXPECT_EQ((size_t)0, ares_buf_tag_length(NULL));
+  EXPECT_NE(ARES_SUCCESS, ares_buf_tag_fetch_bytes(NULL, NULL, NULL));
+  EXPECT_NE(ARES_SUCCESS, ares_buf_tag_fetch_string(NULL, NULL, 0));
+  EXPECT_NE(ARES_SUCCESS, ares_buf_fetch_bytes_dup(NULL, 0, ARES_FALSE, NULL));
+  EXPECT_NE(ARES_SUCCESS, ares_buf_fetch_str_dup(NULL, 0, NULL));
+  EXPECT_EQ((size_t)0, ares_buf_consume_whitespace(NULL, ARES_FALSE));
+  EXPECT_EQ((size_t)0, ares_buf_consume_nonwhitespace(NULL));
+  EXPECT_EQ((size_t)0, ares_buf_consume_line(NULL, ARES_FALSE));
+  EXPECT_EQ(ARES_FALSE, ares_buf_begins_with(NULL, NULL, 0));
+  EXPECT_EQ((size_t)0, ares_buf_get_position(NULL));
+  EXPECT_NE(ARES_SUCCESS, ares_buf_set_position(NULL, 0));
+  EXPECT_NE(ARES_SUCCESS, ares_buf_parse_dns_binstr(NULL, 0, NULL, NULL));
 }
 
 TEST_F(LibraryTest, HtableAsvpMisuse) {
-  EXPECT_EQ(ARES_FALSE, ares__htable_asvp_insert(NULL, ARES_SOCKET_BAD, NULL));
-  EXPECT_EQ(ARES_FALSE, ares__htable_asvp_get(NULL, ARES_SOCKET_BAD, NULL));
-  EXPECT_EQ(ARES_FALSE, ares__htable_asvp_remove(NULL, ARES_SOCKET_BAD));
-  EXPECT_EQ((size_t)0, ares__htable_asvp_num_keys(NULL));
+  EXPECT_EQ(ARES_FALSE, ares_htable_asvp_insert(NULL, ARES_SOCKET_BAD, NULL));
+  EXPECT_EQ(ARES_FALSE, ares_htable_asvp_get(NULL, ARES_SOCKET_BAD, NULL));
+  EXPECT_EQ(ARES_FALSE, ares_htable_asvp_remove(NULL, ARES_SOCKET_BAD));
+  EXPECT_EQ((size_t)0, ares_htable_asvp_num_keys(NULL));
 }
 
 TEST_F(LibraryTest, HtableStrvpMisuse) {
-  EXPECT_EQ(ARES_FALSE, ares__htable_strvp_insert(NULL, NULL, NULL));
-  EXPECT_EQ(ARES_FALSE, ares__htable_strvp_get(NULL, NULL, NULL));
-  EXPECT_EQ(ARES_FALSE, ares__htable_strvp_remove(NULL, NULL));
-  EXPECT_EQ((size_t)0, ares__htable_strvp_num_keys(NULL));
+  EXPECT_EQ(ARES_FALSE, ares_htable_strvp_insert(NULL, NULL, NULL));
+  EXPECT_EQ(ARES_FALSE, ares_htable_strvp_get(NULL, NULL, NULL));
+  EXPECT_EQ(ARES_FALSE, ares_htable_strvp_remove(NULL, NULL));
+  EXPECT_EQ((size_t)0, ares_htable_strvp_num_keys(NULL));
 }
 
 TEST_F(LibraryTest, HtableSzvpMisuse) {
-  EXPECT_EQ(ARES_FALSE, ares__htable_szvp_insert(NULL, 0, NULL));
-  EXPECT_EQ(ARES_FALSE, ares__htable_szvp_get(NULL, 0, NULL));
-  EXPECT_EQ(ARES_FALSE, ares__htable_szvp_remove(NULL, 0));
-  EXPECT_EQ((size_t)0, ares__htable_szvp_num_keys(NULL));
+  EXPECT_EQ(ARES_FALSE, ares_htable_szvp_insert(NULL, 0, NULL));
+  EXPECT_EQ(ARES_FALSE, ares_htable_szvp_get(NULL, 0, NULL));
+  EXPECT_EQ(ARES_FALSE, ares_htable_szvp_remove(NULL, 0));
+  EXPECT_EQ((size_t)0, ares_htable_szvp_num_keys(NULL));
 }
 
 TEST_F(LibraryTest, HtableVpvpMisuse) {
-  EXPECT_EQ(ARES_FALSE, ares__htable_vpvp_insert(NULL, NULL, NULL));
-  EXPECT_EQ(ARES_FALSE, ares__htable_vpvp_get(NULL, NULL, NULL));
-  EXPECT_EQ(ARES_FALSE, ares__htable_vpvp_remove(NULL, NULL));
-  EXPECT_EQ((size_t)0, ares__htable_vpvp_num_keys(NULL));
+  EXPECT_EQ(ARES_FALSE, ares_htable_vpvp_insert(NULL, NULL, NULL));
+  EXPECT_EQ(ARES_FALSE, ares_htable_vpvp_get(NULL, NULL, NULL));
+  EXPECT_EQ(ARES_FALSE, ares_htable_vpvp_remove(NULL, NULL));
+  EXPECT_EQ((size_t)0, ares_htable_vpvp_num_keys(NULL));
 }
 
 TEST_F(LibraryTest, LlistMisuse) {
-  ares__llist_replace_destructor(NULL, NULL);
-  EXPECT_EQ(NULL, ares__llist_insert_before(NULL, NULL));
-  EXPECT_EQ(NULL, ares__llist_insert_after(NULL, NULL));
-  EXPECT_EQ(NULL, ares__llist_node_last(NULL));
-  EXPECT_EQ(NULL, ares__llist_node_next(NULL));
-  EXPECT_EQ(NULL, ares__llist_node_prev(NULL));
-  EXPECT_EQ((size_t)0, ares__llist_len(NULL));
-  EXPECT_EQ(NULL, ares__llist_node_parent(NULL));
-  EXPECT_EQ(NULL, ares__llist_node_claim(NULL));
-  ares__llist_node_replace(NULL, NULL);
+  ares_llist_replace_destructor(NULL, NULL);
+  EXPECT_EQ(NULL, ares_llist_insert_before(NULL, NULL));
+  EXPECT_EQ(NULL, ares_llist_insert_after(NULL, NULL));
+  EXPECT_EQ(NULL, ares_llist_node_last(NULL));
+  EXPECT_EQ(NULL, ares_llist_node_next(NULL));
+  EXPECT_EQ(NULL, ares_llist_node_prev(NULL));
+  EXPECT_EQ((size_t)0, ares_llist_len(NULL));
+  EXPECT_EQ(NULL, ares_llist_node_parent(NULL));
+  EXPECT_EQ(NULL, ares_llist_node_claim(NULL));
+  ares_llist_node_replace(NULL, NULL);
 }
 
 typedef struct {
   unsigned int id;
-  ares__buf_t *buf;
+  ares_buf_t *buf;
 } array_member_t;
 
 static void array_member_init(void *mb, unsigned int id)
 {
   array_member_t *m = (array_member_t *)mb;
   m->id             = id;
-  m->buf            = ares__buf_create();
-  ares__buf_append_be32(m->buf, id);
+  m->buf            = ares_buf_create();
+  ares_buf_append_be32(m->buf, id);
 }
 
 static void array_member_destroy(void *mb)
 {
   array_member_t *m = (array_member_t *)mb;
-  ares__buf_destroy(m->buf);
+  ares_buf_destroy(m->buf);
 }
 
 static int array_sort_cmp(const void *data1, const void *data2)
@@ -1188,7 +1188,7 @@ static int array_sort_cmp(const void *data1, const void *data2)
 }
 
 TEST_F(LibraryTest, Array) {
-  ares__array_t  *a       = NULL;
+  ares_array_t  *a       = NULL;
   array_member_t *m       = NULL;
   array_member_t  mbuf;
   unsigned int    cnt     = 0;
@@ -1196,28 +1196,28 @@ TEST_F(LibraryTest, Array) {
   void           *ptr     = NULL;
   size_t          i;
 
-  a = ares__array_create(sizeof(array_member_t), array_member_destroy);
+  a = ares_array_create(sizeof(array_member_t), array_member_destroy);
   EXPECT_NE(nullptr, a);
 
   /* Add 8 elements */
   for ( ; cnt < 8 ; cnt++) {
-    EXPECT_EQ(ARES_SUCCESS, ares__array_insert_last(&ptr, a));
+    EXPECT_EQ(ARES_SUCCESS, ares_array_insert_last(&ptr, a));
     array_member_init(ptr, cnt+1);
   }
 
   /* Verify count */
-  EXPECT_EQ(cnt, ares__array_len(a));
+  EXPECT_EQ(cnt, ares_array_len(a));
 
   /* Remove the first 2 elements */
-  EXPECT_EQ(ARES_SUCCESS, ares__array_remove_first(a));
-  EXPECT_EQ(ARES_SUCCESS, ares__array_remove_first(a));
+  EXPECT_EQ(ARES_SUCCESS, ares_array_remove_first(a));
+  EXPECT_EQ(ARES_SUCCESS, ares_array_remove_first(a));
   removed += 2;
 
   /* Verify count */
-  EXPECT_EQ(cnt-removed, ares__array_len(a));
+  EXPECT_EQ(cnt-removed, ares_array_len(a));
 
   /* Verify id of first element */
-  m = (array_member_t *)ares__array_first(a);
+  m = (array_member_t *)ares_array_first(a);
   EXPECT_NE(nullptr, m);
   EXPECT_EQ(3, m->id);
 
@@ -1225,139 +1225,139 @@ TEST_F(LibraryTest, Array) {
   /* Add 100 total elements, this should force a shift of memory at some
    * to make sure moves are working */
   for ( ; cnt < 100 ; cnt++) {
-    EXPECT_EQ(ARES_SUCCESS, ares__array_insert_last(&ptr, a));
+    EXPECT_EQ(ARES_SUCCESS, ares_array_insert_last(&ptr, a));
     array_member_init(ptr, cnt+1);
   }
 
   /* Verify count */
-  EXPECT_EQ(cnt-removed, ares__array_len(a));
+  EXPECT_EQ(cnt-removed, ares_array_len(a));
 
   /* Remove 2 from the end */
-  EXPECT_EQ(ARES_SUCCESS, ares__array_remove_last(a));
-  EXPECT_EQ(ARES_SUCCESS, ares__array_remove_last(a));
+  EXPECT_EQ(ARES_SUCCESS, ares_array_remove_last(a));
+  EXPECT_EQ(ARES_SUCCESS, ares_array_remove_last(a));
   removed += 2;
 
   /* Verify count */
-  EXPECT_EQ(cnt-removed, ares__array_len(a));
+  EXPECT_EQ(cnt-removed, ares_array_len(a));
 
   /* Verify expected id of last member */
-  m = (array_member_t *)ares__array_last(a);
+  m = (array_member_t *)ares_array_last(a);
   EXPECT_NE(nullptr, m);
   EXPECT_EQ(cnt-2, m->id);
 
   /* Remove 3 middle members */
-  EXPECT_EQ(ARES_SUCCESS, ares__array_remove_at(a, ares__array_len(a)/2));
-  EXPECT_EQ(ARES_SUCCESS, ares__array_remove_at(a, ares__array_len(a)/2));
-  EXPECT_EQ(ARES_SUCCESS, ares__array_remove_at(a, ares__array_len(a)/2));
+  EXPECT_EQ(ARES_SUCCESS, ares_array_remove_at(a, ares_array_len(a)/2));
+  EXPECT_EQ(ARES_SUCCESS, ares_array_remove_at(a, ares_array_len(a)/2));
+  EXPECT_EQ(ARES_SUCCESS, ares_array_remove_at(a, ares_array_len(a)/2));
   removed += 3;
 
   /* Verify count */
-  EXPECT_EQ(cnt-removed, ares__array_len(a));
+  EXPECT_EQ(cnt-removed, ares_array_len(a));
 
   /* Claim a middle member then re-add it at the same position */
-  i = ares__array_len(a) / 2;
-  EXPECT_EQ(ARES_SUCCESS, ares__array_claim_at(&mbuf, sizeof(mbuf), a, i));
-  EXPECT_EQ(ARES_SUCCESS, ares__array_insert_at(&ptr, a, i));
+  i = ares_array_len(a) / 2;
+  EXPECT_EQ(ARES_SUCCESS, ares_array_claim_at(&mbuf, sizeof(mbuf), a, i));
+  EXPECT_EQ(ARES_SUCCESS, ares_array_insert_at(&ptr, a, i));
   array_member_init(ptr, mbuf.id);
   array_member_destroy((void *)&mbuf);
   /* Verify count */
-  EXPECT_EQ(cnt-removed, ares__array_len(a));
+  EXPECT_EQ(cnt-removed, ares_array_len(a));
 
   /* Iterate across the array, make sure each entry is greater than the last and
    * the data in the buffer matches the id in the array */
   unsigned int last_id = 0;
-  for (i=0; i<ares__array_len(a); i++) {
-    m = (array_member_t *)ares__array_at(a, i);
+  for (i=0; i<ares_array_len(a); i++) {
+    m = (array_member_t *)ares_array_at(a, i);
     EXPECT_NE(nullptr, m);
     EXPECT_GT(m->id, last_id);
     last_id = m->id;
 
     unsigned int bufval = 0;
-    ares__buf_tag(m->buf);
-    EXPECT_EQ(ARES_SUCCESS, ares__buf_fetch_be32(m->buf, &bufval));
-    ares__buf_tag_rollback(m->buf);
+    ares_buf_tag(m->buf);
+    EXPECT_EQ(ARES_SUCCESS, ares_buf_fetch_be32(m->buf, &bufval));
+    ares_buf_tag_rollback(m->buf);
     EXPECT_EQ(bufval, m->id);
   }
 
   /* add a new element in the middle to the beginning with a high id */
-  EXPECT_EQ(ARES_SUCCESS, ares__array_insert_at(&ptr, a, ares__array_len(a)/2));
+  EXPECT_EQ(ARES_SUCCESS, ares_array_insert_at(&ptr, a, ares_array_len(a)/2));
   array_member_init(ptr, 100000);
 
   /* Sort the array */
-  EXPECT_EQ(ARES_SUCCESS, ares__array_sort(a, array_sort_cmp));
+  EXPECT_EQ(ARES_SUCCESS, ares_array_sort(a, array_sort_cmp));
 
   /* Iterate across the array, make sure each entry is greater than the last and
    * the data in the buffer matches the id in the array */
   last_id = 0;
-  for (i=0; i<ares__array_len(a); i++) {
-    m = (array_member_t *)ares__array_at(a, i);
+  for (i=0; i<ares_array_len(a); i++) {
+    m = (array_member_t *)ares_array_at(a, i);
     EXPECT_NE(nullptr, m);
     EXPECT_GT(m->id, last_id);
     last_id = m->id;
 
     unsigned int bufval = 0;
-    ares__buf_tag(m->buf);
-    EXPECT_EQ(ARES_SUCCESS, ares__buf_fetch_be32(m->buf, &bufval));
-    ares__buf_tag_rollback(m->buf);
+    ares_buf_tag(m->buf);
+    EXPECT_EQ(ARES_SUCCESS, ares_buf_fetch_be32(m->buf, &bufval));
+    ares_buf_tag_rollback(m->buf);
     EXPECT_EQ(bufval, m->id);
   }
 
-  ares__array_destroy(a);
+  ares_array_destroy(a);
 }
 
 TEST_F(LibraryTest, HtableVpvp) {
-  ares__llist_t       *l = NULL;
-  ares__htable_vpvp_t *h = NULL;
-  ares__llist_node_t  *n = NULL;
+  ares_llist_t       *l = NULL;
+  ares_htable_vpvp_t *h = NULL;
+  ares_llist_node_t  *n = NULL;
   size_t               i;
 
 #define VPVP_TABLE_SIZE 1000
 
-  l = ares__llist_create(NULL);
+  l = ares_llist_create(NULL);
   EXPECT_NE((void *)NULL, l);
 
-  h = ares__htable_vpvp_create(NULL, ares_free);
+  h = ares_htable_vpvp_create(NULL, ares_free);
   EXPECT_NE((void *)NULL, h);
 
   for (i=0; i<VPVP_TABLE_SIZE; i++) {
     void *p = ares_malloc_zero(4);
     EXPECT_NE((void *)NULL, p);
-    EXPECT_NE((void *)NULL, ares__llist_insert_last(l, p));
-    EXPECT_TRUE(ares__htable_vpvp_insert(h, p, p));
+    EXPECT_NE((void *)NULL, ares_llist_insert_last(l, p));
+    EXPECT_TRUE(ares_htable_vpvp_insert(h, p, p));
   }
 
-  EXPECT_EQ(VPVP_TABLE_SIZE, ares__llist_len(l));
-  EXPECT_EQ(VPVP_TABLE_SIZE, ares__htable_vpvp_num_keys(h));
+  EXPECT_EQ(VPVP_TABLE_SIZE, ares_llist_len(l));
+  EXPECT_EQ(VPVP_TABLE_SIZE, ares_htable_vpvp_num_keys(h));
 
-  n = ares__llist_node_first(l);
+  n = ares_llist_node_first(l);
   EXPECT_NE((void *)NULL, n);
   while (n != NULL) {
-    ares__llist_node_t *next = ares__llist_node_next(n);
-    void               *p    = ares__llist_node_val(n);
+    ares_llist_node_t *next = ares_llist_node_next(n);
+    void               *p    = ares_llist_node_val(n);
     EXPECT_NE((void *)NULL, p);
-    EXPECT_EQ(p, ares__htable_vpvp_get_direct(h, p));
-    EXPECT_TRUE(ares__htable_vpvp_get(h, p, NULL));
-    EXPECT_TRUE(ares__htable_vpvp_remove(h, p));
-    ares__llist_node_destroy(n);
+    EXPECT_EQ(p, ares_htable_vpvp_get_direct(h, p));
+    EXPECT_TRUE(ares_htable_vpvp_get(h, p, NULL));
+    EXPECT_TRUE(ares_htable_vpvp_remove(h, p));
+    ares_llist_node_destroy(n);
     n = next;
   }
 
-  EXPECT_EQ(0, ares__llist_len(l));
-  EXPECT_EQ(0, ares__htable_vpvp_num_keys(h));
+  EXPECT_EQ(0, ares_llist_len(l));
+  EXPECT_EQ(0, ares_htable_vpvp_num_keys(h));
 
-  ares__llist_destroy(l);
-  ares__htable_vpvp_destroy(h);
+  ares_llist_destroy(l);
+  ares_htable_vpvp_destroy(h);
 }
 
 TEST_F(LibraryTest, BufSplitStr) {
-  ares__buf_t  *buf   = NULL;
+  ares_buf_t  *buf   = NULL;
   char        **strs  = NULL;
   size_t        nstrs = 0;
 
-  buf = ares__buf_create();
-  ares__buf_append_str(buf, "string1\nstring2 string3\t   \nstring4");
-  ares__buf_split_str(buf, (const unsigned char *)"\n \t", 2, ARES_BUF_SPLIT_TRIM, 0, &strs, &nstrs);
-  ares__buf_destroy(buf);
+  buf = ares_buf_create();
+  ares_buf_append_str(buf, "string1\nstring2 string3\t   \nstring4");
+  ares_buf_split_str(buf, (const unsigned char *)"\n \t", 2, ARES_BUF_SPLIT_TRIM, 0, &strs, &nstrs);
+  ares_buf_destroy(buf);
 
   EXPECT_EQ(4, nstrs);
   EXPECT_TRUE(ares_streq(strs[0], "string1"));
@@ -1372,48 +1372,48 @@ typedef struct {
 } test_htable_asvp_t;
 
 TEST_F(LibraryTest, HtableAsvp) {
-  ares__llist_t       *l = NULL;
-  ares__htable_asvp_t *h = NULL;
-  ares__llist_node_t  *n = NULL;
+  ares_llist_t       *l = NULL;
+  ares_htable_asvp_t *h = NULL;
+  ares_llist_node_t  *n = NULL;
   size_t               i;
 
 #define ASVP_TABLE_SIZE 1000
 
-  l = ares__llist_create(NULL);
+  l = ares_llist_create(NULL);
   EXPECT_NE((void *)NULL, l);
 
-  h = ares__htable_asvp_create(ares_free);
+  h = ares_htable_asvp_create(ares_free);
   EXPECT_NE((void *)NULL, h);
 
   for (i=0; i<ASVP_TABLE_SIZE; i++) {
     test_htable_asvp_t *a = (test_htable_asvp_t *)ares_malloc_zero(sizeof(*a));
     EXPECT_NE((void *)NULL, a);
     a->s = (ares_socket_t)i+1;
-    EXPECT_NE((void *)NULL, ares__llist_insert_last(l, a));
-    EXPECT_TRUE(ares__htable_asvp_insert(h, a->s, a));
+    EXPECT_NE((void *)NULL, ares_llist_insert_last(l, a));
+    EXPECT_TRUE(ares_htable_asvp_insert(h, a->s, a));
   }
 
-  EXPECT_EQ(ASVP_TABLE_SIZE, ares__llist_len(l));
-  EXPECT_EQ(ASVP_TABLE_SIZE, ares__htable_asvp_num_keys(h));
+  EXPECT_EQ(ASVP_TABLE_SIZE, ares_llist_len(l));
+  EXPECT_EQ(ASVP_TABLE_SIZE, ares_htable_asvp_num_keys(h));
 
-  n = ares__llist_node_first(l);
+  n = ares_llist_node_first(l);
   EXPECT_NE((void *)NULL, n);
   while (n != NULL) {
-    ares__llist_node_t *next = ares__llist_node_next(n);
-    test_htable_asvp_t *a    = (test_htable_asvp_t *)ares__llist_node_val(n);
+    ares_llist_node_t *next = ares_llist_node_next(n);
+    test_htable_asvp_t *a    = (test_htable_asvp_t *)ares_llist_node_val(n);
     EXPECT_NE((void *)NULL, a);
-    EXPECT_EQ(a, ares__htable_asvp_get_direct(h, a->s));
-    EXPECT_TRUE(ares__htable_asvp_get(h, a->s, NULL));
-    EXPECT_TRUE(ares__htable_asvp_remove(h, a->s));
-    ares__llist_node_destroy(n);
+    EXPECT_EQ(a, ares_htable_asvp_get_direct(h, a->s));
+    EXPECT_TRUE(ares_htable_asvp_get(h, a->s, NULL));
+    EXPECT_TRUE(ares_htable_asvp_remove(h, a->s));
+    ares_llist_node_destroy(n);
     n = next;
   }
 
-  EXPECT_EQ(0, ares__llist_len(l));
-  EXPECT_EQ(0, ares__htable_asvp_num_keys(h));
+  EXPECT_EQ(0, ares_llist_len(l));
+  EXPECT_EQ(0, ares_htable_asvp_num_keys(h));
 
-  ares__llist_destroy(l);
-  ares__htable_asvp_destroy(h);
+  ares_llist_destroy(l);
+  ares_htable_asvp_destroy(h);
 }
 
 
@@ -1422,48 +1422,48 @@ typedef struct {
 } test_htable_szvp_t;
 
 TEST_F(LibraryTest, HtableSzvp) {
-  ares__llist_t       *l = NULL;
-  ares__htable_szvp_t *h = NULL;
-  ares__llist_node_t  *n = NULL;
+  ares_llist_t       *l = NULL;
+  ares_htable_szvp_t *h = NULL;
+  ares_llist_node_t  *n = NULL;
   size_t               i;
 
 #define SZVP_TABLE_SIZE 1000
 
-  l = ares__llist_create(NULL);
+  l = ares_llist_create(NULL);
   EXPECT_NE((void *)NULL, l);
 
-  h = ares__htable_szvp_create(ares_free);
+  h = ares_htable_szvp_create(ares_free);
   EXPECT_NE((void *)NULL, h);
 
   for (i=0; i<SZVP_TABLE_SIZE; i++) {
     test_htable_szvp_t *s = (test_htable_szvp_t *)ares_malloc_zero(sizeof(*s));
     EXPECT_NE((void *)NULL, s);
     s->s = i+1;
-    EXPECT_NE((void *)NULL, ares__llist_insert_last(l, s));
-    EXPECT_TRUE(ares__htable_szvp_insert(h, s->s, s));
+    EXPECT_NE((void *)NULL, ares_llist_insert_last(l, s));
+    EXPECT_TRUE(ares_htable_szvp_insert(h, s->s, s));
   }
 
-  EXPECT_EQ(SZVP_TABLE_SIZE, ares__llist_len(l));
-  EXPECT_EQ(SZVP_TABLE_SIZE, ares__htable_szvp_num_keys(h));
+  EXPECT_EQ(SZVP_TABLE_SIZE, ares_llist_len(l));
+  EXPECT_EQ(SZVP_TABLE_SIZE, ares_htable_szvp_num_keys(h));
 
-  n = ares__llist_node_first(l);
+  n = ares_llist_node_first(l);
   EXPECT_NE((void *)NULL, n);
   while (n != NULL) {
-    ares__llist_node_t *next = ares__llist_node_next(n);
-    test_htable_szvp_t *s    = (test_htable_szvp_t *)ares__llist_node_val(n);
+    ares_llist_node_t *next = ares_llist_node_next(n);
+    test_htable_szvp_t *s    = (test_htable_szvp_t *)ares_llist_node_val(n);
     EXPECT_NE((void *)NULL, s);
-    EXPECT_EQ(s, ares__htable_szvp_get_direct(h, s->s));
-    EXPECT_TRUE(ares__htable_szvp_get(h, s->s, NULL));
-    EXPECT_TRUE(ares__htable_szvp_remove(h, s->s));
-    ares__llist_node_destroy(n);
+    EXPECT_EQ(s, ares_htable_szvp_get_direct(h, s->s));
+    EXPECT_TRUE(ares_htable_szvp_get(h, s->s, NULL));
+    EXPECT_TRUE(ares_htable_szvp_remove(h, s->s));
+    ares_llist_node_destroy(n);
     n = next;
   }
 
-  EXPECT_EQ(0, ares__llist_len(l));
-  EXPECT_EQ(0, ares__htable_szvp_num_keys(h));
+  EXPECT_EQ(0, ares_llist_len(l));
+  EXPECT_EQ(0, ares_htable_szvp_num_keys(h));
 
-  ares__llist_destroy(l);
-  ares__htable_szvp_destroy(h);
+  ares_llist_destroy(l);
+  ares_htable_szvp_destroy(h);
 }
 
 typedef struct {
@@ -1471,52 +1471,52 @@ typedef struct {
 } test_htable_strvp_t;
 
 TEST_F(LibraryTest, HtableStrvp) {
-  ares__llist_t        *l = NULL;
-  ares__htable_strvp_t *h = NULL;
-  ares__llist_node_t   *n = NULL;
+  ares_llist_t        *l = NULL;
+  ares_htable_strvp_t *h = NULL;
+  ares_llist_node_t   *n = NULL;
   size_t                i;
 
 #define STRVP_TABLE_SIZE 1000
 
-  l = ares__llist_create(NULL);
+  l = ares_llist_create(NULL);
   EXPECT_NE((void *)NULL, l);
 
-  h = ares__htable_strvp_create(ares_free);
+  h = ares_htable_strvp_create(ares_free);
   EXPECT_NE((void *)NULL, h);
 
   for (i=0; i<STRVP_TABLE_SIZE; i++) {
     test_htable_strvp_t *s = (test_htable_strvp_t *)ares_malloc_zero(sizeof(*s));
     EXPECT_NE((void *)NULL, s);
     snprintf(s->s, sizeof(s->s), "%d", (int)i);
-    EXPECT_NE((void *)NULL, ares__llist_insert_last(l, s));
-    EXPECT_TRUE(ares__htable_strvp_insert(h, s->s, s));
+    EXPECT_NE((void *)NULL, ares_llist_insert_last(l, s));
+    EXPECT_TRUE(ares_htable_strvp_insert(h, s->s, s));
   }
 
-  EXPECT_EQ(STRVP_TABLE_SIZE, ares__llist_len(l));
-  EXPECT_EQ(STRVP_TABLE_SIZE, ares__htable_strvp_num_keys(h));
+  EXPECT_EQ(STRVP_TABLE_SIZE, ares_llist_len(l));
+  EXPECT_EQ(STRVP_TABLE_SIZE, ares_htable_strvp_num_keys(h));
 
-  n = ares__llist_node_first(l);
+  n = ares_llist_node_first(l);
   EXPECT_NE((void *)NULL, n);
   while (n != NULL) {
-    ares__llist_node_t *next = ares__llist_node_next(n);
-    test_htable_strvp_t *s   = (test_htable_strvp_t *)ares__llist_node_val(n);
+    ares_llist_node_t *next = ares_llist_node_next(n);
+    test_htable_strvp_t *s   = (test_htable_strvp_t *)ares_llist_node_val(n);
     EXPECT_NE((void *)NULL, s);
-    EXPECT_EQ(s, ares__htable_strvp_get_direct(h, s->s));
-    EXPECT_TRUE(ares__htable_strvp_get(h, s->s, NULL));
-    EXPECT_TRUE(ares__htable_strvp_remove(h, s->s));
-    ares__llist_node_destroy(n);
+    EXPECT_EQ(s, ares_htable_strvp_get_direct(h, s->s));
+    EXPECT_TRUE(ares_htable_strvp_get(h, s->s, NULL));
+    EXPECT_TRUE(ares_htable_strvp_remove(h, s->s));
+    ares_llist_node_destroy(n);
     n = next;
   }
 
-  EXPECT_EQ(0, ares__llist_len(l));
-  EXPECT_EQ(0, ares__htable_strvp_num_keys(h));
+  EXPECT_EQ(0, ares_llist_len(l));
+  EXPECT_EQ(0, ares_htable_strvp_num_keys(h));
 
-  ares__llist_destroy(l);
-  ares__htable_strvp_destroy(h);
+  ares_llist_destroy(l);
+  ares_htable_strvp_destroy(h);
 }
 
 TEST_F(DefaultChannelTest, SaveInvalidChannel) {
-  ares__slist_t *saved = channel_->servers;
+  ares_slist_t *saved = channel_->servers;
   channel_->servers = NULL;
   struct ares_options opts;
   int optmask = 0;


### PR DESCRIPTION
At some point in time, internal non-public functions were prefixed with `ares__` where as functions that may become public were prefixed with just `ares_`.  This was never very consistent.  Organizing the code better typically provides more benefit in this way, which we've made great progress on.

All non-static symbols must contain the `ares_` prefix, and that should be more than sufficient in preventing any sort of issues.

Authored-By: Brad House (@bradh352)