### PR TITLE
ares_default_socket_functions_ex

### DIFF
--- a/docs/ares_set_socket_functions.3
+++ b/docs/ares_set_socket_functions.3
@@ -2,7 +2,7 @@
 .\" SPDX-License-Identifier: MIT
 .TH ARES_SET_SOCKET_FUNCTIONS 3 "8 Oct 2024"
 .SH NAME
-ares_set_socket_functions, ares_set_socket_functions_ex \- Set socket io callbacks
+ares_set_socket_functions, ares_set_socket_functions_ex, ares_default_socket_functions_ex \- Set socket io callbacks
 .SH SYNOPSIS
 .nf
 #include <ares.h>
@@ -28,7 +28,7 @@ typedef enum {
 } ares_socket_bind_flags_t;
 
 struct ares_socket_functions_ex {
-  unsigned int version; /* ABI Version: must be "1" */
+  unsigned int version; /* ABI Version: must be ARES_SOCKET_FUNCTIONS_EX_VERSION */
   unsigned int flags;
 
   ares_socket_t (*asocket)(int domain, int type, int protocol, void *user_data);
@@ -53,6 +53,11 @@ struct ares_socket_functions_ex {
   const char *(*aif_indextoname)(unsigned int ifindex, char *ifname_buf,
                                  size_t ifname_buf_len, void *user_data);
 };
+
+#define ARES_SOCKET_FUNCTIONS_EX_VERSION 1
+
+ares_status_t ares_default_socket_functions_ex(
+  struct ares_socket_functions_ex *funcs, unsigned int version);
 
 ares_status_t ares_set_socket_functions_ex(ares_channel_t *channel,
   const struct ares_socket_functions_ex *funcs, void *user_data);
@@ -88,6 +93,15 @@ Some callbacks may be optional and are documented as such below, but failing
 to implement such callbacks will disable certain features within c-ares.  It
 is strongly recommended to implement all callbacks.
 
+\fBares_default_socket_functions_ex(3)\fP initializes \fIfuncs\fP with
+c-ares' default socket callbacks for the requested \fIversion\fP.  Pass
+\fBARES_SOCKET_FUNCTIONS_EX_VERSION\fP for the version supported by the
+headers used at build time.  After initialization, applications may replace
+individual callbacks before passing the structure to
+\fBares_set_socket_functions_ex(3)\fP.  The function returns
+\fBARES_EFORMERR\fP if \fIfuncs\fP is \fBNULL\fP or \fIversion\fP is not
+supported by the linked c-ares library.
+
 All callback functions are expected to operate like their system equivalents,
 and to set \fBerrno(2)\fP or \fBWSASetLastError(2)\fP to an appropriate error
 code on failure. It is strongly recommended that io callbacks are implemented
@@ -106,7 +120,8 @@ members and callbacks (which are different from the
 .TP 8
 .B unsigned int \fIversion\fP
 .br
-ABI Version of structure.  Must be set to a value of "1".
+ABI Version of structure.  Must be set to
+\fBARES_SOCKET_FUNCTIONS_EX_VERSION\fP.
 
 .TP 8
 .B unsigned int \fIflags\fP

--- a/include/ares.h
+++ b/include/ares.h
@@ -623,7 +623,7 @@ typedef enum {
 
 /*! Socket functions to call rather than using OS-native functions */
 struct ares_socket_functions_ex {
-  /*! ABI Version: must be "1" */
+  /*! ABI Version: must be ARES_SOCKET_FUNCTIONS_EX_VERSION */
   unsigned int version;
 
   /*! Flags indicating behavior of the subsystem. One or more
@@ -799,6 +799,19 @@ struct ares_socket_functions_ex {
   const char *(*aif_indextoname)(unsigned int ifindex, char *ifname_buf,
                                  size_t ifname_buf_len, void *user_data);
 };
+
+#define ARES_SOCKET_FUNCTIONS_EX_VERSION 1
+
+/*! Initialize socket io callbacks with c-ares' default implementations.
+ *
+ *  \param[out] funcs   Structure to initialize.
+ *  \param[in] version  Socket functions ABI version to initialize. Use
+ *                      ARES_SOCKET_FUNCTIONS_EX_VERSION.
+ *  \return ARES_SUCCESS on success, or another error code such as
+ *          ARES_EFORMERR on misuse.
+ */
+CARES_EXTERN ares_status_t ares_default_socket_functions_ex(
+  struct ares_socket_functions_ex *funcs, unsigned int version);
 
 /*! Override the native socket functions for the OS with the provided set.
  *  An optional user data thunk may be specified which will be passed to

--- a/src/lib/ares_set_socket_functions.c
+++ b/src/lib/ares_set_socket_functions.c
@@ -90,7 +90,7 @@ ares_status_t
                                const struct ares_socket_functions_ex *funcs,
                                void                                  *user_data)
 {
-  unsigned int known_versions[] = { 1 };
+  unsigned int known_versions[] = { ARES_SOCKET_FUNCTIONS_EX_VERSION };
   size_t       i;
 
   if (channel == NULL || funcs == NULL) {
@@ -442,7 +442,7 @@ static const char *default_aif_indextoname(unsigned int ifindex,
 }
 
 static const struct ares_socket_functions_ex default_socket_functions = {
-  1,
+  ARES_SOCKET_FUNCTIONS_EX_VERSION,
   ARES_SOCKFUNC_FLAG_NONBLOCKING,
   default_asocket,
   default_aclose,
@@ -455,6 +455,22 @@ static const struct ares_socket_functions_ex default_socket_functions = {
   default_aif_nametoindex,
   default_aif_indextoname
 };
+
+ares_status_t ares_default_socket_functions_ex(
+  struct ares_socket_functions_ex *funcs, unsigned int version)
+{
+  if (funcs == NULL) {
+    return ARES_EFORMERR;
+  }
+
+  switch (version) {
+    case ARES_SOCKET_FUNCTIONS_EX_VERSION:
+      *funcs = default_socket_functions;
+      return ARES_SUCCESS;
+    default:
+      return ARES_EFORMERR;
+  }
+}
 
 void ares_set_socket_functions_def(ares_channel_t *channel)
 {
@@ -562,7 +578,7 @@ static ares_ssize_t legacycb_asendto(ares_socket_t sock, const void *buffer,
 
 
 static const struct ares_socket_functions_ex legacy_socket_functions = {
-  1,
+  ARES_SOCKET_FUNCTIONS_EX_VERSION,
   0,
   legacycb_asocket,
   legacycb_aclose,

--- a/test/ares-test-misc.cc
+++ b/test/ares-test-misc.cc
@@ -637,6 +637,34 @@ TEST_F(LibraryTest, StrError) {
   EXPECT_EQ("unknown", std::string(str));
 }
 
+TEST_F(DefaultChannelTest, DefaultSocketFunctionsEx) {
+  struct ares_socket_functions_ex funcs;
+
+  EXPECT_EQ(ARES_EFORMERR,
+            ares_default_socket_functions_ex(
+              nullptr, ARES_SOCKET_FUNCTIONS_EX_VERSION));
+  EXPECT_EQ(ARES_EFORMERR,
+            ares_default_socket_functions_ex(&funcs, 0));
+  EXPECT_EQ(ARES_EFORMERR,
+            ares_default_socket_functions_ex(
+              &funcs, ARES_SOCKET_FUNCTIONS_EX_VERSION + 1));
+
+  EXPECT_EQ(ARES_SUCCESS,
+            ares_default_socket_functions_ex(
+              &funcs, ARES_SOCKET_FUNCTIONS_EX_VERSION));
+  EXPECT_EQ(ARES_SOCKET_FUNCTIONS_EX_VERSION, funcs.version);
+  EXPECT_EQ(ARES_SOCKFUNC_FLAG_NONBLOCKING,
+            funcs.flags & ARES_SOCKFUNC_FLAG_NONBLOCKING);
+  EXPECT_NE(nullptr, funcs.asocket);
+  EXPECT_NE(nullptr, funcs.aclose);
+  EXPECT_NE(nullptr, funcs.asetsockopt);
+  EXPECT_NE(nullptr, funcs.aconnect);
+  EXPECT_NE(nullptr, funcs.arecvfrom);
+  EXPECT_NE(nullptr, funcs.asendto);
+  EXPECT_EQ(ARES_SUCCESS,
+            ares_set_socket_functions_ex(channel_, &funcs, nullptr));
+}
+
 TEST_F(LibraryTest, UsageErrors) {
   ares_cancel(NULL);
   ares_set_socket_callback(NULL, NULL, NULL);

--- a/test/ares-test-mock-et.cc
+++ b/test/ares-test-mock-et.cc
@@ -196,7 +196,7 @@ static ares_ssize_t noop_sendto(ares_socket_t sock, const void *buffer,
 TEST_P(MockUDPEventThreadTest, DownServer) {
   struct ares_socket_functions_ex noop_sock_funcs;
   memset(&noop_sock_funcs, 0, sizeof(noop_sock_funcs));
-  noop_sock_funcs.version     = 1;
+  noop_sock_funcs.version     = ARES_SOCKET_FUNCTIONS_EX_VERSION;
   noop_sock_funcs.asocket     = noop_socket;
   noop_sock_funcs.aclose      = noop_close;
   noop_sock_funcs.asetsockopt = noop_setsockopt;


### PR DESCRIPTION
The non-deprecated socket function API requires callers to provide every core callback. This makes it awkward to wrap only a few default socket operations, such as observing socket open and close while otherwise preserving c-ares' native socket behavior.

The older deprecated ares_set_socket_functions API allowed NULL callbacks to fall back to c-ares' defaults, but that API is not equivalent to ares_set_socket_functions_ex and does not expose newer callbacks.

Added ares_default_socket_functions_ex, which initializes an ares_socket_functions_ex structure with c-ares' default socket callbacks. Callers can then replace individual callbacks before installing the table with ares_set_socket_functions_ex.

Also added ARES_SOCKET_FUNCTIONS_EX_VERSION so callers do not need to use a magic constant.