### PR TITLE
chore(man): use exactly same copyright string as for sources

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -5,17 +5,17 @@ Source: https://c-ares.org/
 
 # Fuzzer data
 Files: test/fuzzinput/* test/fuzznames/*
-Copyright: The c-ares project and its contributors.
+Copyright: The c-ares project and its contributors
 License: MIT
 
 # Docs
 Files: AUTHORS CONTRIBUTING.md GIT-INFO README.md README.msvc RELEASE-PROCEDURE.md RELEASE-NOTES.md FEATURES.md SECURITY.md DEVELOPER-NOTES.md INSTALL.md FUZZING.md test/README.md src/lib/include/README.md src/lib/thirdparty/apple/README.md
-Copyright: The c-ares project and its contributors.
+Copyright: The c-ares project and its contributors
 License: MIT
 
 # dotfiles
 Files: .gitignore .gitattributes m4/.gitignore test/.gitignore
-Copyright: The c-ares project and its contributors.
+Copyright: The c-ares project and its contributors
 License: MIT
 
 # Imported m4 files

--- a/docs/ares_dns_class_t.3
+++ b/docs/ares_dns_class_t.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_flags_t.3
+++ b/docs/ares_dns_flags_t.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_mapping.3
+++ b/docs/ares_dns_mapping.3
@@ -1,4 +1,4 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .\"
 .TH ARES_DNS_MAPPINGS 3 "12 November 2023"

--- a/docs/ares_dns_opcode_t.3
+++ b/docs/ares_dns_opcode_t.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_parse.3
+++ b/docs/ares_dns_parse.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_rcode_t.3
+++ b/docs/ares_dns_rcode_t.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_rec_type_t.3
+++ b/docs/ares_dns_rec_type_t.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_record.3
+++ b/docs/ares_dns_record.3
@@ -1,4 +1,4 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .\"
 .TH ARES_DNS_RECORD 3 "12 November 2023"

--- a/docs/ares_dns_record_create.3
+++ b/docs/ares_dns_record_create.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_record_destroy.3
+++ b/docs/ares_dns_record_destroy.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_record_duplicate.3
+++ b/docs/ares_dns_record_duplicate.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_record_get_flags.3
+++ b/docs/ares_dns_record_get_flags.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_record_get_id.3
+++ b/docs/ares_dns_record_get_id.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_record_get_opcode.3
+++ b/docs/ares_dns_record_get_opcode.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_record_get_rcode.3
+++ b/docs/ares_dns_record_get_rcode.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_record_query_add.3
+++ b/docs/ares_dns_record_query_add.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_record_query_cnt.3
+++ b/docs/ares_dns_record_query_cnt.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_record_query_get.3
+++ b/docs/ares_dns_record_query_get.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_record_query_set_name.3
+++ b/docs/ares_dns_record_query_set_name.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_record_query_set_type.3
+++ b/docs/ares_dns_record_query_set_type.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_record_rr_add.3
+++ b/docs/ares_dns_record_rr_add.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_record_rr_cnt.3
+++ b/docs/ares_dns_record_rr_cnt.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_record_rr_del.3
+++ b/docs/ares_dns_record_rr_del.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_record_rr_get.3
+++ b/docs/ares_dns_record_rr_get.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_record_rr_get_const.3
+++ b/docs/ares_dns_record_rr_get_const.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_record_set_id.3
+++ b/docs/ares_dns_record_set_id.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_dns_rr.3
+++ b/docs/ares_dns_rr.3
@@ -1,4 +1,4 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .\"
 .TH ARES_DNS_RR 3 "12 November 2023"

--- a/docs/ares_dns_rr_add_abin.3
+++ b/docs/ares_dns_rr_add_abin.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_del_abin.3
+++ b/docs/ares_dns_rr_del_abin.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_del_opt_byid.3
+++ b/docs/ares_dns_rr_del_opt_byid.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_abin.3
+++ b/docs/ares_dns_rr_get_abin.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_abin_cnt.3
+++ b/docs/ares_dns_rr_get_abin_cnt.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_addr.3
+++ b/docs/ares_dns_rr_get_addr.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_addr6.3
+++ b/docs/ares_dns_rr_get_addr6.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_bin.3
+++ b/docs/ares_dns_rr_get_bin.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_class.3
+++ b/docs/ares_dns_rr_get_class.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_keys.3
+++ b/docs/ares_dns_rr_get_keys.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_mapping.3

--- a/docs/ares_dns_rr_get_name.3
+++ b/docs/ares_dns_rr_get_name.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_opt.3
+++ b/docs/ares_dns_rr_get_opt.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_opt_byid.3
+++ b/docs/ares_dns_rr_get_opt_byid.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_opt_cnt.3
+++ b/docs/ares_dns_rr_get_opt_cnt.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_str.3
+++ b/docs/ares_dns_rr_get_str.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_ttl.3
+++ b/docs/ares_dns_rr_get_ttl.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_type.3
+++ b/docs/ares_dns_rr_get_type.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_u16.3
+++ b/docs/ares_dns_rr_get_u16.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_u32.3
+++ b/docs/ares_dns_rr_get_u32.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_get_u8.3
+++ b/docs/ares_dns_rr_get_u8.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_key_t.3
+++ b/docs/ares_dns_rr_key_t.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_set_addr.3
+++ b/docs/ares_dns_rr_set_addr.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_set_addr6.3
+++ b/docs/ares_dns_rr_set_addr6.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_set_bin.3
+++ b/docs/ares_dns_rr_set_bin.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_set_opt.3
+++ b/docs/ares_dns_rr_set_opt.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_set_str.3
+++ b/docs/ares_dns_rr_set_str.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_set_u16.3
+++ b/docs/ares_dns_rr_set_u16.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_set_u32.3
+++ b/docs/ares_dns_rr_set_u32.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_rr_set_u8.3
+++ b/docs/ares_dns_rr_set_u8.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_section_t.3
+++ b/docs/ares_dns_section_t.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_dns_write.3
+++ b/docs/ares_dns_write.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_record.3

--- a/docs/ares_init.3
+++ b/docs/ares_init.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_init_options.3

--- a/docs/ares_process_fd.3
+++ b/docs/ares_process_fd.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_process.3

--- a/docs/ares_process_fds.3
+++ b/docs/ares_process_fds.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_process.3

--- a/docs/ares_process_pending_write.3
+++ b/docs/ares_process_pending_write.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_set_pending_write_cb.3

--- a/docs/ares_query_dnsrec.3
+++ b/docs/ares_query_dnsrec.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_query.3

--- a/docs/ares_queue.3
+++ b/docs/ares_queue.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright 2024 by the c-ares project and its contributors
+.\" Copyright 2024 by The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .\"
 .TH ARES_QUEUE 3 "16 February 2024"

--- a/docs/ares_queue_active_queries.3
+++ b/docs/ares_queue_active_queries.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2024 The c-ares project and its contributors.
+.\" Copyright (C) 2024 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_queue.3

--- a/docs/ares_queue_wait_empty.3
+++ b/docs/ares_queue_wait_empty.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2024 The c-ares project and its contributors.
+.\" Copyright (C) 2024 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_queue.3

--- a/docs/ares_reinit.3
+++ b/docs/ares_reinit.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright 2023 by the c-ares project and its contributors
+.\" Copyright 2023 by The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .\"
 .TH ARES_REINIT 3 "12 November 2023"

--- a/docs/ares_search_dnsrec.3
+++ b/docs/ares_search_dnsrec.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_search.3

--- a/docs/ares_send_dnsrec.3
+++ b/docs/ares_send_dnsrec.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_send.3

--- a/docs/ares_set_pending_write_cb.3
+++ b/docs/ares_set_pending_write_cb.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright 2024 by the c-ares project and its contributors
+.\" Copyright 2024 by The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .\"
 .TH ARES_SET_NOTIFY_PENDING_WRITE_CALLBACK 3 "13 Aug 2024"

--- a/docs/ares_set_server_state_callback.3
+++ b/docs/ares_set_server_state_callback.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright 2024 by the c-ares project and its contributors
+.\" Copyright 2024 by The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .\"
 .TH ARES_SET_SERVER_STATE_CALLBACK 3 "26 Apr 2024"

--- a/docs/ares_set_socket_functions_ex.3
+++ b/docs/ares_set_socket_functions_ex.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2024 The c-ares project and its contributors.
+.\" Copyright (C) 2024 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_set_socket_functions.3

--- a/docs/ares_threadsafety.3
+++ b/docs/ares_threadsafety.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright 2023 by the c-ares project and its contributors
+.\" Copyright 2023 by The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .\"
 .TH ARES_THREADSAFETY 3 "26 November 2023"

--- a/docs/ares_tlsa_match_t.3
+++ b/docs/ares_tlsa_match_t.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_tlsa_selector_t.3
+++ b/docs/ares_tlsa_selector_t.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3

--- a/docs/ares_tlsa_usage_t.3
+++ b/docs/ares_tlsa_usage_t.3
@@ -1,3 +1,3 @@
-.\" Copyright (C) 2023 The c-ares project and its contributors.
+.\" Copyright (C) 2023 The c-ares project and its contributors
 .\" SPDX-License-Identifier: MIT
 .so man3/ares_dns_rr.3


### PR DESCRIPTION
The (automatically) [generated Debian Copyright file](https://salsa.debian.org/debian/c-ares/-/blob/debian/1.34.4-2.1/debian/copyright) contains more sections than necessary due an inconsistent copyright string:

```
The c-ares project and its contributors[.]
```

While it's not a big deal due to the file is generated automatically, it would be nice to shrink the relatively complex file.

Maybe also the copyrights by "Brad House" and "Daniel Stenberg" could be replaced with "The c-ares project and its contributors".

Thanks for considering.
-Gregor