### PR TITLE
Add the option to disable system configuration monitoring

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -258,3 +258,4 @@ however on other unix-like systems a polling mechanism is used that checks every
 
 This feature requires the c-ares channel to persist for the lifetime of the
 application.
+If you want to disable this feature, you can set `ARES_OPT_DISABLE_MONITOR`.

--- a/docs/ares_init_options.3
+++ b/docs/ares_init_options.3
@@ -328,7 +328,8 @@ any events on the file descriptors, so \fIares_process(3)\fP nor
 \fIares_process_fd(3)\fP should ever be called when this option is enabled.
 
 As of c-ares 1.29.0, when enabled, it will also automatically re-load the
-system configuration when changes are detected.
+system configuration when changes are detected, unless
+\ARES_OPT_DISABLE_MONITOR\fP is set to explicitly disable this feature.
 
 Use \fIares_threadsafety(3)\fP to determine if this option is available to be
 used.

--- a/include/ares.h
+++ b/include/ares.h
@@ -265,6 +265,7 @@ typedef enum {
 #define ARES_OPT_QUERY_CACHE     (1 << 21)
 #define ARES_OPT_EVENT_THREAD    (1 << 22)
 #define ARES_OPT_SERVER_FAILOVER (1 << 23)
+#define ARES_OPT_DISABLE_MONITOR (1 << 24)
 
 /* Nameinfo flag values */
 #define ARES_NI_NOFQDN        (1 << 0)

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -359,12 +359,14 @@ int ares_init_options(ares_channel_t           **channelptr,
 
     /* Initialize monitor for configuration changes.  In some rare cases,
      * ARES_ENOTIMP may occur (OpenWatcom), ignore this. */
-    e      = channel->sock_state_cb_data;
-    status = ares_event_configchg_init(&e->configchg, e);
-    if (status != ARES_SUCCESS && status != ARES_ENOTIMP) {
-      goto done; /* LCOV_EXCL_LINE: UntestablePath */
+    if (!(channel->optmask & ARES_OPT_DISABLE_MONITOR)) {
+      e      = channel->sock_state_cb_data;
+      status = ares_event_configchg_init(&e->configchg, e);
+      if (status != ARES_SUCCESS && status != ARES_ENOTIMP) {
+        goto done; /* LCOV_EXCL_LINE: UntestablePath */
+      }
+      status = ARES_SUCCESS;
     }
-    status = ARES_SUCCESS;
   }
 
 done:


### PR DESCRIPTION
I have seen a case on iOS that ends up failing to set up system change notification. As opposed to the general Apple initialization, where c-ares can continue if `ares_init_by_sysconfig` did not succeed, failure to set up system change notifications would fail the initialization of c-ares.
Specifically for my use case, I not actually interested in notifications for system DNS configuration changes, in a similar manner to how the socket callback option works.
 
I suggest to have a way to disable this automatic re-initialization with an options flag.
Alternatively, it might be good to allow c-ares to continue initialization if this setup failed.