### PR TITLE
CVE-2025-31498: backport

### DIFF
--- a/src/lib/Makefile.inc
+++ b/src/lib/Makefile.inc
@@ -3,6 +3,7 @@
 
 CSOURCES = ares__addrinfo2hostent.c	\
   ares__addrinfo_localhost.c		\
+  ares__array.c				\
   ares__buf.c				\
   ares__close_sockets.c			\
   ares__hosts_file.c			\
@@ -88,7 +89,8 @@ CSOURCES = ares__addrinfo2hostent.c	\
   inet_ntop.c				\
   windows_port.c
 
-HHEADERS = ares__buf.h			\
+HHEADERS = ares__array.h		\
+  ares__buf.h				\
   ares__htable.h			\
   ares__htable_asvp.h			\
   ares__htable_strvp.h			\

--- a/src/lib/ares__array.c
+++ b/src/lib/ares__array.c
@@ -1,0 +1,367 @@
+/* MIT License
+ *
+ * Copyright (c) 2024 Brad House
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "ares_private.h"
+#include "ares__array.h"
+
+#define ARES__ARRAY_MIN 4
+
+struct ares__array {
+  ares__array_destructor_t destruct;
+  void                    *arr;
+  size_t                   member_size;
+  size_t                   cnt;
+  size_t                   offset;
+  size_t                   alloc_cnt;
+};
+
+ares__array_t *ares__array_create(size_t                   member_size,
+                                  ares__array_destructor_t destruct)
+{
+  ares__array_t *arr;
+
+  if (member_size == 0) {
+    return NULL;
+  }
+
+  arr = ares_malloc_zero(sizeof(*arr));
+  if (arr == NULL) {
+    return NULL;
+  }
+
+  arr->member_size = member_size;
+  arr->destruct    = destruct;
+  return arr;
+}
+
+size_t ares__array_len(const ares__array_t *arr)
+{
+  if (arr == NULL) {
+    return 0;
+  }
+  return arr->cnt;
+}
+
+void *ares__array_at(ares__array_t *arr, size_t idx)
+{
+  if (arr == NULL || idx >= arr->cnt) {
+    return NULL;
+  }
+  return (unsigned char *)arr->arr + ((idx + arr->offset) * arr->member_size);
+}
+
+const void *ares__array_at_const(const ares__array_t *arr, size_t idx)
+{
+  if (arr == NULL || idx >= arr->cnt) {
+    return NULL;
+  }
+  return (unsigned char *)arr->arr + ((idx + arr->offset) * arr->member_size);
+}
+
+ares_status_t ares__array_sort(ares__array_t *arr, ares__array_cmp_t cmp)
+{
+  if (arr == NULL || cmp == NULL) {
+    return ARES_EFORMERR;
+  }
+
+  /* Nothing to sort */
+  if (arr->cnt < 2) {
+    return ARES_SUCCESS;
+  }
+
+  qsort((unsigned char *)arr->arr + (arr->offset * arr->member_size), arr->cnt,
+        arr->member_size, cmp);
+  return ARES_SUCCESS;
+}
+
+void ares__array_destroy(ares__array_t *arr)
+{
+  size_t i;
+
+  if (arr == NULL) {
+    return;
+  }
+
+  if (arr->destruct != NULL) {
+    for (i = 0; i < arr->cnt; i++) {
+      arr->destruct(ares__array_at(arr, i));
+    }
+  }
+
+  ares_free(arr->arr);
+  ares_free(arr);
+}
+
+/* NOTE: this function operates on actual indexes, NOT indexes using the
+ *       arr->offset */
+static ares_status_t ares__array_move(ares__array_t *arr, size_t dest_idx,
+                                      size_t src_idx)
+{
+  void       *dest_ptr;
+  const void *src_ptr;
+  size_t      nmembers;
+
+  if (arr == NULL || dest_idx >= arr->alloc_cnt || src_idx >= arr->alloc_cnt) {
+    return ARES_EFORMERR;
+  }
+
+  /* Nothing to do */
+  if (dest_idx == src_idx) {
+    return ARES_SUCCESS;
+  }
+
+  dest_ptr = (unsigned char *)arr->arr + (dest_idx * arr->member_size);
+  src_ptr  = (unsigned char *)arr->arr + (src_idx * arr->member_size);
+
+  /* Check to make sure shifting to the right won't overflow our allocation
+   * boundary */
+  if (dest_idx > src_idx && arr->cnt + (dest_idx - src_idx) > arr->alloc_cnt) {
+    return ARES_EFORMERR;
+  }
+
+  nmembers = arr->cnt - (src_idx - arr->offset);
+  memmove(dest_ptr, src_ptr, nmembers * arr->member_size);
+
+  return ARES_SUCCESS;
+}
+
+void *ares__array_finish(ares__array_t *arr, size_t *num_members)
+{
+  void *ptr;
+
+  if (arr == NULL || num_members == NULL) {
+    return NULL;
+  }
+
+  /* Make sure we move data to beginning of allocation */
+  if (arr->offset != 0) {
+    if (ares__array_move(arr, 0, arr->offset) != ARES_SUCCESS) {
+      return NULL;
+    }
+    arr->offset = 0;
+  }
+
+  ptr          = arr->arr;
+  *num_members = arr->cnt;
+  ares_free(arr);
+  return ptr;
+}
+
+ares_status_t ares__array_set_size(ares__array_t *arr, size_t size)
+{
+  void *temp;
+
+  if (arr == NULL || size == 0 || size < arr->cnt) {
+    return ARES_EFORMERR;
+  }
+
+  /* Always operate on powers of 2 */
+  size = ares__round_up_pow2(size);
+
+  if (size < ARES__ARRAY_MIN) {
+    size = ARES__ARRAY_MIN;
+  }
+
+  /* If our allocation size is already large enough, skip */
+  if (size <= arr->alloc_cnt) {
+    return ARES_SUCCESS;
+  }
+
+  temp = ares_realloc_zero(arr->arr, arr->alloc_cnt * arr->member_size,
+                           size * arr->member_size);
+  if (temp == NULL) {
+    return ARES_ENOMEM;
+  }
+  arr->alloc_cnt = size;
+  arr->arr       = temp;
+  return ARES_SUCCESS;
+}
+
+ares_status_t ares__array_insert_at(void **elem_ptr, ares__array_t *arr,
+                                    size_t idx)
+{
+  void         *ptr;
+  ares_status_t status;
+
+  if (arr == NULL) {
+    return ARES_EFORMERR;
+  }
+
+  /* Not >= since we are allowed to append to the end */
+  if (idx > arr->cnt) {
+    return ARES_EFORMERR;
+  }
+
+  /* Allocate more if needed */
+  status = ares__array_set_size(arr, arr->cnt + 1);
+  if (status != ARES_SUCCESS) {
+    return status;
+  }
+
+  /* Shift if we have memory but not enough room at the end */
+  if (arr->cnt + 1 + arr->offset > arr->alloc_cnt) {
+    status = ares__array_move(arr, 0, arr->offset);
+    if (status != ARES_SUCCESS) {
+      return status;
+    }
+    arr->offset = 0;
+  }
+
+  /* If we're inserting anywhere other than the end, we need to move some
+   * elements out of the way */
+  if (idx != arr->cnt) {
+    status = ares__array_move(arr, idx + arr->offset + 1, idx + arr->offset);
+    if (status != ARES_SUCCESS) {
+      return status;
+    }
+  }
+
+  /* Ok, we're guaranteed to have a gap where we need it, lets zero it out,
+   * and return it */
+  ptr = (unsigned char *)arr->arr + ((idx + arr->offset) * arr->member_size);
+  memset(ptr, 0, arr->member_size);
+  arr->cnt++;
+
+  if (elem_ptr) {
+    *elem_ptr = ptr;
+  }
+
+  return ARES_SUCCESS;
+}
+
+ares_status_t ares__array_insert_last(void **elem_ptr, ares__array_t *arr)
+{
+  return ares__array_insert_at(elem_ptr, arr, ares__array_len(arr));
+}
+
+ares_status_t ares__array_insert_first(void **elem_ptr, ares__array_t *arr)
+{
+  return ares__array_insert_at(elem_ptr, arr, 0);
+}
+
+ares_status_t ares__array_insertdata_last(ares__array_t *arr,
+                                          const void   *data_ptr)
+{
+  ares_status_t status;
+  void         *ptr = NULL;
+
+  status = ares__array_insert_last(&ptr, arr);
+  if (status != ARES_SUCCESS) {
+    return status;
+  }
+  memcpy(ptr, data_ptr, arr->member_size);
+  return ARES_SUCCESS;
+}
+
+
+void *ares__array_first(ares__array_t *arr)
+{
+  return ares__array_at(arr, 0);
+}
+
+void *ares__array_last(ares__array_t *arr)
+{
+  size_t cnt = ares__array_len(arr);
+  if (cnt == 0) {
+    return NULL;
+  }
+  return ares__array_at(arr, cnt - 1);
+}
+
+const void *ares__array_first_const(const ares__array_t *arr)
+{
+  return ares__array_at_const(arr, 0);
+}
+
+const void *ares__array_last_const(const ares__array_t *arr)
+{
+  size_t cnt = ares__array_len(arr);
+  if (cnt == 0) {
+    return NULL;
+  }
+  return ares__array_at_const(arr, cnt - 1);
+}
+
+ares_status_t ares__array_claim_at(void *dest, size_t dest_size,
+                                   ares__array_t *arr, size_t idx)
+{
+  ares_status_t status;
+
+  if (arr == NULL || idx >= arr->cnt) {
+    return ARES_EFORMERR;
+  }
+
+  if (dest != NULL && dest_size < arr->member_size) {
+    return ARES_EFORMERR;
+  }
+
+  if (dest) {
+    memcpy(dest, ares__array_at(arr, idx), arr->member_size);
+  }
+
+  if (idx == 0) {
+    /* Optimization, if first element, just increment offset, makes removing a
+     * lot from the start quick */
+    arr->offset++;
+  } else if (idx != arr->cnt - 1) {
+    /* Must shift entire array if removing an element from the middle. Does
+     * nothing if removing last element other than decrement count. */
+    status = ares__array_move(arr, idx + arr->offset, idx + arr->offset + 1);
+    if (status != ARES_SUCCESS) {
+      return status;
+    }
+  }
+
+  arr->cnt--;
+  return ARES_SUCCESS;
+}
+
+ares_status_t ares__array_remove_at(ares__array_t *arr, size_t idx)
+{
+  void *ptr = ares__array_at(arr, idx);
+  if (arr == NULL || ptr == NULL) {
+    return ARES_EFORMERR;
+  }
+
+  if (arr->destruct != NULL) {
+    arr->destruct(ptr);
+  }
+
+  return ares__array_claim_at(NULL, 0, arr, idx);
+}
+
+ares_status_t ares__array_remove_first(ares__array_t *arr)
+{
+  return ares__array_remove_at(arr, 0);
+}
+
+ares_status_t ares__array_remove_last(ares__array_t *arr)
+{
+  size_t cnt = ares__array_len(arr);
+  if (cnt == 0) {
+    return ARES_EFORMERR;
+  }
+  return ares__array_remove_at(arr, cnt - 1);
+}

