### PR TITLE
Defer TCP connection error handling until DNS responses are parsed

### DIFF
--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -515,6 +515,14 @@ static ares_status_t read_conn_packets(ares_conn_t *conn,
   } while (read_again);
 
   if (err != ARES_CONN_ERR_SUCCESS && err != ARES_CONN_ERR_WOULDBLOCK) {
+    /* If there is no packet data buffered, preserve the historical
+     * immediate connection-failure behavior so retries happen promptly.
+     * Only defer if there is buffered data to parse first. */
+    if (ares_buf_len(conn->in_buf) == 0) {
+      handle_conn_error(conn, ARES_TRUE, ARES_ECONNREFUSED);
+      return ARES_ECONNREFUSED;
+    }
+
     *conn_error = ARES_TRUE;
   }
 

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -445,11 +445,18 @@ void ares_process_pending_write(ares_channel_t *channel)
   ares_channel_unlock(channel);
 }
 
-static ares_status_t read_conn_packets(ares_conn_t *conn)
+static ares_status_t read_conn_packets(ares_conn_t *conn,
+  ares_bool_t *conn_error)
 {
   ares_bool_t           read_again;
   ares_conn_err_t       err;
   const ares_channel_t *channel = conn->server->channel;
+
+  if (conn_error == NULL) {
+    return ARES_EFORMERR;
+  }
+
+  *conn_error = ARES_FALSE;
 
   do {
     size_t         count;
@@ -508,8 +515,7 @@ static ares_status_t read_conn_packets(ares_conn_t *conn)
   } while (read_again);
 
   if (err != ARES_CONN_ERR_SUCCESS && err != ARES_CONN_ERR_WOULDBLOCK) {
-    handle_conn_error(conn, ARES_TRUE, ARES_ECONNREFUSED);
-    return ARES_ECONNREFUSED;
+    *conn_error = ARES_TRUE;
   }
 
   return ARES_SUCCESS;
@@ -671,24 +677,32 @@ static ares_status_t process_read(ares_channel_t       *channel,
                                   const ares_timeval_t *now)
 {
   ares_conn_t  *conn = ares_conn_from_fd(channel, read_fd);
+  ares_bool_t   conn_error;
   ares_status_t status;
 
   if (conn == NULL) {
     return ARES_SUCCESS;
   }
 
-  /* TODO: There might be a potential issue here where there was a read that
-   *       read some data, then looped and read again and got a disconnect.
-   *       Right now, that would cause a resend instead of processing the data
-   *       we have.  This is fairly unlikely to occur due to only looping if
-   *       a full buffer of 65535 bytes was read. */
-  status = read_conn_packets(conn);
+  status = read_conn_packets(conn, &conn_error);
 
   if (status != ARES_SUCCESS) {
     return status;
   }
 
-  return read_answers(conn, now);
+  status = read_answers(conn, now);
+  if (status != ARES_SUCCESS) {
+    return status;
+  }
+
+  if (conn_error) {
+    conn = ares_conn_from_fd(channel, read_fd);
+    if (conn != NULL) {
+      handle_conn_error(conn, ARES_TRUE, ARES_ECONNREFUSED);
+    }
+  }
+
+  return ARES_SUCCESS;
 }
 
 /* If any queries have timed out, note the timeout and move them on. */

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -57,6 +57,37 @@ class NoDNS0x20MockTest
   struct ares_options opts_;
 };
 
