### PR TITLE
SonarCloud: Migrate to SonarSource/sonarqube-scan-action

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
   workflow_dispatch:
-  pull_request:
+#  pull_request:
 #    types: [opened, synchronize, reopened]
 
 concurrency:


### PR DESCRIPTION
The old SonarSource/sonarcloud-github-c-cpp has been completely removed so Sonarcloud scanning has stopped.  Move to new action.