### PR TITLE
Fix microsecond overflow in ares_queue_wait_empty timeout

### DIFF
--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -45,7 +45,6 @@
 #include <limits.h>
 
 
-static void          timeadd(ares_timeval_t *now, size_t millisecs);
 static ares_status_t process_write(ares_channel_t *channel,
                                    ares_socket_t   write_fd);
 static ares_status_t process_read(ares_channel_t       *channel,
@@ -128,7 +127,7 @@ static void server_increment_failures(ares_server_t *server,
   ares_slist_node_reinsert(node);
 
   ares_tvnow(&next_retry_time);
-  timeadd(&next_retry_time, channel->server_retry_delay);
+  ares_timeval_add(&next_retry_time, channel->server_retry_delay);
   server->next_retry_time = next_retry_time;
 
   invoke_server_state_cb(server, ARES_FALSE,
@@ -176,18 +175,6 @@ ares_bool_t ares_timedout(const ares_timeval_t *now,
   return ((ares_int64_t)now->usec - (ares_int64_t)check->usec) >= 0
            ? ARES_TRUE
            : ARES_FALSE;
-}
-
-/* add the specific number of milliseconds to the time in the first argument */
-static void timeadd(ares_timeval_t *now, size_t millisecs)
-{
-  now->sec  += (ares_int64_t)millisecs / 1000;
-  now->usec += (unsigned int)((millisecs % 1000) * 1000);
-
-  if (now->usec >= 1000000) {
-    now->sec  += now->usec / 1000000;
-    now->usec %= 1000000;
-  }
 }
 
 static ares_status_t ares_process_fds_nolock(ares_channel_t         *channel,
@@ -1360,7 +1347,7 @@ ares_status_t ares_send_query(ares_server_t *requested_server,
   ares_slist_node_destroy(query->node_queries_by_timeout);
   query->ts      = *now;
   query->timeout = *now;
-  timeadd(&query->timeout, timeplus);
+  ares_timeval_add(&query->timeout, timeplus);
   query->node_queries_by_timeout =
     ares_slist_insert(channel->queries_by_timeout, query);
   if (!query->node_queries_by_timeout) {

--- a/src/lib/ares_timeout.c
+++ b/src/lib/ares_timeout.c
@@ -32,6 +32,17 @@
 #endif
 
 
+void ares_timeval_add(ares_timeval_t *now, size_t millisecs)
+{
+  now->sec  += (ares_int64_t)millisecs / 1000;
+  now->usec += (unsigned int)((millisecs % 1000) * 1000);
+
+  if (now->usec >= 1000000) {
+    now->sec  += now->usec / 1000000;
+    now->usec %= 1000000;
+  }
+}
+
 void ares_timeval_remaining(ares_timeval_t       *remaining,
                             const ares_timeval_t *now,
                             const ares_timeval_t *tout)

--- a/src/lib/util/ares_threads.c
+++ b/src/lib/util/ares_threads.c
@@ -780,8 +780,7 @@ ares_status_t ares_queue_wait_empty(ares_channel_t *channel, int timeout_ms)
 
   if (timeout_ms >= 0) {
     ares_tvnow(&tout);
-    tout.sec  += (ares_int64_t)(timeout_ms / 1000);
-    tout.usec += (unsigned int)(timeout_ms % 1000) * 1000;
+    ares_timeval_add(&tout, (size_t)timeout_ms);
   }
 
   ares_thread_mutex_lock(channel->lock);

--- a/src/lib/util/ares_time.h
+++ b/src/lib/util/ares_time.h
@@ -39,6 +39,7 @@ ares_bool_t ares_timedout(const ares_timeval_t *now,
                           const ares_timeval_t *check);
 
 void        ares_tvnow(ares_timeval_t *now);
+void        ares_timeval_add(ares_timeval_t *now, size_t millisecs);
 void        ares_timeval_remaining(ares_timeval_t       *remaining,
                                    const ares_timeval_t *now,
                                    const ares_timeval_t *tout);


### PR DESCRIPTION
When computing the deadline in ares_queue_wait_empty(), the millisecond-to-microsecond addition could cause tout.usec to exceed 1,000,000 if ares_tvnow() returned a non-zero usec component. This corrupted the ares_timeval_remaining() comparison, causing premature timeouts.

Extract the static timeadd() from ares_process.c into a shared ares_timeval_add() utility in ares_timeout.c (alongside the existing ares_timeval_remaining and ares_timeval_diff), and use it in both ares_process.c and ares_threads.c.