### PR TITLE
ares_buf: turn off buffering when loading a file

### DIFF
--- a/src/lib/str/ares_buf.c
+++ b/src/lib/str/ares_buf.c
@@ -1384,6 +1384,11 @@ ares_status_t ares_buf_load_file(const char *filename, ares_buf_t *buf)
     }
   }
 
+  if (setvbuf(fp, NULL, _IONBF, 0) != 0) {
+    status = ARES_EFILE; /* LCOV_EXCL_LINE: DefensiveCoding */
+    goto done;           /* LCOV_EXCL_LINE: DefensiveCoding */
+  }
+
   /* Get length portably, fstat() is POSIX, not C */
   if (fseek(fp, 0, SEEK_END) != 0) {
     status = ARES_EFILE; /* LCOV_EXCL_LINE: DefensiveCoding */


### PR DESCRIPTION
The commit is a small optimization in how a file is loaded into memory.

`FILE` buffering is just a libc (or user) provided buffer that transparently reduces (typically) the number of system calls to I/O. `fseek()` is not affected (not because `fseek()` will not perform I/O but because it won't use that buffer, apart from potentially flushing it).

In this case we predetermine the number of bytes to read (the entire file) and then we load the entire file in one `fread()`, and in this case buffering can only hurt: it results in multiple system `read()` calls instead of a single `read()`, as well as copying each read byte from the I/O buffer to the `fread()` buffer.

Furthermore, the `setvbuf()` call eagerly (before `fclose()`) releases the buffer memory back to the system (at least `BUFSIZ` >= 256 bytes). Releasing memory eagerly before performing I/O may be advantageous on a low-memory system with slow I/O.