### PR TITLE
Fix malloc(0) in ares_htable_all_buckets on empty table

### DIFF
--- a/src/lib/dsa/ares_htable.c
+++ b/src/lib/dsa/ares_htable.c
@@ -150,6 +150,10 @@ const void **ares_htable_all_buckets(const ares_htable_t *htable, size_t *num)
 
   *num = 0;
 
+  if (htable->num_keys == 0) {
+    return NULL;
+  }
+
   out = ares_malloc_zero(sizeof(*out) * htable->num_keys);
   if (out == NULL) {
     return NULL; /* LCOV_EXCL_LINE */


### PR DESCRIPTION
When num_keys is 0, ares_malloc_zero(0) is called. On platforms where malloc(0) returns non-NULL, both callers leak the pointer since they check for NULL-or-empty and return without freeing. On platforms where malloc(0) returns NULL, callers cannot distinguish empty from OOM. Return NULL early when the table is empty.