### PR TITLE
ares_socket: add virtual function for getsockname()

### DIFF
--- a/docs/ares_set_socket_functions.3
+++ b/docs/ares_set_socket_functions.3
@@ -14,6 +14,7 @@ struct ares_socket_functions {
     ares_ssize_t (*\fIarecvfrom\fP)(ares_socket_t, void *, size_t, int,
                               struct sockaddr *, ares_socklen_t *, void *);
     ares_ssize_t (*\fIasendv\fP)(ares_socket_t, const struct iovec *, int, void *);
+    int (*\fIagetsockname\fP)(ares_socket_t, struct sockaddr *, ares_socklen_t *);
 };
 
 void ares_set_socket_functions(ares_channel_t *\fIchannel\fP,

--- a/include/ares.h
+++ b/include/ares.h
@@ -565,6 +565,7 @@ struct ares_socket_functions {
   ares_ssize_t (*arecvfrom)(ares_socket_t, void *, size_t, int,
                             struct sockaddr *, ares_socklen_t *, void *);
   ares_ssize_t (*asendv)(ares_socket_t, const struct iovec *, int, void *);
+  int (*agetsockname)(ares_socket_t, struct sockaddr *, ares_socklen_t *);
 };
 
 CARES_EXTERN void

--- a/src/lib/ares_conn.c
+++ b/src/lib/ares_conn.c
@@ -129,8 +129,9 @@ static ares_status_t ares_conn_set_sockaddr(const ares_conn_t *conn,
 
 static ares_status_t ares_conn_set_self_ip(ares_conn_t *conn, ares_bool_t early)
 {
+  ares_channel_t         *channel = conn->server->channel;
   struct sockaddr_storage sa_storage;
-  int                     rv;
+  ares_conn_err_t         err = ARES_CONN_ERR_SUCCESS;
   ares_socklen_t          len = sizeof(sa_storage);
 
   /* We call this twice on TFO, if we already have the IP we can go ahead and
@@ -141,8 +142,8 @@ static ares_status_t ares_conn_set_self_ip(ares_conn_t *conn, ares_bool_t early)
 
   memset(&sa_storage, 0, sizeof(sa_storage));
 
-  rv = getsockname(conn->fd, (struct sockaddr *)(void *)&sa_storage, &len);
-  if (rv != 0) {
+  err = ares_socket_get_sockname(channel, conn->fd, (struct sockaddr *)(void *)&sa_storage, &len);
+  if (err != ARES_CONN_ERR_SUCCESS) {
     /* During TCP FastOpen, we can't get the IP this early since connect()
      * may not be called.  That's ok, we'll try again later */
     if (early && conn->flags & ARES_CONN_FLAG_TCP &&

--- a/src/lib/ares_socket.c
+++ b/src/lib/ares_socket.c
@@ -730,6 +730,25 @@ void ares_socket_close(ares_channel_t *channel, ares_socket_t s)
   }
 }
 
+ares_conn_err_t ares_socket_get_sockname(ares_channel_t *channel, ares_socket_t s,
+                                         struct sockaddr *sa,
+                                         ares_socklen_t *addrlen)
+{
+  int             rv;
+  ares_conn_err_t err = ARES_CONN_ERR_SUCCESS;
+
+  if (channel->sock_funcs && channel->sock_funcs->agetsockname) {
+    rv = channel->sock_funcs->agetsockname(s, sa, addrlen);
+  } else {
+    rv = getsockname(s, sa, addrlen);
+  }
+
+  if (rv < 0) {
+    err = ares_socket_deref_error(SOCKERRNO);
+  }
+  return err;
+}
+
 void ares_set_socket_callback(ares_channel_t           *channel,
                               ares_sock_create_callback cb, void *data)
 {

--- a/src/lib/ares_socket.h
+++ b/src/lib/ares_socket.h
@@ -77,4 +77,7 @@ ares_conn_err_t ares_socket_write_tfo(ares_channel_t *channel, ares_socket_t fd,
                                       size_t                *written,
                                       const struct sockaddr *sa,
                                       ares_socklen_t         salen);
+ares_conn_err_t ares_socket_get_sockname(ares_channel_t *channel, ares_socket_t fd,
+                                         struct sockaddr *sa,
+                                         ares_socklen_t *addrlen);
 #endif

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -1790,6 +1790,7 @@ const struct ares_socket_functions VirtualizeIO::default_functions = {
   NULL,
   NULL,
   NULL,
+  NULL,
   NULL
 };
 


### PR DESCRIPTION
in 4bedfd0d, we introduced DNS cookie support, which uses `getsockname()` to retrieve the client IP address. but this broke the use case where the parent project uses an abstraction layer on top of userspace TCP/UDP stack, and the fd is not necessarily a real file descriptor in system, instead, it could be an index in a map in application, and the map keeps track of the state of sockets implemented with user space IP stack. in that case, `ECONNREFUSED` is always used as the fd passed to `getsockname()` is not necessily a valid socket fd, not to mention the real fd under the hood.

in this change, we

* introduce another virtual function to `ares_socket_functions`. this allows a c-ares application to provide its own implementatino in the place of `getsockname()`.
* use the new virtual function if it is defined.