--- a/src/lib/ares__array.h
+++ b/src/lib/ares__array.h
@@ -1,0 +1,237 @@
+/* MIT License
+ *
+ * Copyright (c) 2024 Brad House
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef __ARES__ARRAY_H
+#define __ARES__ARRAY_H
+
+/*! \addtogroup ares__array Array Data Structure
+ *
+ * This is an array with helpers.  It is meant to have as little overhead
+ * as possible over direct array management by applications but to provide
+ * safety and some optimization features.  It can also return the array in
+ * native form once all manipulation has been performed.
+ *
+ * @{
+ */
+
+struct ares__array;
+
+/*! Opaque data structure for array */
+typedef struct ares__array ares__array_t;
+
+/*! Callback to free user-defined member data
+ *
+ *  \param[in] data  pointer to member of array to be destroyed. The pointer
+ *                   itself must not be destroyed, just the data it contains.
+ */
+typedef void (*ares__array_destructor_t)(void *data);
+
+/*! Callback to compare two array elements used for sorting
+ *
+ *  \param[in] data1 array member 1
+ *  \param[in] data2 array member 2
+ *  \return < 0 if data1 < data2, > 0 if data1 > data2, 0 if data1 == data2
+ */
+typedef int (*ares__array_cmp_t)(const void *data1, const void *data2);
+
+/*! Create an array object
+ *
+ *  NOTE: members of the array are typically going to be an going to be a
+ *        struct with compiler/ABI specific padding to ensure proper alignment.
+ *        Care needs to be taken if using primitive types, especially floating
+ *        point numbers which size may not indicate the required alignment.
+ *        For example, a double may be 80 bits (10 bytes), but required
+ *        alignment of 16 bytes.  In such a case, a member_size of 16 would be
+ *        required to be used.
+ *
+ *  \param[in] destruct     Optional. Destructor to call on a removed member
+ *  \param[in] member_size  Size of array member, usually determined using
+ *                          sizeof() for the member such as a struct.
+ *
+ *  \return array object or NULL on out of memory
+ */
+ares__array_t *ares__array_create(size_t                   member_size,
+                                  ares__array_destructor_t destruct);
+
+
+/*! Request the array be at least the requested size.  Useful if the desired
+ *  array size is known prior to populating the array to prevent reallocations.
+ *
+ *  \param[in] arr  Initialized array object.
+ *  \param[in] size Minimum number of members
+ *  \return ARES_SUCCESS on success, ARES_EFORMERR on misuse,
+ *    ARES_ENOMEM on out of memory */
+ares_status_t  ares__array_set_size(ares__array_t *arr, size_t size);
+
+/*! Sort the array using the given comparison function.  This is not
+ *  persistent, any future elements inserted will not maintain this sort.
+ *
+ *  \param[in]  arr      Initialized array object.
+ *  \param[in]  cb       Sort callback
+ *  \return ARES_SUCCESS on success
+ */
+ares_status_t  ares__array_sort(ares__array_t *arr, ares__array_cmp_t cmp);
+
+/*! Destroy an array object.  If a destructor is set, will be called on each
+ *  member of the array.
+ *
+ *  \param[in] arr     Initialized array object.
+ */
+void           ares__array_destroy(ares__array_t *arr);
+
+/*! Retrieve the array in the native format.  This will also destroy the
+ *  container.  It is the responsibility of the caller to free the returned
+ *  pointer and also any data within each array element.
+ *
+ *  \param[in] arr  Initialized array object
+ *  \param[out] num_members the number of members in the returned array
+ *  \return pointer to native array on success, NULL on failure.
+ */
+void          *ares__array_finish(ares__array_t *arr, size_t *num_members);
+
+/*! Retrieve the number of members in the array
+ *
+ *  \param[in] arr     Initialized array object.
+ *  \return numbrer of members
+ */
+size_t         ares__array_len(const ares__array_t *arr);
+
+/*! Insert a new array member at the given index
+ *
+ *  \param[out] elem_ptr Optional. Pointer to the returned array element.
+ *  \param[in]  arr      Initialized array object.
+ *  \param[in]  idx      Index in array to place new element, will shift any
+ *                       elements down that exist after this point.
+ *  \return ARES_SUCCESS on success, ARES_EFORMERR on bad index,
+ *          ARES_ENOMEM on out of memory.
+ */
+ares_status_t  ares__array_insert_at(void **elem_ptr, ares__array_t *arr,
+                                     size_t idx);
+
+/*! Insert a new array member at the end of the array
+ *
+ *  \param[out] elem_ptr Optional. Pointer to the returned array element.
+ *  \param[in]  arr      Initialized array object.
+ *  \return ARES_SUCCESS on success, ARES_ENOMEM on out of memory.
+ */
+ares_status_t  ares__array_insert_last(void **elem_ptr, ares__array_t *arr);
+
+/*! Insert a new array member at the beginning of the array
+ *
+ *  \param[out] elem_ptr Optional. Pointer to the returned array element.
+ *  \param[in]  arr      Initialized array object.
+ *  \return ARES_SUCCESS on success, ARES_ENOMEM on out of memory.
+ */
+ares_status_t  ares__array_insert_first(void **elem_ptr, ares__array_t *arr);
+
+/*! Fetch a pointer to the given element in the array
+ *  \param[in]  array  Initialized array object
+ *  \param[in]  idx    Index to fetch
+ *  \return pointer on success, NULL on failure */
+void          *ares__array_at(ares__array_t *arr, size_t idx);
+
+/*! Fetch a pointer to the first element in the array
+ *  \param[in]  array  Initialized array object
+ *  \return pointer on success, NULL on failure */
+void          *ares__array_first(ares__array_t *arr);
+
+/*! Fetch a pointer to the last element in the array
+ *  \param[in]  array  Initialized array object
+ *  \return pointer on success, NULL on failure */
+void          *ares__array_last(ares__array_t *arr);
+
+/*! Fetch a constant pointer to the given element in the array
+ *  \param[in]  array  Initialized array object
+ *  \param[in]  idx    Index to fetch
+ *  \return pointer on success, NULL on failure */
+const void    *ares__array_at_const(const ares__array_t *arr, size_t idx);
+
+/*! Fetch a constant pointer to the first element in the array
+ *  \param[in]  array  Initialized array object
+ *  \return pointer on success, NULL on failure */
+const void    *ares__array_first_const(const ares__array_t *arr);
+
+/*! Fetch a constant pointer to the last element in the array
+ *  \param[in]  array  Initialized array object
+ *  \return pointer on success, NULL on failure */
+const void    *ares__array_last_const(const ares__array_t *arr);
+
+/*! Claim the data from the specified array index, copying it to the buffer
+ *  provided by the caller.  The index specified in the array will then be
+ *  removed (without calling any possible destructor)
+ *
+ *  \param[in,out] dest      Optional. Buffer to hold array member. Pass NULL
+ *                           if not needed.  This could leak memory if array
+ *                           member needs destructor if not provided.
+ *  \param[in]     dest_size Size of buffer provided, used as a sanity check.
+ *                           Must match member_size provided to
+ *                           ares__array_create() if dest_size specified.
+ *  \param[in]     arr       Initialized array object
+ *  \param[in]     idx       Index to claim
+ *  \return ARES_SUCCESS on success, ARES_EFORMERR on usage failure.
+ */
+ares_status_t  ares__array_claim_at(void *dest, size_t dest_size,
+                                    ares__array_t *arr, size_t idx);
+
+/*! Remove the member at the specified array index.  The destructor will be
+ *  called.
+ *
+ *  \param[in] arr  Initialized array object
+ *  \param[in] idx  Index to remove
+ *  \return ARES_SUCCESS if removed, ARES_EFORMERR on invalid use
+ */
+ares_status_t  ares__array_remove_at(ares__array_t *arr, size_t idx);
+
+/*! Remove the first member of the array.
+ *
+ *  \param[in] arr  Initialized array object
+ *  \return ARES_SUCCESS if removed, ARES_EFORMERR on invalid use
+ */
+ares_status_t  ares__array_remove_first(ares__array_t *arr);
+
+/*! Remove the last member of the array.
+ *
+ *  \param[in] arr  Initialized array object
+ *  \return ARES_SUCCESS if removed, ARES_EFORMERR on invalid use
+ */
+ares_status_t  ares__array_remove_last(ares__array_t *arr);
+
+/*! Insert a new array member at the end of the array and copy the data pointed
+ *  to by the data pointer into the array.  This will copy member_size bytes
+ *  from the provided pointer, this may not be safe for some data types
+ *  that may have a smaller size than the provided member_size which includes
+ *  padding as discussed in ares_array_create().
+ *
+ *  \param[in]  arr      Initialized array object.
+ *  \param[in]  data_ptr Pointer to data to copy into array.
+ *  \return ARES_SUCCESS on success, ARES_EFORMERR on bad index or null data
+ * ptr, ARES_ENOMEM on out of memory.
+ */
+CARES_EXTERN ares_status_t ares__array_insertdata_last(ares__array_t *arr,
+                                                       const void   *data_ptr);
+
+/*! @} */
+
+#endif /* __ARES__ARRAY_H */

