### PR TITLE
try to fix compat with googletest 1.15

### DIFF
--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -768,6 +768,17 @@ int RunInContainer(ContainerFilesystem *fs, const std::string &hostname,
     }                                                                         \
     int ICLASS_NAME(casename, testname)::InnerTestBody()
 
+
+
+/* Derived from googletest/include/gtest/gtest-param-test.h, specifically the
+ * TEST_P() macro, and some fixes to try to be compatible with different
+ * versions. */
+#ifndef GTEST_ATTRIBUTE_UNUSED_
+#  define GTEST_ATTRIBUTE_UNUSED_
+#endif
+#ifndef GTEST_INTERNAL_ATTRIBUTE_MAYBE_UNUSED
+#  define GTEST_INTERNAL_ATTRIBUTE_MAYBE_UNUSED
+#endif
 #  define CONTAINED_TEST_P(test_suite_name, test_name, hostname, domainname, \
                            files)                                            \
     class GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                 \
@@ -781,9 +792,9 @@ int RunInContainer(ContainerFilesystem *fs, const std::string &hostname,
       {                                                                      \
         ContainerFilesystem chroot(files, "..");                             \
         VoidToIntFn         fn = [this](void) -> int {                       \
-          ares_reinit(this->channel_);                               \
-          ares_sleep_time(100);                                      \
-          return this->InnerTestBody();                              \
+          ares_reinit(this->channel_);                                       \
+          ares_sleep_time(100);                                              \
+          return this->InnerTestBody();                                      \
         };                                                                   \
         EXPECT_EQ(0, RunInContainer(&chroot, hostname, domainname, fn));     \
       }                                                                      \
@@ -803,12 +814,8 @@ int RunInContainer(ContainerFilesystem *fs, const std::string &hostname,
             ::testing::internal::CodeLocation(__FILE__, __LINE__));          \
         return 0;                                                            \
       }                                                                      \
-      static int gtest_registering_dummy_ GTEST_ATTRIBUTE_UNUSED_;           \
-      GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                     \
-      (const GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) &) = delete; \
-      GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) &operator=(         \
-        const GTEST_TEST_CLASS_NAME_(test_suite_name,                        \
-                                     test_name) &) = delete; /* NOLINT */    \
+      GTEST_INTERNAL_ATTRIBUTE_MAYBE_UNUSED static int                       \
+        gtest_registering_dummy_ GTEST_ATTRIBUTE_UNUSED_;                    \
     };                                                                       \
     int GTEST_TEST_CLASS_NAME_(test_suite_name,                              \
                                test_name)::gtest_registering_dummy_ =        \


### PR DESCRIPTION
Due to running containerized tests we had to cut and paste the `TEST_P` macro definition in `googletest/include/gtest/gtest-param-test.h`, and modify it as it isn't designed to be wrapped in any way.  Unfortunately this tends to change from release to release, usually in minor ways ... but also google test specifically doesn't advertise its own version so it can be hard to work around.

Lets try to fix compatibility with google test 1.15

Fixes #873
Authored-By: Brad House (@bradh352)