### PR TITLE
adig and ahost should return failure exit codes on resolution failures

### DIFF
--- a/docs/adig.1
+++ b/docs/adig.1
@@ -170,6 +170,21 @@ Alias for +[no]tcp
 
 ${XDG_CONFIG_HOME}/adigrc
 
+.SH RETURN VALUES
+.TP
+\fB0\fR
+Success
+.TP
+\fB1\fR
+Internal System Error
+.TP
+\fB2\fR
+Command line misuse
+.TP
+\fB3\fR
+At least one DNS query failed
+.TP
+
 .SH "REPORTING BUGS"
 Report bugs to the c-ares github issues tracker
 .br

--- a/docs/ahost.1
+++ b/docs/ahost.1
@@ -41,6 +41,22 @@ Specify the \fIdomain\fP to search instead of using the default values from
 /etc/resolv.conf
 for DNS configuration; it has no effect on other platforms (such as Win32
 or Android).
+
+.SH RETURN VALUES
+.TP
+\fB0\fR
+Success
+.TP
+\fB1\fR
+Internal System Error
+.TP
+\fB2\fR
+Command line misuse
+.TP
+\fB3\fR
+At least one DNS query failed
+.TP
+
 .SH "REPORTING BUGS"
 Report bugs to the c-ares mailing list:
 .br


### PR DESCRIPTION
If someone is using adig or ahost as part of a script, having it return a proper error code is necessary in order to detect failures rather than relying on text output.

Signed-off-by: Brad House (@bradh352)