### PR TITLE
release automation

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -25,7 +25,6 @@ jobs:
       matrix:
         include:
           - { msystem: CLANG64, env: clang-x86_64, extra_packages: "mingw-w64-clang-x86_64-clang mingw-w64-clang-x86_64-clang-analyzer" }
-          - { msystem: CLANG32, env: clang-i686,   extra_packages: "mingw-w64-clang-i686-clang mingw-w64-clang-i686-clang-analyzer"     }
           - { msystem: MINGW64, env: x86_64,       extra_packages: "mingw-w64-x86_64-gcc"                                               }
           - { msystem: MINGW32, env: i686,         extra_packages: "mingw-w64-i686-gcc"                                                 }
           # No need to test UCRT64 since clang64 uses UCRT

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -48,6 +48,7 @@ jobs:
           path: 'c-ares-*.tar.gz'
           if-no-files-found: error
           overwrite: true
+          retention-days: 7
       - name: Upload Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,3 +1,5 @@
+# Copyright (C) The c-ares project and its contributors
+# SPDX-License-Identifier: MIT
 name: Build Release Package
 on:
   push:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,6 +16,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      discussions: write
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
       version: ${{ steps.version.outputs.version }}
@@ -57,7 +60,7 @@ jobs:
           draft: true
           make_latest: true
           name: ${{ steps.version.outputs.version }}
-          files: c-ares-${{ steps.version.outputs.version }}.tar.gz'
+          files: c-ares-${{ steps.version.outputs.version }}.tar.gz
           fail_on_unmatched_files: true
           discussion_category_name: "Announcements"
       - name: Generate subject

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -55,6 +55,8 @@ jobs:
           make_latest: true
           name: ${{ steps.version.outputs.version }}
           files: c-ares-${{ steps.version.outputs.version }}.tar.gz'
+          fail_on_unmatched_files: true
+          discussion_category_name: "Announcements"
       - name: Generate subject
         id: hash
         run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,7 +3,6 @@
 name: Build Release Package
 on:
   push:
-  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-build-release-package

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,70 @@
+name: Build Release Package
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.ref }}-build-release-package
+  cancel-in-progress: true
+
+env:
+  TEST_FILTER: "--gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*"
+  MAKE: make
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+      version: ${{ steps.gettag.outputs.version }}
+    name: "build"
+    steps:
+      - name: Install packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: autoconf automake libtool g++ libgmock-dev pkg-config gdb
+          version: 1.0
+      - name: Checkout c-ares
+        uses: actions/checkout@v4
+      - name: Get Tag version
+        id: gettag
+        run: |
+          version=`echo ${GITHUB_REF} | grep '^refs/tags/v' | sed -e 's|^refs/tags/v\(.*\)|\1|'`
+          if [ "$version" = "" ] ; then
+            version="prerelease"
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+      - name: "build c-ares tarball"
+        run: |
+          autoreconf -fi
+          ./configure
+          make dist
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "c-ares-src-tarball"
+          path: 'c-ares-*.tar.gz'
+          if-no-files-found: error
+          overwrite: true
+      - name: Upload Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: c-ares-${{ steps.version.outputs.version }}.tar.gz'
+      - name: Generate subject
+        id: hash
+        run: |
+          set -euo pipefail
+          echo "hashes=$(sha256sum c-ares-*.tar.gz | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      upload-assets: ${{ startsWith(github.ref, 'refs/tags/') }}
+      provenance-name: "c-ares-${{ needs.build.outputs.version }}.intoto.jsonl"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
-      version: ${{ steps.gettag.outputs.version }}
+      version: ${{ steps.version.outputs.version }}
     name: "build"
     steps:
       - name: Install packages
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout c-ares
         uses: actions/checkout@v4
       - name: Get Tag version
-        id: gettag
+        id: version
         run: |
           version=`echo ${GITHUB_REF} | grep '^refs/tags/v' | sed -e 's|^refs/tags/v\(.*\)|\1|'`
           if [ "$version" = "" ] ; then
@@ -50,6 +50,10 @@ jobs:
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
+          body_path: RELEASE-NOTES.md
+          draft: true
+          make_latest: true
+          name: ${{ steps.version.outputs.version }}
           files: c-ares-${{ steps.version.outputs.version }}.tar.gz'
       - name: Generate subject
         id: hash

--- a/ci/distcheck.sh
+++ b/ci/distcheck.sh
@@ -3,14 +3,9 @@
 # SPDX-License-Identifier: MIT
 set -e -x
 
-OS=""
-if [ "$TRAVIS_OS_NAME" != "" ]; then
-    OS="$TRAVIS_OS_NAME"
-elif [ "$CIRRUS_OS" != "" ]; then
-    OS="$CIRRUS_OS"
-fi
+OS=`uname -s || true`
 
-if [ "$OS" = "linux" ]; then
+if [ "$OS" = "Linux" ]; then
     # Make distribution tarball
     autoreconf -fi
     ./configure


### PR DESCRIPTION
When a release is tagged, automatically build the release package and create a draft of the release.  Since the build is automated we are also performing provenance as per [SLSA3](https://slsa.dev/) and uploading that as a release asset.

This also fixes a couple of recent issues:
 * validation of the packaging itself was broken when we migrated from cirrus ci to github actions. 
 * clang32 for msys2 has been deprecated causing building to fail.

Authored-By: Brad House (@bradh352)