### PR TITLE
ares_cancel: Avoid Allocation

### DIFF
--- a/src/lib/ares_cancel.c
+++ b/src/lib/ares_cancel.c
@@ -43,21 +43,18 @@ void ares_cancel(ares_channel_t *channel)
     ares_llist_node_t *node = NULL;
     ares_llist_node_t *next = NULL;
 
-    /* Swap list heads, so that only those queries which were present on entry
-     * into this function are cancelled. New queries added by callbacks of
-     * queries being cancelled will not be cancelled themselves.
+    /* Move the current queries to the cancellation list, so that only those
+     * queries which were present on entry into this function are cancelled.
+     * New queries added by callbacks of queries being cancelled will not be
+     * cancelled themselves unless a callback calls ares_cancel() again.
+     *
+     * Nodes moved to queries_being_cancelled intentionally keep each query's
+     * node_all_queries pointer. It remains the removal handle for the query's
+     * channel-owned query list node until the cancel loop claims that node.
      */
-    ares_llist_t      *list_copy = channel->all_queries;
-    channel->all_queries         = ares_llist_create(NULL);
+    node = ares_llist_move_all_last(channel->queries_being_cancelled,
+                                    channel->all_queries);
 
-    /* Out of memory, this function doesn't return a result code though so we
-     * can't report to caller */
-    if (channel->all_queries == NULL) {
-      channel->all_queries = list_copy; /* LCOV_EXCL_LINE: OutOfMemory */
-      goto done;                        /* LCOV_EXCL_LINE: OutOfMemory */
-    }
-
-    node = ares_llist_node_first(list_copy);
     while (node != NULL) {
       ares_query_t *query;
 
@@ -73,15 +70,11 @@ void ares_cancel(ares_channel_t *channel)
 
       node = next;
     }
-
-    ares_llist_destroy(list_copy);
   }
 
   /* See if the connections should be cleaned up */
   ares_check_cleanup_conns(channel);
 
   ares_queue_notify_empty(channel);
-
-done:
   ares_channel_unlock(channel);
 }

--- a/src/lib/ares_destroy.c
+++ b/src/lib/ares_destroy.c
@@ -89,6 +89,7 @@ void ares_destroy(ares_channel_t *channel)
    * so all query lists should be empty now.
    */
   assert(ares_llist_len(channel->all_queries) == 0);
+  assert(ares_llist_len(channel->queries_being_cancelled) == 0);
   assert(ares_htable_szvp_num_keys(channel->queries_by_qid) == 0);
   assert(ares_slist_len(channel->queries_by_timeout) == 0);
 #endif
@@ -115,6 +116,7 @@ void ares_destroy(ares_channel_t *channel)
   }
 
   ares_llist_destroy(channel->all_queries);
+  ares_llist_destroy(channel->queries_being_cancelled);
   ares_slist_destroy(channel->queries_by_timeout);
   ares_htable_szvp_destroy(channel->queries_by_qid);
   ares_htable_asvp_destroy(channel->connnode_by_socket);

--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -288,6 +288,12 @@ int ares_init_options(ares_channel_t           **channelptr,
     goto done;
   }
 
