### PR TITLE
route numeric config parsing through range-checked ares_str_parse_uint

### DIFF
--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -582,23 +582,6 @@ static void host_callback(void *arg, ares_status_t status, size_t timeouts,
   /* at this point we keep on waiting for the next query to finish */
 }
 
-static ares_bool_t numeric_service_to_port(const char *service,
-                                           unsigned short *port)
-{
-  char *end;
-  unsigned long val;
-
-  errno = 0;
-  val   = strtoul(service, &end, 10);
-
-  if (errno == 0 && *end == '\0' && val <= 65535) {
-    *port = (unsigned short)val;
-    return ARES_TRUE;
-  }
-
-  return ARES_FALSE;
-}
-
 /* Per POSIX getaddrinfo(), when no node/hostname is provided the returned
  * addresses are synthesized from the service: the wildcard address when
  * ARES_AI_PASSIVE is set (suitable for bind()ing a listening socket),
@@ -688,14 +671,14 @@ static void ares_getaddrinfo_int(ares_channel_t *channel, const char *name,
 
   if (service) {
     if (hints->ai_flags & ARES_AI_NUMERICSERV) {
-      if (!numeric_service_to_port(service, &port)) {
+      if (!ares_parse_port(service, &port, ARES_TRUE)) {
         callback(arg, ARES_ESERVICE, 0, NULL);
         return;
       }
     } else {
       port = lookup_service(service, 0);
       if (!port) {
-        if (!numeric_service_to_port(service, &port)) {
+        if (!ares_parse_port(service, &port, ARES_TRUE)) {
           callback(arg, ARES_ESERVICE, 0, NULL);
           return;
         }

--- a/src/lib/ares_sysconfig_files.c
+++ b/src/lib/ares_sysconfig_files.c
@@ -27,6 +27,8 @@
 
 #include "ares_private.h"
 
+#include <limits.h>
+
 #ifdef HAVE_SYS_PARAM_H
 #  include <sys/param.h>
 #endif
@@ -170,8 +172,8 @@ static ares_status_t parse_sort(ares_buf_t *buf, struct apattern *pat)
 
     if (ares_str_isnum(maskstr)) {
       /* Numeric mask */
