### PR TITLE
Fix incorrect check for empty wide string

### DIFF
--- a/src/lib/ares_sysconfig_win.c
+++ b/src/lib/ares_sysconfig_win.c
@@ -106,7 +106,7 @@ static ares_bool_t get_REG_SZ(HKEY hKey, const WCHAR *leafKeyName, char **outptr
 
   /* Get the value for real */
   res = RegQueryValueExW(hKey, leafKeyName, 0, NULL, (BYTE *)val, &size);
-  if (res != ERROR_SUCCESS || size == 1) {
+  if (res != ERROR_SUCCESS || size == sizeof(WCHAR)) {
     ares_free(val);
     return ARES_FALSE;
   }


### PR DESCRIPTION
Fixes #1056 

The commit https://github.com/c-ares/c-ares/commit/1d1b3d4a808dff9359cacb4539ac1b775876dcb6 refactored the function to use wide strings, but didn't touch this check. Because an empty wide string would now be size 2 and not 1, the empty string would go on and cause the DNS domain list to be replaced with nothing.