### PR TITLE
Replace atoi-based port parsing with validated helper

### DIFF
--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -413,7 +413,8 @@ ares_status_t ares_parse_sortlist(struct apattern **sortlist, size_t *nsort,
 ares_status_t ares_lookup_hostaliases(const ares_channel_t *channel,
                                       const char *name, char **alias);
 
-ares_bool_t   ares_parse_port(const char *str, unsigned short *port);
+ares_bool_t   ares_parse_port(const char *str, unsigned short *port,
+                              ares_bool_t allow_zero);
 
 ares_status_t ares_cat_domain(const char *name, const char *domain, char **s);
 ares_status_t ares_sortaddrinfo(ares_channel_t            *channel,

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -413,6 +413,8 @@ ares_status_t ares_parse_sortlist(struct apattern **sortlist, size_t *nsort,
 ares_status_t ares_lookup_hostaliases(const ares_channel_t *channel,
                                       const char *name, char **alias);
 
+ares_bool_t   ares_parse_port(const char *str, unsigned short *port);
+
 ares_status_t ares_cat_domain(const char *name, const char *domain, char **s);
 ares_status_t ares_sortaddrinfo(ares_channel_t            *channel,
                                 struct ares_addrinfo_node *ai_node);

--- a/src/lib/ares_update_servers.c
+++ b/src/lib/ares_update_servers.c
@@ -234,7 +234,10 @@ static ares_status_t parse_nameserver_uri(ares_buf_t     *buf,
   sconfig->tcp_port = sconfig->udp_port;
   port              = ares_uri_get_query_key(uri, "tcpport");
   if (port != NULL) {
-    sconfig->tcp_port = (unsigned short)atoi(port);
+    if (!ares_parse_port(port, &sconfig->tcp_port)) {
+      status = ARES_EBADSTR;
+      goto done;
+    }
   }
 
 done:
@@ -352,7 +355,9 @@ static ares_status_t parse_nameserver(ares_buf_t *buf, ares_sconfig_t *sconfig)
       return status;
     }
 
-    sconfig->udp_port = (unsigned short)atoi(portstr);
+    if (!ares_parse_port(portstr, &sconfig->udp_port)) {
+      return ARES_EBADSTR;
+    }
     sconfig->tcp_port = sconfig->udp_port;
   }
 

--- a/src/lib/ares_update_servers.c
+++ b/src/lib/ares_update_servers.c
@@ -234,7 +234,7 @@ static ares_status_t parse_nameserver_uri(ares_buf_t     *buf,
   sconfig->tcp_port = sconfig->udp_port;
   port              = ares_uri_get_query_key(uri, "tcpport");
   if (port != NULL) {
-    if (!ares_parse_port(port, &sconfig->tcp_port)) {
+    if (!ares_parse_port(port, &sconfig->tcp_port, ARES_FALSE)) {
       status = ARES_EBADSTR;
       goto done;
     }
@@ -355,7 +355,7 @@ static ares_status_t parse_nameserver(ares_buf_t *buf, ares_sconfig_t *sconfig)
       return status;
     }
 
-    if (!ares_parse_port(portstr, &sconfig->udp_port)) {
+    if (!ares_parse_port(portstr, &sconfig->udp_port, ARES_FALSE)) {
       return ARES_EBADSTR;
     }
     sconfig->tcp_port = sconfig->udp_port;

--- a/src/lib/ares_update_servers.c
+++ b/src/lib/ares_update_servers.c
@@ -234,7 +234,7 @@ static ares_status_t parse_nameserver_uri(ares_buf_t     *buf,
   sconfig->tcp_port = sconfig->udp_port;
   port              = ares_uri_get_query_key(uri, "tcpport");
   if (port != NULL) {
-    if (!ares_parse_port(port, &sconfig->tcp_port, ARES_FALSE)) {
+    if (!ares_parse_port(port, &sconfig->tcp_port, ARES_TRUE)) {
       status = ARES_EBADSTR;
       goto done;
     }
@@ -355,7 +355,7 @@ static ares_status_t parse_nameserver(ares_buf_t *buf, ares_sconfig_t *sconfig)
       return status;
     }
 
-    if (!ares_parse_port(portstr, &sconfig->udp_port, ARES_FALSE)) {
+    if (!ares_parse_port(portstr, &sconfig->udp_port, ARES_TRUE)) {
       return ARES_EBADSTR;
     }
     sconfig->tcp_port = sconfig->udp_port;

--- a/src/lib/str/ares_str.c
+++ b/src/lib/str/ares_str.c
@@ -127,7 +127,8 @@ ares_bool_t ares_str_isnum(const char *str)
   return ARES_TRUE;
 }
 
-ares_bool_t ares_parse_port(const char *str, unsigned short *port)
+ares_bool_t ares_parse_port(const char *str, unsigned short *port,
+                            ares_bool_t allow_zero)
 {
   char         *endptr = NULL;
   unsigned long val;
@@ -143,6 +144,10 @@ ares_bool_t ares_parse_port(const char *str, unsigned short *port)
   }
 
   if (val > 65535UL) {
+    return ARES_FALSE;
+  }
+
+  if (!allow_zero && val == 0) {
     return ARES_FALSE;
   }
 

--- a/src/lib/str/ares_str.c
+++ b/src/lib/str/ares_str.c
@@ -28,6 +28,8 @@
 #include "ares_private.h"
 #include "ares_str.h"
 
+#include <errno.h>
+
 #ifdef HAVE_STDINT_H
 #  include <stdint.h>
 #endif
@@ -122,6 +124,30 @@ ares_bool_t ares_str_isnum(const char *str)
       return ARES_FALSE;
     }
   }
+  return ARES_TRUE;
+}
+
+ares_bool_t ares_parse_port(const char *str, unsigned short *port)
+{
+  char         *endptr = NULL;
+  unsigned long val;
+
+  if (str == NULL || port == NULL || *str == 0) {
+    return ARES_FALSE;
+  }
+
+  errno = 0;
+  val   = strtoul(str, &endptr, 10);
+  if (errno == ERANGE || endptr == str || *endptr != '\0') {
+    return ARES_FALSE;
+  }
+
+  if (val > 65535UL) {
+    return ARES_FALSE;
+  }
+
+  *port = (unsigned short)val;
+
   return ARES_TRUE;
 }
 

--- a/src/lib/util/ares_uri.c
+++ b/src/lib/util/ares_uri.c
@@ -1174,6 +1174,7 @@ static ares_status_t ares_uri_parse_hostport(ares_uri_t *uri, ares_buf_t *buf)
   unsigned char b;
   char          host[256];
   char          port[6];
+  unsigned short parsed_port;
   size_t        len;
   ares_status_t status;
 
@@ -1242,15 +1243,11 @@ static ares_status_t ares_uri_parse_hostport(ares_uri_t *uri, ares_buf_t *buf)
   }
   port[len] = 0;
 
-  {
-    unsigned short parsed_port;
-
-    if (!ares_parse_port(port, &parsed_port)) {
-      return ARES_EBADSTR;
-    }
-
-    status = ares_uri_set_port(uri, parsed_port);
+  if (!ares_parse_port(port, &parsed_port)) {
+    return ARES_EBADSTR;
   }
+
+  status = ares_uri_set_port(uri, parsed_port);
   if (status != ARES_SUCCESS) {
     return status;
   }

--- a/src/lib/util/ares_uri.c
+++ b/src/lib/util/ares_uri.c
@@ -1242,11 +1242,15 @@ static ares_status_t ares_uri_parse_hostport(ares_uri_t *uri, ares_buf_t *buf)
   }
   port[len] = 0;
 
-  if (!ares_str_isnum(port)) {
-    return ARES_EBADSTR;
-  }
+  {
+    unsigned short parsed_port;
 
-  status = ares_uri_set_port(uri, (unsigned short)atoi(port));
+    if (!ares_parse_port(port, &parsed_port)) {
+      return ARES_EBADSTR;
+    }
+
+    status = ares_uri_set_port(uri, parsed_port);
+  }
   if (status != ARES_SUCCESS) {
     return status;
   }

--- a/src/lib/util/ares_uri.c
+++ b/src/lib/util/ares_uri.c
@@ -1243,7 +1243,7 @@ static ares_status_t ares_uri_parse_hostport(ares_uri_t *uri, ares_buf_t *buf)
   }
   port[len] = 0;
 
-  if (!ares_parse_port(port, &parsed_port)) {
+  if (!ares_parse_port(port, &parsed_port, ARES_FALSE)) {
     return ARES_EBADSTR;
   }
 

--- a/src/lib/util/ares_uri.c
+++ b/src/lib/util/ares_uri.c
@@ -1243,7 +1243,7 @@ static ares_status_t ares_uri_parse_hostport(ares_uri_t *uri, ares_buf_t *buf)
   }
   port[len] = 0;
 
-  if (!ares_parse_port(port, &parsed_port, ARES_FALSE)) {
+  if (!ares_parse_port(port, &parsed_port, ARES_TRUE)) {
     return ARES_EBADSTR;
   }
 


### PR DESCRIPTION
## Description

Replace `atoi()`-based port parsing with a validated helper.

- Introduce `ares_parse_port` using `strtoul` with validation  
- Update port parsing in `ares_update_servers.c` and `ares_uri.c`  
- Avoid silent truncation and improve parsing reliability  

No changes to public APIs or behaviour for valid inputs.