### PR TITLE
CI: GitHub actions ubuntu-latest now points to 24.04 causing some minor issues

### DIFF
--- a/.github/workflows/alpine-latest.yml
+++ b/.github/workflows/alpine-latest.yml
@@ -38,7 +38,7 @@ jobs:
           TEST_DEBUGGER: gdb
         run: |
           ./ci/build.sh
-          ./ci/test.sh
+          sudo ./ci/test.sh
       - name: "Autotools: build and test c-ares"
         env:
           BUILD_TYPE: autotools
@@ -58,7 +58,7 @@ jobs:
           TEST_DEBUGGER: "none"
         run: |
           ./ci/build.sh
-          ./ci/test.sh
+          sudo ./ci/test.sh
       - name: "CMake: ASAN: build and test c-ares"
         env:
           BUILD_TYPE: "asan"
@@ -71,7 +71,7 @@ jobs:
           TEST_DEBUGGER: "none"
         run: |
           ./ci/build.sh
-          ./ci/test.sh
+          sudo ./ci/test.sh
       - name: "CMake: Static Analyzer: build c-ares"
         env:
           BUILD_TYPE: "analyze"

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   build:
     name: Coveralls
-    runs-on: ubuntu-latest
+    # Note gcov on ubuntu-latest (24.04) has some bugs:
+    # https://www.reddit.com/r/cpp_questions/comments/1ewnv8d/lcov_geninfo_error/
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: awalsh128/cache-apt-pkgs-action@latest
@@ -25,7 +27,7 @@ jobs:
         shell: bash
         run: |
           cd build
-          ./bin/arestest -v --gtest_filter='-*LiveSearchTXT*:*LiveSearchANY*:*LiveSearchNS*'
+          sudo ./bin/arestest -v --gtest_filter='-*LiveSearchTXT*:*LiveSearchANY*:*LiveSearchNS*'
       - name: Generate Coverage
         shell: bash
         run: |

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -36,7 +36,7 @@ jobs:
           TEST_DEBUGGER: gdb
         run: |
           ./ci/build.sh
-          ./ci/test.sh
+          sudo ./ci/test.sh
       - name: "Autotools: build and test c-ares"
         env:
           BUILD_TYPE: autotools
@@ -53,7 +53,7 @@ jobs:
           TEST_DEBUGGER: gdb
         run: |
           ./ci/build.sh
-          ./ci/test.sh
+          sudo ./ci/test.sh
       - name: "CMake: (hide symbols) build and test c-ares"
         env:
           BUILD_TYPE: CMAKE
@@ -62,7 +62,7 @@ jobs:
           TEST_DEBUGGER: gdb
         run: |
           ./ci/build.sh
-          ./ci/test.sh
+          sudo ./ci/test.sh
       - name: "CMake: UBSAN: build and test c-ares"
         env:
           BUILD_TYPE: "ubsan"
@@ -75,7 +75,7 @@ jobs:
           TEST_DEBUGGER: "none"
         run: |
           ./ci/build.sh
-          ./ci/test.sh
+          sudo ./ci/test.sh
       - name: "CMake: ASAN: build and test c-ares"
         env:
           BUILD_TYPE: "asan"
@@ -88,7 +88,7 @@ jobs:
           TEST_DEBUGGER: "none"
         run: |
           ./ci/build.sh
-          ./ci/test.sh
+          sudo ./ci/test.sh
       - name: "CMake: Static Analyzer: build c-ares"
         env:
           BUILD_TYPE: "analyze"
@@ -119,4 +119,4 @@ jobs:
         run: |
           sudo sysctl -w net.ipv4.tcp_fastopen=0
           ./ci/build.sh
-          ./ci/test.sh
+          sudo ./ci/test.sh

--- a/include/ares_dns_record.h
+++ b/include/ares_dns_record.h
@@ -1106,7 +1106,7 @@ CARES_EXTERN ares_status_t ares_dns_write(const ares_dns_record_t *dnsrec,
  *  Returns NULL if \p dnsrec is NULL.
  *
  *  \param[in] dnsrec Pointer to initialized and filled DNS record object.
- *  \return duplicted DNS record object, or NULL on out of memory.
+ *  \return duplicated DNS record object, or NULL on out of memory.
  */
 CARES_EXTERN ares_dns_record_t *
   ares_dns_record_duplicate(const ares_dns_record_t *dnsrec);

--- a/src/lib/ares_cookie.c
+++ b/src/lib/ares_cookie.c
@@ -115,7 +115,7 @@
  *     - If `cookie.unsupported_ts` evaluates less than
  *       `COOKIE_UNSUPPORTED_TIMEOUT`
  *        - Ensure there is no EDNS cookie opt (10) set (shouldn't be unless
- *          requestor had put this themselves), then **skip any remaining
+ *          requester had put this themselves), then **skip any remaining
  *          processing** as we don't want to try to send cookies.
  *     - Otherwise:
  *       - clear all cookie settings, set `cookie.state = INITIAL`.

--- a/src/lib/event/ares_event_win32.c
+++ b/src/lib/event/ares_event_win32.c
@@ -667,7 +667,7 @@ static ares_bool_t ares_evsys_win32_afd_cancel(ares_evsys_win32_eventdata_t *ed)
 
   /* NtCancelIoFileEx() may return STATUS_NOT_FOUND if the operation completed
    * just before calling NtCancelIoFileEx(), but we have not yet received the
-   * notifiction (but it should be queued for the next IOCP event).  */
+   * notification (but it should be queued for the next IOCP event).  */
   if (status == STATUS_SUCCESS || status == STATUS_NOT_FOUND) {
     return ARES_TRUE;
   }

--- a/src/lib/util/ares_uri.h
+++ b/src/lib/util/ares_uri.h
@@ -175,7 +175,7 @@ ares_status_t  ares_uri_set_query_key(ares_uri_t *uri, const char *key,
  */
 ares_status_t  ares_uri_del_query_key(ares_uri_t *uri, const char *key);
 
-/*! Retrieve the value associted with a query key. Keys are case-insensitive.
+/*! Retrieve the value associated with a query key. Keys are case-insensitive.
  *
  *  \param[in] uri Initialized URI object
  *  \param[in] key Key to retrieve.


### PR DESCRIPTION
Containerized tests now need to be run with sudo to gain access to chroot().  Also, `gcov` in ubuntu 24.04 is broken with googletest so revert back to 22.04 for coverage.

Finally, codespell is updated in 24.04 to detect more issues and there were some typos that needed to be fixed.

Signed-off-by: Brad House (@bradh352)