### PR TITLE
Fix NULL dereference after ares_malloc_zero in Win32 IOCP event add

### DIFF
--- a/src/lib/event/ares_event_win32.c
+++ b/src/lib/event/ares_event_win32.c
@@ -715,6 +715,9 @@ static ares_bool_t ares_evsys_win32_event_add(ares_event_t *event)
   ares_bool_t                   rc = ARES_FALSE;
 
   ed              = ares_malloc_zero(sizeof(*ed));
+  if (ed == NULL) {
+    return ARES_FALSE; /* LCOV_EXCL_LINE: OutOfMemory */
+  }
   ed->event       = event;
   ed->socket      = event->fd;
   ed->base_socket = ARES_SOCKET_BAD;


### PR DESCRIPTION
ares_evsys_win32_event_add() calls ares_malloc_zero() to allocate eventdata but immediately dereferences the result without checking for NULL. On OOM this would crash. Add early return of ARES_FALSE before the dereference.