### PR TITLE
Limit GitHub Actions token permissions

### DIFF
--- a/.github/workflows/alpine-latest.yml
+++ b/.github/workflows/alpine-latest.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: Alpine (latest)
+permissions:
+  contents: read
 on:
   push:
   pull_request:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: Android
+permissions:
+  contents: read
 on:
   push:
   pull_request:

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: CentOS 7
+permissions:
+  contents: read
 on:
   push:
   pull_request:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 name: Codespell
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: coverity
+permissions:
+  contents: read
 on:
   schedule:
     - cron: "0 10 * * 1" # Mondays at 00:10 UTC

--- a/.github/workflows/djgpp.yml
+++ b/.github/workflows/djgpp.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: DJGPP
+permissions:
+  contents: read
 on:
   push:
   pull_request:

--- a/.github/workflows/fedora-latest.yml
+++ b/.github/workflows/fedora-latest.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: Fedora Latest (bleeding edge)
+permissions:
+  contents: read
 on:
   push:
   pull_request:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: iOS
+permissions:
+  contents: read
 on:
   push:
   pull_request:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: MacOS
+permissions:
+  contents: read
 on:
   push:
   pull_request:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: MSYS2 (Windows)
+permissions:
+  contents: read
 on:
   push:
   pull_request:

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: NetBSD
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: OpenBSD
+permissions:
+  contents: read
 on:
   push:
   pull_request:

--- a/.github/workflows/qnx.yml
+++ b/.github/workflows/qnx.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: QNX
+permissions:
+  contents: read
 on:
   push:
 

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: Solaris
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: Ubuntu 20.04
+permissions:
+  contents: read
 on:
   push:
   pull_request:

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: Ubuntu (latest)
+permissions:
+  contents: read
 on:
   push:
   pull_request:

--- a/.github/workflows/uwp.yml
+++ b/.github/workflows/uwp.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: Windows UWP (Store)
+permissions:
+  contents: read
 on:
   push:
   pull_request:

--- a/.github/workflows/watcom.yml
+++ b/.github/workflows/watcom.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: OpenWatcom
+permissions:
+  contents: read
 on:
   push:
   pull_request:

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -1,6 +1,8 @@
 # Copyright (C) The c-ares project and its contributors
 # SPDX-License-Identifier: MIT
 name: WATT32
+permissions:
+  contents: read
 on:
   push:
   pull_request:


### PR DESCRIPTION
This declares explicit read-only `GITHUB_TOKEN` permissions for CI workflows that only need repository checkout/read access.

By setting `permissions: contents: read`, these workflows no longer depend on the repository's default token permission setting. This follows GitHub Actions least-privilege guidance and reduces the impact if a build step or third-party action is compromised.

Workflows with existing custom permissions or service-specific behavior were left unchanged.

Verification:

- Parsed all workflow YAML files successfully.
- `git diff --check`