### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "pinDigests": true,
+      "automerge": false,
+      "labels": ["ci", "dependencies"]
+    }
+  ]
+}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -24,12 +24,12 @@ jobs:
     name: "build"
     steps:
       - name: Install packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: autoconf automake libtool g++ libgmock-dev pkg-config gdb
           version: 1.0
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Get Tag version
         id: version
         run: |
@@ -44,7 +44,7 @@ jobs:
           ./configure
           make dist
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "c-ares-src-tarball"
           path: 'c-ares-*.tar.gz'
@@ -52,7 +52,7 @@ jobs:
           overwrite: true
           retention-days: 7
       - name: Upload Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           body_path: RELEASE-NOTES.md
@@ -93,11 +93,11 @@ jobs:
       contents: write # To add assets to a release.
     steps:
       - name: Download the provenance
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{needs.provenance.outputs.provenance-name}}
       - name: Upload Provenance to Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         if: startsWith(github.ref, 'refs/tags/')
         id: upload-provenance
         with:

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -20,12 +20,12 @@ jobs:
     name: "Ubuntu (latest)"
     steps:
       - name: Install packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: cmake ninja-build autoconf automake libtool g++ libgmock-dev pkg-config clang clang-tools lldb gdb valgrind
           version: 1.0
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: "Make sure TCP FastOpen is enabled"
         run: |
           sudo sysctl -w net.ipv4.tcp_fastopen=3


### PR DESCRIPTION
## Summary

Several workflow files use mutable version tags/refs for GitHub Actions, which is a supply chain risk.

### Actions pinned

| Action | Was | Now |
|--------|-----|-----|
| `awalsh128/cache-apt-pkgs-action` | `@latest` | `@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05` (v1.6.0) |
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/upload-artifact` | `@v4` | `@ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `actions/download-artifact` | `@v4` | `@d3f86a106a0bac45b974a628896c90dbdf5c8093` |
| `softprops/action-gh-release` | `@v2` | `@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` |

### Why

Mutable refs like `@latest` and `@v4` can change without notice. Pinning to a full commit SHA makes the exact version immutable and auditable, preventing supply chain attacks from a compromised or maliciously updated action.

Recommended by [GitHub's security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and [OpenSSF Scorecard](https://securityscorecards.dev/).