### PR TITLE
Localhost resolution can fail if only one address family is in /etc/hosts

### DIFF
--- a/src/lib/ares_free_hostent.c
+++ b/src/lib/ares_free_hostent.c
@@ -44,9 +44,10 @@ void ares_free_hostent(struct hostent *host)
   }
   ares_free(host->h_aliases);
   if (host->h_addr_list) {
-    ares_free(
-      host->h_addr_list[0]); /* no matter if there is one or many entries,
-                           there is only one malloc for all of them */
+    size_t i;
+    for (i=0; host->h_addr_list[i] != NULL; i++) {
+      ares_free(host->h_addr_list[i]);
+    }
     ares_free(host->h_addr_list);
   }
   ares_free(host);

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -418,9 +418,13 @@ done:
    * SHOULD recognize localhost names as special and SHOULD always return the
    * IP loopback address for address queries".
    * We will also ignore ALL errors when trying to resolve localhost, such
-   * as permissions errors reading /etc/hosts or a malformed /etc/hosts */
-  if (status != ARES_SUCCESS && status != ARES_ENOMEM &&
-      ares_is_localhost(hquery->name)) {
+   * as permissions errors reading /etc/hosts or a malformed /etc/hosts.
+   *
+   * Also, just because the query itself returned success from /etc/hosts
+   * lookup doesn't mean it returned everything it needed to for all requested
+   * address families. As long as we're not on a critical out of memory
+   * condition pass it through to fill in any other address classes. */
+  if (status != ARES_ENOMEM && ares_is_localhost(hquery->name)) {
     return ares_addrinfo_localhost(hquery->name, hquery->port, &hquery->hints,
                                    hquery->ai);
   }

--- a/src/lib/ares_gethostbyaddr.c
+++ b/src/lib/ares_gethostbyaddr.c
@@ -120,7 +120,7 @@ static void next_lookup(struct addr_query *aquery)
 {
   const char     *p;
   ares_status_t   status;
-  struct hostent *host;
+  struct hostent *host = NULL;
   char           *name;
 
   for (p = aquery->remaining_lookups; *p; p++) {

--- a/src/lib/ares_hosts_file.c
+++ b/src/lib/ares_hosts_file.c
@@ -845,7 +845,7 @@ ares_status_t ares_hosts_entry_to_addrinfo(const ares_hosts_entry_t *entry,
                                            ares_bool_t           want_cnames,
                                            struct ares_addrinfo *ai)
 {
-  ares_status_t               status;
+  ares_status_t               status  = ARES_ENOTFOUND;
   struct ares_addrinfo_cname *cnames  = NULL;
   struct ares_addrinfo_node  *ainodes = NULL;
   ares_llist_node_t          *node;
@@ -860,6 +860,7 @@ ares_status_t ares_hosts_entry_to_addrinfo(const ares_hosts_entry_t *entry,
   }
 
   if (name != NULL) {
+    ares_free(ai->name);
     ai->name = ares_strdup(name);
     if (ai->name == NULL) {
       status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
@@ -886,6 +887,11 @@ ares_status_t ares_hosts_entry_to_addrinfo(const ares_hosts_entry_t *entry,
     if (status != ARES_SUCCESS) {
       goto done; /* LCOV_EXCL_LINE: DefensiveCoding */
     }
+  }
+
+  /* Might be ARES_ENOTFOUND here if no ips matched requested address family */
+  if (status != ARES_SUCCESS) {
+    goto done;
   }
 
   if (want_cnames) {

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -455,8 +455,10 @@ ares_status_t ares_parse_ptr_reply_dnsrec(const ares_dns_record_t *dnsrec,
                                           const void *addr, int addrlen,
                                           int family, struct hostent **host);
 
+/* host address must be valid or NULL as will create or append */
 ares_status_t ares_addrinfo2hostent(const struct ares_addrinfo *ai, int family,
                                     struct hostent **host);
+
 ares_status_t ares_addrinfo2addrttl(const struct ares_addrinfo *ai, int family,
                                     size_t                req_naddrttls,
                                     struct ares_addrttl  *addrttls,

--- a/src/lib/legacy/ares_parse_a_reply.c
+++ b/src/lib/legacy/ares_parse_a_reply.c
@@ -77,6 +77,7 @@ int ares_parse_a_reply(const unsigned char *abuf, int alen,
   }
 
   if (host != NULL) {
+    *host  = NULL;
     status = ares_addrinfo2hostent(&ai, AF_INET, host);
     if (status != ARES_SUCCESS && status != ARES_ENODATA) {
       goto fail; /* LCOV_EXCL_LINE: DefensiveCoding */

--- a/src/lib/legacy/ares_parse_aaaa_reply.c
+++ b/src/lib/legacy/ares_parse_aaaa_reply.c
@@ -80,6 +80,7 @@ int ares_parse_aaaa_reply(const unsigned char *abuf, int alen,
   }
 
   if (host != NULL) {
+    *host  = NULL;
     status = ares_addrinfo2hostent(&ai, AF_INET6, host);
     if (status != ARES_SUCCESS && status != ARES_ENODATA) {
       goto fail; /* LCOV_EXCL_LINE: DefensiveCoding */

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -850,7 +850,7 @@ class ContainedMockChannelSysConfig
     : MockChannelOptsTest(1, GetParam().first, GetParam().second, true, nullptr, 0) {}
 };
 
-NameContentList files_no_ndots = {
+static NameContentList files_no_ndots = {
   {"/etc/resolv.conf", "nameserver 1.2.3.4\n" // Will be replaced
                        "search example.com example.org\n"
                        "options edns0 trust-ad\n"}, // ndots:1 is default
@@ -875,7 +875,8 @@ CONTAINED_TEST_P(ContainedMockChannelSysConfig, SysConfigNdotsDefault,
   return HasFailure();
 }
 
-NameContentList files_ndots0 = {
+
+static NameContentList files_ndots0 = {
   {"/etc/resolv.conf", "nameserver 1.2.3.4\n" // Will be replaced
                        "search example.com example.org\n"
                        "options edns0 trust-ad ndots:0\n"}, // ndots:1 is default


### PR DESCRIPTION
Resolution of 'localhost' is required to be resolved locally as per RFC6761, and c-ares implements fallback cases if `/etc/hosts` does not contain an entry for `localhost` as is common for Windows.  However, if `/etc/hosts` does have an address entry for one family (e.g. ipv4) but not the other (e.g. ipv6), the fallback wasn't being called since an entry was found.

We need to enhance the logic to always fallback if an address family is missing after reading `/etc/hosts`.  We will also add specific test cases for this scenario to ensure it doesn't regress in the future.

Fixes #946 
Signed-off-by: Brad House (@bradh352)