### PR TITLE
Guard DNS record binary length overflow

### DIFF
--- a/src/lib/record/ares_dns_record.c
+++ b/src/lib/record/ares_dns_record.c
@@ -1102,13 +1102,22 @@ ares_status_t ares_dns_rr_add_abin(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
   ares_dns_datatype_t datatype = ares_dns_rr_key_datatype(key);
   ares_bool_t         is_nullterm =
     (datatype == ARES_DATATYPE_ABINP) ? ARES_TRUE : ARES_FALSE;
-  size_t                   alloclen = is_nullterm ? len + 1 : len;
+  size_t                   alloclen;
   unsigned char           *temp;
   ares_dns_multistring_t **strs;
 
   if (ares_dns_rr_key_datatype(key) != ARES_DATATYPE_ABINP) {
     return ARES_EFORMERR;
   }
+
+  if (val == NULL && len != 0) {
+    return ARES_EFORMERR;
+  }
+
+  if (is_nullterm && len == SIZE_MAX) {
+    return ARES_ENOMEM;
+  }
+  alloclen = is_nullterm ? len + 1 : len;
 
   strs = ares_dns_rr_data_ptr(dns_rr, key, NULL);
   if (strs == NULL) {
@@ -1127,7 +1136,9 @@ ares_status_t ares_dns_rr_add_abin(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
     return ARES_ENOMEM;
   }
 
-  memcpy(temp, val, len);
+  if (len != 0) {
+    memcpy(temp, val, len);
+  }
 
   /* NULL-term ABINP */
   if (is_nullterm) {
@@ -1410,14 +1421,32 @@ ares_status_t ares_dns_rr_set_bin(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
     (datatype == ARES_DATATYPE_BINP || datatype == ARES_DATATYPE_ABINP)
               ? ARES_TRUE
               : ARES_FALSE;
-  size_t         alloclen = is_nullterm ? len + 1 : len;
-  unsigned char *temp     = ares_malloc(alloclen);
+  size_t         alloclen;
+  unsigned char *temp;
+
+  if (datatype != ARES_DATATYPE_BIN && datatype != ARES_DATATYPE_BINP &&
+      datatype != ARES_DATATYPE_ABINP) {
+    return ARES_EFORMERR;
+  }
+
+  if (val == NULL && len != 0) {
+    return ARES_EFORMERR;
+  }
+
+  if (is_nullterm && len == SIZE_MAX) {
+    return ARES_ENOMEM;
+  }
+  alloclen = is_nullterm ? len + 1 : len;
+
+  temp = ares_malloc(alloclen);
 
   if (temp == NULL) {
     return ARES_ENOMEM;
   }
 
-  memcpy(temp, val, len);
+  if (len != 0) {
+    memcpy(temp, val, len);
+  }
 
   /* NULL-term BINP */
   if (is_nullterm) {
@@ -1573,12 +1602,23 @@ ares_status_t ares_dns_rr_set_opt(ares_dns_rr_t *dns_rr, ares_dns_rr_key_t key,
   ares_status_t  status;
 
   if (val != NULL) {
-    temp = ares_malloc(val_len + 1);
+    size_t alloclen;
+
+    if (val_len == SIZE_MAX) {
+      return ARES_ENOMEM;
+    }
+    alloclen = val_len + 1;
+
+    temp = ares_malloc(alloclen);
     if (temp == NULL) {
       return ARES_ENOMEM;
     }
-    memcpy(temp, val, val_len);
+    if (val_len != 0) {
+      memcpy(temp, val, val_len);
+    }
     temp[val_len] = 0;
+  } else if (val_len != 0) {
+    return ARES_EFORMERR;
   }
 
   status = ares_dns_rr_set_opt_own(dns_rr, key, opt, temp, val_len);

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -1550,6 +1550,44 @@ TEST_F(LibraryTest, DNSRecordNSEC3EmptyFields) {
 }
 #endif /* !CARES_SYMBOL_HIDING */
 
+TEST_F(LibraryTest, DNSRecordRejectsInvalidBinaryInput) {
+  ares_dns_record_t *dnsrec = NULL;
+  ares_dns_rr_t     *rr     = NULL;
+  unsigned char      data[] = { 'x' };
+
+  EXPECT_EQ(ARES_SUCCESS,
+    ares_dns_record_create(&dnsrec, 0x1234, ARES_FLAG_RD,
+      ARES_OPCODE_QUERY, ARES_RCODE_NOERROR));
+
+  EXPECT_EQ(ARES_SUCCESS,
+    ares_dns_record_rr_add(&rr, dnsrec, ARES_SECTION_ANSWER, "example.com",
+      ARES_REC_TYPE_TXT, ARES_CLASS_IN, 60));
+  EXPECT_EQ(ARES_ENOMEM,
+    ares_dns_rr_add_abin(rr, ARES_RR_TXT_DATA, data, SIZE_MAX));
+  EXPECT_EQ(ARES_EFORMERR,
+    ares_dns_rr_add_abin(rr, ARES_RR_TXT_DATA, NULL, 1));
+
+  EXPECT_EQ(ARES_SUCCESS,
+    ares_dns_record_rr_add(&rr, dnsrec, ARES_SECTION_ANSWER, "example.com",
+      ARES_REC_TYPE_CAA, ARES_CLASS_IN, 60));
+  EXPECT_EQ(ARES_ENOMEM,
+    ares_dns_rr_set_bin(rr, ARES_RR_CAA_VALUE, data, SIZE_MAX));
+  EXPECT_EQ(ARES_EFORMERR,
+    ares_dns_rr_set_bin(rr, ARES_RR_CAA_VALUE, NULL, 1));
+  EXPECT_EQ(ARES_EFORMERR,
+    ares_dns_rr_set_bin(rr, ARES_RR_CAA_TAG, data, sizeof(data)));
+
+  EXPECT_EQ(ARES_SUCCESS,
+    ares_dns_record_rr_add(&rr, dnsrec, ARES_SECTION_ADDITIONAL, "",
+      ARES_REC_TYPE_OPT, ARES_CLASS_IN, 0));
+  EXPECT_EQ(ARES_ENOMEM,
+    ares_dns_rr_set_opt(rr, ARES_RR_OPT_OPTIONS, 3, data, SIZE_MAX));
+  EXPECT_EQ(ARES_EFORMERR,
+    ares_dns_rr_set_opt(rr, ARES_RR_OPT_OPTIONS, 3, NULL, 1));
+
+  ares_dns_record_destroy(dnsrec);
+}
+
 TEST_F(LibraryTest, DNSParseFlags) {
   ares_dns_record_t   *dnsrec = NULL;
   ares_dns_rr_t       *rr     = NULL;


### PR DESCRIPTION
## Summary
- validate null-terminated DNS record binary allocation sizes before adding the trailing NUL byte
- reject nonzero copy lengths with NULL input pointers in the public binary/option setters
- add regression coverage for SIZE_MAX lengths across TXT ABINP, SIG BINP, and OPT option paths

## Testing
- `/tmp/cmake-3.29.6-linux-x86_64/bin/cmake -S . -B build -G "Unix Makefiles" -DCARES_BUILD_TESTS=OFF -DCARES_STATIC=ON -DCARES_SHARED=OFF`
- `/tmp/cmake-3.29.6-linux-x86_64/bin/cmake --build build -j2`
- `/tmp/cmake-3.29.6-linux-x86_64/bin/cmake -S . -B build-test -G "Unix Makefiles" -DCARES_BUILD_TESTS=ON -DCARES_STATIC=ON -DCARES_SHARED=OFF -DCMAKE_PREFIX_PATH=/tmp/googletest-cares-install`
- `/tmp/cmake-3.29.6-linux-x86_64/bin/cmake --build build-test -j2 --target arestest`
- `./build-test/bin/arestest --gtest_filter=LibraryTest.DNSRecordRejectsInvalidBinaryInput`
- `./build-test/bin/arestest --gtest_filter=LibraryTest.DNSRecord*:LibraryTest.DNSParseFlags`
- `./build-test/bin/arestest --gtest_filter=-*.Live*:*Live*` (1063 tests passed)