### PR TITLE
New function `ares_process_fds()`

### DIFF
--- a/docs/Makefile.inc
+++ b/docs/Makefile.inc
@@ -115,6 +115,7 @@ MANPAGES = ares_cancel.3		\
   ares_parse_uri_reply.3		\
   ares_process.3			\
   ares_process_fd.3			\
+  ares_process_fd2.3			\
   ares_process_pending_write.3		\
   ares_query.3				\
   ares_query_dnsrec.3			\

--- a/docs/Makefile.inc
+++ b/docs/Makefile.inc
@@ -115,7 +115,7 @@ MANPAGES = ares_cancel.3		\
   ares_parse_uri_reply.3		\
   ares_process.3			\
   ares_process_fd.3			\
-  ares_process_fd2.3			\
+  ares_process_fds.3			\
   ares_process_pending_write.3		\
   ares_query.3				\
   ares_query_dnsrec.3			\

--- a/docs/ares_process.3
+++ b/docs/ares_process.3
@@ -23,10 +23,16 @@ typedef struct {
   unsigned int  events; /*!< Mask of ares_fd_event_t */
 } ares_fd_events_t;
 
+typedef enum {
+  ARES_PROCESS_FLAG_NONE        = 0,
+  ARES_PROCESS_FLAG_SKIP_NON_FD = 1 << 0
+} ares_process_flag_t;
+
 
 void ares_process_fds(ares_channel_t         *\fIchannel\fP,
                       const ares_fd_events_t *\fIevents\fP,
-                      size_t                  \fInevents\fP)
+                      size_t                  \fInevents\fP,
+                      unsigned int            \fIflags\fP)
 
 void ares_process_fd(ares_channel_t *\fIchannel\fP,
                      ares_socket_t \fIread_fd\fP,
@@ -50,7 +56,16 @@ identified by \fIchannel\fP.  The file descriptors to be processed are passed
 in an array of \fIares_fd_events_t\fP data structures in the \fIfd\fP member,
 and events are a bitwise mask of \fIares_event_fd_t\fP in the \fIevent\fP
 member.  This function can also be used to process timeouts by passing NULL
-to the \fIevents\fP member with \fInevents\fP value of 0.
+to the \fIevents\fP member with \fInevents\fP value of 0.  Flags may also be
+specified in the \fIflags\fP field and are defined in \fBares_process_flag_t\fP.
+
+\fBARES_PROCESS_FLAG_SKIP_NON_FD\fP can be specified to specifically skip any
+processing unrelated to the file descriptor events passed in, examples include
+timeout processing and cleanup handling.  This is useful if an integrator
+knows they will be sending multiple \fIares_process_fds(3)\fP requests and
+wants to skip that extra processing.  However, the integrator must send the
+final request with the flag so that timeout and other processing gets performed
+before their event loop waits on additional events.
 
 It is allowable to use an \fIares_fd_events_t\fP with \fIevents\fP member of
 value \fIARES_FD_EVENT_NONE\fP (0) if there are no events for a given file

--- a/docs/ares_process.3
+++ b/docs/ares_process.3
@@ -14,7 +14,7 @@ typedef enum {
   ARES_FD_EVENT_NONE  = 0,      /*!< No events */
   ARES_FD_EVENT_READ  = 1 << 0, /*!< Read event (including disconnect/error) */
   ARES_FD_EVENT_WRITE = 1 << 1  /*!< Write event */
-} ares_fd_event_t;
+} ares_fd_eventflag_t;
 
 /*! Type holding a file descriptor and mask of events, used by
  *  ares_process_fds() */
@@ -54,7 +54,7 @@ The \fBares_process_fds(3)\fP function handles input/output events on file
 descriptors and timeouts associated with queries pending on the channel
 identified by \fIchannel\fP.  The file descriptors to be processed are passed
 in an array of \fIares_fd_events_t\fP data structures in the \fIfd\fP member,
