### PR TITLE
ares_socket: set IP_BIND_ADDRESS_NO_PORT on ares_set_local_ip* tcp sockets

### DIFF
--- a/src/lib/ares_socket.c
+++ b/src/lib/ares_socket.c
@@ -574,7 +574,12 @@ ares_status_t ares_socket_configure(ares_channel_t *channel, int family,
            sizeof(channel->local_ip6));
     bindlen = sizeof(local.sa6);
   }
-
+#ifdef IP_BIND_ADDRESS_NO_PORT
+  if (is_tcp && bindlen) {
+    int opt = 1;
+    (void) setsockopt(fd, SOL_IP, IP_BIND_ADDRESS_NO_PORT, &opt, sizeof(opt));
+  }
+#endif
   if (bindlen && bind(fd, &local.sa, bindlen) < 0) {
     return ARES_ECONNREFUSED;
   }


### PR DESCRIPTION
If you bind to a local address, you now only have approx 32k possible source ports to initiate connections.
In modern days that can quickly run out.
setting IP_BIND_ADDRESS_NO_PORT let's the kernel choose a port at connect time, increasing the limit of combinations to around a million.