### PR TITLE
Changes to server selection and polling behaviour

### DIFF
--- a/include/ares.h
+++ b/include/ares.h
@@ -547,6 +547,12 @@ CARES_EXTERN void ares_getaddrinfo(ares_channel_t *channel, const char *node,
 
 CARES_EXTERN void ares_freeaddrinfo(struct ares_addrinfo *ai);
 
+CARES_EXTERN void ares_set_min_server_successes(ares_channel_t *channel,
+                                                unsigned int minimum_successes);
+
+CARES_EXTERN void ares_set_max_server_failures(ares_channel_t *channel,
+                                               unsigned int maximum_failures);
+
 /*
  * Virtual function set to have user-managed socket IO.
  * Note that all functions need to be defined, and when

--- a/include/ares.h
+++ b/include/ares.h
@@ -241,30 +241,31 @@ typedef enum {
 #define ARES_FLAG_DNS0x20     (1 << 10)
 
 /* Option mask values */
-#define ARES_OPT_FLAGS           (1 << 0)
-#define ARES_OPT_TIMEOUT         (1 << 1)
-#define ARES_OPT_TRIES           (1 << 2)
-#define ARES_OPT_NDOTS           (1 << 3)
-#define ARES_OPT_UDP_PORT        (1 << 4)
-#define ARES_OPT_TCP_PORT        (1 << 5)
-#define ARES_OPT_SERVERS         (1 << 6)
-#define ARES_OPT_DOMAINS         (1 << 7)
-#define ARES_OPT_LOOKUPS         (1 << 8)
-#define ARES_OPT_SOCK_STATE_CB   (1 << 9)
-#define ARES_OPT_SORTLIST        (1 << 10)
-#define ARES_OPT_SOCK_SNDBUF     (1 << 11)
-#define ARES_OPT_SOCK_RCVBUF     (1 << 12)
-#define ARES_OPT_TIMEOUTMS       (1 << 13)
-#define ARES_OPT_ROTATE          (1 << 14)
-#define ARES_OPT_EDNSPSZ         (1 << 15)
-#define ARES_OPT_NOROTATE        (1 << 16)
-#define ARES_OPT_RESOLVCONF      (1 << 17)
-#define ARES_OPT_HOSTS_FILE      (1 << 18)
-#define ARES_OPT_UDP_MAX_QUERIES (1 << 19)
-#define ARES_OPT_MAXTIMEOUTMS    (1 << 20)
-#define ARES_OPT_QUERY_CACHE     (1 << 21)
-#define ARES_OPT_EVENT_THREAD    (1 << 22)
-#define ARES_OPT_SERVER_FAILOVER (1 << 23)
+#define ARES_OPT_FLAGS            (1 << 0)
+#define ARES_OPT_TIMEOUT          (1 << 1)
+#define ARES_OPT_TRIES            (1 << 2)
+#define ARES_OPT_NDOTS            (1 << 3)
+#define ARES_OPT_UDP_PORT         (1 << 4)
+#define ARES_OPT_TCP_PORT         (1 << 5)
+#define ARES_OPT_SERVERS          (1 << 6)
+#define ARES_OPT_DOMAINS          (1 << 7)
+#define ARES_OPT_LOOKUPS          (1 << 8)
+#define ARES_OPT_SOCK_STATE_CB    (1 << 9)
+#define ARES_OPT_SORTLIST         (1 << 10)
+#define ARES_OPT_SOCK_SNDBUF      (1 << 11)
+#define ARES_OPT_SOCK_RCVBUF      (1 << 12)
+#define ARES_OPT_TIMEOUTMS        (1 << 13)
+#define ARES_OPT_ROTATE           (1 << 14)
+#define ARES_OPT_EDNSPSZ          (1 << 15)
+#define ARES_OPT_NOROTATE         (1 << 16)
+#define ARES_OPT_RESOLVCONF       (1 << 17)
+#define ARES_OPT_HOSTS_FILE       (1 << 18)
+#define ARES_OPT_UDP_MAX_QUERIES  (1 << 19)
+#define ARES_OPT_MAXTIMEOUTMS     (1 << 20)
+#define ARES_OPT_QUERY_CACHE      (1 << 21)
+#define ARES_OPT_EVENT_THREAD     (1 << 22)
+#define ARES_OPT_SERVER_FAILOVER  (1 << 23)
+#define ARES_OPT_SERVER_RISE_FALL (1 << 24)
 
 /* Nameinfo flag values */
 #define ARES_NI_NOFQDN        (1 << 0)
@@ -345,10 +346,16 @@ struct apattern;
  * to.
  * The retry delay is the minimum time in milliseconds to wait between doing
  * such retries (applied per-server).
+ * The min_consec_successes is the minimum number of consecutive successful
+ * queries before a server is considered "up" again.
+ * The max_consec_failures is the maximum number of consecutive failed
+ * queries before a server is considered "down".
  */
 struct ares_server_failover_options {
   unsigned short retry_chance;
   size_t         retry_delay;
+  size_t         min_consec_successes;
+  size_t         max_consec_failures;
 };
 
 /* NOTE about the ares_options struct to users and developers.

--- a/src/lib/ares_conn.h
+++ b/src/lib/ares_conn.h
@@ -140,14 +140,16 @@ struct ares_server {
   struct ares_addr      addr;
   unsigned short        udp_port; /* host byte order */
   unsigned short        tcp_port; /* host byte order */
-  char                  ll_iface[64];    /* IPv6 Link Local Interface */
-  unsigned int          ll_scope;        /* IPv6 Link Local Scope */
+  char                  ll_iface[64];     /* IPv6 Link Local Interface */
+  unsigned int          ll_scope;         /* IPv6 Link Local Scope */
 
-  size_t                consec_failures; /* Consecutive query failure count
-                                          * can be hard errors or timeouts
-                                          */
-  ares_bool_t           probe_pending;   /* Whether a probe is pending for this
-                                          * server due to prior failures */
+  size_t                consec_failures;  /* Consecutive query failure count
+                                           * can be hard errors or timeouts
+                                           */
+  size_t                consec_successes; /* Consecutive query success count */
+  ares_bool_t           is_failed;        /* Whether this server is failed */
+  ares_bool_t           probe_pending;    /* Whether a probe is pending for this
+                                           * server due to prior failures */
   ares_llist_t         *connections;
   ares_conn_t          *tcp_conn;
 

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -240,6 +240,12 @@ static ares_status_t init_by_defaults(ares_channel_t *channel)
     channel->server_retry_delay  = DEFAULT_SERVER_RETRY_DELAY;
   }
 
