### PR TITLE
Fix RAW_RR type tostr/fromstr roundtrip mismatch

### DIFF
--- a/src/lib/record/ares_dns_mapping.c
+++ b/src/lib/record/ares_dns_mapping.c
@@ -228,7 +228,7 @@ const char *ares_dns_rec_type_tostr(ares_dns_rec_type_t type)
     case ARES_REC_TYPE_CAA:
       return "CAA";
     case ARES_REC_TYPE_RAW_RR:
-      return "RAWRR";
+      return "RAW_RR";
   }
   return "UNKNOWN";
 }

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -1574,6 +1574,16 @@ typedef struct {
   ares_socket_t s;
 } test_htable_asvp_t;
 
+TEST_F(LibraryTest, RawRrTypeTostrFromstrRoundtrip) {
+  const char         *str;
+  ares_dns_rec_type_t qtype = (ares_dns_rec_type_t)0;
+
+  str = ares_dns_rec_type_tostr(ARES_REC_TYPE_RAW_RR);
+  EXPECT_NE((const char *)NULL, str);
+  EXPECT_TRUE(ares_dns_rec_type_fromstr(&qtype, str));
+  EXPECT_EQ(ARES_REC_TYPE_RAW_RR, qtype);
+}
+
 TEST_F(LibraryTest, HtableAsvp) {
   ares_llist_t       *l = NULL;
   ares_htable_asvp_t *h = NULL;


### PR DESCRIPTION
ares_dns_rec_type_tostr() returned "RAWRR" but
ares_dns_rec_type_fromstr() expected "RAW_RR", so a roundtrip through tostr then fromstr would fail. Fix tostr to return "RAW_RR" to match the fromstr table and the enum name ARES_REC_TYPE_RAW_RR.

Add roundtrip test verifying fromstr(tostr(RAW_RR)) == RAW_RR.