### PR TITLE
Fix wrong sizeof in QNX confstr() call truncating domain names

### DIFF
--- a/src/lib/ares_sysconfig.c
+++ b/src/lib/ares_sysconfig.c
@@ -333,7 +333,7 @@ static ares_status_t
     char   domain[256];
     size_t domain_len;
 
-    domain_len = confstr(_CS_DOMAIN, domain, sizeof(domain_len));
+    domain_len = confstr(_CS_DOMAIN, domain, sizeof(domain));
     if (domain_len != 0) {
       ares_strsplit_free(sysconfig->domains, sysconfig->ndomains);
       sysconfig->domains = ares_strsplit(domain, ", ", &sysconfig->ndomains);


### PR DESCRIPTION
confstr(_CS_DOMAIN, domain, sizeof(domain_len)) passes the size of the size_t variable (8 bytes) instead of the 256-byte buffer. This silently truncates any domain name longer than 7 characters. Fix by passing sizeof(domain) instead.