### PR TITLE
adig: set fallback TCP port

### DIFF
--- a/src/tools/adig.c
+++ b/src/tools/adig.c
@@ -1450,7 +1450,9 @@ static void config_opts(void)
   }
   if (global_config.opts.port) {
     global_config.optmask          |= ARES_OPT_UDP_PORT;
+    global_config.optmask          |= ARES_OPT_TCP_PORT;
     global_config.options.udp_port  = global_config.opts.port;
+    global_config.options.tcp_port  = global_config.opts.port;
   }
 
   global_config.optmask       |= ARES_OPT_TRIES;


### PR DESCRIPTION
When got a truncated UDP packet and switch the query to TCP, use the same port.

Fallback TCP port was always default 53.

Tested on e037002. Also existed before a41b85e.

To reproduce it, on Windows:
1. Build and launch a "parrot" DNS server, which just echo back the query with `data[3] |= 0x82`, meaning with flag truncated is true. For example on: `127.0.0.2:33053`.
2. Launch another DNS server, on `127.0.0.2:53`. Or use a packet capture tool, like Wireshark.
3. Run `adig @127.0.0.2 -p 33053 google.com`. You will see the log appears on TCP port 53.

Using a non-default port DNS server, `adig @127.0.0.2 -p 33053 -t txt gitlab.com` is very likely to trigger it, as the answer would be very long (rcvd: 1465).