-and events are a bitwise mask of \fIares_event_fd_t\fP in the \fIevent\fP
+and events are a bitwise mask of \fIares_fd_eventflag_t\fP in the \fIevent\fP
 member.  This function can also be used to process timeouts by passing NULL
 to the \fIevents\fP member with \fInevents\fP value of 0.  Flags may also be
 specified in the \fIflags\fP field and are defined in \fBares_process_flag_t\fP.

--- a/docs/ares_process.3
+++ b/docs/ares_process.3
@@ -4,10 +4,29 @@
 .\"
 .TH ARES_PROCESS 3 "25 July 1998"
 .SH NAME
-ares_process_fd, ares_process \- Process events for name resolution
+ares_process_fds, ares_process_fd, ares_process \- Process events for name resolution
 .SH SYNOPSIS
 .nf
 #include <ares.h>
+
+/*! Events used by ares_fd_events_t */
+typedef enum {
+  ARES_FD_EVENT_NONE  = 0,      /*!< No events */
+  ARES_FD_EVENT_READ  = 1 << 0, /*!< Read event (including disconnect/error) */
+  ARES_FD_EVENT_WRITE = 1 << 1  /*!< Write event */
+} ares_fd_event_t;
+
+/*! Type holding a file descriptor and mask of events, used by
+ *  ares_process_fds() */
+typedef struct {
+  ares_socket_t fd;     /*!< File descriptor */
+  unsigned int  events; /*!< Mask of ares_fd_event_t */
+} ares_fd_events_t;
+
+
+void ares_process_fds(ares_channel_t         *\fIchannel\fP,
+                      const ares_fd_events_t *\fIevents\fP,
+                      size_t                  \fInevents\fP)
 
 void ares_process_fd(ares_channel_t *\fIchannel\fP,
                      ares_socket_t \fIread_fd\fP,
@@ -19,26 +38,51 @@ void ares_process(ares_channel_t *\fIchannel\fP,
 
 .fi
 .SH DESCRIPTION
-The \fBares_process_fd(3)\fP function handles input/output events and timeouts
-associated with queries pending on the name service channel identified by
-\fIchannel\fP. The file descriptor passed in \fIread_fd\fP and \fIwrite_fd\fP
-indicate if the file descriptor has been notified of a read event or write
-event, respectively.  If a notification has not occurred, use
-\fIARES_SOCKET_BAD\fP.
+These functions must be used by integrators choosing not to use the
+EventThread enabled via \fBARES_OPT_EVENT_THREAD\fP passed to
+\fBares_init_options\fP.  This assumes integrators already have their own
+event loop handling event notifications for various file descriptors and
+wish to do the same with their integration with c-ares.
+
+The \fBares_process_fds(3)\fP function handles input/output events on file
+descriptors and timeouts associated with queries pending on the channel
+identified by \fIchannel\fP.  The file descriptors to be processed are passed
+in an array of \fIares_fd_events_t\fP data structures in the \fIfd\fP member,
+and events are a bitwise mask of \fIares_event_fd_t\fP in the \fIevent\fP
+member.  This function can also be used to process timeouts by passing NULL
+to the \fIevents\fP member with \fInevents\fP value of 0.
+
+It is allowable to use an \fIares_fd_events_t\fP with \fIevents\fP member of
+value \fIARES_FD_EVENT_NONE\fP (0) if there are no events for a given file
+descriptor if an integrator wishes to simply maintain an array with all
+possible file descriptors and update readiness via the \fIevent\fP member.
+
+This function is recommended over \fBares_process_fd(3)\fP since it can
+handle processing of multiple file descriptors at once, thus skipping repeating
+additional logic such as timeout processing which would be required if calling
+\fBares_process_fd(3)\fP for multiple file descriptors notified at the same
+time.
 
 This function is typically used with the \fIARES_OPT_SOCK_STATE_CB\fP option.
 
 \fBares_timeout(3)\fP should be used to retrieve the desired timeout, and when
-the timeout expires, the integrator must call \fBares_process_fd(3)\fP with
-both sockets set to \fIARES_SOCKET_BAD\fP.  There is no need to do this if
-events are also delivered for any file descriptors as timeout processing
-will automatically be handled by any call to \fBares_process_fd(3)\fP.
+the timeout expires, the integrator must call \fBares_process_fds(3)\fP with
+a NULL \fIevents\fP array. (or \fBares_process_fd(3)\fP with both sockets set
+to \fIARES_SOCKET_BAD\fP). There is no need to do this if events are also
+delivered for any file descriptors as timeout processing will automatically be
+handled by any call to \fBares_process_fds(3)\fP or \fBares_process_fd(3)\fP.
+
+The \fBares_process_fd(3)\fP function is the same as \fBares_process_fds(3)\fP
+except can only process a single read and write file descriptor at a time.
+New integrators should use \fBares_process_fds(3)\fP if possible.
 
 The \fBares_process(3)\fP function works in the same manner, except it works
 on \fIfd_sets\fP as is used by \fBselect(3)\fP and retrieved by
 \fBares_fds(3)\fP.  This method is deprecated and should not be used in modern
 applications due to known limitations to the \fBselect(3)\fP implementation.
 
+.SH AVAILABILITY
+\fBares_process_fds(3)\fP was introduced in c-ares 1.34.0.
 
 .SH SEE ALSO
 .BR ares_fds (3),

--- a/docs/ares_process_fds.3
+++ b/docs/ares_process_fds.3
@@ -1,0 +1,3 @@
+.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" SPDX-License-Identifier: MIT
+.so man3/ares_process.3

--- a/include/ares.h
+++ b/include/ares.h
@@ -680,6 +680,14 @@ typedef struct {
   unsigned int  events; /*!< Mask of ares_fd_event_t */
 } ares_fd_events_t;
 
+/*! Flags used by ares_process_fds() */
+typedef enum {
+  ARES_PROCESS_FLAG_NONE        = 0,     /*!< No flag value */
+  ARES_PROCESS_FLAG_SKIP_NON_FD = 1 << 0 /*!< skip any processing unrelated to
+                                          *   the file descriptor events passed
+                                          *    in */
+} ares_process_flag_t;
+
 /*! Process events on multiple file descriptors based on the event mask
  *  associated with each file descriptor.  Recommended over calling
  *  ares_process_fd() multiple times since it would trigger additional logic
@@ -690,10 +698,12 @@ typedef struct {
  *                      no events, but may have timeouts to process.
  *  \param[in] nevents  Number of elements in the events array.  May be 0 if
  *                      no events, but may have timeouts to process.
+ *  \param[in] flags    Flags to alter behavior of the process command.
  */
 CARES_EXTERN void ares_process_fds(ares_channel_t         *channel,
                                    const ares_fd_events_t *events,
-                                   size_t                  nevents);
+                                   size_t                  nevents,
+                                   unsigned int            flags);
 
 CARES_EXTERN void ares_process_fd(ares_channel_t *channel,
                                   ares_socket_t   read_fd,

--- a/include/ares.h
+++ b/include/ares.h
@@ -671,13 +671,13 @@ typedef enum {
   ARES_FD_EVENT_NONE  = 0,      /*!< No events */
   ARES_FD_EVENT_READ  = 1 << 0, /*!< Read event (including disconnect/error) */
   ARES_FD_EVENT_WRITE = 1 << 1  /*!< Write event */
-} ares_fd_event_t;
+} ares_fd_eventflag_t;
 
 /*! Type holding a file descriptor and mask of events, used by
  *  ares_process_fds() */
 typedef struct {
   ares_socket_t fd;     /*!< File descriptor */
-  unsigned int  events; /*!< Mask of ares_fd_event_t */
+  unsigned int  events; /*!< Mask of ares_fd_eventflag_t */
 } ares_fd_events_t;
 
 /*! Flags used by ares_process_fds() */
@@ -702,8 +702,7 @@ typedef enum {
  */
 CARES_EXTERN void ares_process_fds(ares_channel_t         *channel,
                                    const ares_fd_events_t *events,
-                                   size_t                  nevents,
-                                   unsigned int            flags);
+                                   size_t nevents, unsigned int flags);
 
 CARES_EXTERN void ares_process_fd(ares_channel_t *channel,
                                   ares_socket_t   read_fd,

--- a/include/ares.h
+++ b/include/ares.h
@@ -663,8 +663,37 @@ CARES_EXTERN struct timeval *ares_timeout(const ares_channel_t *channel,
                                           struct timeval       *maxtv,
                                           struct timeval       *tv);
 
-CARES_EXTERN CARES_DEPRECATED_FOR(ares_process_fd) void ares_process(
+CARES_EXTERN CARES_DEPRECATED_FOR(ares_process_fds) void ares_process(
   ares_channel_t *channel, fd_set *read_fds, fd_set *write_fds);
+
+/*! Events used by ares_fd_events_t */
+typedef enum {
+  ARES_FD_EVENT_NONE  = 0,      /*!< No events */
+  ARES_FD_EVENT_READ  = 1 << 0, /*!< Read event (including disconnect/error) */
+  ARES_FD_EVENT_WRITE = 1 << 1  /*!< Write event */
+} ares_fd_event_t;
+
+/*! Type holding a file descriptor and mask of events, used by
+ *  ares_process_fds() */
+typedef struct {
+  ares_socket_t fd;     /*!< File descriptor */
+  unsigned int  events; /*!< Mask of ares_fd_event_t */
+} ares_fd_events_t;
+
+/*! Process events on multiple file descriptors based on the event mask
+ *  associated with each file descriptor.  Recommended over calling
+ *  ares_process_fd() multiple times since it would trigger additional logic
+ *  such as timeout processing on each call.
+ *
+ *  \param[in] channel  Initialized ares channel
+ *  \param[in] events   Array of file descriptors with events.  May be NULL if
+ *                      no events, but may have timeouts to process.
+ *  \param[in] nevents  Number of elements in the events array.  May be 0 if
+ *                      no events, but may have timeouts to process.
+ */
+CARES_EXTERN void ares_process_fds(ares_channel_t         *channel,
+                                   const ares_fd_events_t *events,
+                                   size_t                  nevents);
 
 CARES_EXTERN void ares_process_fd(ares_channel_t *channel,
                                   ares_socket_t   read_fd,

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -46,10 +46,10 @@
 
 
 static void timeadd(ares_timeval_t *now, size_t millisecs);
-static void process_write(const ares_channel_t *channel, fd_set *write_fds,
+static void process_write(const ares_channel_t *channel,
                           ares_socket_t write_fd);
-static void process_read(const ares_channel_t *channel, fd_set *read_fds,
-                         ares_socket_t read_fd, const ares_timeval_t *now);
+static void process_read(const ares_channel_t *channel, ares_socket_t read_fd,
+                         const ares_timeval_t *now);
 static void process_timeouts(ares_channel_t       *channel,
                              const ares_timeval_t *now);
 static ares_status_t process_answer(ares_channel_t      *channel,
@@ -187,47 +187,82 @@ static void timeadd(ares_timeval_t *now, size_t millisecs)
   }
 }
 
-/*
- * generic process function
- */
-static void processfds(ares_channel_t *channel, fd_set *read_fds,
-                       ares_socket_t read_fd, fd_set *write_fds,
-                       ares_socket_t write_fd)
+static void ares_process_fds_nolock(ares_channel_t         *channel,
+                                    const ares_fd_events_t *events,
+                                    size_t                  nevents)
 {
   ares_timeval_t now;
+  size_t         i;
 
-  if (channel == NULL) {
+  if (channel == NULL || (events == NULL && nevents != 0)) {
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
   ares_channel_lock(channel);
   ares_tvnow(&now);
-  process_read(channel, read_fds, read_fd, &now);
+
+  /* Process read events */
+  for (i=0; i<nevents; i++) {
+    if (events[i].fd == ARES_SOCKET_BAD ||
+        !(events[i].events & ARES_FD_EVENT_READ)) {
+      continue;
+    }
+    process_read(channel, events[i].fd, &now);
+  }
+
   process_timeouts(channel, &now);
-  process_write(channel, write_fds, write_fd);
+
+  /* Process write events */
+  for (i=0; i<nevents; i++) {
+    if (events[i].fd == ARES_SOCKET_BAD ||
+        !(events[i].events & ARES_FD_EVENT_WRITE)) {
+      continue;
+    }
+    process_write(channel, events[i].fd);
+  }
 
   /* See if any connections should be cleaned up */
   ares_check_cleanup_conns(channel);
   ares_channel_unlock(channel);
 }
 
-/* Something interesting happened on the wire, or there was a timeout.
- * See what's up and respond accordingly.
- */
-void ares_process(ares_channel_t *channel, fd_set *read_fds, fd_set *write_fds)
+void ares_process_fds(ares_channel_t         *channel,
+                      const ares_fd_events_t *events,
+                      size_t                  nevents)
 {
-  processfds(channel, read_fds, ARES_SOCKET_BAD, write_fds, ARES_SOCKET_BAD);
+  if (channel == NULL) {
+    return;
+  }
+
+  ares_channel_lock(channel);
+  ares_process_fds_nolock(channel, events, nevents);
+  ares_channel_unlock(channel);
 }
 
-/* Something interesting happened on the wire, or there was a timeout.
- * See what's up and respond accordingly.
- */
 void ares_process_fd(ares_channel_t *channel,
-                     ares_socket_t   read_fd, /* use ARES_SOCKET_BAD or valid
-                                                 file descriptors */
+                     ares_socket_t   read_fd,
                      ares_socket_t   write_fd)
 {
-  processfds(channel, NULL, read_fd, NULL, write_fd);
+  ares_fd_events_t events[2];
+  size_t           nevents = 0;
+
+  memset(events, 0, sizeof(events));
+
+  if (read_fd != ARES_SOCKET_BAD) {
+    nevents++;
+    events[nevents-1].fd      = read_fd;
+    events[nevents-1].events |= ARES_FD_EVENT_READ;
+  }
+
+  if (write_fd != ARES_SOCKET_BAD) {
+    if (write_fd != read_fd) {
+      nevents++;
+    }
+    events[nevents-1].fd      = read_fd;
+    events[nevents-1].events |= ARES_FD_EVENT_WRITE;
+  }
+
+  ares_process_fds(channel, events, nevents);
 }
 
 static ares_socket_t *channel_socket_list(const ares_channel_t *channel,
@@ -269,12 +304,73 @@ static ares_socket_t *channel_socket_list(const ares_channel_t *channel,
   return ares_array_finish(arr, num);
 }
 
-/* If any TCP sockets select true for writing, write out queued data
- * we have for them.
+/* Something interesting happened on the wire, or there was a timeout.
+ * See what's up and respond accordingly.
  */
-static void ares_notify_write(ares_conn_t *conn)
+void ares_process(ares_channel_t *channel, fd_set *read_fds, fd_set *write_fds)
 {
-  ares_status_t status;
+  size_t            i;
+  size_t            num_sockets;
+  ares_socket_t    *socketlist;
+  ares_fd_events_t *events  = NULL;
+  size_t            nevents = 0;
+
+  if (channel == NULL) {
+    return;
+  }
+
+  ares_channel_lock(channel);
+
+  /* There is no good way to iterate across an fd_set, instead we must pull a
+   * list of all known fds, and iterate across that checking against the fd_set.
+   */
+  socketlist = channel_socket_list(channel, &num_sockets);
+
+  /* Lets create an events array, maximum number is the number of sockets in
+   * the list, so we'll use that and just track entries with nevents */
+  if (num_sockets) {
+    events = ares_malloc_zero(sizeof(*events) * num_sockets);
+    if (events == NULL) {
+      goto done;
+    }
+  }
+
+  for (i = 0; i < num_sockets; i++) {
+    ares_bool_t had_read = ARES_FALSE;
+    if (read_fds && FD_ISSET(socketlist[i], read_fds)) {
+      nevents++;
+      events[nevents-1].fd      = socketlist[i];
+      events[nevents-1].events |= ARES_FD_EVENT_READ;
+      had_read                  = ARES_TRUE;
+    }
+    if (write_fds && FD_ISSET(socketlist[i], write_fds)) {
+      if (!had_read) {
+        nevents++;
+      }
+      events[nevents-1].fd      = socketlist[i];
+      events[nevents-1].events |= ARES_FD_EVENT_WRITE;
+    }
+  }
+
+done:
+  ares_process_fds_nolock(channel, events, nevents);
+  ares_free(events);
+  ares_free(socketlist);
+  ares_channel_unlock(channel);
+}
+
+static void process_write(const ares_channel_t *channel, ares_socket_t write_fd)
+{
+  ares_llist_node_t *node;
+  ares_conn_t       *conn;
+  ares_status_t      status;
+
+  node = ares_htable_asvp_get_direct(channel->connnode_by_socket, write_fd);
+  if (node == NULL) {
+    return;
+  }
+
+  conn = ares_llist_node_val(node);
 
   /* Mark as connected if we got here and TFO Initial not set */
   if (!(conn->flags & ARES_CONN_FLAG_TFO_INITIAL)) {
@@ -285,59 +381,6 @@ static void ares_notify_write(ares_conn_t *conn)
   if (status != ARES_SUCCESS) {
     handle_conn_error(conn, ARES_TRUE, status);
   }
-}
-
-static void process_write(const ares_channel_t *channel, fd_set *write_fds,
-                          ares_socket_t write_fd)
-{
-  size_t             i;
-  ares_socket_t     *socketlist  = NULL;
-  size_t             num_sockets = 0;
-  ares_llist_node_t *node        = NULL;
-
-  if (!write_fds && write_fd == ARES_SOCKET_BAD) {
-    /* no possible action */
-    return;
-  }
-
-  /* Single socket specified */
-  if (!write_fds) {
-    node = ares_htable_asvp_get_direct(channel->connnode_by_socket, write_fd);
-    if (node == NULL) {
-      return;
-    }
-
-    ares_notify_write(ares_llist_node_val(node));
-    return;
-  }
-
-  /* There is no good way to iterate across an fd_set, instead we must pull a
-   * list of all known fds, and iterate across that checking against the fd_set.
-   */
-  socketlist = channel_socket_list(channel, &num_sockets);
-
-  for (i = 0; i < num_sockets; i++) {
-    if (!FD_ISSET(socketlist[i], write_fds)) {
-      continue;
-    }
-
-    /* If there's an error and we close this socket, then open
-     * another with the same fd to talk to another server, then we
-     * don't want to think that it was the new socket that was
-     * ready. This is not disastrous, but is likely to result in
-     * extra system calls and confusion. */
-    FD_CLR(socketlist[i], write_fds);
-
-    node =
-      ares_htable_asvp_get_direct(channel->connnode_by_socket, socketlist[i]);
-    if (node == NULL) {
-      return;
-    }
-
-    ares_notify_write(ares_llist_node_val(node));
-  }
-
-  ares_free(socketlist);
 }
 
 void ares_process_pending_write(ares_channel_t *channel)
@@ -502,8 +545,20 @@ static void read_answers(ares_conn_t *conn, const ares_timeval_t *now)
   }
 }
 
-static void read_conn(ares_conn_t *conn, const ares_timeval_t *now)
+
+static void process_read(const ares_channel_t *channel, ares_socket_t read_fd,
+                         const ares_timeval_t *now)
 {
+  ares_llist_node_t *node;
+  ares_conn_t       *conn;
+
+  node = ares_htable_asvp_get_direct(channel->connnode_by_socket, read_fd);
+  if (node == NULL) {
+    return;
+  }
+
+  conn = ares_llist_node_val(node);
+
   /* TODO: There might be a potential issue here where there was a read that
    *       read some data, then looped and read again and got a disconnect.
    *       Right now, that would cause a resend instead of processing the data
@@ -512,62 +567,10 @@ static void read_conn(ares_conn_t *conn, const ares_timeval_t *now)
   if (read_conn_packets(conn) != ARES_SUCCESS) {
     return;
   }
+
   read_answers(conn, now);
 }
 
-static void process_read(const ares_channel_t *channel, fd_set *read_fds,
-                         ares_socket_t read_fd, const ares_timeval_t *now)
-{
-  size_t             i;
-  ares_socket_t     *socketlist  = NULL;
-  size_t             num_sockets = 0;
-  ares_llist_node_t *node        = NULL;
-
-  if (!read_fds && (read_fd == ARES_SOCKET_BAD)) {
-    /* no possible action */
-    return;
-  }
-
-  /* Single socket specified */
-  if (!read_fds) {
-    node = ares_htable_asvp_get_direct(channel->connnode_by_socket, read_fd);
-    if (node == NULL) {
-      return;
-    }
-
-    read_conn(ares_llist_node_val(node), now);
-
-    return;
-  }
-
-  /* There is no good way to iterate across an fd_set, instead we must pull a
-   * list of all known fds, and iterate across that checking against the fd_set.
-   */
-  socketlist = channel_socket_list(channel, &num_sockets);
-
-  for (i = 0; i < num_sockets; i++) {
-    if (!FD_ISSET(socketlist[i], read_fds)) {
-      continue;
-    }
-
-    /* If there's an error and we close this socket, then open
-     * another with the same fd to talk to another server, then we
-     * don't want to think that it was the new socket that was
-     * ready. This is not disastrous, but is likely to result in
-     * extra system calls and confusion. */
-    FD_CLR(socketlist[i], read_fds);
-
-    node =
-      ares_htable_asvp_get_direct(channel->connnode_by_socket, socketlist[i]);
-    if (node == NULL) {
-      return;
-    }
-
-    read_conn(ares_llist_node_val(node), now);
-  }
-
-  ares_free(socketlist);
-}
 
 /* If any queries have timed out, note the timeout and move them on. */
 static void process_timeouts(ares_channel_t *channel, const ares_timeval_t *now)

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -47,7 +47,7 @@
 
 static void timeadd(ares_timeval_t *now, size_t millisecs);
 static void process_write(const ares_channel_t *channel,
-                          ares_socket_t write_fd);
+                          ares_socket_t         write_fd);
 static void process_read(const ares_channel_t *channel, ares_socket_t read_fd,
                          const ares_timeval_t *now);
 static void process_timeouts(ares_channel_t       *channel,
@@ -189,8 +189,7 @@ static void timeadd(ares_timeval_t *now, size_t millisecs)
 
 static void ares_process_fds_nolock(ares_channel_t         *channel,
                                     const ares_fd_events_t *events,
-                                    size_t                  nevents,
-                                    unsigned int            flags)
+                                    size_t nevents, unsigned int flags)
 {
   ares_timeval_t now;
   size_t         i;
@@ -202,7 +201,7 @@ static void ares_process_fds_nolock(ares_channel_t         *channel,
   ares_tvnow(&now);
 
   /* Process read events */
-  for (i=0; i<nevents; i++) {
+  for (i = 0; i < nevents; i++) {
     if (events[i].fd == ARES_SOCKET_BAD ||
         !(events[i].events & ARES_FD_EVENT_READ)) {
       continue;
@@ -211,7 +210,7 @@ static void ares_process_fds_nolock(ares_channel_t         *channel,
   }
 
   /* Process write events */
-  for (i=0; i<nevents; i++) {
+  for (i = 0; i < nevents; i++) {
     if (events[i].fd == ARES_SOCKET_BAD ||
         !(events[i].events & ARES_FD_EVENT_WRITE)) {
       continue;
@@ -225,10 +224,8 @@ static void ares_process_fds_nolock(ares_channel_t         *channel,
   }
 }
 
-void ares_process_fds(ares_channel_t         *channel,
-                      const ares_fd_events_t *events,
-                      size_t                  nevents,
-                      unsigned int            flags)
+void ares_process_fds(ares_channel_t *channel, const ares_fd_events_t *events,
+                      size_t nevents, unsigned int flags)
 {
   if (channel == NULL) {
     return;
@@ -239,9 +236,8 @@ void ares_process_fds(ares_channel_t         *channel,
   ares_channel_unlock(channel);
 }
 
-void ares_process_fd(ares_channel_t *channel,
-                     ares_socket_t   read_fd,
-                     ares_socket_t   write_fd)
+void ares_process_fd(ares_channel_t *channel, ares_socket_t read_fd,
+                     ares_socket_t write_fd)
 {
   ares_fd_events_t events[2];
   size_t           nevents = 0;
@@ -250,16 +246,16 @@ void ares_process_fd(ares_channel_t *channel,
 
   if (read_fd != ARES_SOCKET_BAD) {
     nevents++;
-    events[nevents-1].fd      = read_fd;
-    events[nevents-1].events |= ARES_FD_EVENT_READ;
+    events[nevents - 1].fd      = read_fd;
+    events[nevents - 1].events |= ARES_FD_EVENT_READ;
   }
 
   if (write_fd != ARES_SOCKET_BAD) {
     if (write_fd != read_fd) {
       nevents++;
     }
-    events[nevents-1].fd      = read_fd;
-    events[nevents-1].events |= ARES_FD_EVENT_WRITE;
+    events[nevents - 1].fd      = read_fd;
+    events[nevents - 1].events |= ARES_FD_EVENT_WRITE;
   }
 
   ares_process_fds(channel, events, nevents, ARES_PROCESS_FLAG_NONE);
@@ -339,16 +335,16 @@ void ares_process(ares_channel_t *channel, fd_set *read_fds, fd_set *write_fds)
     ares_bool_t had_read = ARES_FALSE;
     if (read_fds && FD_ISSET(socketlist[i], read_fds)) {
       nevents++;
-      events[nevents-1].fd      = socketlist[i];
-      events[nevents-1].events |= ARES_FD_EVENT_READ;
-      had_read                  = ARES_TRUE;
+      events[nevents - 1].fd      = socketlist[i];
+      events[nevents - 1].events |= ARES_FD_EVENT_READ;
+      had_read                    = ARES_TRUE;
     }
     if (write_fds && FD_ISSET(socketlist[i], write_fds)) {
       if (!had_read) {
         nevents++;
       }
-      events[nevents-1].fd      = socketlist[i];
-      events[nevents-1].events |= ARES_FD_EVENT_WRITE;
+      events[nevents - 1].fd      = socketlist[i];
+      events[nevents - 1].events |= ARES_FD_EVENT_WRITE;
     }
   }
 
@@ -545,7 +541,6 @@ static void read_answers(ares_conn_t *conn, const ares_timeval_t *now)
   }
 }
 
-
 static void process_read(const ares_channel_t *channel, ares_socket_t read_fd,
                          const ares_timeval_t *now)
 {
@@ -570,7 +565,6 @@ static void process_read(const ares_channel_t *channel, ares_socket_t read_fd,
 
   read_answers(conn, now);
 }
-
 
 /* If any queries have timed out, note the timeout and move them on. */
 static void process_timeouts(ares_channel_t *channel, const ares_timeval_t *now)


### PR DESCRIPTION
Add a new public function of `ares_process_fds()` to work around the shortcomings of `ares_process_fd()` and `ares_process()`. 

This new function allows integrators to specify more than one file descriptor at a time in an array, with an event mask per file descriptor.  It also adds a flags parameter which can be used to skip extra expensive processing if they may be calling the function multiple times before waiting on more events.

This new function is used by the event thread, and all the other functions internally call this new function simplifying the code structure.

Authored-By: Brad House (@bradh352)