### PR TITLE
harden ares_array against integer overflow and unsafe size arithmetic

### DIFF
--- a/src/lib/dsa/ares_array.c
+++ b/src/lib/dsa/ares_array.c
@@ -147,7 +147,7 @@ static ares_status_t ares_array_move(ares_array_t *arr, size_t dest_idx,
   }
 
   nmembers = arr->cnt - (src_idx - arr->offset);
-  if (ares_size_mul_overflow(nmembers, arr->member_size, &nbytes)) {
+  if (ares_size_t_mul_overflow(nmembers, arr->member_size, &nbytes)) {
     return ARES_ENOMEM;
   }
 
@@ -206,8 +206,8 @@ ares_status_t ares_array_set_size(ares_array_t *arr, size_t size)
     return ARES_SUCCESS;
   }
 
-  if (ares_size_mul_overflow(arr->alloc_cnt, arr->member_size, &orig_size) ||
-      ares_size_mul_overflow(size, arr->member_size, &new_size)) {
+  if (ares_size_t_mul_overflow(arr->alloc_cnt, arr->member_size, &orig_size) ||
+      ares_size_t_mul_overflow(size, arr->member_size, &new_size)) {
     return ARES_ENOMEM;
   }
 

--- a/src/lib/dsa/ares_array.c
+++ b/src/lib/dsa/ares_array.c
@@ -194,7 +194,7 @@ void *ares_array_finish(ares_array_t *arr, size_t *num_members)
 
 ares_status_t ares_array_set_size(ares_array_t *arr, size_t size)
 {
-  void  *temp;
+  void *temp;
   size_t orig_size;
   size_t new_size;
   size_t rounded_size;
@@ -250,7 +250,7 @@ ares_status_t ares_array_insert_at(void **elem_ptr, ares_array_t *arr,
   }
 
   if (arr->cnt == SIZE_MAX) {
-    return ARES_ENOMEM;
+    return ARES_EFORMERR;
   }
 
   /* Allocate more if needed */

--- a/src/lib/dsa/ares_array.c
+++ b/src/lib/dsa/ares_array.c
@@ -37,20 +37,6 @@ struct ares_array {
   size_t                  alloc_cnt;
 };
 
-static ares_bool_t ares_array_mult_overflow(size_t a, size_t b, size_t *out)
-{
-  if (out == NULL) {
-    return ARES_TRUE;
-  }
-
-  if (a != 0 && b > SIZE_MAX / a) {
-    return ARES_TRUE;
-  }
-
-  *out = a * b;
-  return ARES_FALSE;
-}
-
 ares_array_t *ares_array_create(size_t                  member_size,
                                 ares_array_destructor_t destruct)
 {
@@ -161,7 +147,7 @@ static ares_status_t ares_array_move(ares_array_t *arr, size_t dest_idx,
   }
 
   nmembers = arr->cnt - (src_idx - arr->offset);
-  if (ares_array_mult_overflow(nmembers, arr->member_size, &nbytes)) {
+  if (ares_size_mul_overflow(nmembers, arr->member_size, &nbytes)) {
     return ARES_ENOMEM;
   }
 
@@ -220,8 +206,8 @@ ares_status_t ares_array_set_size(ares_array_t *arr, size_t size)
     return ARES_SUCCESS;
   }
 
-  if (ares_array_mult_overflow(arr->alloc_cnt, arr->member_size, &orig_size) ||
-      ares_array_mult_overflow(size, arr->member_size, &new_size)) {
+  if (ares_size_mul_overflow(arr->alloc_cnt, arr->member_size, &orig_size) ||
+      ares_size_mul_overflow(size, arr->member_size, &new_size)) {
     return ARES_ENOMEM;
   }
 

--- a/src/lib/dsa/ares_array.c
+++ b/src/lib/dsa/ares_array.c
@@ -37,6 +37,20 @@ struct ares_array {
   size_t                  alloc_cnt;
 };
 
+static ares_bool_t ares_array_mult_overflow(size_t a, size_t b, size_t *out)
+{
+  if (out == NULL) {
+    return ARES_TRUE;
+  }
+
+  if (a != 0 && b > SIZE_MAX / a) {
+    return ARES_TRUE;
+  }
+
+  *out = a * b;
+  return ARES_FALSE;
+}
+
 ares_array_t *ares_array_create(size_t                  member_size,
                                 ares_array_destructor_t destruct)
 {
@@ -122,6 +136,7 @@ static ares_status_t ares_array_move(ares_array_t *arr, size_t dest_idx,
   void       *dest_ptr;
   const void *src_ptr;
   size_t      nmembers;
+  size_t      nbytes;
 
   if (arr == NULL || dest_idx >= arr->alloc_cnt || src_idx >= arr->alloc_cnt) {
     return ARES_EFORMERR;
@@ -141,8 +156,16 @@ static ares_status_t ares_array_move(ares_array_t *arr, size_t dest_idx,
     return ARES_EFORMERR;
   }
 
+  if (src_idx < arr->offset || (src_idx - arr->offset) >= arr->cnt) {
+    return ARES_EFORMERR;
+  }
+
   nmembers = arr->cnt - (src_idx - arr->offset);
-  memmove(dest_ptr, src_ptr, nmembers * arr->member_size);
+  if (ares_array_mult_overflow(nmembers, arr->member_size, &nbytes)) {
+    return ARES_ENOMEM;
+  }
+
+  memmove(dest_ptr, src_ptr, nbytes);
 
   return ARES_SUCCESS;
 }
@@ -171,14 +194,22 @@ void *ares_array_finish(ares_array_t *arr, size_t *num_members)
 
 ares_status_t ares_array_set_size(ares_array_t *arr, size_t size)
 {
-  void *temp;
+  void  *temp;
+  size_t orig_size;
+  size_t new_size;
+  size_t rounded_size;
 
   if (arr == NULL || size == 0 || size < arr->cnt) {
     return ARES_EFORMERR;
   }
 
   /* Always operate on powers of 2 */
-  size = ares_round_up_pow2(size);
+  rounded_size = ares_round_up_pow2(size);
+  if (rounded_size < size) {
+    /* Overflow while rounding to next power-of-two growth target. */
+    return ARES_ENOMEM;
+  }
+  size = rounded_size;
 
   if (size < ARES__ARRAY_MIN) {
     size = ARES__ARRAY_MIN;
@@ -189,8 +220,12 @@ ares_status_t ares_array_set_size(ares_array_t *arr, size_t size)
     return ARES_SUCCESS;
   }
 
-  temp = ares_realloc_zero(arr->arr, arr->alloc_cnt * arr->member_size,
-                           size * arr->member_size);
+  if (ares_array_mult_overflow(arr->alloc_cnt, arr->member_size, &orig_size) ||
+      ares_array_mult_overflow(size, arr->member_size, &new_size)) {
+    return ARES_ENOMEM;
+  }
+
+  temp = ares_realloc_zero(arr->arr, orig_size, new_size);
   if (temp == NULL) {
     return ARES_ENOMEM;
   }
@@ -214,6 +249,10 @@ ares_status_t ares_array_insert_at(void **elem_ptr, ares_array_t *arr,
     return ARES_EFORMERR;
   }
 
+  if (arr->cnt == SIZE_MAX) {
+    return ARES_ENOMEM;
+  }
+
   /* Allocate more if needed */
   status = ares_array_set_size(arr, arr->cnt + 1);
   if (status != ARES_SUCCESS) {
@@ -221,6 +260,10 @@ ares_status_t ares_array_insert_at(void **elem_ptr, ares_array_t *arr,
   }
 
   /* Shift if we have memory but not enough room at the end */
+  if (arr->offset > SIZE_MAX - (arr->cnt + 1)) {
+    return ARES_ENOMEM;
+  }
+
   if (arr->cnt + 1 + arr->offset > arr->alloc_cnt) {
     status = ares_array_move(arr, 0, arr->offset);
     if (status != ARES_SUCCESS) {

--- a/src/lib/util/ares_math.c
+++ b/src/lib/util/ares_math.c
@@ -146,6 +146,39 @@ size_t ares_count_hexdigits(size_t n)
   return digits;
 }
 
+/* Detect __builtin_mul_overflow availability:
+ *   - Clang exposes it via __has_builtin
+ *   - GCC has supported it since 5.0
+ * Everything else (notably MSVC) falls back to the portable divide check. */
+#if defined(__has_builtin)
+#  if __has_builtin(__builtin_mul_overflow)
+#    define ARES_HAVE_BUILTIN_MUL_OVERFLOW 1
+#  endif
+#endif
+#if !defined(ARES_HAVE_BUILTIN_MUL_OVERFLOW) && \
+    defined(__GNUC__) && (__GNUC__ >= 5)
+#  define ARES_HAVE_BUILTIN_MUL_OVERFLOW 1
+#endif
+
+ares_bool_t ares_size_mul_overflow(size_t a, size_t b, size_t *out)
+{
+  if (out == NULL) {
+    return ARES_TRUE;
+  }
+
+#ifdef ARES_HAVE_BUILTIN_MUL_OVERFLOW
+  if (__builtin_mul_overflow(a, b, out)) {
+    return ARES_TRUE;
+  }
+#else
+  if (a != 0 && b > SIZE_MAX / a) {
+    return ARES_TRUE;
+  }
+  *out = a * b;
+#endif
+  return ARES_FALSE;
+}
+
 unsigned char ares_count_bits_u8(unsigned char x)
 {
   /* Implementation obtained from:

--- a/src/lib/util/ares_math.c
+++ b/src/lib/util/ares_math.c
@@ -146,36 +146,12 @@ size_t ares_count_hexdigits(size_t n)
   return digits;
 }
 
-/* Detect __builtin_mul_overflow availability:
- *   - Clang exposes it via __has_builtin
- *   - GCC has supported it since 5.0
- * Everything else (notably MSVC) falls back to the portable divide check. */
-#if defined(__has_builtin)
-#  if __has_builtin(__builtin_mul_overflow)
-#    define ARES_HAVE_BUILTIN_MUL_OVERFLOW 1
-#  endif
-#endif
-#if !defined(ARES_HAVE_BUILTIN_MUL_OVERFLOW) && \
-    defined(__GNUC__) && (__GNUC__ >= 5)
-#  define ARES_HAVE_BUILTIN_MUL_OVERFLOW 1
-#endif
-
-ares_bool_t ares_size_mul_overflow(size_t a, size_t b, size_t *out)
+ares_bool_t ares_size_t_mul_overflow(size_t a, size_t b, size_t *res)
 {
-  if (out == NULL) {
+  if (a > 0 && b > SIZE_MAX / a) {
     return ARES_TRUE;
   }
-
-#ifdef ARES_HAVE_BUILTIN_MUL_OVERFLOW
-  if (__builtin_mul_overflow(a, b, out)) {
-    return ARES_TRUE;
-  }
-#else
-  if (a != 0 && b > SIZE_MAX / a) {
-    return ARES_TRUE;
-  }
-  *out = a * b;
-#endif
+  *res = a * b;
   return ARES_FALSE;
 }
 

--- a/src/lib/util/ares_math.h
+++ b/src/lib/util/ares_math.h
@@ -51,8 +51,8 @@ size_t        ares_count_hexdigits(size_t n);
 unsigned char ares_count_bits_u8(unsigned char x);
 
 /* Multiply two size_t values, detecting overflow. On success, writes the
- * product to *out and returns ARES_FALSE. On overflow (or if out is NULL),
- * returns ARES_TRUE and *out is left untouched. */
-ares_bool_t   ares_size_mul_overflow(size_t a, size_t b, size_t *out);
+ * product to *res and returns ARES_FALSE. On overflow, returns ARES_TRUE and
+ * *res is left untouched. */
+ares_bool_t   ares_size_t_mul_overflow(size_t a, size_t b, size_t *res);
 
 #endif

--- a/src/lib/util/ares_math.h
+++ b/src/lib/util/ares_math.h
@@ -50,4 +50,9 @@ size_t        ares_count_digits(size_t n);
 size_t        ares_count_hexdigits(size_t n);
 unsigned char ares_count_bits_u8(unsigned char x);
 
+/* Multiply two size_t values, detecting overflow. On success, writes the
+ * product to *out and returns ARES_FALSE. On overflow (or if out is NULL),
+ * returns ARES_TRUE and *out is left untouched. */
+ares_bool_t   ares_size_mul_overflow(size_t a, size_t b, size_t *out);
+
 #endif

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -1223,6 +1223,12 @@ TEST_F(LibraryTest, DNSParseFlags) {
 
 TEST_F(LibraryTest, ArrayMisuse) {
   EXPECT_EQ(NULL, ares_array_create(0, NULL));
+  ares_array_t *overflow_array =
+    ares_array_create((SIZE_MAX / 2) + 1, NULL);
+  EXPECT_NE((void *)NULL, overflow_array);
+  EXPECT_NE(ARES_SUCCESS, ares_array_set_size(overflow_array, 2));
+  EXPECT_NE(ARES_SUCCESS, ares_array_set_size(overflow_array, SIZE_MAX));
+  ares_array_destroy(overflow_array);
   ares_array_destroy(NULL);
   EXPECT_EQ(NULL, ares_array_finish(NULL, NULL));
   EXPECT_EQ(0, ares_array_len(NULL));


### PR DESCRIPTION
This patch adds overflow checks to size calculations in ares_array to prevent integer wraparound during memory allocation and element movement.

Changes Done:

- Added checked multiplication helper to detect overflow in size calculations
- Hardened memmove byte-size computation to prevent overflow
- Added validation in capacity growth (ares_array_set_size) to detect:
- multiplication overflow
- power-of-two rounding overflow
- Added bounds checks in insertion logic to prevent size and offset overflow
- Ensured safe failure (returning error) instead of proceeding with unsafe memory operations
- Added regression checks to verify that:
     1. oversized member_size values are safely rejected
     2. large allocation requests (e.g., SIZE_MAX) fail instead of wrapping
     
The fix improves the safety of a core container used throughout the library and aligns allocation logic with safe arithmetic practices.