### PR TITLE
prevent integer overflow in buffer size calculation

### DIFF
--- a/src/lib/str/ares_buf.c
+++ b/src/lib/str/ares_buf.c
@@ -153,24 +153,22 @@ static ares_status_t ares_buf_ensure_space(ares_buf_t *buf, size_t needed_size)
   /* When calling ares_buf_finish_str() we end up adding a null terminator,
    * so we want to ensure the size is always sufficient for this as we don't
    * want an ARES_ENOMEM at that point.
-   *
-   * This change enforces a strict upper bound invariant: all buffer capacity
-   * calculations must be validated before arithmetic, ensuring no intermediate
-   * wraparound can influence allocation decisions.
    */
   if (buf->data_len >= SIZE_MAX - 1) {
     return ARES_ENOMEM;
   }
 
-  if (needed_size > SIZE_MAX - buf->data_len - 1) {
+  needed_size++;
+
+  if (needed_size > SIZE_MAX - buf->data_len) {
     return ARES_ENOMEM;
   }
 
-  total_required = buf->data_len + needed_size + 1;
+  total_required = buf->data_len + needed_size;
 
   /* No need to do an expensive move operation, we have enough to just append */
   remaining_size = buf->alloc_buf_len - buf->data_len;
-  if (remaining_size >= needed_size + 1) {
+  if (remaining_size >= needed_size) {
     return ARES_SUCCESS;
   }
 
@@ -178,26 +176,24 @@ static ares_status_t ares_buf_ensure_space(ares_buf_t *buf, size_t needed_size)
   ares_buf_reclaim(buf);
 
   remaining_size = buf->alloc_buf_len - buf->data_len;
-  if (remaining_size >= needed_size + 1) {
+  if (remaining_size >= needed_size) {
     return ARES_SUCCESS;
   }
 
   alloc_size = buf->alloc_buf_len;
 
-  /* Increase allocation by powers of 2 */
-  while (alloc_size < total_required) {
-    if (alloc_size == 0) {
-      alloc_size = total_required;
-    } else if (alloc_size > SIZE_MAX / 2) {
-      alloc_size = total_required;
-    } else {
-      alloc_size <<= 1;
-    }
-
-    if (alloc_size < total_required) {
-      alloc_size = total_required;
-    }
+  /* Not yet started */
+  if (alloc_size == 0) {
+    alloc_size = 16; /* Always shifts 1, so ends up being 32 minimum */
   }
+
+  /* Increase allocation by powers of 2 */
+  do {
+    if (alloc_size > SIZE_MAX >> 1) {
+      return ARES_ENOMEM;
+    }
+    alloc_size <<= 1;
+  } while (alloc_size < total_required);
 
   ptr = ares_realloc(buf->alloc_buf, alloc_size);
   if (ptr == NULL) {

--- a/src/lib/str/ares_buf.c
+++ b/src/lib/str/ares_buf.c
@@ -139,6 +139,7 @@ static ares_status_t ares_buf_ensure_space(ares_buf_t *buf, size_t needed_size)
 {
   size_t         remaining_size;
   size_t         alloc_size;
+  size_t         total_required;
   unsigned char *ptr;
 
   if (buf == NULL) {
@@ -151,15 +152,25 @@ static ares_status_t ares_buf_ensure_space(ares_buf_t *buf, size_t needed_size)
 
   /* When calling ares_buf_finish_str() we end up adding a null terminator,
    * so we want to ensure the size is always sufficient for this as we don't
-   * want an ARES_ENOMEM at that point */
-  if (needed_size == SIZE_MAX) {
+   * want an ARES_ENOMEM at that point.
+   *
+   * This change enforces a strict upper bound invariant: all buffer capacity
+   * calculations must be validated before arithmetic, ensuring no intermediate
+   * wraparound can influence allocation decisions.
+   */
+  if (buf->data_len >= SIZE_MAX - 1) {
     return ARES_ENOMEM;
   }
-  needed_size++;
+
+  if (needed_size > SIZE_MAX - buf->data_len - 1) {
+    return ARES_ENOMEM;
+  }
+
+  total_required = buf->data_len + needed_size + 1;
 
   /* No need to do an expensive move operation, we have enough to just append */
   remaining_size = buf->alloc_buf_len - buf->data_len;
-  if (remaining_size >= needed_size) {
+  if (remaining_size >= needed_size + 1) {
     return ARES_SUCCESS;
   }
 
@@ -167,25 +178,26 @@ static ares_status_t ares_buf_ensure_space(ares_buf_t *buf, size_t needed_size)
   ares_buf_reclaim(buf);
 
   remaining_size = buf->alloc_buf_len - buf->data_len;
-  if (remaining_size >= needed_size) {
+  if (remaining_size >= needed_size + 1) {
     return ARES_SUCCESS;
   }
 
   alloc_size = buf->alloc_buf_len;
 
-  /* Not yet started */
-  if (alloc_size == 0) {
-    alloc_size = 16; /* Always shifts 1, so ends up being 32 minimum */
-  }
-
   /* Increase allocation by powers of 2 */
-  do {
-    if (alloc_size > SIZE_MAX >> 1) {
-      return ARES_ENOMEM;
+  while (alloc_size < total_required) {
+    if (alloc_size == 0) {
+      alloc_size = total_required;
+    } else if (alloc_size > SIZE_MAX / 2) {
+      alloc_size = total_required;
+    } else {
+      alloc_size <<= 1;
     }
-    alloc_size     <<= 1;
-    remaining_size   = alloc_size - buf->data_len;
-  } while (remaining_size < needed_size);
+
+    if (alloc_size < total_required) {
+      alloc_size = total_required;
+    }
+  }
 
   ptr = ares_realloc(buf->alloc_buf, alloc_size);
   if (ptr == NULL) {


### PR DESCRIPTION
fix: prevent integer overflow in buffer size calculation

Validate buffer growth using a safe pre-check to ensure
data_len + needed_size + 1 does not overflow size_t.

Also harden growth logic to avoid wraparound during doubling
and handle zero-sized allocations safely.