### PR TITLE
enforce strict RDLENGTH consumption for fixed-size RDATA types

### DIFF
--- a/src/lib/record/ares_dns_parse.c
+++ b/src/lib/record/ares_dns_parse.c
@@ -1164,16 +1164,11 @@ static ares_status_t ares_dns_parse_rr(ares_buf_t *buf, unsigned int flags,
   /* Determine how many bytes were processed */
   processed_len = remaining_len - ares_buf_len(buf);
 
-  /* If too many bytes were processed, error! */
-  if (processed_len > rdlength) {
+  /* RDATA parsers must consume exactly rdlength bytes to avoid accepting
+   * malformed trailing data. */
+  if (processed_len != rdlength) {
     status = ARES_EBADRESP;
     goto done;
-  }
-
-  /* If too few bytes were processed, consume the unprocessed data for this
-   * record as the parser may not have wanted/needed to use it */
-  if (processed_len < rdlength) {
-    ares_buf_consume(buf, rdlength - processed_len);
   }
 
 

--- a/test/ares-test-parse-a.cc
+++ b/test/ares-test-parse-a.cc
@@ -132,6 +132,14 @@ TEST_F(LibraryTest, ParseMalformedAReply) {
   EXPECT_EQ(ARES_EBADRESP, ares_parse_a_reply(invalid_rrlen.data(), (int)invalid_rrlen.size(),
                                               &host, info, &count));
 
+  // RDLENGTH is larger than A RDATA with trailing bytes.
+  std::vector<byte> invalid_trailing(data);
+  invalid_trailing[50] = 0x00;
+  invalid_trailing[51] = 0x05;
+  invalid_trailing.push_back(0x00);
+  EXPECT_EQ(ARES_EBADRESP, ares_parse_a_reply(invalid_trailing.data(), (int)invalid_trailing.size(),
+                                              &host, info, &count));
+
   // Truncate mid-question.
   EXPECT_EQ(ARES_EBADRESP, ares_parse_a_reply(data.data(), 26,
                                               &host, info, &count));

--- a/test/ares-test-parse-aaaa.cc
+++ b/test/ares-test-parse-aaaa.cc
@@ -196,6 +196,16 @@ TEST_F(LibraryTest, ParseAaaaReplyErrors) {
                                                    nullptr, info, &count));
   }
 
+  // AAAA RDLENGTH with trailing bytes must be rejected.
+  std::vector<byte> invalid_trailing = data;
+  invalid_trailing[50] = 0x00;
+  invalid_trailing[51] = 0x11;
+  invalid_trailing.insert(invalid_trailing.begin() + 68, 0x00);
+  EXPECT_EQ(ARES_EBADRESP, ares_parse_aaaa_reply(invalid_trailing.data(),
+                                                 (int)invalid_trailing.size(),
+                                                 &host, info, &count));
+  EXPECT_EQ(nullptr, host);
+
   // Negative length
   EXPECT_EQ(ARES_EBADRESP, ares_parse_aaaa_reply(data.data(), -1,
                                                  &host, info, &count));


### PR DESCRIPTION
c-ares currently accepts DNS resource records where the declared RDLENGTH exceeds the number of bytes actually consumed by the type-specific parser. 
This results in trailing bytes within RDATA being silently ignored.

This patch enforces strict validation by requiring that the parser consumes exactly RDLENGTH bytes for known RDATA types.

- Enforce exact-length validation:
- Implemented in `ares_dns_parse.c`
- Added regression tests to validate the fix:
  1. `ares-test-parse-a.cc` — A record with oversized RDLENGTH
   2. `ares-test-parse-aaaa.cc` — AAAA record with oversized RDLENGTH