### PR TITLE
Ignore ares_event_configchg_init failures

### DIFF
--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -362,7 +362,8 @@ int ares_init_options(ares_channel_t           **channelptr,
     e      = channel->sock_state_cb_data;
     status = ares_event_configchg_init(&e->configchg, e);
     if (status != ARES_SUCCESS && status != ARES_ENOTIMP) {
-      goto done; /* LCOV_EXCL_LINE: UntestablePath */
+      DEBUGF(fprintf(stderr, "Error: ares_event_configchg_init failed: %s\n",
+                     ares_strerror(status)));
     }
     status = ARES_SUCCESS;
   }


### PR DESCRIPTION
As discussed on https://github.com/c-ares/c-ares/pull/1002, ignore failure when trying to set up configuration notifications.

Similar to failures when calling `ares_init_by_sysconfig` https://github.com/c-ares/c-ares/blob/71663adcd95acdb1c198806d626dfc8640d132be/src/lib/ares_init.c#L335