### PR TITLE
Fix IPv6 link-local nameservers in /etc/resolv.conf

### DIFF
--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -271,6 +271,8 @@ int ares_init_options(ares_channel_t           **channelptr,
     goto done;
   }
 
+  ares_set_socket_functions_def(channel);
+
   /* Initialize Server List */
   channel->servers =
     ares_slist_create(channel->rand_state, server_sort_cb, server_destroy_cb);
@@ -345,8 +347,6 @@ int ares_init_options(ares_channel_t           **channelptr,
                    ares_strerror(status)));
     goto done;
   }
-
-  ares_set_socket_functions_def(channel);
 
   /* Initialize the event thread */
   if (channel->optmask & ARES_OPT_EVENT_THREAD) {

--- a/src/lib/ares_set_socket_functions.c
+++ b/src/lib/ares_set_socket_functions.c
@@ -127,6 +127,8 @@ ares_status_t
     channel->sock_funcs.asendto      = funcs->asendto;
     channel->sock_funcs.agetsockname = funcs->agetsockname;
     channel->sock_funcs.abind        = funcs->abind;
+    channel->sock_funcs.aif_nametoindex = funcs->aif_nametoindex;
+    channel->sock_funcs.aif_indextoname = funcs->aif_indextoname;
   }
 
   /* Implement newer versions here ...*/


### PR DESCRIPTION
There are two issues that broke link-local nameservers in resolv.conf
1. channel->sock_funcs needs to be initialized before ares_init_by_sysconfig()
2. The aif_nametoindex and aif_indextoname function pointers were not initlized at all.