### PR TITLE
Add ares_queue_empty()

### DIFF
--- a/docs/ares_queue.3
+++ b/docs/ares_queue.3
@@ -4,13 +4,15 @@
 .\"
 .TH ARES_QUEUE 3 "16 February 2024"
 .SH NAME
-ares_queue_wait_empty, ares_queue_active_queries \- Functions for checking the
-c-ares queue status
+ares_queue_wait_empty, ares_queue_active_queries ares_queue_empty, \-
+Functions for checking the c-ares queue status
 .SH SYNOPSIS
 .nf
 #include <ares.h>
 
 size_t ares_queue_active_queries(const ares_channel_t *channel);
+
+ares_bool_t ares_queue_empty(const ares_channel_t *channel);
 
 ares_status_t ares_queue_wait_empty(ares_channel_t *channel,
                                     int timeout_ms);
@@ -22,6 +24,11 @@ multiple queries, such as \fIares_getaddrinfo(3)\fP when using \fIAF_UNSPEC\fP,
 which will be reflected in this number. The \fBchannel\fP parameter must be set
 to an initialized channel.
 
+The \fBares_queue_empty(3)\fP function returns \fBARES_TRUE\fP if there are
+no longer any queries in queue and \fBARES_FALSE\fP if there are any active
+queries pending answers from servers. The \fBchannel\fP parameter must be
+set to an initialized channel.
+
 The \fBares_queue_wait_empty(3)\fP function blocks until notified that there are
 no longer any queries in queue, or the specified timeout has expired. The
 \fBchannel\fP parameter must be set to an initialized channel. The
@@ -30,6 +37,9 @@ to be empty or -1 for Infinite.
 
 .SH RETURN VALUES
 \fIares_queue_active_queries(3)\fP returns the active query count.
+
+\fIares_queue_empty(3)\fP returns ARES_TRUE if the queue is empty,
+ARES_FALSE if there are active queries
 
 \fIares_queue_wait_empty(3)\fP can return any of the following values:
 .TP 14
@@ -44,8 +54,11 @@ when queue is empty.
 .TP 14
 
 .SH AVAILABILITY
-This function was first introduced in c-ares version 1.27.0, and requires the
-c-ares library to be built with threading support.
+\fIares_queue_active_queries(3)\fP and \fIares_queue_wait_empty(3)\fP were
+first introduced in c-ares version 1.27.0, and requires the c-ares library
+to be built with threading support.
+
+\fIares_queue_empty(3)\fP was first introduced in c-ares version 1.35.0.
 
 .SH SEE ALSO
 .BR ares_init_options (3),

--- a/include/ares.h
+++ b/include/ares.h
@@ -1222,6 +1222,15 @@ CARES_EXTERN ares_status_t ares_queue_wait_empty(ares_channel_t *channel,
  */
 CARES_EXTERN size_t ares_queue_active_queries(const ares_channel_t *channel);
 
+
+/*! Whether or not there are any active queries in queue.
+ *
+ *  \param[in] channel Initialized ares channel
+ *  \return ARES_TRUE if query queue is empty, ARES_FALSE if active queries
+ */
+
+CARES_EXTERN ares_bool_t ares_queue_empty(const ares_channel_t *channel);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/ares_send.c
+++ b/src/lib/ares_send.c
@@ -298,3 +298,20 @@ size_t ares_queue_active_queries(const ares_channel_t *channel)
 
   return len;
 }
+
+ares_bool_t ares_queue_empty(const ares_channel_t *channel)
+{
+  const void *val;
+
+  if (channel == NULL) {
+    return ARES_TRUE;
+  }
+
+  ares_channel_lock(channel);
+
+  val = ares_llist_first_val(channel->all_queries);
+
+  ares_channel_unlock(channel);
+
+  return val == NULL ? ARES_TRUE : ARES_FALSE;
+}

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -936,7 +936,7 @@ void MockEventThreadOptsTest::Process(unsigned int cancel_ms) {
     tv_cancel += std::chrono::milliseconds(cancel_ms);
   }
 
-  while (ares_queue_active_queries(channel_)) {
+  while (ARES_FALSE == ares_queue_empty(channel_)) {
     //if (verbose) std::cerr << "pending queries: " << ares_queue_active_queries(channel_) << std::endl;
 
     int nfds = 0;


### PR DESCRIPTION
Add a function to indicate whether the queries queue is empty.  Unlike ares_queue_active_queries(), does not walk the entire queue.

Signed-off-by: Derrick Lyndon Pallas (@pallas)