### PR TITLE
docs: fix troff escape sequence typos

### DIFF
--- a/docs/ares_init_options.3
+++ b/docs/ares_init_options.3
@@ -200,7 +200,7 @@ The default value is 53, the standard name service port.
 .br
 The list of IPv4 servers to contact, instead of the servers specified in
 resolv.conf or the local named. In order to allow specification of either IPv4
-or IPv6 name servers, the \Bares_set_servers(3)\fP function must be used
+or IPv6 name servers, the \fBares_set_servers(3)\fP function must be used
 instead.
 .TP 18
 .B ARES_OPT_DOMAINS

--- a/docs/ares_reinit.3
+++ b/docs/ares_reinit.3
@@ -23,7 +23,7 @@ currently assigned to is removed from the system configuration.
 This function may cause additional file descriptors to be created, and existing
 ones to be destroyed if server configuration has changed.
 
-\Bares_reinit(3)\fP, when compiled with thread safety, will spawn a background
+\fBares_reinit(3)\fP, when compiled with thread safety, will spawn a background
 thread to read the configuration and apply it.  It is crucial that developers
 use the \fBARES_OPT_SOCK_STATE_CB\fP or \fBARES_OPT_EVENT_THREAD\fP so that
 notifications of changes are alerted.  If using \fBares_getsock(3)\fP or


### PR DESCRIPTION
The \B was meant to be \fB to turn on bold lettering.