### PR TITLE
Fix polling ares_event_configchg_init: initialize mutex

### DIFF
--- a/src/lib/event/ares_event_configchg.c
+++ b/src/lib/event/ares_event_configchg.c
@@ -665,6 +665,12 @@ ares_status_t ares_event_configchg_init(ares_event_configchg_t **configchg,
     goto done;
   }
 
+  c->lock = ares_thread_mutex_create();
+  if (c->lock == NULL) {
+    status = ARES_ENOMEM;
+    goto done;
+  }
+
   c->resolvconf_path = c->e->channel->resolvconf_path;
   if (c->resolvconf_path == NULL) {
     c->resolvconf_path = PATH_RESOLV_CONF;


### PR DESCRIPTION
The polling-based implementation of ares_event_configchg_init previously
did not initialize the mutex ares_event_configchg_t->lock. This caused
ares_thread_cond_timedwait to immediately return, which means that the
thread running ares_event_configchg_thread is busy-waiting without
sleeping between config change checks. In addition to the high CPU usage
this causes, the DNS config is actually never checked in this case.

This commit fixes the issue by initializing the mutex. Thereby, the
config polling thread correctly only wakes up every 30 seconds and
properly checks for a config change.

Note: the bug only came into effect if the combination of the polling-
based implementation of ares_event_configchg_init and the pthread-based
implementation of ares_thread_cond_timedwait was used.