### PR TITLE
discard oversized UDP datagrams instead of truncating the length frame

### DIFF
--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -496,7 +496,10 @@ static ares_status_t read_conn_packets(ares_conn_t *conn,
        * return more than the 2-byte length prefix is able to represent.  A
        * datagram that large can't be a valid DNS message, and writing the
        * truncated (unsigned short)count would desync the framing of everything
-       * buffered after it, so discard it. */
+       * buffered after it, so discard it.  Standard UDP can't actually deliver
+       * a payload this large (max is 65507 IPv4 / 65527 IPv6); the only vector
+       * is IPv6 jumbograms (RFC 2675), which DNS never uses.  This is purely
+       * defense-in-depth. */
       if (count > 65535) {
         ares_buf_set_length(conn->in_buf, start_len);
         break;

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -492,6 +492,15 @@ static ares_status_t read_conn_packets(ares_conn_t *conn,
 
     /* If UDP, overwrite length */
     if (!(conn->flags & ARES_CONN_FLAG_TCP)) {
+      /* The read buffer is grown in powers of two, so a single recvfrom() can
+       * return more than the 2-byte length prefix is able to represent.  A
+       * datagram that large can't be a valid DNS message, and writing the
+       * truncated (unsigned short)count would desync the framing of everything
+       * buffered after it, so discard it. */
+      if (count > 65535) {
+        ares_buf_set_length(conn->in_buf, start_len);
+        break;
+      }
       len = ares_buf_len(conn->in_buf);
       ares_buf_set_length(conn->in_buf, start_len);
       ares_buf_append_be16(conn->in_buf, (unsigned short)count);


### PR DESCRIPTION
Defense-in-depth hardening for the UDP receive path.

read_conn_packets() prefixes each buffered UDP datagram with a 2-byte length so read_answers() can later split the buffer back into messages. The read buffer handed to recvfrom() comes from ares_buf_append_start(), which grows in powers of two and so can be larger than 65535 bytes, while count is written back through (unsigned short). If a datagram larger than 65535 ever landed there, count & 0xFFFF would be stored and the framing of everything buffered after it would desync.

This isn't reachable over standard UDP: max payload is 65507 (IPv4) / 65527 (IPv6), both below 65535. The only vector is IPv6 jumbograms (RFC 2675), which DNS never uses and which would still have to pass the source-address check in ares_conn_read(). So this is purely hardening, not a fix for an observed bug on real networks.

The guard rolls the datagram back to the iteration start and stops reading, matching the existing short-read rollback just above. Only ares_buf_* is used.