+  /* Set default fields for server rise/fall behavior */
+  if (!(channel->optmask & ARES_OPT_SERVER_RISE_FALL)) {
+    channel->min_consec_successes = DEFAULT_SERVER_MIN_SUCCESSES;
+    channel->max_consec_failures  = DEFAULT_SERVER_MAX_FAILURES;
+  }
+
 error:
   if (hostname) {
     ares_free(hostname);
@@ -612,26 +618,4 @@ int ares_set_sortlist(ares_channel_t *channel, const char *sortstr)
   }
   ares_channel_unlock(channel);
   return (int)status;
-}
-
-void ares_set_min_server_successes(ares_channel_t *channel,
-                                   unsigned int    minimum_successes)
-{
-  if (channel == NULL) {
-    return;
-  }
-  ares_channel_lock(channel);
-  channel->min_consec_successes = minimum_successes;
-  ares_channel_unlock(channel);
-}
-
-void ares_set_max_server_failures(ares_channel_t *channel,
-                                  unsigned int    maximum_failures)
-{
-  if (channel == NULL) {
-    return;
-  }
-  ares_channel_lock(channel);
-  channel->max_consec_failures = maximum_failures;
-  ares_channel_unlock(channel);
 }

--- a/src/lib/ares_options.c
+++ b/src/lib/ares_options.c
@@ -233,6 +233,14 @@ int ares_save_options(const ares_channel_t *channel,
     options->server_failover_opts.retry_delay  = channel->server_retry_delay;
   }
 
