### PR TITLE
fix: initialize *read_bytes in ares_socket_recvfrom()

### DIFF
--- a/src/lib/ares_socket.c
+++ b/src/lib/ares_socket.c
@@ -188,6 +188,8 @@ ares_conn_err_t ares_socket_recvfrom(ares_channel_t *channel, ares_socket_t s,
 {
   ares_ssize_t rv;
 
+  *read_bytes = 0;
+
   rv = channel->sock_funcs.arecvfrom(s, data, data_len, flags, from, from_len,
                                      channel->sock_func_cb_data);
 


### PR DESCRIPTION
ares_socket_recv() initializes *read_bytes = 0 at the top, but the sibling function ares_socket_recvfrom() does not. When a 0-byte UDP packet arrives (rv == 0), SUCCESS is returned but *read_bytes is never written. The caller read_conn_packets() then uses the garbage value in ares_buf_append_finish(), corrupting the input buffer.