### PR TITLE
enforce 255 octet name limit when parsing dns names

### DIFF
--- a/src/lib/record/ares_dns_name.c
+++ b/src/lib/record/ares_dns_name.c
@@ -543,6 +543,7 @@ ares_status_t ares_dns_name_parse(ares_buf_t *buf, char **name,
   ares_status_t status;
   ares_buf_t   *namebuf     = NULL;
   size_t        label_start = ares_buf_get_position(buf);
+  size_t        name_len    = 0;
 
   if (buf == NULL) {
     return ARES_EFORMERR;
@@ -636,6 +637,19 @@ ares_status_t ares_dns_name_parse(ares_buf_t *buf, char **name,
     }
 
     /* New label */
+
+    /* RFC 1035 3.1: a name is limited to 255 octets.  Enforce it during
+     * decompression so a chain of pointers can't expand a single name without
+     * bound.  Track the unescaped length (label data plus the separator that
+     * precedes each label after the first), matching ares_split_dns_name(). */
+    if (name_len) {
+      name_len++;
+    }
+    name_len += c;
+    if (name_len > 255) {
+      status = ARES_EBADNAME;
+      goto fail;
+    }
 
     /* Labels are separated by periods */
     if (ares_buf_len(namebuf) != 0 && name != NULL) {

--- a/src/lib/record/ares_dns_name.c
+++ b/src/lib/record/ares_dns_name.c
@@ -25,6 +25,18 @@
  */
 #include "ares_private.h"
 
+/* RFC 1035 3.1 limits a name to 255 octets.  We track presentation length
+ * (label octets plus one separator before each label after the first), which is
+ * up to ~2 octets looser than the strict wire limit and so never rejects a
+ * compliant name.  Shared by the read and write paths. */
+#define ARES_MAX_NAME_PRESENTATION_LEN 255
+
+/* A name of <= 255 octets holds at most 128 labels, so it can never legitimately
+ * require more than that many compression-pointer jumps.  Bounding the number of
+ * indirections stops a name built purely from pointers (which never adds label
+ * bytes, so the length cap never fires) from being walked without limit. */
+#define ARES_MAX_INDIRS 128
+
 typedef struct {
   char  *name;
   size_t name_len;
@@ -48,7 +60,7 @@ static ares_status_t ares_nameoffset_create(ares_llist_t **list,
   ares_nameoffset_t *off = NULL;
 
   if (list == NULL || name == NULL || ares_strlen(name) == 0 ||
-      ares_strlen(name) > 255) {
+      ares_strlen(name) > ARES_MAX_NAME_PRESENTATION_LEN) {
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
@@ -340,7 +352,8 @@ static ares_status_t ares_split_dns_name(ares_array_t *labels,
   }
 
   /* Can't exceed maximum (unescaped) length */
-  if (ares_array_len(labels) && total_len + ares_array_len(labels) - 1 > 255) {
+  if (ares_array_len(labels) &&
+      total_len + ares_array_len(labels) - 1 > ARES_MAX_NAME_PRESENTATION_LEN) {
     status = ARES_EBADNAME;
     goto done;
   }
@@ -544,6 +557,7 @@ ares_status_t ares_dns_name_parse(ares_buf_t *buf, char **name,
   ares_buf_t   *namebuf     = NULL;
   size_t        label_start = ares_buf_get_position(buf);
   size_t        name_len    = 0;
+  size_t        indir       = 0;
 
   if (buf == NULL) {
     return ARES_EFORMERR;
@@ -615,6 +629,16 @@ ares_status_t ares_dns_name_parse(ares_buf_t *buf, char **name,
         goto fail;
       }
 
+      /* Bound the number of indirections.  A name made purely of pointers never
+       * adds label bytes, so the length cap below can't stop it; the
+       * strictly-decreasing rule alone still allows thousands of jumps per name.
+       * No legitimate <= 255 octet name needs more than 128 labels/jumps. */
+      indir++;
+      if (indir > ARES_MAX_INDIRS) {
+        status = ARES_EBADNAME;
+        goto fail;
+      }
+
       /* First time we make a jump, save the current position */
       if (save_offset == 0) {
         save_offset = ares_buf_get_position(buf);
@@ -638,15 +662,16 @@ ares_status_t ares_dns_name_parse(ares_buf_t *buf, char **name,
 
     /* New label */
 
-    /* RFC 1035 3.1: a name is limited to 255 octets.  Enforce it during
-     * decompression so a chain of pointers can't expand a single name without
-     * bound.  Track the unescaped length (label data plus the separator that
-     * precedes each label after the first), matching ares_split_dns_name(). */
+    /* RFC 1035 3.1 limits a name to 255 octets.  Enforce it during
+     * decompression so labels reached through a chain of pointers can't expand a
+     * single name without bound.  Track the presentation length (label data plus
+     * the separator that precedes each label after the first), matching
+     * ares_split_dns_name() on the write side. */
     if (name_len) {
       name_len++;
     }
     name_len += c;
-    if (name_len > 255) {
+    if (name_len > ARES_MAX_NAME_PRESENTATION_LEN) {
       status = ARES_EBADNAME;
       goto fail;
     }

--- a/test/ares-test-parse.cc
+++ b/test/ares-test-parse.cc
@@ -219,5 +219,41 @@ TEST_F(LibraryTest, ParseMalformedRRCount) {
   EXPECT_EQ(nullptr, dnsrec);
 }
 
+TEST_F(LibraryTest, ParseRejectsOverlongName) {
+  // RFC 1035 3.1 limits a name to 255 octets.  A longer name (here built from
+  // six 63-octet labels) must be rejected instead of expanded.
+  std::vector<byte> data = {
+    0x12, 0x34, 0x81, 0x80,
+    0x00, 0x01,  // num questions
+    0x00, 0x01,  // num answer RRs
+    0x00, 0x00,  // num authority RRs
+    0x00, 0x00,  // num additional RRs
+    // Question
+    0x01, 'a', 0x00,
+    0x00, 0x01,  // type A
+    0x00, 0x01,  // class IN
+  };
+  // Answer name: 6 x 63 = 378 octets, then root terminator
+  for (int i = 0; i < 6; i++) {
+    data.push_back(63);
+    for (int j = 0; j < 63; j++) {
+      data.push_back('a');
+    }
+  }
+  data.push_back(0x00);
+  std::vector<byte> tail = {
+    0x00, 0x01,              // type A
+    0x00, 0x01,              // class IN
+    0x00, 0x00, 0x00, 0x00,  // TTL
+    0x00, 0x04,              // rdata length
+    0x01, 0x02, 0x03, 0x04,
+  };
+  data.insert(data.end(), tail.begin(), tail.end());
+
+  ares_dns_record_t *dnsrec = NULL;
+  EXPECT_EQ(ARES_EBADNAME, ares_dns_parse(data.data(), data.size(), 0, &dnsrec));
+  EXPECT_EQ(nullptr, dnsrec);
+}
+
 }  // namespace test
 }  // namespace ares

--- a/test/ares-test-parse.cc
+++ b/test/ares-test-parse.cc
@@ -233,7 +233,8 @@ TEST_F(LibraryTest, ParseRejectsOverlongName) {
     0x00, 0x01,  // type A
     0x00, 0x01,  // class IN
   };
-  // Answer name: 6 x 63 = 378 octets, then root terminator
+  // Answer name: 6 x 63 label octets + 5 separators = 383 presentation octets
+  // (> 255), then root terminator
   for (int i = 0; i < 6; i++) {
     data.push_back(63);
     for (int j = 0; j < 63; j++) {
@@ -250,6 +251,145 @@ TEST_F(LibraryTest, ParseRejectsOverlongName) {
   };
   data.insert(data.end(), tail.begin(), tail.end());
 
+  ares_dns_record_t *dnsrec = NULL;
+  EXPECT_EQ(ARES_EBADNAME, ares_dns_parse(data.data(), data.size(), 0, &dnsrec));
+  EXPECT_EQ(nullptr, dnsrec);
+}
+
+TEST_F(LibraryTest, ParseRejectsOverlongNameViaPointers) {
+  // The answer name is one 63-octet label followed by a compression pointer back
+  // to the question name (four 63-octet labels).  Expanded that is 5 x 63 label
+  // octets + 4 separators = 319 presentation octets (> 255), so the length has
+  // to accumulate across the pointer jump for this to be rejected.
+  std::vector<byte> data = {
+    0x12, 0x34, 0x81, 0x80,
+    0x00, 0x01,  // num questions
+    0x00, 0x01,  // num answer RRs
+    0x00, 0x00,  // num authority RRs
+    0x00, 0x00,  // num additional RRs
+  };
+  // Question name: 4 x 63 label octets + 3 separators = 255 presentation octets,
+  // exactly the limit, so the question itself is accepted.
+  for (int i = 0; i < 4; i++) {
+    data.push_back(63);
+    for (int j = 0; j < 63; j++) {
+      data.push_back('a');
+    }
+  }
+  data.push_back(0x00);
+  std::vector<byte> qtail = {0x00, 0x01, 0x00, 0x01};  // type A, class IN
+  data.insert(data.end(), qtail.begin(), qtail.end());
+  // Answer name: one 63-octet label, then a pointer to the question name.
+  data.push_back(63);
+  for (int j = 0; j < 63; j++) {
+    data.push_back('a');
+  }
+  data.push_back(0xc0);
+  data.push_back(0x0c);  // -> offset 12, start of question name
+  std::vector<byte> tail = {
+    0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 1, 2, 3, 4,
+  };
+  data.insert(data.end(), tail.begin(), tail.end());
+  ares_dns_record_t *dnsrec = NULL;
+  EXPECT_EQ(ARES_EBADNAME, ares_dns_parse(data.data(), data.size(), 0, &dnsrec));
+  EXPECT_EQ(nullptr, dnsrec);
+}
+
+TEST_F(LibraryTest, ParseRejectsPointerChain) {
+  // A name built purely from compression pointers adds no label octets, so the
+  // length cap alone can never stop it.  A long backward chain of pointers is
+  // hidden in the opaque rdata of a raw RR, and a second RR's name points at the
+  // top of the chain; walking it must trip the indirection cap and return
+  // EBADNAME rather than following every jump.
+  std::vector<byte> data = {
+    0x12, 0x34, 0x81, 0x80,
+    0x00, 0x01,  // num questions
+    0x00, 0x02,  // num answer RRs
+    0x00, 0x00,  // num authority RRs
+    0x00, 0x00,  // num additional RRs
+    // Question
+    0x01, 'a', 0x00,
+    0x00, 0x01,  // type A
+    0x00, 0x01,  // class IN
+    // RR1: raw RR (unknown type) whose rdata carries the pointer chain
+    0x00,        // name = root
+    0xff, 0xfe,  // type (unknown -> stored raw, rdata not name-parsed)
+    0x00, 0x01,  // class IN
+    0x00, 0x00, 0x00, 0x00,  // TTL
+  };
+  // The chain lives in RR1's rdata, which begins two octets past here (after the
+  // rdlength we are about to write), so compute absolute offsets from there.
+  const size_t rdata_off = data.size() + 2;
+  std::vector<byte> chain;
+  chain.push_back(0x00);          // deepest target: root terminator
+  size_t prev = rdata_off;        // absolute offset of the root
+  size_t top  = prev;
+  const int N = 200;              // well past the 128 indirection cap
+  for (int i = 0; i < N; i++) {
+    size_t here = rdata_off + chain.size();
+    chain.push_back(0xc0 | ((prev >> 8) & 0x3f));
+    chain.push_back(prev & 0xff);
+    top  = here;
+    prev = here;
+  }
+  data.push_back((chain.size() >> 8) & 0xff);  // rdlength
+  data.push_back(chain.size() & 0xff);
+  data.insert(data.end(), chain.begin(), chain.end());
+  // RR2: name = pointer to the top of the chain.
+  data.push_back(0xc0 | ((top >> 8) & 0x3f));
+  data.push_back(top & 0xff);
+  std::vector<byte> tail = {
+    0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 1, 2, 3, 4,
+  };
+  data.insert(data.end(), tail.begin(), tail.end());
+
+  ares_dns_record_t *dnsrec = NULL;
+  EXPECT_EQ(ARES_EBADNAME, ares_dns_parse(data.data(), data.size(), 0, &dnsrec));
+  EXPECT_EQ(nullptr, dnsrec);
+}
+
+TEST_F(LibraryTest, ParseAcceptsMaxLengthName) {
+  // Exactly 255 presentation octets: 4 x 63 = 252 + 3 separators = 255, which
+  // must still be accepted (the bound is "> 255", not ">= 255").
+  std::vector<byte> data = {
+    0x12, 0x34, 0x81, 0x80, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+    0x00, 0x00, 0x01, 'a',  0x00, 0x00, 0x01, 0x00, 0x01,
+  };
+  for (int i = 0; i < 4; i++) {
+    data.push_back(63);
+    for (int j = 0; j < 63; j++) {
+      data.push_back('a');
+    }
+  }
+  data.push_back(0x00);
+  std::vector<byte> tail = {
+    0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 1, 2, 3, 4,
+  };
+  data.insert(data.end(), tail.begin(), tail.end());
+  ares_dns_record_t *dnsrec = NULL;
+  EXPECT_EQ(ARES_SUCCESS, ares_dns_parse(data.data(), data.size(), 0, &dnsrec));
+  EXPECT_NE(nullptr, dnsrec);
+  ares_dns_record_destroy(dnsrec);
+}
+
+TEST_F(LibraryTest, ParseRejectsName256) {
+  // One octet over: labels 63,63,63,62,1 = 252 + 4 separators = 256 -> reject.
+  std::vector<byte> data = {
+    0x12, 0x34, 0x81, 0x80, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+    0x00, 0x00, 0x01, 'a',  0x00, 0x00, 0x01, 0x00, 0x01,
+  };
+  const int lens[] = {63, 63, 63, 62, 1};
+  for (int i = 0; i < 5; i++) {
+    data.push_back(static_cast<byte>(lens[i]));
+    for (int j = 0; j < lens[i]; j++) {
+      data.push_back('a');
+    }
+  }
+  data.push_back(0x00);
+  std::vector<byte> tail = {
+    0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 1, 2, 3, 4,
+  };
+  data.insert(data.end(), tail.begin(), tail.end());
   ares_dns_record_t *dnsrec = NULL;
   EXPECT_EQ(ARES_EBADNAME, ares_dns_parse(data.data(), data.size(), 0, &dnsrec));
   EXPECT_EQ(nullptr, dnsrec);


### PR DESCRIPTION
ares_dns_name_parse had no upper bound on the assembled name length:

- the strictly-decreasing pointer rule stops loops but not unbounded expansion
- it accepted names past the RFC 1035 255 octet limit
- a ~64KB reply with one long name plus answer RRs that are just a pointer back to it re-expands that name per RR (~1.2s to parse a single packet here)
- a name built purely from compression pointers adds no label bytes, so a length cap alone never bounds it: a ~65KB reply (an ~8k descending pointer chain plus RRs whose name points at the top of it) still parses in ~0.9s and returns SUCCESS, and every RR is walked with no early exit

Fixes:

- cap the running presentation length at 255 in the parse loop and return ARES_EBADNAME past it, matching the existing check in ares_split_dns_name on the write side
- cap compression-pointer indirections per name at 128 (a <=255 octet name has <=128 labels), which bounds the pointer-only case the length cap misses
- factor the 255 limit into a shared constant used by the read cap and both write-side checks

Tests (test/ares-test-parse.cc):

- ParseRejectsOverlongName / ParseRejectsOverlongNameViaPointers (literal labels, and length accumulated across a backward pointer)
- ParseRejectsPointerChain (pure pointer chain -> ARES_EBADNAME)
- ParseAcceptsMaxLengthName / ParseRejectsName256 (255 accepted, 256 rejected)

Duplicate #1114 is already closed; keeping this one.