### PR TITLE
CMake: strip -l prefix on CMAKE_THREAD_LIBS_INIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,7 +500,10 @@ IF (CARES_THREADS)
 			CARES_EXTRAINCLUDE_IFSET (HAVE_PTHREAD_NP_H                    pthread_np.h)
 			CHECK_SYMBOL_EXISTS (pthread_init  "${CMAKE_EXTRA_INCLUDE_FILES}" HAVE_PTHREAD_INIT)
 			# Make sure libcares.pc.cmake knows about thread libraries on static builds
-			LIST (APPEND CARES_DEPENDENT_LIBS ${CMAKE_THREAD_LIBS_INIT})
+			# The variable set by FIND_PACKAGE(Threads) has a -l prefix on it, we need
+			# to strip that first since CARES_DEPENDENT_LIBS doesn't expect that.
+			STRING (REPLACE "-l" "" CARES_THREAD_LIBRARY "${CMAKE_THREAD_LIBS_INIT}")
+			LIST (APPEND CARES_DEPENDENT_LIBS ${CARES_THREAD_LIBRARY})
 		ELSE ()
 			MESSAGE (WARNING "Threading support not found, disabling...")
 			SET (CARES_THREADS OFF)


### PR DESCRIPTION
As per Issue #883, an incorrect `libcares.pc` can be generated when `CMAKE_THREAD_LIBS_INIT` contains a value like `-lpthread` because it gets added to `libcares.pc` with another `-l` prefix.  We can't control the behavior of `CMAKE_THREAD_LIBS_INIT` since its set by `FIND_PACKAGE (Threads)`.

Lets strip the `-l` prefix from the library before adding it to `CARES_DEPENDENT_LIBS` which is used in the generation of `libcares.pc`.

Fixes #883 
Reported-By: 前进，前进，进 (@leleliu008)
Fix By: Brad House (@bradh352)