### PR TITLE
added a possibility to change ttl value of a RR

### DIFF
--- a/include/ares_dns_record.h
+++ b/include/ares_dns_record.h
@@ -789,6 +789,16 @@ CARES_EXTERN ares_dns_class_t    ares_dns_rr_get_class(const ares_dns_rr_t *rr);
  */
 CARES_EXTERN unsigned int        ares_dns_rr_get_ttl(const ares_dns_rr_t *rr);
 
+
+/*! Overwrite the resource record TTL
+ *
+ * \param[in] dns_rr Pointer to resource record
+ * \param[in] ttl    TTL
+ * \return ARES_SUCCESS on success
+ */
+CARES_EXTERN ares_status_t       ares_dns_rr_set_ttl(ares_dns_rr_t *dns_rr, 
+                                                    unsigned int    ttl);
+
 /*! Set ipv4 address data type for specified resource record and key.  Can
  *  only be used on keys with datatype ARES_DATATYPE_INADDR
  *

--- a/src/lib/record/ares_dns_record.c
+++ b/src/lib/record/ares_dns_record.c
@@ -534,6 +534,15 @@ unsigned int ares_dns_rr_get_ttl(const ares_dns_rr_t *rr)
   return rr->ttl;
 }
 
+ares_status_t ares_dns_rr_set_ttl(ares_dns_rr_t *dns_rr, unsigned int ttl)
+{
+  if (dns_rr == NULL) {
+    return ARES_EFORMERR;
+  }
+  dns_rr->ttl = ttl;
+  return ARES_SUCCESS;
+}
+
 static void *ares_dns_rr_data_ptr(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
                                   size_t **lenptr)
 {

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -669,7 +669,12 @@ TEST_F(LibraryTest, DNSRecord) {
   /* A */
   EXPECT_EQ(ARES_SUCCESS,
     ares_dns_record_rr_add(&rr, dnsrec, ARES_SECTION_ANSWER, "example.com",
-      ARES_REC_TYPE_A, ARES_CLASS_IN, 300));
+      ARES_REC_TYPE_A, ARES_CLASS_IN, 600));
+
+  EXPECT_EQ(600, ares_dns_rr_get_ttl(rr));
+  EXPECT_EQ(ARES_SUCCESS, ares_dns_rr_set_ttl(rr, 300));
+  EXPECT_EQ(300, ares_dns_rr_get_ttl(rr));
+
   EXPECT_LT(0, ares_inet_pton(AF_INET, "1.1.1.1", &addr));
   EXPECT_EQ(ARES_SUCCESS,
     ares_dns_rr_set_addr(rr, ARES_RR_A_ADDR, &addr));
@@ -1073,6 +1078,7 @@ TEST_F(LibraryTest, DNSRecord) {
   EXPECT_EQ(0, (int)ares_dns_rr_get_type(NULL));
   EXPECT_EQ(0, (int)ares_dns_rr_get_class(NULL));
   EXPECT_EQ(0, ares_dns_rr_get_ttl(NULL));
+  EXPECT_NE(ARES_SUCCESS, ares_dns_rr_set_ttl(NULL, 100));
   EXPECT_NE(ARES_SUCCESS, ares_dns_write(NULL, NULL, NULL));
 #ifndef CARES_SYMBOL_HIDING
   ares_dns_record_ttl_decrement(NULL, 0);


### PR DESCRIPTION
The parser is very flexible in other ways, but does not allow for TTL in RR to be changed. This makes it hard to use in case it is to be used for modification of DNS messages. This should make it much easier to use in these use cases