+  /* Set options for server rise/fall behavior */
+  if (channel->optmask & ARES_OPT_SERVER_RISE_FALL) {
+    options->server_failover_opts.min_consec_successes =
+      channel->min_consec_successes;
+    options->server_failover_opts.max_consec_failures =
+      channel->max_consec_failures;
+  }
+
   *optmask = (int)channel->optmask;
 
   return ARES_SUCCESS;
@@ -484,6 +492,14 @@ ares_status_t ares_init_by_options(ares_channel_t            *channel,
   if (optmask & ARES_OPT_SERVER_FAILOVER) {
     channel->server_retry_chance = options->server_failover_opts.retry_chance;
     channel->server_retry_delay  = options->server_failover_opts.retry_delay;
+  }
+
+  /* Set options for server rise/fall behavior */
+  if (optmask & ARES_OPT_SERVER_RISE_FALL) {
+    channel->min_consec_successes =
+      options->server_failover_opts.min_consec_successes;
+    channel->max_consec_failures =
+      options->server_failover_opts.max_consec_failures;
   }
 
   channel->optmask = (unsigned int)optmask;

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -181,6 +181,8 @@ struct ares_query {
   size_t        timeouts;   /* number of timeouts we saw for this request */
   ares_bool_t   no_retries; /* do not perform any additional retries, this is
                              * set when a query is to be canceled */
+  ares_array_t *failed_servers_attempted; /* Failed servers attempted to be used
+                                             by this query. */
 };
 
 struct apattern {
@@ -321,11 +323,14 @@ struct ares_channeldata {
 };
 
 /* Does the domain end in ".onion" or ".onion."? Case-insensitive. */
-ares_bool_t   ares_is_onion_domain(const char *name);
+ares_bool_t    ares_is_onion_domain(const char *name);
+
+/* Select the server to be used by the query. */
+ares_server_t *ares_select_server(ares_channel_t *channel, ares_query_t *query);
 
 /* Returns one of the normal ares status codes like ARES_SUCCESS */
-ares_status_t ares_send_query(ares_server_t *requested_server /* Optional */,
-                              ares_query_t *query, const ares_timeval_t *now);
+ares_status_t  ares_send_query(ares_server_t *requested_server /* Optional */,
+                               ares_query_t *query, const ares_timeval_t *now);
 ares_status_t ares_requeue_query(ares_query_t *query, const ares_timeval_t *now,
                                  ares_status_t            status,
                                  ares_bool_t              inc_try_count,
@@ -519,6 +524,8 @@ ares_status_t ares_query_nolock(ares_channel_t *channel, const char *name,
                                 ares_dns_rec_type_t  type,
                                 ares_callback_dnsrec callback, void *arg,
                                 unsigned short *qid);
+
+ares_bool_t   ares_query_sent_to_server(ares_query_t *query, size_t server_idx);
 
 /*! Flags controlling behavior for ares_send_nolock() */
 typedef enum {

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -141,9 +141,12 @@ W32_FUNC const char *_w32_GetHostsFile(void);
 
 /* Default values for server failover behavior. We retry failed servers with
  * a 10% probability and a minimum delay of 5 seconds between retries.
+ * We will promote/demote servers after 1 success/failure. 
  */
-#define DEFAULT_SERVER_RETRY_CHANCE 10
-#define DEFAULT_SERVER_RETRY_DELAY  5000
+#define DEFAULT_SERVER_RETRY_CHANCE  10
+#define DEFAULT_SERVER_RETRY_DELAY   5000
+#define DEFAULT_SERVER_MIN_SUCCESSES 1
+#define DEFAULT_SERVER_MAX_FAILURES  1
 
 struct ares_query;
 typedef struct ares_query ares_query_t;

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -285,14 +285,22 @@ struct ares_channeldata {
   ares_qcache_t                      *qcache;
 
   /* Fields controlling server failover behavior.
-   * The retry chance is the probability (1/N) by which we will retry a failed
-   * server instead of the best server when selecting a server to send queries
-   * to.
+   * The retry chance is the probability (1/N) by which we will duplicate a
+   * query to send to a failed server to determine if it is up again.
+   *
    * The retry delay is the minimum time in milliseconds to wait between doing
    * such retries (applied per-server).
+   *
+   * The min_consec_successes is the minimum number of consecutive successful
+   * queries before a server is considered "up" again.
+   *
+   * The max_consec_failures is the maximum number of consecutive failed
+   * queries before a server is considered "down" again.
    */
   unsigned short                      server_retry_chance;
   size_t                              server_retry_delay;
+  size_t                              min_consec_successes;
+  size_t                              max_consec_failures;
 
   /* Callback triggered when a server has a successful or failed response */
   ares_server_state_callback          server_state_cb;

--- a/src/lib/ares_query.c
+++ b/src/lib/ares_query.c
@@ -149,3 +149,26 @@ void ares_query(ares_channel_t *channel, const char *name, int dnsclass,
                     (ares_dns_rec_type_t)type, ares_dnsrec_convert_cb, carg,
                     NULL);
 }
+
+/* Determine if this query has been sent to the server at server_idx, while
+ * that server was in the downed state. */
+ares_bool_t ares_query_sent_to_server(ares_query_t *query, size_t server_idx)
+{
+  ares_bool_t sent = ARES_FALSE;
+  size_t      idx;
+  size_t     *test_idx;
+
+  if (query == NULL) {
+    return sent; /* LCOV_EXCL_START: DefensiveCoding */
+  }
+
+  for (idx = 0; idx < ares_array_len(query->failed_servers_attempted); idx++) {
+    test_idx = ares_array_at(query->failed_servers_attempted, idx);
+    if (*test_idx == server_idx) {
+      sent = ARES_TRUE;
+      break;
+    }
+  }
+
+  return sent;
+}

--- a/src/lib/ares_send.c
+++ b/src/lib/ares_send.c
@@ -194,6 +194,9 @@ ares_status_t ares_send_nolock(ares_channel_t *channel, ares_server_t *server,
   query->node_queries_by_timeout = NULL;
   query->node_queries_to_conn    = NULL;
 
+  query->failed_servers_attempted =
+    ares_array_create(sizeof(ares_server_t *), NULL);
+
   /* Chain the query into the list of all queries. */
   query->node_all_queries = ares_llist_insert_last(channel->all_queries, query);
   if (query->node_all_queries == NULL) {

--- a/src/lib/ares_update_servers.c
+++ b/src/lib/ares_update_servers.c
@@ -658,6 +658,7 @@ static ares_status_t ares_server_create(ares_channel_t       *channel,
   server->addr.family = sconfig->addr.family;
   server->next_retry_time.sec  = 0;
   server->next_retry_time.usec = 0;
+  server->is_failed            = ARES_FALSE;
 
   if (sconfig->addr.family == AF_INET) {
     memcpy(&server->addr.addr.addr4, &sconfig->addr.addr.addr4,

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -2453,73 +2453,71 @@ TEST_P(ServerFailoverOptsMultiMockTest, ServerFailoverOpts) {
 
   // Sleep for the retry delay and send in another query. Server #1 is the
   // highest priority server and will respond with success, however a probe
-  // will be sent for Server #2 which will succeed:
-  //  #1 (failures: 0), #2 (failures: 0), #3 (failures: 1 - expired), #0 (failures: 2 - expired)
+  // will be sent to all other servers, only #2 will succeed.  This leaves
+  // the server order of:
+  //  #1 (failures: 0), #2 (failures: 0), #3 (failures: 2), #0 (failures: 3)
   tv_now = std::chrono::high_resolution_clock::now();
   delay_ms = SERVER_FAILOVER_RETRY_DELAY + (SERVER_FAILOVER_RETRY_DELAY / 10);
   if (verbose) std::cerr << std::chrono::duration_cast<std::chrono::milliseconds>(tv_now - tv_begin).count() << "ms: sleep " << delay_ms << "ms" << std::endl;
   ares_sleep_time(delay_ms);
   tv_now = std::chrono::high_resolution_clock::now();
-  if (verbose) std::cerr << std::chrono::duration_cast<std::chrono::milliseconds>(tv_now - tv_begin).count() << "ms: Past retry delay, will query Server 1 and probe Server 2, both will succeed." << std::endl;
+  if (verbose) std::cerr << std::chrono::duration_cast<std::chrono::milliseconds>(tv_now - tv_begin).count() << "ms: Past retry delay, will query Server 1 and probe all other servers, Server 2 will succeed." << std::endl;
   EXPECT_CALL(*servers_[1], OnRequest("www.example.com", T_A))
     .WillOnce(SetReply(servers_[1].get(), &okrsp));
   EXPECT_CALL(*servers_[2], OnRequest("www.example.com", T_A))
     .WillOnce(SetReply(servers_[2].get(), &okrsp));
+  EXPECT_CALL(*servers_[0], OnRequest("www.example.com", T_A))
+    .WillOnce(SetReply(servers_[0].get(), &servfailrsp));
+  EXPECT_CALL(*servers_[3], OnRequest("www.example.com", T_A))
+    .WillOnce(SetReply(servers_[3].get(), &servfailrsp));
   CheckExample();
 
-  // Cause another server to fail so we have at least one non-expired failed
-  // server and one expired failed server.  #1 is highest priority, which we
-  // will fail, #2 will succeed, and #3 will be probed and succeed:
-  //  #2 (failures: 0), #3 (failures: 0), #1 (failures: 1 not expired), #0 (failures: 2 expired)
+  // Sleep for half of the retry period to ensure that servers are not retried
+  // during the retry period. Cause another server to fail.  #1 is highest
+  // priority, which we will fail, #2 will succeed:
+  //  #2 (failures: 0), #1 (failures: 1 not expired), #3 (failures: 2 not
+  //  expired), #0 (failures: 3 not expired)
   tv_now = std::chrono::high_resolution_clock::now();
-  if (verbose) std::cerr << std::chrono::duration_cast<std::chrono::milliseconds>(tv_now - tv_begin).count() << "ms: Will query Server 1 and fail, Server 2 will answer successfully. Server 3 will be probed and succeed." << std::endl;
+  delay_ms = (SERVER_FAILOVER_RETRY_DELAY / 2) + (SERVER_FAILOVER_RETRY_DELAY / 10);
+  if (verbose) std::cerr << std::chrono::duration_cast<std::chrono::milliseconds>(tv_now - tv_begin).count() << "ms: sleep " << delay_ms << "ms" << std::endl;
+  ares_sleep_time(delay_ms);
+  tv_now = std::chrono::high_resolution_clock::now();
+  if (verbose) std::cerr << std::chrono::duration_cast<std::chrono::milliseconds>(tv_now - tv_begin).count() << "ms: Will query Server 1 and fail, Server 2 will answer successfully. No servers will be probed." << std::endl;
   EXPECT_CALL(*servers_[1], OnRequest("www.example.com", T_A))
     .WillOnce(SetReply(servers_[1].get(), &servfailrsp));
   EXPECT_CALL(*servers_[2], OnRequest("www.example.com", T_A))
     .WillOnce(SetReply(servers_[2].get(), &okrsp));
-  EXPECT_CALL(*servers_[3], OnRequest("www.example.com", T_A))
-    .WillOnce(SetReply(servers_[3].get(), &okrsp));
   CheckExample();
 
   // We need to make sure that if there is a failed server that is higher priority
-  // but not yet expired that it will probe the next failed server instead.
+  // but not yet expired then it will still probe the other failed servers.
   // In this case #2 is the server that the query will go to and succeed, and
-  // then a probe will be sent for #0 (since #1 is not expired) and succeed.  We
-  // will sleep for 1/4 the retry duration before spawning the queries so we can
+  // then a probe will be sent for #0 & #3 (since #1 is not expired) and succeed.  We
+  // will sleep for 1/2 the retry duration before spawning the queries so we can
   // then sleep for the rest for the follow-up test.  This will leave the servers
   // in this state:
   //   #0 (failures: 0), #2 (failures: 0), #3 (failures: 0), #1 (failures: 1 not expired)
   tv_now = std::chrono::high_resolution_clock::now();
-
-  // We need to track retry delay time to know what is expired when.
-  auto elapse_start = tv_now;
-
-  delay_ms = (SERVER_FAILOVER_RETRY_DELAY/4);
+  delay_ms = (SERVER_FAILOVER_RETRY_DELAY / 2) + (SERVER_FAILOVER_RETRY_DELAY / 10);
   if (verbose) std::cerr << std::chrono::duration_cast<std::chrono::milliseconds>(tv_now - tv_begin).count() << "ms: sleep " << delay_ms << "ms" << std::endl;
   ares_sleep_time(delay_ms);
-  tv_now = std::chrono::high_resolution_clock::now();
 
-  if (verbose) std::cerr << std::chrono::duration_cast<std::chrono::milliseconds>(tv_now - tv_begin).count() << "ms: Retry delay has not been hit yet. Server2 will be queried and succeed. Server 0 (not server 1 due to non-expired retry delay) will be probed and succeed." << std::endl;
+  if (verbose) std::cerr << std::chrono::duration_cast<std::chrono::milliseconds>(tv_now - tv_begin).count() << "ms: Retry delay has not been hit yet on Server1. Server2 will be queried and succeed. Server 0 & 3 (not server 1 due to non-expired retry delay) will be probed and succeed." << std::endl;
   EXPECT_CALL(*servers_[2], OnRequest("www.example.com", T_A))
     .WillOnce(SetReply(servers_[2].get(), &okrsp));
   EXPECT_CALL(*servers_[0], OnRequest("www.example.com", T_A))
     .WillOnce(SetReply(servers_[0].get(), &okrsp));
+  EXPECT_CALL(*servers_[3], OnRequest("www.example.com", T_A))
+    .WillOnce(SetReply(servers_[3].get(), &okrsp));
   CheckExample();
 
   // Finally we sleep for the remainder of the retry delay, send another
   // query, which should succeed on Server #0, and also probe Server #1 which
   // will also succeed.
   tv_now = std::chrono::high_resolution_clock::now();
-
-  unsigned int elapsed_time = (unsigned int)std::chrono::duration_cast<std::chrono::milliseconds>(tv_now - elapse_start).count();
-  delay_ms = (SERVER_FAILOVER_RETRY_DELAY) + (SERVER_FAILOVER_RETRY_DELAY / 10);
-  if (elapsed_time > delay_ms) {
-    if (verbose) std::cerr << "elapsed duration " << elapsed_time << "ms greater than desired delay of " << delay_ms << "ms, not sleeping" << std::endl;
-  } else {
-    delay_ms -= elapsed_time; // subtract already elapsed time
-    if (verbose) std::cerr << std::chrono::duration_cast<std::chrono::milliseconds>(tv_now - tv_begin).count() << "ms: sleep " << delay_ms << "ms" << std::endl;
-    ares_sleep_time(delay_ms);
-  }
+  delay_ms = (SERVER_FAILOVER_RETRY_DELAY / 2) + (SERVER_FAILOVER_RETRY_DELAY / 10);
+  if (verbose) std::cerr << std::chrono::duration_cast<std::chrono::milliseconds>(tv_now - tv_begin).count() << "ms: sleep " << delay_ms << "ms" << std::endl;
+  ares_sleep_time(delay_ms);
   tv_now = std::chrono::high_resolution_clock::now();
   if (verbose) std::cerr << std::chrono::duration_cast<std::chrono::milliseconds>(tv_now - tv_begin).count() << "ms: Retry delay has expired on Server1, Server 0 will be queried and succeed, Server 1 will be probed and succeed." << std::endl;
   EXPECT_CALL(*servers_[0], OnRequest("www.example.com", T_A))


### PR DESCRIPTION
Fixes #987

This PR contains the following changes:
- The addition of configurable rise/fall server behaviour (only mark servers as up or down after a certain number of successes or failures) (this is issue #987) 
- Changes to server selection when all servers are failed, instead of picking the highest priority server at all times, a query will prioritise trying all failed servers at least once.
- Polling now polls all failed servers that are outside of the timeout rather than just the highest priority one.