### PR TITLE
Fix memory leak of binbuf in ares_buf_parse_dns_binstr_int

### DIFF
--- a/src/lib/str/ares_buf.c
+++ b/src/lib/str/ares_buf.c
@@ -1268,17 +1268,15 @@ static ares_status_t
   }
 
 done:
-  if (status != ARES_SUCCESS) {
-    ares_buf_destroy(binbuf);
+  if (status == ARES_SUCCESS && bin != NULL) {
+    size_t mylen = 0;
+    /* NOTE: we use ares_buf_finish_str() here as we guarantee NULL
+     *       Termination even though we are technically returning binary data.
+     */
+    *bin     = (unsigned char *)ares_buf_finish_str(binbuf, &mylen);
+    *bin_len = mylen;
   } else {
-    if (bin != NULL) {
-      size_t mylen = 0;
-      /* NOTE: we use ares_buf_finish_str() here as we guarantee NULL
-       *       Termination even though we are technically returning binary data.
-       */
-      *bin     = (unsigned char *)ares_buf_finish_str(binbuf, &mylen);
-      *bin_len = mylen;
-    }
+    ares_buf_destroy(binbuf);
   }
 
   return status;


### PR DESCRIPTION
On the success path when bin is NULL (consume-only mode), binbuf was never freed. Simplify the cleanup by combining the error and bin==NULL paths: only transfer ownership via ares_buf_finish_str() when both successful and bin is requested, otherwise always destroy binbuf.