### PR TITLE
ares_free_string(), not ares_free()

### DIFF
--- a/include/ares_dns_record.h
+++ b/include/ares_dns_record.h
@@ -796,7 +796,7 @@ CARES_EXTERN unsigned int        ares_dns_rr_get_ttl(const ares_dns_rr_t *rr);
  * \param[in] ttl    TTL
  * \return ARES_SUCCESS on success
  */
-CARES_EXTERN ares_status_t       ares_dns_rr_set_ttl(ares_dns_rr_t *dns_rr, 
+CARES_EXTERN ares_status_t       ares_dns_rr_set_ttl(ares_dns_rr_t *dns_rr,
                                                     unsigned int    ttl);
 
 /*! Set ipv4 address data type for specified resource record and key.  Can
@@ -1102,7 +1102,7 @@ CARES_EXTERN ares_status_t ares_dns_parse(const unsigned char *buf,
  *
  *  \param[in]  dnsrec   Pointer to initialized and filled DNS record object.
  *  \param[out] buf      Pointer passed by reference to be filled in with with
- *                       DNS message.  Must be ares_free()'d by caller.
+ *                       DNS message.  Must be ares_free_string()'d by caller.
  *  \param[out] buf_len  Length of returned buffer containing DNS message.
  *  \return ARES_SUCCESS on success
  */


### PR DESCRIPTION
ares_free() is not on the public API