### PR TITLE
Fix builds with clang on windows

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -15,6 +15,14 @@ IF (CARES_SHARED)
 	# Include resource file in windows builds for versioned DLLs
 	IF (WIN32)
 		TARGET_SOURCES (${PROJECT_NAME} PRIVATE cares.rc)
+		
+		# Check for use of llvm-rc (implies clang is being used). We need to set the
+		# compile flags to use the correct codepage for the resource compiler.
+		# This is needed for the copyright symbol to be encoded correctly.
+		# The default codepage is 1252 (Windows Latin-1) but llvm-rc defaults to UTF-8.
+		if (CMAKE_RC_COMPILER MATCHES "llvm-rc")
+			set_source_files_properties(cares.rc PROPERTIES COMPILE_FLAGS "/C 1252")
+		endif()
 	ENDIF()
 
 	# Convert CARES_LIB_VERSIONINFO libtool version format into VERSION and SOVERSION

--- a/src/lib/util/ares_math.h
+++ b/src/lib/util/ares_math.h
@@ -26,13 +26,9 @@
 #ifndef __ARES_MATH_H
 #define __ARES_MATH_H
 
-#ifdef _MSC_VER
-typedef __int64          ares_int64_t;
-typedef unsigned __int64 ares_uint64_t;
-#else
-typedef long long          ares_int64_t;
-typedef unsigned long long ares_uint64_t;
-#endif
+#include <stdint.h>
+typedef int64_t  ares_int64_t;
+typedef uint64_t ares_uint64_t;
 
 ares_bool_t   ares_is_64bit(void);
 size_t        ares_round_up_pow2(size_t n);


### PR DESCRIPTION
We are using c-ares in a project and hit issues with running clang-format as part of our CI on Windows. These patches now result in a clean build when using llvm/clang tooling.