### PR TITLE
QNX: enhance config reading

### DIFF
--- a/.github/workflows/qnx.yml
+++ b/.github/workflows/qnx.yml
@@ -68,19 +68,19 @@ jobs:
           source "${{ github.workspace }}/qnx800/qnxsdp-env.sh"
           echo "QNX_TARGET=${QNX_TARGET}" >> $GITHUB_ENV
           echo "CMAKE_FIND_ROOT_PATH=${QNX_TARGET};${QNX_TARGET}/${CPUVARDIR}" >> $GITHUB_ENV
+      - name: "CMake: build c-ares"
+        env:
+          BUILD_TYPE: CMAKE
+          CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON -G Ninja -DCMAKE_SYSTEM_NAME=QNX -DCMAKE_FIND_ROOT_PATH=${{ env.CMAKE_FIND_ROOT_PATH }} -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY"
+        run: |
+          source "${{ github.workspace }}/qnx800/qnxsdp-env.sh"
+          cd c-ares
+          ./ci/build.sh
       - name: "Autotools: build c-ares"
         env:
           BUILD_TYPE: autotools
           PKG_CONFIG_PATH: "${{ env.QNX_TARGET }}/${{ env.CPUVARDIR }}/usr/lib/pkgconfig"
           CONFIG_OPTS: "--host=x86_64-unknown-nto-qnx8.0.0 --enable-tests-crossbuild"
-        run: |
-          source "${{ github.workspace }}/qnx800/qnxsdp-env.sh"
-          cd c-ares
-          ./ci/build.sh
-      - name: "CMake: build c-ares"
-        env:
-          BUILD_TYPE: CMAKE
-          CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCARES_BUILD_TESTS=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_SYSTEM_NAME=QNX -DCMAKE_FIND_ROOT_PATH=${{ env.CMAKE_FIND_ROOT_PATH }} -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY"
         run: |
           source "${{ github.workspace }}/qnx800/qnxsdp-env.sh"
           cd c-ares

--- a/.github/workflows/qnx.yml
+++ b/.github/workflows/qnx.yml
@@ -3,7 +3,6 @@
 name: QNX
 on:
   push:
-  pull_request:
 
 concurrency:
   group: ${{ github.ref }}-qnx

--- a/configure.ac
+++ b/configure.ac
@@ -247,18 +247,21 @@ if test "$enable_warnings" = "yes"; then
     [AM_CFLAGS], [-Werror])
 fi
 
-dnl Android requires c99, QNX requires gnu90, all others should use c90
+dnl Android and QNX require c99, all others should use c90
 case $host_os in
-  *qnx*)
-    AX_APPEND_COMPILE_FLAGS([-std=gnu90], [AM_CFLAGS], [-Werror])
-    AX_APPEND_COMPILE_FLAGS([-D_QNX_SOURCE], [AM_CPPFLAGS], [-Werror])
-    ;;
-  *android*)
+  *qnx*|*android*)
     AX_APPEND_COMPILE_FLAGS([-std=c99], [AM_CFLAGS], [-Werror])
     ;;
   *)
     AX_APPEND_COMPILE_FLAGS([-std=c90], [AM_CFLAGS], [-Werror])
     ;;
+esac
+
+dnl QNX needs -D_QNX_SOURCE
+case $host_os in
+  *qnx*)
+    AX_APPEND_COMPILE_FLAGS([-D_QNX_SOURCE], [AM_CPPFLAGS], [-Werror])
+  ;;
 esac
 
 if test "$ax_cv_c_compiler_vendor" = "intel"; then

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -388,8 +388,23 @@ ares_status_t ares_sysconfig_set_options(ares_sysconfig_t *sysconfig,
 
 ares_status_t ares_init_by_environment(ares_sysconfig_t *sysconfig);
 
+
+typedef ares_status_t (*ares_sysconfig_line_cb_t)(const ares_channel_t *channel,
+                                                  ares_sysconfig_t     *sysconfig,
+                                                  ares_buf_t           *line);
+
+ares_status_t ares_sysconfig_parse_resolv_line(const ares_channel_t *channel,
+                                               ares_sysconfig_t     *sysconfig,
+                                               ares_buf_t           *line);
+
+ares_status_t ares_sysconfig_process_buf(const ares_channel_t    *channel,
+                                         ares_sysconfig_t        *sysconfig,
+                                         ares_buf_t              *buf,
+                                         ares_sysconfig_line_cb_t cb);
+
 ares_status_t ares_init_sysconfig_files(const ares_channel_t *channel,
-                                        ares_sysconfig_t     *sysconfig);
+                                        ares_sysconfig_t     *sysconfig,
+                                        ares_bool_t process_resolvconf);
 #ifdef __APPLE__
 ares_status_t ares_init_sysconfig_macos(const ares_channel_t *channel,
                                         ares_sysconfig_t     *sysconfig);

--- a/src/lib/ares_sysconfig.c
+++ b/src/lib/ares_sysconfig.c
@@ -260,6 +260,91 @@ static ares_status_t ares_init_sysconfig_android(const ares_channel_t *channel,
 }
 #endif
 
