### PR TITLE
ares_array: reset offset when array becomes empty

### DIFF
--- a/src/lib/dsa/ares_array.c
+++ b/src/lib/dsa/ares_array.c
@@ -378,6 +378,13 @@ ares_status_t ares_array_claim_at(void *dest, size_t dest_size,
   }
 
   arr->cnt--;
+
+  /* When empty, reset offset so a later insert doesn't compact from an
+   * out-of-range index (offset can reach alloc_cnt after front claims). */
+  if (arr->cnt == 0) {
+    arr->offset = 0;
+  }
+
   return ARES_SUCCESS;
 }
 

--- a/src/lib/dsa/ares_array.c
+++ b/src/lib/dsa/ares_array.c
@@ -380,7 +380,10 @@ ares_status_t ares_array_claim_at(void *dest, size_t dest_size,
   arr->cnt--;
 
   /* When empty, reset offset so a later insert doesn't compact from an
-   * out-of-range index (offset can reach alloc_cnt after front claims). */
+   * out-of-range index (offset can reach alloc_cnt after front claims).
+   * This also protects ares_array_finish(), which has the same
+   * move(0, offset) and would otherwise fail on an offset == alloc_cnt
+   * array. */
   if (arr->cnt == 0) {
     arr->offset = 0;
   }

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -1488,22 +1488,32 @@ TEST_F(LibraryTest, ArrayClaimFrontThenReuse) {
   ares_array_t *a = ares_array_create(sizeof(size_t), NULL);
   EXPECT_NE(nullptr, a);
 
-  /* Interleave front-claim and append many times. */
-  for (size_t i = 0; i < 1000; i++) {
-    size_t  val = i;
-    size_t *ptr = NULL;
+  for (size_t iter = 0; iter < 4; iter++) {
+    /* Fill exactly to the minimum allocation (ARES__ARRAY_MIN == 4) so a
+     * full front-drain later pushes offset to precisely alloc_cnt. */
+    for (size_t i = 0; i < 4; i++) {
+      size_t val = iter * 100 + i;
+      EXPECT_EQ(ARES_SUCCESS, ares_array_insertdata_last(a, &val));
+    }
+    EXPECT_EQ((size_t)4, ares_array_len(a));
 
-    EXPECT_EQ(ARES_SUCCESS, ares_array_insertdata_last(a, &val));
-    EXPECT_EQ((size_t)1, ares_array_len(a));
-
-    EXPECT_EQ(ARES_SUCCESS, ares_array_claim_at(NULL, 0, a, 0));
+    /* Drain ALL elements from the front so offset climbs to alloc_cnt (the
+     * condition the fix guards); verify copy-out value and FIFO order. */
+    for (size_t i = 0; i < 4; i++) {
+      size_t out = 0;
+      EXPECT_EQ(ARES_SUCCESS, ares_array_claim_at(&out, sizeof(out), a, 0));
+      EXPECT_EQ(iter * 100 + i, out);
+    }
     EXPECT_EQ((size_t)0, ares_array_len(a));
 
-    /* Array is now empty; appending must continue to work. */
+    /* Array is now empty with offset == alloc_cnt; appending must still
+     * work, and the data must be readable back out. */
+    size_t *ptr = NULL;
     EXPECT_EQ(ARES_SUCCESS, ares_array_insert_last((void **)&ptr, a));
     EXPECT_NE(nullptr, ptr);
-    *ptr = i;
-    EXPECT_EQ(ARES_SUCCESS, ares_array_claim_at(NULL, 0, a, 0));
+    *ptr = 424242;
+    EXPECT_EQ((size_t)424242, *(size_t *)ares_array_at(a, 0));
+    EXPECT_EQ(ARES_SUCCESS, ares_array_remove_first(a));
   }
 
   EXPECT_EQ((size_t)0, ares_array_len(a));

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -1480,6 +1480,36 @@ TEST_F(LibraryTest, Array) {
   ares_array_destroy(a);
 }
 
+/* Regression: repeatedly claiming the first element drives the internal
+ * offset up to the allocation size.  Re-inserting afterwards must still
+ * succeed (previously ares_array_insert_at() failed with ARES_EFORMERR
+ * because compaction tried to move from an out-of-range source index). */
+TEST_F(LibraryTest, ArrayClaimFrontThenReuse) {
+  ares_array_t *a = ares_array_create(sizeof(size_t), NULL);
+  EXPECT_NE(nullptr, a);
+
+  /* Interleave front-claim and append many times. */
+  for (size_t i = 0; i < 1000; i++) {
+    size_t  val = i;
+    size_t *ptr = NULL;
+
+    EXPECT_EQ(ARES_SUCCESS, ares_array_insertdata_last(a, &val));
+    EXPECT_EQ((size_t)1, ares_array_len(a));
+
+    EXPECT_EQ(ARES_SUCCESS, ares_array_claim_at(NULL, 0, a, 0));
+    EXPECT_EQ((size_t)0, ares_array_len(a));
+
+    /* Array is now empty; appending must continue to work. */
+    EXPECT_EQ(ARES_SUCCESS, ares_array_insert_last((void **)&ptr, a));
+    EXPECT_NE(nullptr, ptr);
+    *ptr = i;
+    EXPECT_EQ(ARES_SUCCESS, ares_array_claim_at(NULL, 0, a, 0));
+  }
+
+  EXPECT_EQ((size_t)0, ares_array_len(a));
+  ares_array_destroy(a);
+}
+
 TEST_F(LibraryTest, HtableVpvp) {
   ares_llist_t       *l = NULL;
   ares_htable_vpvp_t *h = NULL;


### PR DESCRIPTION
ares_array_claim_at() removes the first element in O(1) by advancing arr->offset instead of shifting. If every element is claimed from the front, offset can climb to arr->alloc_cnt. Reusing the array afterwards (appending while draining from the front) then made ares_array_insert_at() compact via ares_array_move() with an out-of-range source index, failing with ARES_EFORMERR.

Reset offset to 0 once the array is empty. There is nothing to preserve, and this is provably the only case ares_array_move() could fail: the invariant offset + cnt <= alloc_cnt holds everywhere, so offset can only reach alloc_cnt when cnt == 0.

Add a regression test exercising interleaved front-claim and append.