### PR TITLE
Fix NULL dereference in ares_buf_replace() on NULL buf

### DIFF
--- a/src/lib/str/ares_buf.c
+++ b/src/lib/str/ares_buf.c
@@ -1117,7 +1117,7 @@ ares_status_t ares_buf_replace(ares_buf_t *buf, const unsigned char *srch,
   size_t        processed_len = 0;
   ares_status_t status;
 
-  if (buf->alloc_buf == NULL || srch == NULL || srch_size == 0 ||
+  if (buf == NULL || buf->alloc_buf == NULL || srch == NULL || srch_size == 0 ||
       (rplc == NULL && rplc_size != 0)) {
     return ARES_EFORMERR;
   }

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -1574,6 +1574,13 @@ typedef struct {
   ares_socket_t s;
 } test_htable_asvp_t;
 
+TEST_F(LibraryTest, BufReplaceNullBuf) {
+  EXPECT_EQ(ARES_EFORMERR,
+            ares_buf_replace(NULL,
+                             (const unsigned char *)"x", 1,
+                             (const unsigned char *)"y", 1));
+}
+
 TEST_F(LibraryTest, HtableAsvp) {
   ares_llist_t       *l = NULL;
   ares_htable_asvp_t *h = NULL;


### PR DESCRIPTION
ares_buf_replace() dereferences buf without checking for NULL first, unlike every other function in ares_buf.c. Add buf == NULL to the existing validation guard. Add test case verifying ARES_EFORMERR is returned.