+#if defined(__QNX__)
+static ares_status_t
+  ares_init_sysconfig_qnx(const ares_channel_t *channel,
+                          ares_sysconfig_t     *sysconfig)
+{
+  /* QNX:
+   *   1. use confstr(_CS_RESOLVE, ...) as primary resolv.conf data, replacing
+   *      "_" with " ".  If that is empty, then do normal /etc/resolv.conf
+   *      processing.
+   *   2. We want to process /etc/nsswitch.conf as normal.
+   *   3. if confstr(_CS_DOMAIN, ...) this is the domain name.  Use this as
+   *      preference over anything else found.
+   */
+  ares_buf_t    *buf                = ares_buf_create();
+  unsigned char *data               = NULL;
+  size_t         data_size          = 0;
+  ares_bool_t    process_resolvconf = ARES_TRUE;
+  ares_status_t  status             = ARES_SUCCESS;
+
+  /* Prefer confstr(_CS_RESOLVE, ...) */
+  buf = ares_buf_create();
+  if (buf == NULL) {
+    status = ARES_ENOMEM;
+    goto done;
+  }
+
+  data_size = 1024;
+  data      = ares_buf_append_start(buf, &data_size);
+  if (data == NULL) {
+    status = ARES_ENOMEM;
+    goto done;
+  }
+
+  data_size = confstr(_CS_RESOLVE, (char *)data, data_size);
+  if (data_size > 0) {
+    ares_buf_append_finish(buf, data_size);
+    /* Its odd, this uses _ instead of " " between keywords, otherwise the
+     * format is the same as resolv.conf, replace. */
+    ares_buf_replace(buf, (const unsigned char *)"_", 1,
+                     (const unsigned char *)" ", 1);
+
+    status = ares_sysconfig_process_buf(channel, sysconfig, buf,
+                                        ares_sysconfig_parse_resolv_line);
+    if (status != ARES_SUCCESS) {
+      /* ENOMEM is really the only error we'll get here */
+      goto done;
+    }
+
+    /* don't read resolv.conf if we processed *any* nameservers */
+    if (ares_llist_len(sysconfig->sconfig) != 0) {
+      process_resolvconf = ARES_FALSE;
+    }
+  }
+
+  /* Process files */
+  status = ares_init_sysconfig_files(channel, sysconfig, process_resolvconf);
+  if (status != ARES_SUCCESS) {
+    goto done;
+  }
+
+  /* Read confstr(_CS_DOMAIN, ...), but if we had a search path specified with
+   * more than one domain, lets prefer that instead.  Its not exactly clear
+   * the best way to handle this. */
+  if (sysconfig->ndomains <= 1) {
+    char   domain[256];
+    size_t domain_len;
+
+    domain_len = confstr(_CS_DOMAIN, domain, sizeof(domain_len));
+    if (domain_len != 0) {
+      ares_strsplit_free(sysconfig->domains, sysconfig->ndomains);
+      sysconfig->domains = ares_strsplit(domain, ", ", &sysconfig->ndomains);
+      if (sysconfig->domains == NULL) {
+        status = ARES_ENOMEM;
+        goto done;
+      }
+    }
+  }
+
+done:
+  ares_buf_destroy(buf);
+
+  return status;
+}
+#endif
+
 #if defined(CARES_USE_LIBRESOLV)
 static ares_status_t
   ares_init_sysconfig_libresolv(const ares_channel_t *channel,
@@ -516,8 +601,10 @@ ares_status_t ares_init_by_sysconfig(ares_channel_t *channel)
   status = ares_init_sysconfig_macos(channel, &sysconfig);
 #elif defined(CARES_USE_LIBRESOLV)
   status = ares_init_sysconfig_libresolv(channel, &sysconfig);
+#elif defined(__QNX__)
+  status = ares_init_sysconfig_qnx(channel, &sysconfig);
 #else
-  status = ares_init_sysconfig_files(channel, &sysconfig);
+  status = ares_init_sysconfig_files(channel, &sysconfig, ARES_TRUE);
 #endif
 
   if (status != ARES_SUCCESS) {

--- a/src/lib/ares_sysconfig.c
+++ b/src/lib/ares_sysconfig.c
@@ -294,7 +294,10 @@ static ares_status_t
   }
 
   data_size = confstr(_CS_RESOLVE, (char *)data, data_size);
-  if (data_size > 0) {
+  if (data_size > 1) {
+    /* confstr returns byte for NULL terminator, strip */
+    data_size--;
+
     ares_buf_append_finish(buf, data_size);
     /* Its odd, this uses _ instead of " " between keywords, otherwise the
      * format is the same as resolv.conf, replace. */

--- a/src/lib/event/ares_event_configchg.c
+++ b/src/lib/event/ares_event_configchg.c
@@ -558,14 +558,24 @@ static ares_status_t config_change_check(ares_htable_strvp_t *filestat,
                                          const char          *resolvconf_path)
 {
   size_t      i;
-  const char *configfiles[5];
+  const char *configfiles[16];
   ares_bool_t changed = ARES_FALSE;
+  size_t      cnt = 0;
 
-  configfiles[0] = resolvconf_path;
-  configfiles[1] = "/etc/nsswitch.conf";
-  configfiles[2] = "/etc/netsvc.conf";
-  configfiles[3] = "/etc/svc.conf";
-  configfiles[4] = NULL;
+  memset(configfiles, 0, sizeof(configfiles));
+
+  configfiles[cnt++] = resolvconf_path;
+  configfiles[cnt++] = "/etc/nsswitch.conf";
+#ifdef _AIX
+  configfiles[cnt++] = "/etc/netsvc.conf";
+#endif
+#ifdef __osf /* Tru64 */
+  configfiles[cnt++] = "/etc/svc.conf";
+#endif
+#ifdef __QNX__
+  configfiles[cnt++] = "/etc/net.cfg";
+#endif
+  configfiles[cnt++] = NULL;
 
   for (i = 0; configfiles[i] != NULL; i++) {
     fileinfo_t *fi = ares_htable_strvp_get_direct(filestat, configfiles[i]);

--- a/src/lib/include/ares_buf.h
+++ b/src/lib/include/ares_buf.h
@@ -219,6 +219,26 @@ CARES_EXTERN unsigned char *ares_buf_finish_bin(ares_buf_t *buf, size_t *len);
  */
 CARES_EXTERN char          *ares_buf_finish_str(ares_buf_t *buf, size_t *len);
 
+/*! Replace the given search byte sequence with the replacement byte sequence.
+ *  This is only valid for allocated buffers, not const buffers.  Will replace
+ *  all byte sequences starting at the current offset to the end of the buffer.
+ *
+ *  \param[in]  buf       Initialized buffer object. Can not be a "const" buffer.
+ *  \param[in]  srch      Search byte sequence, must not be NULL.
+ *  \param[in]  srch_size Size of byte sequence, must not be zero.
+ *  \param[in]  rplc      Byte sequence to use as replacement.  May be NULL if
+ *                        rplc_size is zero.
+ *  \param[in]  rplc_size Size of replacement byte sequence, may be 0.
+ *  \return ARES_SUCCESS on success, otherwise on may return failure only on
+ *          memory allocation failure or misuse.  Will not return indication
+ *          if any replacements occurred
+ */
+CARES_EXTERN ares_status_t  ares_buf_replace(ares_buf_t *buf,
+                                             const unsigned char *srch,
+                                             size_t srch_size,
+                                             const unsigned char *rplc,
+                                             size_t rplc_size);
+
 /*! Tag a position to save in the buffer in case parsing needs to rollback,
  *  such as if insufficient data is available, but more data may be added in
  *  the future.  Only a single tag can be set per buffer object.  Setting a

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -1516,6 +1516,34 @@ TEST_F(LibraryTest, BufSplitStr) {
   ares_free_array(strs, nstrs, ares_free);
 }
 
+TEST_F(LibraryTest, BufReplace) {
+  ares_buf_t  *buf = NULL;
+  size_t       i;
+  struct {
+    const char *input;
+    const char *srch;
+    const char *rplc;
+    const char *output;
+  } tests[] = {
+    /* Same size */
+    { "nameserver_1.2.3.4\nnameserver_2.3.4.5\n", "_", " ", "nameserver 1.2.3.4\nnameserver 2.3.4.5\n" },
+    /* Longer */
+    { "nameserver_1.2.3.4\nnameserver_2.3.4.5\n", "_", "|||", "nameserver|||1.2.3.4\nnameserver|||2.3.4.5\n" },
+    /* Shorter */
+    { "nameserver_1.2.3.4\nnameserver_2.3.4.5\n", "_", "", "nameserver1.2.3.4\nnameserver2.3.4.5\n" }
+  };
+  char        *str = NULL;
+
+  for (i=0; i<sizeof(tests)/sizeof(*tests); i++) {
+    buf = ares_buf_create();
+    EXPECT_EQ(ARES_SUCCESS, ares_buf_append_str(buf, tests[i].input));
+    EXPECT_EQ(ARES_SUCCESS, ares_buf_replace(buf, (const unsigned char *)tests[i].srch, ares_strlen(tests[i].srch), (const unsigned char *)tests[i].rplc, ares_strlen(tests[i].rplc)));
+    str = ares_buf_finish_str(buf, NULL);
+    EXPECT_STREQ(str, tests[i].output);
+    ares_free(str);
+  }
+}
+
 typedef struct {
   ares_socket_t s;
 } test_htable_asvp_t;


### PR DESCRIPTION
QNX prefers config read from confstr(_CS_RESOLVE, ...) and confstr(_CS_DOMAIN, ...) rather than those read from /etc/resolv.conf and friends which are only used as fallbacks.  Its documented that confstr() reads from /etc/net.cfg, but that file format is NOT documented so we can't read directly from there ... however, we can monitor that file for changes to know when the system config has been updated.

This has been validated to successfully build, but has not yet had the tests run on an actual QNX platform.  Build results here:
https://github.com/bradh352/c-ares/actions/runs/12324751945/job/34402863134

Signed-off-by: Brad House (@bradh352)