### PR TITLE
Fix bind local device

### DIFF
--- a/src/lib/ares_socket.c
+++ b/src/lib/ares_socket.c
@@ -263,7 +263,7 @@ ares_status_t ares_socket_configure(ares_channel_t *channel, int family,
      * compatibility */
     (void)channel->sock_funcs.asetsockopt(
       fd, ARES_SOCKET_OPT_BIND_DEVICE, channel->local_dev_name,
-      sizeof(channel->local_dev_name), channel->sock_func_cb_data);
+      ares_strlen(channel->local_dev_name), channel->sock_func_cb_data);
   }
 
   /* Bind to ip address if configured */


### PR DESCRIPTION
sizeof(channel->local_dev_name) will always be 32 and cause ares_str_isprint() check failed in default_asetsockopt()