### PR TITLE
validate RR counts before preallocation to reject malformed packets early

### DIFF
--- a/src/lib/record/ares_dns_parse.c
+++ b/src/lib/record/ares_dns_parse.c
@@ -923,30 +923,6 @@ static ares_status_t ares_dns_parse_header(ares_buf_t *buf, unsigned int flags,
 
   (*dnsrec)->raw_rcode = rcode;
 
-  if (*ancount > 0) {
-    status =
-      ares_dns_record_rr_prealloc(*dnsrec, ARES_SECTION_ANSWER, *ancount);
-    if (status != ARES_SUCCESS) {
-      goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
-    }
-  }
-
-  if (*nscount > 0) {
-    status =
-      ares_dns_record_rr_prealloc(*dnsrec, ARES_SECTION_AUTHORITY, *nscount);
-    if (status != ARES_SUCCESS) {
-      goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
-    }
-  }
-
-  if (*arcount > 0) {
-    status =
-      ares_dns_record_rr_prealloc(*dnsrec, ARES_SECTION_ADDITIONAL, *arcount);
-    if (status != ARES_SUCCESS) {
-      goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
-    }
-  }
-
   return ARES_SUCCESS;
 
 fail:
@@ -1211,6 +1187,8 @@ static ares_status_t ares_dns_parse_buf(ares_buf_t *buf, unsigned int flags,
                                         ares_dns_record_t **dnsrec)
 {
   ares_status_t  status;
+  size_t         total_rr_count;
+  const size_t   min_rr_wire_len = 11;
   unsigned short qdcount;
   unsigned short ancount;
   unsigned short nscount;
@@ -1268,6 +1246,35 @@ static ares_status_t ares_dns_parse_buf(ares_buf_t *buf, unsigned int flags,
     status = ares_dns_parse_qd(buf, *dnsrec);
     if (status != ARES_SUCCESS) {
       goto fail;
+    }
+  }
+
+  total_rr_count = (size_t)ancount + (size_t)nscount + (size_t)arcount;
+  if (total_rr_count > ares_buf_len(buf) / min_rr_wire_len) {
+    status = ARES_EBADRESP;
+    goto fail;
+  }
+
+  if (ancount > 0) {
+    status = ares_dns_record_rr_prealloc(*dnsrec, ARES_SECTION_ANSWER, ancount);
+    if (status != ARES_SUCCESS) {
+      goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+  }
+
+  if (nscount > 0) {
+    status =
+      ares_dns_record_rr_prealloc(*dnsrec, ARES_SECTION_AUTHORITY, nscount);
+    if (status != ARES_SUCCESS) {
+      goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+  }
+
+  if (arcount > 0) {
+    status =
+      ares_dns_record_rr_prealloc(*dnsrec, ARES_SECTION_ADDITIONAL, arcount);
+    if (status != ARES_SUCCESS) {
+      goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
 

--- a/test/ares-test-parse.cc
+++ b/test/ares-test-parse.cc
@@ -207,6 +207,17 @@ TEST_F(LibraryTest, ParseFullyCompressedName) {
   ares_free_hostent(host);
 }
 
+TEST_F(LibraryTest, ParseMalformedRRCount) {
+  ares_dns_record_t *dnsrec = NULL;
+  const unsigned char data[] = {
+    0x12, 0x34, 0x81, 0x80, 0x00, 0x01, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00, 0x01, 'a',  0x00, 0x00,
+    0x01, 0x00, 0x01,
+  };
+
+  EXPECT_EQ(ARES_EBADRESP, ares_dns_parse(data, sizeof(data), 0, &dnsrec));
+  EXPECT_EQ(nullptr, dnsrec);
+}
 
 }  // namespace test
 }  // namespace ares


### PR DESCRIPTION
## Summary

Validate DNS RR counts before preallocation to reject malformed packets early.

## What’s the issue?

The parser currently trusts RR counts from the DNS header (`ANCOUNT`, `NSCOUNT`, `ARCOUNT`) without verifying that the packet contains enough data.

A malformed packet can claim a large number of records without providing sufficient payload, causing the parser to proceed with unnecessary work and incorrect handling.

## What changed?

- Added validation to ensure RR counts are feasible based on the remaining buffer size  
- Moved RR preallocation from `ares_dns_parse_header` to `ares_dns_parse_buf`  
- Perform validation after question parsing and before preallocation  
- Return `ARES_EBADRESP` early for malformed packets  

## Why this approach?

This keeps the parser aligned with its natural flow:

parse header → parse question → validate → preallocate → parse records

It avoids trusting unverified input and ensures malformed packets are rejected early and consistently.

## Test

Added a regression test (`ParseMalformedRRCount`) that reproduces the issue using a malformed packet with inconsistent RR count.