### PR TITLE
parse sortlist netmask with strtoul instead of atoi

### DIFF
--- a/src/lib/ares_sysconfig_files.c
+++ b/src/lib/ares_sysconfig_files.c
@@ -170,11 +170,9 @@ static ares_status_t parse_sort(ares_buf_t *buf, struct apattern *pat)
 
     if (ares_str_isnum(maskstr)) {
       /* Numeric mask */
-      int mask = atoi(maskstr);
-      if (mask < 0 || mask > 128) {
-        return ARES_EBADSTR;
-      }
-      if (pat->addr.family == AF_INET && mask > 32) {
+      unsigned int mask;
+      unsigned int maxmask = (pat->addr.family == AF_INET) ? 32 : 128;
+      if (!ares_str_to_num(maskstr, maxmask, &mask)) {
         return ARES_EBADSTR;
       }
       pat->mask = (unsigned char)mask;

--- a/src/lib/ares_update_servers.c
+++ b/src/lib/ares_update_servers.c
@@ -42,6 +42,7 @@
 #ifdef HAVE_STDINT_H
 #  include <stdint.h>
 #endif
+#include <limits.h>
 
 #if defined(USE_WINSOCK)
 #  if defined(HAVE_IPHLPAPI_H)
@@ -403,7 +404,9 @@ static ares_status_t ares_sconfig_linklocal(const ares_channel_t *channel,
 
   if (ares_str_isnum(ll_iface)) {
     char ifname[IF_NAMESIZE] = "";
-    ll_scope                 = (unsigned int)atoi(ll_iface);
+    if (!ares_str_to_num(ll_iface, UINT_MAX, &ll_scope)) {
+      return ARES_ENOTFOUND;
+    }
     if (channel->sock_funcs.aif_indextoname == NULL ||
         channel->sock_funcs.aif_indextoname(ll_scope, ifname, sizeof(ifname),
                                             channel->sock_func_cb_data) ==

--- a/src/lib/include/ares_str.h
+++ b/src/lib/include/ares_str.h
@@ -60,6 +60,19 @@ CARES_EXTERN size_t ares_strcpy(char *dest, const char *src, size_t dest_size);
 CARES_EXTERN ares_bool_t    ares_str_isnum(const char *str);
 CARES_EXTERN ares_bool_t    ares_str_isalnum(const char *str);
 
+/*! Parse a base-10 unsigned integer from a NULL-terminated string.  Unlike
+ *  atoi(), this is well-defined on out-of-range input: empty strings, trailing
+ *  non-digit characters, values that overflow, and values greater than the
+ *  provided maximum are all rejected.
+ *
+ *  \param[in]  str  String to parse
+ *  \param[in]  max  Maximum permitted value (inclusive)
+ *  \param[out] num  Parsed value on success
+ *  \return ARES_TRUE on success, ARES_FALSE on invalid or out-of-range input
+ */
+CARES_EXTERN ares_bool_t    ares_str_to_num(const char *str, unsigned int max,
+                                            unsigned int *num);
+
 CARES_EXTERN void           ares_str_ltrim(char *str);
 CARES_EXTERN void           ares_str_rtrim(char *str);
 CARES_EXTERN void           ares_str_trim(char *str);

--- a/src/lib/str/ares_str.c
+++ b/src/lib/str/ares_str.c
@@ -156,6 +156,31 @@ ares_bool_t ares_parse_port(const char *str, unsigned short *port,
   return ARES_TRUE;
 }
 
+ares_bool_t ares_str_to_num(const char *str, unsigned int max,
+                            unsigned int *num)
+{
+  char         *endptr = NULL;
+  unsigned long val;
+
+  if (str == NULL || num == NULL || *str == 0) {
+    return ARES_FALSE;
+  }
+
+  errno = 0;
+  val   = strtoul(str, &endptr, 10);
+  if (errno == ERANGE || endptr == str || *endptr != '\0') {
+    return ARES_FALSE;
+  }
+
+  if (val > (unsigned long)max) {
+    return ARES_FALSE;
+  }
+
+  *num = (unsigned int)val;
+
+  return ARES_TRUE;
+}
+
 ares_bool_t ares_str_isalnum(const char *str)
 {
   size_t i;

--- a/src/lib/util/ares_iface_ips.c
+++ b/src/lib/util/ares_iface_ips.c
@@ -25,6 +25,8 @@
  */
 #include "ares_private.h"
 
+#include <limits.h>
+
 #ifdef USE_WINSOCK
 #  include <winsock2.h>
 #  include <ws2tcpip.h>
@@ -337,8 +339,11 @@ static ares_bool_t name_match(const char *name, const char *adapter_name,
     return ARES_TRUE;
   }
 
-  if (ares_str_isnum(name) && (unsigned int)atoi(name) == ll_scope) {
-    return ARES_TRUE;
+  {
+    unsigned int idx;
+    if (ares_str_to_num(name, UINT_MAX, &idx) && idx == ll_scope) {
+      return ARES_TRUE;
+    }
   }
 
   return ARES_FALSE;

--- a/test/ares-test-init.cc
+++ b/test/ares-test-init.cc
@@ -329,6 +329,10 @@ TEST_F(DefaultChannelTest, SetSortlistFailures) {
   EXPECT_EQ(ARES_EBADSTR, ares_set_sortlist(channel_, "1 /01234567890123456789012345678901"));
   EXPECT_EQ(ARES_EBADSTR, ares_set_sortlist(channel_, "xyzzy ; lwk"));
   EXPECT_EQ(ARES_EBADSTR, ares_set_sortlist(channel_, "xyzzy ; 0x123"));
+  /* Numeric netmask in-charset and buffer-fitting but out of range */
+  EXPECT_EQ(ARES_EBADSTR, ares_set_sortlist(channel_, "1.2.3.0/129"));
+  EXPECT_EQ(ARES_EBADSTR, ares_set_sortlist(channel_, "1.2.3.0/33"));
+  EXPECT_EQ(ARES_EBADSTR, ares_set_sortlist(channel_, "1.2.3.0/4294967296"));
 }
 
 TEST_F(DefaultChannelTest, SetSortlistVariants) {


### PR DESCRIPTION
Noticed parse_sort() reads the numeric sortlist mask with atoi(). The mask field accepts up to 15 digits, and atoi() on a value past INT_MAX is undefined; on common platforms it wraps, so `1.2.3.0/4294967296` is accepted as mask 0 rather than rejected. strtoul() with a 128 cap is well defined and matches the numeric parsing already used elsewhere in this file.