### PR TITLE
docs: remove twice mentioned status value from list

### DIFF
--- a/docs/ares_send.3
+++ b/docs/ares_send.3
@@ -113,9 +113,6 @@ is being destroyed; the query will not be completed.
 .B ARES_ENOSERVER
 The query will not be completed because no DNS servers were configured on the
 channel.
-.TP 19
-.B ARES_EBADQUERY
-Misformatted DNS query.
 .PP
 
 The callback argument


### PR DESCRIPTION
The value ARES_EBADQUERY is mentioned already above with a better description.