### PR TITLE
Fix latency_max_ms

### DIFF
--- a/src/lib/ares_metrics.c
+++ b/src/lib/ares_metrics.c
@@ -197,7 +197,7 @@ void ares_metrics_record(const ares_query_t *query, ares_server_t *server,
     }
 
     if (query_ms > server->metrics[i].latency_max_ms) {
-      server->metrics[i].latency_min_ms = query_ms;
+      server->metrics[i].latency_max_ms = query_ms;
     }
 
     server->metrics[i].total_count++;


### PR DESCRIPTION
I know that `latency_max_ms` isn't used for now, but I think it better be fixed in case it will be used later.

Also I've wanted to clarify: [here](https://github.com/c-ares/c-ares/blob/main/src/lib/ares_metrics.c#L243) and in the [docs](https://c-ares.org/docs/ares_init_options.html) for `ARES_OPT_TIMEOUTMS` stated that initial timeout option is only honored on the first successful query to any given server, but to me, after looking at the code, it seems that it will be honored until there will be at least `MIN_COUNT_FOR_AVERAGE` (which is 3) queries in any bucket, because otherwise the code will always be hitting [this line](https://github.com/c-ares/c-ares/blob/main/src/lib/ares_metrics.c#L227). Correct me please, If I'm wrong.