### PR TITLE
googletest 1.17.0 requires c++17 or higher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,15 +45,6 @@ OPTION (CARES_THREADS       "Build with thread-safety support"                  
 OPTION (CARES_COVERAGE      "Build for code coverage"                                               OFF)
 SET    (CARES_RANDOM_FILE "/dev/urandom" CACHE STRING "Suitable File / Device Path for entropy, such as /dev/urandom")
 
-
-# Tests require a C++14 compiler
-IF (CARES_BUILD_TESTS OR CARES_BUILD_CONTAINER_TESTS)
-	set(CMAKE_CXX_STANDARD 14)
-	set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-	set(CMAKE_CXX_EXTENSIONS FALSE)
-	enable_language(CXX)
-ENDIF ()
-
 # Tests require static to be enabled on Windows to be able to access otherwise hidden symbols
 IF ((CARES_BUILD_TESTS OR CARES_BUILD_CONTAINER_TESTS) AND (NOT CARES_STATIC) AND WIN32)
 	SET (CARES_STATIC ON)

--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,8 @@ AC_CONFIG_HEADERS([src/lib/ares_config.h include/ares_build.h])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR([m4])
 AC_USE_SYSTEM_EXTENSIONS
-AX_CXX_COMPILE_STDCXX_14([noext],[optional])
+AX_CXX_COMPILE_STDCXX(14,[noext],[optional])
+AX_CXX_COMPILE_STDCXX(17,[noext],[optional])
 AM_INIT_AUTOMAKE([foreign subdir-objects 1.9.6])
 LT_INIT([win32-dll,pic,disable-fast-install,aix-soname=svr4])
 AC_LANG([C])
@@ -811,14 +812,6 @@ BUILD_SUBDIRS="include src docs"
 
 dnl ******** TESTS *******
 
-if test "x$build_tests" != "xno" -a "x$HAVE_CXX14" = "0" ; then
-  if test "x$build_tests" = "xmaybe" ; then
-    AC_MSG_WARN([cannot build tests without a CXX14 compiler])
-    build_tests=no
-  else
-    AC_MSG_ERROR([*** Building tests requires a CXX14 compiler])
-  fi
-fi
 if test "x$build_tests" != "xno" -a "x$cross_compiling" = "xyes" ; then
   if test "x$build_tests" = "xmaybe" ; then
     AC_MSG_WARN([cannot build tests when cross compiling])
@@ -849,12 +842,19 @@ if test "x$build_tests" != "xno" ; then
       ARES_CHECK_USER_NAMESPACE
       ARES_CHECK_UTS_NAMESPACE
     fi
+    PKG_CHECK_MODULES([GMOCK117], [gmock >= 1.17.0], [ have_gmock_v117=yes ], [ have_gmock_v117=no ])
+    if test "x$have_gmock_v117" = "xyes" ; then
+      dnl GMock v1.17.0 requires C++17 or higher
+      AX_CXX_COMPILE_STDCXX(17,[noext],[mandatory])
+    else
+      dnl older version needed v1.14.0
+      AX_CXX_COMPILE_STDCXX(14,[noext],[mandatory])
+    fi
   fi
 fi
 if test "x$build_tests" != "xno" ; then
   build_tests=yes
 
-  AX_CXX_COMPILE_STDCXX_14([noext],[mandatory])
   if test "$ac_cv_native_windows" != "yes" ; then
     AX_PTHREAD([ CARES_TEST_PTHREADS="yes" ], [ AC_MSG_ERROR([threading required for tests]) ])
   fi

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 
+enable_language(CXX)
+
 # Get rid of: warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
 IF (MSVC)
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
@@ -50,6 +52,7 @@ IF (CMAKE_VERSION VERSION_LESS "3.23.0")
 ELSE ()
   target_link_libraries(arestest PRIVATE caresinternal GTest::gmock)
 ENDIF()
+target_compile_features(arestest PRIVATE cxx_std_14)
 target_compile_definitions(arestest PRIVATE CARES_NO_DEPRECATED)
 
 IF (CARES_BUILD_CONTAINER_TESTS)
@@ -75,6 +78,7 @@ set_target_properties(aresfuzzname PROPERTIES COMPILE_PDB_NAME aresfuzzname.pdb)
 
 add_executable(dnsdump ${DUMPSOURCES})
 target_compile_definitions(dnsdump PRIVATE CARES_NO_DEPRECATED)
+target_compile_features(dnsdump PRIVATE cxx_std_14)
 target_link_libraries(dnsdump PRIVATE caresinternal)
 # Avoid "fatal error C1041: cannot open program database" due to multiple
 # targets trying to use the same PDB.  /FS does NOT resolve this issue.


### PR DESCRIPTION
googletest 1.17.0 requires c++17 or higher.  The previous check for c++14 would cause issues.

Fixes Issue #993
Signed-off-by: Brad House (@bradh352)