### PR TITLE
include/ares.h: fix the QNX #ifdef check

### DIFF
--- a/include/ares.h
+++ b/include/ares.h
@@ -74,7 +74,7 @@
 #if defined(_AIX) || defined(__NOVELL_LIBC__) || defined(__NetBSD__) || \
   defined(__minix) || defined(__SYMBIAN32__) || defined(__INTEGRITY) || \
   defined(ANDROID) || defined(__ANDROID__) || defined(__OpenBSD__) ||   \
-  defined(__QNXNTO__) || defined(__MVS__) || defined(__HAIKU__)
+  defined(__QNX__) || defined(__MVS__) || defined(__HAIKU__)
 #  include <sys/select.h>
 #endif
 


### PR DESCRIPTION
Unfortunately I have no public way to "prove" this is correct.