+  channel->queries_being_cancelled = ares_llist_create(NULL);
+  if (channel->queries_being_cancelled == NULL) {
+    status = ARES_ENOMEM;
+    goto done;
+  }
+
   channel->queries_by_qid = ares_htable_szvp_create(NULL);
   if (channel->queries_by_qid == NULL) {
     status = ARES_ENOMEM;

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -225,6 +225,8 @@ struct ares_channeldata {
 
   /* All active queries in a single list */
   ares_llist_t        *all_queries;
+  /* Queries currently being cancelled */
+  ares_llist_t        *queries_being_cancelled;
   /* Queries bucketed by qid, for quickly dispatching DNS responses: */
   ares_htable_szvp_t  *queries_by_qid;
 

--- a/src/lib/dsa/ares_llist.c
+++ b/src/lib/dsa/ares_llist.c
@@ -383,3 +383,38 @@ void ares_llist_node_mvparent_first(ares_llist_node_t *node,
   ares_llist_node_detach(node);
   ares_llist_attach_at(new_parent, ARES__LLIST_INSERT_HEAD, NULL, node);
 }
+
+ares_llist_node_t *ares_llist_move_all_last(ares_llist_t *new_parent,
+                                            ares_llist_t *old_parent)
+{
+  ares_llist_node_t *first;
+  ares_llist_node_t *node;
+
+  if (new_parent == NULL || old_parent == NULL || new_parent == old_parent) {
+    return NULL; /* LCOV_EXCL_LINE: DefensiveCoding */
+  }
+
+  first = old_parent->head;
+  if (first == NULL) {
+    return NULL;
+  }
+
+  if (new_parent->tail != NULL) {
+    new_parent->tail->next = old_parent->head;
+    old_parent->head->prev = new_parent->tail;
+  } else {
+    new_parent->head = old_parent->head;
+  }
+  new_parent->tail = old_parent->tail;
+  new_parent->cnt += old_parent->cnt;
+
+  for (node = old_parent->head; node != NULL; node = node->next) {
+    node->parent = new_parent;
+  }
+
+  old_parent->head = NULL;
+  old_parent->tail = NULL;
+  old_parent->cnt  = 0;
+
+  return first;
+}

--- a/src/lib/include/ares_llist.h
+++ b/src/lib/include/ares_llist.h
@@ -234,6 +234,15 @@ CARES_EXTERN void ares_llist_node_mvparent_last(ares_llist_node_t *node,
  */
 CARES_EXTERN void ares_llist_node_mvparent_first(ares_llist_node_t *node,
                                                  ares_llist_t      *new_parent);
+
+/*! Move all nodes from one list to the end of another list.
+ *
+ *  \param[in] new_parent list to receive nodes
+ *  \param[in] old_parent list to move nodes from
+ *  \return first node moved, or NULL if no nodes moved
+ */
+CARES_EXTERN ares_llist_node_t *
+  ares_llist_move_all_last(ares_llist_t *new_parent, ares_llist_t *old_parent);
 /*! @} */
 
 #endif /* __ARES__LLIST_H */

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -40,6 +40,38 @@ using testing::DoAll;
 namespace ares {
 namespace test {
 
+struct CancelCallbackArg {
+  ares_channel_t *channel_;
+  HostResult     *result_;
+  HostResult     *enqueued_result_;
+  ares_bool_t     reenter_;
+  std::vector<size_t> *active_queries_;
+};
+
+static void CancelCallback(void *data, int status, int timeouts,
+                           const struct hostent *hostent)
+{
+  CancelCallbackArg *arg = reinterpret_cast<CancelCallbackArg *>(data);
+
+  HostCallback(arg->result_, status, timeouts, hostent);
+  if (status != ARES_ECANCELLED) {
+    return;
+  }
+
+  if (arg->active_queries_ != NULL) {
+    arg->active_queries_->push_back(ares_queue_active_queries(arg->channel_));
+  }
+
+  if (arg->enqueued_result_ != NULL) {
+    ares_gethostbyname(arg->channel_, "www.third.gov.", AF_INET, HostCallback,
+                       arg->enqueued_result_);
+  }
+
+  if (arg->reenter_) {
+    ares_cancel(arg->channel_);
+  }
+}
+
 class NoDNS0x20MockTest
     : public MockChannelOptsTest,
       public ::testing::WithParamInterface<int> {
@@ -1607,10 +1639,127 @@ TEST_P(MockUDPChannelTest, Resend) {
 TEST_P(MockChannelTest, CancelImmediate) {
   HostResult result;
   ares_gethostbyname(channel_, "www.google.com.", AF_INET, HostCallback, &result);
+  LibraryTest::SetAllocFail(1);
   ares_cancel(channel_);
+  LibraryTest::ClearFails();
   EXPECT_TRUE(result.done_);
   EXPECT_EQ(ARES_ECANCELLED, result.status_);
   EXPECT_EQ(0, result.timeouts_);
+}
+
+TEST_P(MockChannelTest, CancelCallbackQueryNotCancelled) {
+  DNSPacket reply;
+  reply.set_response().set_aa()
+    .add_question(new DNSQuestion("www.third.gov", T_A))
+    .add_answer(new DNSARR("www.third.gov", 0x0100, {0x01, 0x02, 0x03, 0x04}));
+
+  ON_CALL(server_, OnRequest("www.third.gov", T_A))
+    .WillByDefault(SetReply(&server_, &reply));
+
+  HostResult        first;
+  HostResult        second;
+  HostResult        third;
+  CancelCallbackArg arg = { channel_, &first, &third, ARES_FALSE, NULL };
+
+  ares_gethostbyname(channel_, "www.first.com.", AF_INET, CancelCallback, &arg);
+  ares_gethostbyname(channel_, "www.second.org.", AF_INET, HostCallback,
+                     &second);
+
+  ares_cancel(channel_);
+  EXPECT_TRUE(first.done_);
+  EXPECT_EQ(ARES_ECANCELLED, first.status_);
+  EXPECT_TRUE(second.done_);
+  EXPECT_EQ(ARES_ECANCELLED, second.status_);
+  EXPECT_FALSE(third.done_);
+
+  Process();
+  EXPECT_TRUE(third.done_);
+  EXPECT_EQ(ARES_SUCCESS, third.status_);
+}
+
+TEST_P(MockChannelTest, CancelReentrant) {
+  HostResult        first;
+  HostResult        second;
+  CancelCallbackArg arg = { channel_, &first, NULL, ARES_TRUE, NULL };
+
+  ares_gethostbyname(channel_, "www.first.com.", AF_INET, CancelCallback, &arg);
+  ares_gethostbyname(channel_, "www.second.org.", AF_INET, HostCallback,
+                     &second);
+
+  ares_cancel(channel_);
+  EXPECT_TRUE(first.done_);
+  EXPECT_EQ(ARES_ECANCELLED, first.status_);
+  EXPECT_TRUE(second.done_);
+  EXPECT_EQ(ARES_ECANCELLED, second.status_);
+}
+
+TEST_P(MockChannelTest, CancelCallbackQueryCancelledByReentrantCancel) {
+  HostResult        first;
+  HostResult        second;
+  HostResult        third;
+  CancelCallbackArg arg = { channel_, &first, &third, ARES_TRUE, NULL };
+
+  ares_gethostbyname(channel_, "www.first.com.", AF_INET, CancelCallback, &arg);
+  ares_gethostbyname(channel_, "www.second.org.", AF_INET, HostCallback,
+                     &second);
+
+  ares_cancel(channel_);
+  EXPECT_TRUE(first.done_);
+  EXPECT_EQ(ARES_ECANCELLED, first.status_);
+  EXPECT_TRUE(second.done_);
+  EXPECT_EQ(ARES_ECANCELLED, second.status_);
+  EXPECT_TRUE(third.done_);
+  EXPECT_EQ(ARES_ECANCELLED, third.status_);
+}
+
+TEST_P(MockChannelTest, CancelActiveQueryCount) {
+  HostResult          first;
+  HostResult          second;
+  std::vector<size_t> active_queries;
+  CancelCallbackArg   first_arg = { channel_, &first, NULL, ARES_FALSE,
+                                    &active_queries };
+  CancelCallbackArg   second_arg = { channel_, &second, NULL, ARES_FALSE,
+                                     &active_queries };
+
+  ares_gethostbyname(channel_, "www.first.com.", AF_INET, CancelCallback,
+                     &first_arg);
+  ares_gethostbyname(channel_, "www.second.org.", AF_INET, CancelCallback,
+                     &second_arg);
+
+  ares_cancel(channel_);
+  EXPECT_TRUE(first.done_);
+  EXPECT_EQ(ARES_ECANCELLED, first.status_);
+  EXPECT_TRUE(second.done_);
+  EXPECT_EQ(ARES_ECANCELLED, second.status_);
+
+  ASSERT_EQ(2, active_queries.size());
+  EXPECT_EQ(0, active_queries[0]);
+  EXPECT_EQ(0, active_queries[1]);
+}
+
+TEST_P(MockChannelTest, CancelReentrantActiveQueryCount) {
+  HostResult          first;
+  HostResult          second;
+  std::vector<size_t> active_queries;
+  CancelCallbackArg   first_arg = { channel_, &first, NULL, ARES_TRUE,
+                                    &active_queries };
+  CancelCallbackArg   second_arg = { channel_, &second, NULL, ARES_FALSE,
+                                     &active_queries };
+
+  ares_gethostbyname(channel_, "www.first.com.", AF_INET, CancelCallback,
+                     &first_arg);
+  ares_gethostbyname(channel_, "www.second.org.", AF_INET, CancelCallback,
+                     &second_arg);
+
+  ares_cancel(channel_);
+  EXPECT_TRUE(first.done_);
+  EXPECT_EQ(ARES_ECANCELLED, first.status_);
+  EXPECT_TRUE(second.done_);
+  EXPECT_EQ(ARES_ECANCELLED, second.status_);
+
+  ASSERT_EQ(2, active_queries.size());
+  EXPECT_EQ(0, active_queries[0]);
+  EXPECT_EQ(0, active_queries[1]);
 }
 
 TEST_P(MockChannelTest, CancelImmediateGetHostByAddr) {


### PR DESCRIPTION
Previously ares_cancel:

1. Extracted the current list of all queries
2. Allocated a new, empty list of queries and made that the list of all queries (note that this can fail if allocation fails)
3. Iterated the list extracted in step 1 canceling all queries therein
4. Destroyed the list extracted in step 1

Note that not only does the above mean that ares_cancel could fail (due to allocation failure in step 2), but also that due to the fact it returns void that failure was silently ignored.

Updated the implementation so that ares_cancel does not allocate, and therefore always succeeds. This is accomplished by:

1. Inserting a dummy node at the end of the list of all queries
2. Traversing the list of all queries canceling each query until the dummy node inserted in step 1 is reached (dummy nodes inserted by re-entrant calls are skipped)
3. Removing the dummy node inserted in step 1

Note that since queries are only appended to the list of all queries the above formulation ensures that:

- Re-entrant calls to ares_cancel, and
- Adding queries from the callback of a cancelled query

Continue to work as before.