### PR TITLE
Fix HASH_IDX macro missing parentheses

### DIFF
--- a/src/lib/dsa/ares_htable.c
+++ b/src/lib/dsa/ares_htable.c
@@ -172,7 +172,7 @@ const void **ares_htable_all_buckets(const ares_htable_t *htable, size_t *num)
  *  We are doing "hash & (size - 1)" since we are guaranteeing a power of
  *  2 for size. This is equivalent to "hash % size", but should be more
  * efficient */
-#define HASH_IDX(h, key) h->hash(key, h->seed) & (h->size - 1)
+#define HASH_IDX(h, key) ((h)->hash((key), (h)->seed) & ((h)->size - 1))
 
 static ares_llist_node_t *ares_htable_find(const ares_htable_t *htable,
                                            unsigned int idx, const void *key)


### PR DESCRIPTION
The macro lacked outer parentheses and parameter parentheses, so the bitwise AND could bind incorrectly if the macro were used in a larger expression. Wrap the full expression and all parameters.

macro was fine in all current uses, this is hygiene rather than bug fix.