### PR TITLE
Fix memory leak of qcache entry on key allocation failure

### DIFF
--- a/src/lib/ares_qcache.c
+++ b/src/lib/ares_qcache.c
@@ -371,9 +371,11 @@ static ares_status_t ares_qcache_insert_int(ares_qcache_t           *qcache,
 
 /* LCOV_EXCL_START: OutOfMemory */
 fail:
-  if (entry != NULL && entry->key != NULL) {
-    ares_htable_strvp_remove(qcache->cache, entry->key);
-    ares_free(entry->key);
+  if (entry != NULL) {
+    if (entry->key != NULL) {
+      ares_htable_strvp_remove(qcache->cache, entry->key);
+      ares_free(entry->key);
+    }
     ares_free(entry);
   }
   return ARES_ENOMEM;


### PR DESCRIPTION
In ares_qcache_insert_int(), when ares_qcache_calc_key() returns NULL (OOM), the fail handler's guard (entry != NULL && entry->key != NULL) skips cleanup because entry->key is NULL - leaking the entry struct. Restructure the guard so entry is always freed when non-NULL.