### PR TITLE
Fix remaining unchecked atoi/strtoul usages missed in PR #1097 sweep

### DIFF
--- a/src/lib/ares_sysconfig_files.c
+++ b/src/lib/ares_sysconfig_files.c
@@ -1,4 +1,3 @@
-#include <errno.h>
 /* MIT License
  *
  * Copyright (c) 1998 Massachusetts Institute of Technology

--- a/src/lib/ares_sysconfig_files.c
+++ b/src/lib/ares_sysconfig_files.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 /* MIT License
  *
  * Copyright (c) 1998 Massachusetts Institute of Technology
@@ -410,7 +411,18 @@ static ares_status_t process_option(ares_sysconfig_t *sysconfig,
   key = kv[0];
   if (num == 2) {
     val    = kv[1];
-    valint = (unsigned int)strtoul(val, NULL, 10);
+    {
+      char         *strtoul_end = NULL;
+      unsigned long strtoul_val;
+      errno      = 0;
+      strtoul_val = strtoul(val, &strtoul_end, 10);
+      if (errno != 0 || strtoul_end == val || *strtoul_end != '\0' ||
+          strtoul_val > UINT_MAX) {
+        status = ARES_EBADSTR;
+        goto done;
+      }
+      valint = (unsigned int)strtoul_val;
+    }
   }
 
   if (ares_streq(key, "ndots")) {

--- a/src/lib/ares_update_servers.c
+++ b/src/lib/ares_update_servers.c
@@ -403,7 +403,19 @@ static ares_status_t ares_sconfig_linklocal(const ares_channel_t *channel,
 
   if (ares_str_isnum(ll_iface)) {
     char ifname[IF_NAMESIZE] = "";
-    ll_scope                 = (unsigned int)atoi(ll_iface);
+    {
+      /* Use validated integer parsing instead of atoi() to avoid silent
+       * overflow or undefined behavior on inputs that exceed INT_MAX. */
+      unsigned long parsed;
+      char         *endptr = NULL;
+      errno  = 0;
+      parsed = strtoul(ll_iface, &endptr, 10);
+      if (errno != 0 || endptr == ll_iface || *endptr != '\0' ||
+          parsed > UINT_MAX) {
+        return ARES_EBADSTR;
+      }
+      ll_scope = (unsigned int)parsed;
+    }
     if (channel->sock_funcs.aif_indextoname == NULL ||
         channel->sock_funcs.aif_indextoname(ll_scope, ifname, sizeof(ifname),
                                             channel->sock_func_cb_data) ==


### PR DESCRIPTION
## Summary

Follow-up to #1097 (replace `atoi`-based port parsing) and #1116 (buffer overflow fix): two remaining sites using `atoi()` or unchecked `strtoul()` with `NULL` error pointer that were missed in the earlier sweep.

---

### Fix 1: `src/lib/ares_sysconfig_files.c` line 413 — unchecked `strtoul(val, NULL, 10)`

The resolver options parser (`ndots`, `timeout`, `attempts`, etc.) converts the value string with:

```c
valint = (unsigned int)strtoul(val, NULL, 10);
```

Passing `NULL` as `endptr` means there is no way to detect non-numeric trailing characters or overflow. If `val` is `"999999999999999999"` (exceeds `ULONG_MAX` on 32-bit), `strtoul` sets `errno=ERANGE` and returns `ULONG_MAX`, which silently wraps to a small `unsigned int`. For `timeout`, this multiplied by 1000 produces a wildly incorrect timeout.

**Fix:** Use a local `endptr` + `errno` check matching the pattern established by `ares_parse_port()` in #1097.

---

### Fix 2: `src/lib/ares_update_servers.c` line 406 — `atoi(ll_iface)` for link-local scope index

```c
ll_scope = (unsigned int)atoi(ll_iface);
```

`atoi()` has undefined behavior on overflow (e.g. input `"99999999999"`). The result is then passed to `aif_indextoname()` as a network interface index. PR #1097 replaced other `atoi` calls with `ares_parse_port()`, but this site was missed because it parses an interface index rather than a port.

**Fix:** Replace with validated `strtoul()` + `endptr` + `errno` check, consistent with the rest of the codebase.

Both fixes follow the exact pattern established in PR #1097 and the `ares_parse_port()` helper.