+static std::vector<byte> MakeMaxReadTcpAReply(void) {
+  std::vector<byte> reply = {
+    0x00, 0x00,  // qid
+    0x84, 0x00,  // response + query + AA + noerror
+    0x00, 0x01,  // qdcount
+    0x00, 0x01,  // ancount
+    0x00, 0x00,  // nscount
+    0x00, 0x00,  // arcount
+    // Question: www.google.com IN A
+    0x03, 'w', 'w', 'w',
+    0x06, 'g', 'o', 'o', 'g', 'l', 'e',
+    0x03, 'c', 'o', 'm',
+    0x00,
+    0x00, 0x01,
+    0x00, 0x01,
+    // Answer: name ptr, IN A 1.2.3.4
+    0xc0, 0x0c,
+    0x00, 0x01,
+    0x00, 0x01,
+    0x00, 0x00, 0x00, 0x64,
+    0x00, 0x04,
+    0x01, 0x02, 0x03, 0x04
+  };
+
+  /* Keep payload at 65533 bytes so TCP frame length is exactly 65535,
+   * forcing the read loop to attempt one more recv() where disconnect can
+   * race with already-buffered data. */
+  reply.resize(65533, 0x00);
+  return reply;
+}
+
 
 TEST_P(NoDNS0x20MockTest, Basic) {
   std::vector<byte> reply = {
@@ -576,6 +607,27 @@ TEST_P(MockTCPChannelTest, GetHostByNameParallelLookups) {
     ss << result[i].host_;
     EXPECT_EQ("{'www.google.com' aliases=[] addrs=[2.3.4.5]}", ss.str());
   }
+}
+
+TEST_P(MockTCPChannelTest, ReadFullFrameThenDisconnect) {
+  std::vector<byte> reply = MakeMaxReadTcpAReply();
+
+  EXPECT_CALL(server_, OnRequest("www.google.com", T_A))
+    .WillOnce(DoAll(SetReplyData(&server_, reply),
+                    DisconnectAfterReply(&server_)));
+
+  HostResult result;
+  ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback,
+                     &result);
+  Process();
+
+  EXPECT_TRUE(result.done_);
+  EXPECT_EQ(ARES_SUCCESS, result.status_);
+  EXPECT_EQ(0, result.timeouts_);
+
+  std::stringstream ss;
+  ss << result.host_;
+  EXPECT_EQ("{'www.google.com' aliases=[] addrs=[1.2.3.4]}", ss.str());
 }
 
 TEST_P(MockTCPChannelTest, MalformedResponse) {

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -443,7 +443,7 @@ void DefaultChannelModeTest::Process(unsigned int cancel_ms) {
 }
 
 MockServer::MockServer(int family, unsigned short port)
-  : udpport_(port), tcpport_(port), qid_(-1) {
+  : udpport_(port), tcpport_(port), qid_(-1), disconnect_after_reply_(false) {
   reply_ = nullptr;
   // Create a TCP socket to receive data on.
   tcp_data_ = NULL;
@@ -772,6 +772,15 @@ void MockServer::ProcessRequest(ares_socket_t fd, struct sockaddr_storage* addr,
                                          (struct sockaddr *)addr, addrlen);
   if (rc < static_cast<ares_ssize_t>(reply.size())) {
     std::cerr << "Failed to send full reply, rc=" << rc << std::endl;
+  }
+
+  if (disconnect_after_reply_ && fd != udpfd_) {
+    disconnect_after_reply_ = false;
+    connfds_.erase(fd);
+    sclose(fd);
+    free(tcp_data_);
+    tcp_data_     = NULL;
+    tcp_data_len_ = 0;
   }
 
 }

--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -288,6 +288,7 @@ public:
   {
     reply_ = nullptr;
     exact_reply_.clear();
+    disconnect_after_reply_ = false;
     for (ares_socket_t fd : connfds_) {
       sclose(fd);
     }
@@ -295,6 +296,11 @@ public:
     free(tcp_data_);
     tcp_data_     = NULL;
     tcp_data_len_ = 0;
+  }
+
+  void DisconnectAfterReply()
+  {
+    disconnect_after_reply_ = true;
   }
 
   // The set of file descriptors that the server handles.
@@ -330,6 +336,7 @@ private:
   const DNSPacket        *reply_;
   std::string             expected_request_;
   int                     qid_;
+  bool                    disconnect_after_reply_;
   unsigned char          *tcp_data_;
   size_t                  tcp_data_len_;
 };
@@ -500,6 +507,11 @@ ACTION_P2(CancelChannel, mockserver, channel)
 ACTION_P(Disconnect, mockserver)
 {
   mockserver->Disconnect();
+}
+
+ACTION_P(DisconnectAfterReply, mockserver)
+{
+  mockserver->DisconnectAfterReply();
 }
 
 // C++ wrapper for struct hostent.


### PR DESCRIPTION
This PR fixes a TCP read/disconnect ordering flaw in c-ares where valid DNS responses can be dropped if a peer disconnects immediately after sending data.

Connection error handling is deferred:
-Read packets from the socket
-Parse all buffered DNS responses
-Apply connection error handling afterward if needed

This guarantees that buffered data is always processed before teardown