--- a/src/lib/ares__close_sockets.c
+++ b/src/lib/ares__close_sockets.c
@@ -37,7 +37,7 @@ static void ares__requeue_queries(struct server_connection *conn,
   ares__tvnow(&now);
 
   while ((query = ares__llist_first_val(conn->queries_to_conn)) != NULL) {
-    ares__requeue_query(query, &now, requeue_status);
+    ares__requeue_query(query, &now, requeue_status, NULL);
   }
 }
 

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -105,6 +105,7 @@ W32_FUNC const char *_w32_GetHostsFile(void);
 struct ares_rand_state;
 typedef struct ares_rand_state ares_rand_state;
 
+#include "ares__array.h"
 #include "ares__llist.h"
 #include "ares__slist.h"
 #include "ares__htable_strvp.h"
@@ -411,7 +412,8 @@ ares_bool_t   ares__timedout(const ares_timeval_t *now,
 ares_status_t ares__send_query(struct query *query, const ares_timeval_t *now);
 ares_status_t ares__requeue_query(struct query         *query,
                                   const ares_timeval_t *now,
-                                  ares_status_t         status);
+                                  ares_status_t         status,
+                                  ares__array_t       **requeue);
 
 /*! Retrieve a list of names to use for searching.  The first successful
  *  query in the list wins.  This function also uses the HOSTSALIASES file

--- a/test/ares-test-mock-ai.cc
+++ b/test/ares-test-mock-ai.cc
@@ -596,6 +596,100 @@ TEST_P(MockChannelTestAI, FamilyUnspecified) {
   EXPECT_THAT(result.ai_, IncludesV6Address("2121:0000:0000:0000:0000:0000:0000:0303"));
 }
 
+
+TEST_P(MockChannelTestAI, TriggerResendThenConnFailSERVFAIL) {
+  // Set up the server response. The server always returns SERVFAIL.
+  DNSPacket badrsp4;
+  badrsp4.set_response().set_aa().set_rcode(SERVFAIL)
+    .add_question(new DNSQuestion("www.google.com", T_A));
+  DNSPacket goodrsp4;
+  goodrsp4.set_response().set_aa()
+    .add_question(new DNSQuestion("www.google.com", T_A))
+    .add_answer(new DNSARR("www.google.com", 0x0100, {0x01, 0x02, 0x03, 0x04}));
+
+  DNSPacket goodrsp6;
+  goodrsp6.set_response().set_aa()
+    .add_question(new DNSQuestion("www.google.com", T_AAAA))
+    .add_answer(new DNSAaaaRR("www.google.com", 100,
+                              {0x21, 0x21, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x03}));
+
+  EXPECT_CALL(server_, OnRequest("www.google.com", T_A))
+    .WillOnce(SetReplyAndFailSend(&server_, &badrsp4))
+    .WillOnce(SetReply(&server_, &goodrsp4));
+
+  EXPECT_CALL(server_, OnRequest("www.google.com", T_AAAA))
+    .WillRepeatedly(SetReply(&server_, &goodrsp6));
+
+  ares_socket_functions sock_funcs;
+  memset(&sock_funcs, 0, sizeof(sock_funcs));
+
+  sock_funcs.asendv = ares_sendv_fail;
+
+  ares_set_socket_functions(channel_, &sock_funcs, NULL);
+
+  AddrInfoResult result;
+  struct ares_addrinfo_hints hints = {0, 0, 0, 0};
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_flags = ARES_AI_NOSORT;
+  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints,
+                   AddrInfoCallback, &result);
+
+  Process();
+  EXPECT_TRUE(result.done_);
+  EXPECT_TRUE(result.done_);
+  EXPECT_THAT(result.ai_, IncludesNumAddresses(2));
+  EXPECT_THAT(result.ai_, IncludesV4Address("1.2.3.4"));
+  EXPECT_THAT(result.ai_, IncludesV6Address("2121:0000:0000:0000:0000:0000:0000:0303"));
+}
+
+TEST_P(MockUDPChannelTestAI, TriggerResendThenConnFailEDNS) {
+  // Set up the server response to simulate an EDNS failure
+ DNSPacket badrsp4;
+  badrsp4.set_response().set_aa().set_rcode(FORMERR)
+    .add_question(new DNSQuestion("www.google.com", T_A));
+  DNSPacket goodrsp4;
+  goodrsp4.set_response().set_aa()
+    .add_question(new DNSQuestion("www.google.com", T_A))
+    .add_answer(new DNSARR("www.google.com", 0x0100, {0x01, 0x02, 0x03, 0x04}));
+  DNSPacket goodrsp6;
+  goodrsp6.set_response().set_aa()
+    .add_question(new DNSQuestion("www.google.com", T_AAAA))
+    .add_answer(new DNSAaaaRR("www.google.com", 100,
+                              {0x21, 0x21, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x03}));
+
+  EXPECT_CALL(server_, OnRequest("www.google.com", T_A))
+    .WillOnce(SetReplyAndFailSend(&server_, &badrsp4))
+    .WillOnce(SetReply(&server_, &goodrsp4));
+
+  EXPECT_CALL(server_, OnRequest("www.google.com", T_AAAA))
+    .WillRepeatedly(SetReply(&server_, &goodrsp6));
+
+  ares_socket_functions sock_funcs;
+  memset(&sock_funcs, 0, sizeof(sock_funcs));
+
+  sock_funcs.asendv = ares_sendv_fail;
+
+  ares_set_socket_functions(channel_, &sock_funcs, NULL);
+
+  AddrInfoResult result;
+  struct ares_addrinfo_hints hints = {0, 0, 0, 0};
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_flags = ARES_AI_NOSORT;
+  ares_getaddrinfo(channel_, "www.google.com.", NULL, &hints,
+                   AddrInfoCallback, &result);
+
+  Process();
+  EXPECT_TRUE(result.done_);
+  EXPECT_TRUE(result.done_);
+  EXPECT_THAT(result.ai_, IncludesNumAddresses(2));
+  EXPECT_THAT(result.ai_, IncludesV4Address("1.2.3.4"));
+  EXPECT_THAT(result.ai_, IncludesV6Address("2121:0000:0000:0000:0000:0000:0000:0303"));
+}
+
+
+
 class MockEDNSChannelTestAI : public MockFlagsChannelOptsTestAI {
  public:
   MockEDNSChannelTestAI() : MockFlagsChannelOptsTestAI(ARES_FLAG_EDNS) {}

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -1595,6 +1595,66 @@ TEST_P(MockChannelTest, GetHostByAddrDestroy) {
   EXPECT_EQ(0, result.timeouts_);
 }
 
+TEST_P(MockChannelTest, TriggerResendThenConnFailSERVFAIL) {
+  // Set up the server response. The server always returns SERVFAIL.
+  DNSPacket badrsp;
+  badrsp.set_response().set_aa().set_rcode(SERVFAIL)
+    .add_question(new DNSQuestion("www.google.com", T_A));
+  DNSPacket goodrsp;
+  goodrsp.set_response().set_aa()
+    .add_question(new DNSQuestion("www.google.com", T_A))
+    .add_answer(new DNSARR("www.google.com", 0x0100, {0x01, 0x02, 0x03, 0x04}));
+  EXPECT_CALL(server_, OnRequest("www.google.com", T_A))
+    .WillOnce(SetReplyAndFailSend(&server_, &badrsp))
+    .WillOnce(SetReply(&server_, &goodrsp));
+
+  ares_socket_functions sock_funcs;
+  memset(&sock_funcs, 0, sizeof(sock_funcs));
+
+  sock_funcs.asendv = ares_sendv_fail;
+
+  ares_set_socket_functions(channel_, &sock_funcs, NULL);
+
+  HostResult result;
+  ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback,
+                     &result);
+  Process();
+  EXPECT_TRUE(result.done_);
+  std::stringstream ss;
+  ss << result.host_;
+  EXPECT_EQ("{'www.google.com' aliases=[] addrs=[1.2.3.4]}", ss.str());
+}
+
+TEST_P(MockUDPChannelTest, TriggerResendThenConnFailEDNS) {
+  // Set up the server response to simulate an EDNS failure
+  DNSPacket badrsp;
+  badrsp.set_response().set_aa().set_rcode(FORMERR)
+    .add_question(new DNSQuestion("www.google.com", T_A));
+  DNSPacket goodrsp;
+  goodrsp.set_response().set_aa()
+    .add_question(new DNSQuestion("www.google.com", T_A))
+    .add_answer(new DNSARR("www.google.com", 0x0100, {0x01, 0x02, 0x03, 0x04}));
+  EXPECT_CALL(server_, OnRequest("www.google.com", T_A))
+    .WillOnce(SetReplyAndFailSend(&server_, &badrsp))
+    .WillOnce(SetReply(&server_, &goodrsp));
+
+  ares_socket_functions sock_funcs;
+  memset(&sock_funcs, 0, sizeof(sock_funcs));
+
+  sock_funcs.asendv = ares_sendv_fail;
+
+  ares_set_socket_functions(channel_, &sock_funcs, NULL);
+
+  HostResult result;
+  ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback,
+                     &result);
+  Process();
+  EXPECT_TRUE(result.done_);
+  std::stringstream ss;
+  ss << result.host_;
+  EXPECT_EQ("{'www.google.com' aliases=[] addrs=[1.2.3.4]}", ss.str());
+}
+
 #ifndef WIN32
 TEST_P(MockChannelTest, HostAlias) {
   DNSPacket reply;

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -250,6 +250,7 @@ std::vector<std::pair<int, bool>> families_modes = both_families_both_modes;
 unsigned long long LibraryTest::fails_ = 0;
 std::map<size_t, int> LibraryTest::size_fails_;
 std::mutex            LibraryTest::lock_;
+bool LibraryTest::failsend_ = false;
 
 void ares_sleep_time(unsigned int ms)
 {
@@ -340,7 +341,29 @@ void ProcessWork(ares_channel_t *channel,
 }
 
 
+void LibraryTest::SetFailSend() {
+  failsend_ = true;
+}
+
 // static
+ares_ssize_t LibraryTest::ares_sendv_fail(ares_socket_t socket, const struct iovec *vec, int len, void *user_data)
+{
+  (void)user_data;
+
+  if (failsend_) {
+#ifdef USE_WINSOCK
+    WSASetLastError(WSAECONNREFUSED);
+#else
+    errno = ECONNREFUSED;
+#endif
+    failsend_ = false;
+    return -1;
+  }
+
+  return send(socket, (const char *)vec[0].iov_base, vec[0].iov_len, 0);
+}
+
+
 void LibraryTest::SetAllocFail(int nth) {
   lock_.lock();
   assert(nth > 0);
@@ -672,6 +695,7 @@ void MockServer::ProcessRequest(ares_socket_t fd, struct sockaddr_storage* addr,
   /* DNS 0x20 will mix case, do case-insensitive matching of name in request */
   char lower_name[256];
   int flags = 0;
+
   arestest_strtolower(lower_name, name, sizeof(lower_name));
 
   // Before processing, let gMock know the request is happening.
@@ -723,10 +747,11 @@ void MockServer::ProcessRequest(ares_socket_t fd, struct sockaddr_storage* addr,
 #endif
 
   ares_ssize_t rc = (ares_ssize_t)sendto(fd, BYTE_CAST reply.data(), (SEND_TYPE_ARG3)reply.size(), flags,
-                  (struct sockaddr *)addr, addrlen);
+                                         (struct sockaddr *)addr, addrlen);
   if (rc < static_cast<ares_ssize_t>(reply.size())) {
     std::cerr << "Failed to send full reply, rc=" << rc << std::endl;
   }
+
 }
 
 // static


### PR DESCRIPTION
At no point should a resend occur directly during answer parsing. It needs to be queued up to be processed after all the answers are taken off the wire to re-send any queries.  Because immediate resending can hit error conditions that can cause the conneciton to be closed this needs to be avoided at all costs.

This patch simply introduces a queue of queries to be resent which will then be sent after all answers are processed when the connection handle is no longer needed.

Signed-off-by: Brad House (@bradh352)