### PR TITLE
adig: fix negated option prefix parsing

### DIFF
--- a/src/tools/adig.c
+++ b/src/tools/adig.c
@@ -1177,12 +1177,12 @@ static ares_bool_t read_cmdline(int argc, const char * const *argv,
       /* skip prefix */
       if (dig_options[opt].prefix != 0) {
         nameptr++;
-      }
-
-      /* Negated option if it has a 'no' prefix */
-      if (ares_streq_max(nameptr, "no", 2)) {
-        is_true  = ARES_FALSE;
-        nameptr += 2;
+        /* Negated option if it has a 'no' prefix */
+        if (dig_options[opt].prefix == '+' &&
+            ares_streq_max(nameptr, "no", 2)) {
+          is_true  = ARES_FALSE;
+          nameptr += 2;
+        }
       }
 
       if (dig_options[opt].separator != 0) {


### PR DESCRIPTION
Fixed issue:
`adig nosig.example.com` yields host "sig.example.com".