### PR TITLE
event: include `stdbool.h` for macOS gcc builds

### DIFF
--- a/src/lib/event/ares_event_configchg.c
+++ b/src/lib/event/ares_event_configchg.c
@@ -383,6 +383,7 @@ done:
 
 #  include <sys/types.h>
 #  include <unistd.h>
+#  include <stdbool.h>
 #  include <notify.h>
 #  include <dlfcn.h>
 #  include <fcntl.h>


### PR DESCRIPTION
Fixing:
```
In file included from src/lib/event/ares_event_configchg.c:386:
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/notify.h:336:11: error: unknown type name 'bool'
  336 | OS_EXPORT bool notify_is_valid_token(int val)
      |           ^~~~
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/sys/_endian.h:131,
                 from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/arm/endian.h:61,
                 from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/machine/endian.h:37,
                 from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/sys/types.h:81,
                 from _bld-gcc/ares_build.h:24,
                 from src/lib/ares_setup.h:55,
                 from src/lib/ares_private.h:36,
                 from src/lib/event/ares_event_configchg.c:26:
```

Ref: https://github.com/curl/curl-for-win/commit/0434f35e07082d59332305aacc38401d6f607c45
