### PR TITLE
MacOS and iOS CI fixes

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install packages
         run: |
           brew uninstall cmake || true
-          brew install googletest llvm autoconf automake libtool make ninja
+          brew install cmake googletest llvm autoconf automake libtool make ninja
       - name: Checkout c-ares
         uses: actions/checkout@v4
       - name: "CMake: build and test c-ares"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,7 +12,7 @@ concurrency:
 env:
   DIST: "iOS"
   MAKE: "make"
-  CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_DEPLOYMENT_TARGET=10.0 -DCMAKE_OSX_ARCHITECTURES=armv7;armv7s;arm64 -G Ninja"
+  CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_DEPLOYMENT_TARGET=10.0 -DCMAKE_OSX_ARCHITECTURES=arm64 -G Ninja"
   CMAKE_TEST_FLAGS: "-DCARES_BUILD_TESTS=OFF"
 
 jobs:
@@ -21,7 +21,9 @@ jobs:
     name: "iOS"
     steps:
       - name: Install packages
-        run: brew install cmake googletest llvm autoconf automake libtool make ninja
+        run: |
+          brew uninstall cmake || true
+          brew install googletest llvm autoconf automake libtool make ninja
       - name: Checkout c-ares
         uses: actions/checkout@v4
       - name: "CMake: build and test c-ares"
@@ -32,7 +34,7 @@ jobs:
       - name: "Autotools: build and test c-ares"
         env:
           BUILD_TYPE: autotools
-          CFLAGS: "-arch armv7 -arch armv7s -arch arm64 -miphoneos-version-min=10.0"
+          CFLAGS: "-arch arm64 -miphoneos-version-min=10.0"
           CONFIG_OPTS: "--host=arm-apple-darwin10 --disable-tests"
         run: |
           ./ci/build.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,9 @@ jobs:
     name: "MacOS"
     steps:
       - name: Install packages
-        run: brew install cmake googletest llvm autoconf automake libtool make ninja
+        run: |
+          brew uninstall cmake || true
+          brew install cmake googletest llvm autoconf automake libtool make ninja
       - name: Checkout c-ares
         uses: actions/checkout@v4
       - name: "Make sure TCP FastOpen is enabled"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -39,7 +39,7 @@ else
     mkdir cmakebld
     cd cmakebld
     if [ "$DIST" = "iOS" ] ; then
-        CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_OSX_SYSROOT=${SYSROOT}"
+        CMAKE_FLAGS="${CMAKE_FLAGS}"
     fi
     $SCAN_WRAP cmake ${CMAKE_FLAGS} ${CMAKE_TEST_FLAGS} ..
     $SCAN_WRAP cmake --build .


### PR DESCRIPTION
Github updated the MacOS runner to pin cmake to 3.31.  We need to uninstall cmake and reinstall it to update it.

Also on iOS the new XCode dropped support for 32bit architectures so builds were failing.