-      int mask = atoi(maskstr);
-      if (mask < 0 || mask > 128) {
+      unsigned int mask;
+      if (!ares_str_parse_uint(maskstr, 128, &mask)) {
         return ARES_EBADSTR;
       }
       if (pat->addr.family == AF_INET && mask > 32) {
@@ -414,8 +416,11 @@ static ares_status_t process_option(ares_sysconfig_t *sysconfig,
 
   key = kv[0];
   if (num == 2) {
-    val    = kv[1];
-    valint = (unsigned int)strtoul(val, NULL, 10);
+    val = kv[1];
+    if (!ares_str_parse_uint(val, UINT_MAX, &valint)) {
+      status = ARES_EBADSTR;
+      goto done;
+    }
   }
 
   if (ares_streq(key, "ndots")) {

--- a/src/lib/ares_update_servers.c
+++ b/src/lib/ares_update_servers.c
@@ -27,6 +27,8 @@
  */
 #include "ares_private.h"
 
+#include <limits.h>
+
 #ifdef HAVE_ARPA_INET_H
 #  include <arpa/inet.h>
 #endif
@@ -403,7 +405,13 @@ static ares_status_t ares_sconfig_linklocal(const ares_channel_t *channel,
 
   if (ares_str_isnum(ll_iface)) {
     char ifname[IF_NAMESIZE] = "";
-    ll_scope                 = (unsigned int)atoi(ll_iface);
+
+    /* A numeric interface index can be up to 15 digits; parse with the
+     * range-checked helper so an out-of-range value is rejected rather than
+     * silently wrapped as atoi() would */
+    if (!ares_str_parse_uint(ll_iface, UINT_MAX, &ll_scope)) {
+      return ARES_ENOTFOUND;
+    }
     if (channel->sock_funcs.aif_indextoname == NULL ||
         channel->sock_funcs.aif_indextoname(ll_scope, ifname, sizeof(ifname),
                                             channel->sock_func_cb_data) ==

--- a/src/lib/ares_update_servers.c
+++ b/src/lib/ares_update_servers.c
@@ -406,9 +406,9 @@ static ares_status_t ares_sconfig_linklocal(const ares_channel_t *channel,
   if (ares_str_isnum(ll_iface)) {
     char ifname[IF_NAMESIZE] = "";
 
-    /* A numeric interface index can be up to 15 digits; parse with the
-     * range-checked helper so an out-of-range value is rejected rather than
-     * silently wrapped as atoi() would */
+    /* The interface identifier is all digits but may not fit in an
+     * unsigned int; parse with the range-checked helper rather than atoi(),
+     * whose behavior on overflow is undefined. */
     if (!ares_str_parse_uint(ll_iface, UINT_MAX, &ll_scope)) {
       return ARES_ENOTFOUND;
     }

--- a/src/lib/include/ares_str.h
+++ b/src/lib/include/ares_str.h
@@ -60,6 +60,21 @@ CARES_EXTERN size_t ares_strcpy(char *dest, const char *src, size_t dest_size);
 CARES_EXTERN ares_bool_t    ares_str_isnum(const char *str);
 CARES_EXTERN ares_bool_t    ares_str_isalnum(const char *str);
 
+/*! Parse a base-10 unsigned integer from a NULL-terminated string.  Unlike
+ *  atoi(), this rejects overflow, trailing garbage, and any value that does
+ *  not fit within the caller-provided maximum.
+ *
+ *  \param[in]  str  String to parse.  Must be non-NULL and non-empty.
+ *  \param[in]  max  Largest value considered valid.
+ *  \param[out] out  On success, receives the parsed value.  Untouched on
+ *                   failure.
+ *  \return ARES_TRUE if a valid in-range integer was parsed, ARES_FALSE
+ *          otherwise.
+ */
+CARES_EXTERN ares_bool_t    ares_str_parse_uint(const char *str,
+                                                unsigned long max,
+                                                unsigned int *out);
+
 CARES_EXTERN void           ares_str_ltrim(char *str);
 CARES_EXTERN void           ares_str_rtrim(char *str);
 CARES_EXTERN void           ares_str_trim(char *str);

--- a/src/lib/include/ares_str.h
+++ b/src/lib/include/ares_str.h
@@ -61,11 +61,14 @@ CARES_EXTERN ares_bool_t    ares_str_isnum(const char *str);
 CARES_EXTERN ares_bool_t    ares_str_isalnum(const char *str);
 
 /*! Parse a base-10 unsigned integer from a NULL-terminated string.  Unlike
- *  atoi(), this rejects overflow, trailing garbage, and any value that does
- *  not fit within the caller-provided maximum.
+ *  atoi(), this rejects overflow, leading or trailing garbage (a sign,
+ *  whitespace, or non-digit characters), and any value that does not fit
+ *  within the caller-provided maximum.
  *
- *  \param[in]  str  String to parse.  Must be non-NULL and non-empty.
- *  \param[in]  max  Largest value considered valid.
+ *  \param[in]  str  String to parse.  May be NULL or empty, in which case
+ *                   ARES_FALSE is returned.
+ *  \param[in]  max  Largest value considered valid.  Values above UINT_MAX
+ *                   are capped to UINT_MAX since out is an unsigned int.
  *  \param[out] out  On success, receives the parsed value.  Untouched on
  *                   failure.
  *  \return ARES_TRUE if a valid in-range integer was parsed, ARES_FALSE

--- a/src/lib/include/ares_str.h
+++ b/src/lib/include/ares_str.h
@@ -74,9 +74,8 @@ CARES_EXTERN ares_bool_t    ares_str_isalnum(const char *str);
  *  \return ARES_TRUE if a valid in-range integer was parsed, ARES_FALSE
  *          otherwise.
  */
-CARES_EXTERN ares_bool_t    ares_str_parse_uint(const char *str,
-                                                unsigned long max,
-                                                unsigned int *out);
+CARES_EXTERN ares_bool_t ares_str_parse_uint(const char *str, unsigned long max,
+                                             unsigned int *out);
 
 CARES_EXTERN void           ares_str_ltrim(char *str);
 CARES_EXTERN void           ares_str_rtrim(char *str);

--- a/src/lib/str/ares_str.c
+++ b/src/lib/str/ares_str.c
@@ -127,23 +127,36 @@ ares_bool_t ares_str_isnum(const char *str)
   return ARES_TRUE;
 }
 
-ares_bool_t ares_parse_port(const char *str, unsigned short *port,
-                            ares_bool_t allow_zero)
+ares_bool_t ares_str_parse_uint(const char *str, unsigned long max,
+                                unsigned int *out)
 {
-  char         *endptr = NULL;
+  char         *end = NULL;
   unsigned long val;
 
-  if (str == NULL || port == NULL || *str == 0) {
+  if (str == NULL || out == NULL || *str == 0) {
     return ARES_FALSE;
   }
 
   errno = 0;
-  val   = strtoul(str, &endptr, 10);
-  if (errno == ERANGE || endptr == str || *endptr != '\0') {
+  val   = strtoul(str, &end, 10);
+  if (errno == ERANGE || end == str || *end != '\0' || val > max) {
     return ARES_FALSE;
   }
 
-  if (val > 65535UL) {
+  *out = (unsigned int)val;
+  return ARES_TRUE;
+}
+
+ares_bool_t ares_parse_port(const char *str, unsigned short *port,
+                            ares_bool_t allow_zero)
+{
+  unsigned int val;
+
+  if (port == NULL) {
+    return ARES_FALSE;
+  }
+
+  if (!ares_str_parse_uint(str, 65535UL, &val)) {
     return ARES_FALSE;
   }
 

--- a/src/lib/str/ares_str.c
+++ b/src/lib/str/ares_str.c
@@ -29,6 +29,7 @@
 #include "ares_str.h"
 
 #include <errno.h>
+#include <limits.h>
 
 #ifdef HAVE_STDINT_H
 #  include <stdint.h>
@@ -133,13 +134,22 @@ ares_bool_t ares_str_parse_uint(const char *str, unsigned long max,
   char         *end = NULL;
   unsigned long val;
 
-  if (str == NULL || out == NULL || *str == 0) {
+  /* Require a leading digit so strtoul()'s tolerance of a sign or leading
+   * whitespace (e.g. "-1" wrapping to UINT_MAX) can't slip through here. This
+   * also rejects NULL and empty strings. */
+  if (str == NULL || out == NULL || !ares_isdigit(*str)) {
     return ARES_FALSE;
+  }
+
+  /* out is unsigned int, so a max above UINT_MAX would let strtoul's result
+   * truncate silently on assignment.  Cap it. */
+  if (max > UINT_MAX) {
+    max = UINT_MAX;
   }
 
   errno = 0;
   val   = strtoul(str, &end, 10);
-  if (errno == ERANGE || end == str || *end != '\0' || val > max) {
+  if (errno == ERANGE || *end != '\0' || val > max) {
     return ARES_FALSE;
   }
 

--- a/src/lib/util/ares_iface_ips.c
+++ b/src/lib/util/ares_iface_ips.c
@@ -25,6 +25,8 @@
  */
 #include "ares_private.h"
 
+#include <limits.h>
+
 #ifdef USE_WINSOCK
 #  include <winsock2.h>
 #  include <ws2tcpip.h>
@@ -337,8 +339,11 @@ static ares_bool_t name_match(const char *name, const char *adapter_name,
     return ARES_TRUE;
   }
 
-  if (ares_str_isnum(name) && (unsigned int)atoi(name) == ll_scope) {
-    return ARES_TRUE;
+  {
+    unsigned int scope;
+    if (ares_str_parse_uint(name, UINT_MAX, &scope) && scope == ll_scope) {
+      return ARES_TRUE;
+    }
   }
 
   return ARES_FALSE;

--- a/src/lib/util/ares_iface_ips.c
+++ b/src/lib/util/ares_iface_ips.c
@@ -331,6 +331,8 @@ static char *wcharp_to_charp(const wchar_t *in)
 static ares_bool_t name_match(const char *name, const char *adapter_name,
                               unsigned int ll_scope)
 {
+  unsigned int scope;
+
   if (name == NULL || *name == 0) {
     return ARES_TRUE;
   }
@@ -339,11 +341,8 @@ static ares_bool_t name_match(const char *name, const char *adapter_name,
     return ARES_TRUE;
   }
 
-  {
-    unsigned int scope;
-    if (ares_str_parse_uint(name, UINT_MAX, &scope) && scope == ll_scope) {
-      return ARES_TRUE;
-    }
+  if (ares_str_parse_uint(name, UINT_MAX, &scope) && scope == ll_scope) {
+    return ARES_TRUE;
   }
 
   return ARES_FALSE;

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -26,6 +26,7 @@
 #include "ares-test.h"
 #include "dns-proto.h"
 
+#include <climits>
 #include <stdio.h>
 
 #ifdef HAVE_UNISTD_H
@@ -86,14 +87,35 @@ TEST_F(LibraryTest, StringLengthWithoutNullTerminator) {
 }
 
 TEST_F(LibraryTest, StrParseUint) {
-  unsigned int v = 0;
-  EXPECT_TRUE(ares_str_parse_uint("0", 128, &v));    EXPECT_EQ(0u, v);
-  EXPECT_TRUE(ares_str_parse_uint("128", 128, &v));  EXPECT_EQ(128u, v);
-  EXPECT_FALSE(ares_str_parse_uint("129", 128, &v));            /* > max      */
-  EXPECT_FALSE(ares_str_parse_uint("4294967296", UINT_MAX, &v));/* LP64 fit   */
-  EXPECT_FALSE(ares_str_parse_uint("12x", UINT_MAX, &v));       /* trailing   */
-  EXPECT_FALSE(ares_str_parse_uint(" 5", UINT_MAX, &v));        /* leading ws */
-  EXPECT_FALSE(ares_str_parse_uint("-1", UINT_MAX, &v));        /* sign wrap  */
+  unsigned int v = 42;
+
+  EXPECT_TRUE(ares_str_parse_uint("0", 128, &v));
+  EXPECT_EQ(0u, v);
+  EXPECT_TRUE(ares_str_parse_uint("128", 128, &v));
+  EXPECT_EQ(128u, v);
+
+  // Exactly UINT_MAX is accepted (the interesting boundary: on a 32-bit
+  // unsigned long it parses to ULONG_MAX without ERANGE).
+  EXPECT_TRUE(ares_str_parse_uint("4294967295", UINT_MAX, &v));
+  EXPECT_EQ(UINT_MAX, v);
+
+  // max == 0 permits only "0".
+  EXPECT_TRUE(ares_str_parse_uint("0", 0, &v));
+  EXPECT_EQ(0u, v);
+
+  // Failure leaves *out untouched.
+  v = 42;
+  EXPECT_FALSE(ares_str_parse_uint("1", 0, &v));
+  EXPECT_EQ(42u, v);
+  EXPECT_FALSE(ares_str_parse_uint("129", 128, &v));
+  EXPECT_EQ(42u, v);
+
+  EXPECT_FALSE(ares_str_parse_uint("4294967296", UINT_MAX, &v)); // over on LP64
+  EXPECT_FALSE(ares_str_parse_uint("12x", UINT_MAX, &v));        // trailing
+  EXPECT_FALSE(ares_str_parse_uint("0x10", UINT_MAX, &v));       // trailing hex
+  EXPECT_FALSE(ares_str_parse_uint(" 5", UINT_MAX, &v));         // leading space
+  EXPECT_FALSE(ares_str_parse_uint("+5", UINT_MAX, &v));         // leading sign
+  EXPECT_FALSE(ares_str_parse_uint("-1", UINT_MAX, &v));         // sign wrap
   EXPECT_FALSE(ares_str_parse_uint("", UINT_MAX, &v));
   EXPECT_FALSE(ares_str_parse_uint(NULL, UINT_MAX, &v));
 }

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -85,6 +85,19 @@ TEST_F(LibraryTest, StringLengthWithoutNullTerminator) {
   }
 }
 
+TEST_F(LibraryTest, StrParseUint) {
+  unsigned int v = 0;
+  EXPECT_TRUE(ares_str_parse_uint("0", 128, &v));    EXPECT_EQ(0u, v);
+  EXPECT_TRUE(ares_str_parse_uint("128", 128, &v));  EXPECT_EQ(128u, v);
+  EXPECT_FALSE(ares_str_parse_uint("129", 128, &v));            /* > max      */
+  EXPECT_FALSE(ares_str_parse_uint("4294967296", UINT_MAX, &v));/* LP64 fit   */
+  EXPECT_FALSE(ares_str_parse_uint("12x", UINT_MAX, &v));       /* trailing   */
+  EXPECT_FALSE(ares_str_parse_uint(" 5", UINT_MAX, &v));        /* leading ws */
+  EXPECT_FALSE(ares_str_parse_uint("-1", UINT_MAX, &v));        /* sign wrap  */
+  EXPECT_FALSE(ares_str_parse_uint("", UINT_MAX, &v));
+  EXPECT_FALSE(ares_str_parse_uint(NULL, UINT_MAX, &v));
+}
+
 void CheckPtoN4(int size, unsigned int value, const char *input) {
   struct in_addr a4;
   a4.s_addr = 0;

--- a/test/ares-test-misc.cc
+++ b/test/ares-test-misc.cc
@@ -149,6 +149,12 @@ TEST_F(DefaultChannelTest, SetServersCSV) {
             ares_set_servers_csv(channel_, "1.2.3.4 , [0102:0304:0506:0708:0910:1112:1314:1516]:53, [fe80::1]:53%iface0, 2.3.4.5"));
   EXPECT_EQ(expected, GetNameServers(channel_));
 
+  // Reject an out-of-range numeric link-local scope, keep rest.  Validation
+  // fails before the interface is looked up, so no real interface is needed.
+  EXPECT_EQ(ARES_SUCCESS,
+            ares_set_servers_csv(channel_, "1.2.3.4 , [0102:0304:0506:0708:0910:1112:1314:1516]:53, [fe80::1]:53%99999999999, 2.3.4.5"));
+  EXPECT_EQ(expected, GetNameServers(channel_));
+
   // Same, with ports
   EXPECT_EQ(ARES_SUCCESS,
             ares_set_servers_ports_csv(channel_, "1.2.3.4:54,[0102:0304:0506:0708:0910:1112:1314:1516]:80,2.3.4.5:55"));

--- a/test/ares-test-misc.cc
+++ b/test/ares-test-misc.cc
@@ -149,10 +149,12 @@ TEST_F(DefaultChannelTest, SetServersCSV) {
             ares_set_servers_csv(channel_, "1.2.3.4 , [0102:0304:0506:0708:0910:1112:1314:1516]:53, [fe80::1]:53%iface0, 2.3.4.5"));
   EXPECT_EQ(expected, GetNameServers(channel_));
 
-  // Reject an out-of-range numeric link-local scope, keep rest.  Validation
-  // fails before the interface is looked up, so no real interface is needed.
+  // Reject an out-of-range numeric link-local scope, keep rest.  2^32+1 wraps
+  // to index 1 under the old atoi() and would have been accepted; the
+  // range-checked parse rejects it before the interface is looked up, so no
+  // real interface is needed.
   EXPECT_EQ(ARES_SUCCESS,
-            ares_set_servers_csv(channel_, "1.2.3.4 , [0102:0304:0506:0708:0910:1112:1314:1516]:53, [fe80::1]:53%99999999999, 2.3.4.5"));
+            ares_set_servers_csv(channel_, "1.2.3.4 , [0102:0304:0506:0708:0910:1112:1314:1516]:53, [fe80::1]:53%4294967297, 2.3.4.5"));
   EXPECT_EQ(expected, GetNameServers(channel_));
 
   // Same, with ports


### PR DESCRIPTION
Consolidates the atoi->strtoul sweep into one audited path, per review. This is the single consolidated PR; #1157 and #1162 are closed in favor of it.

- add `ares_str_parse_uint()`, a strtoul-based helper with errno/end/range checks, and rework `ares_parse_port()` on top of it
- route link-local interface scope, sortlist netmask (was #1157), and `name_match` (was #1162) through it
- fold the hand-rolled numeric-service port parser in `ares_getaddrinfo.c` into `ares_parse_port()` so there's a single validated path
- also validate the previously-unchecked `strtoul` in the resolv.conf options parser (`ares_sysconfig_files.c`)

`atoi()` is undefined behavior on overflow, and the numeric tokens here are only validated as digits (up to 15 for the zone id), so an out-of-range value like `[fe80::1]:53%4294967297` was accepted instead of rejected. The helper rejects overflow, trailing garbage, and anything that doesn't fit the target width.

Behavior change worth noting: a numeric `getaddrinfo()` service that the old hand-rolled parser tolerated now returns `ARES_ESERVICE`. This covers an empty service `""` (previously yielded port 0), and leading whitespace/sign like `" 80"` / `"+80"`. This matches musl; glibc treats `""` like NULL and accepts the other two. POSIX-defensible either way.

Tests: direct `ares_str_parse_uint` unit test (`StrParseUint`) covering the boundary/overflow/garbage cases, plus a `SetServersCSV` case rejecting an out-of-range numeric scope.

Rebased on main to resolve the `ares_getaddrinfo.c` conflict with #1186.
