### PR TITLE
ci: add permissions and pin all actions to full commit SHAs

### DIFF
--- a/.github/workflows/alpine-latest.yml
+++ b/.github/workflows/alpine-latest.yml
@@ -14,6 +14,9 @@ env:
   CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -G Ninja"
   MAKE: make
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,7 +30,7 @@ jobs:
         run: |
           apk add bash cmake samurai gtest-dev autoconf autoconf-archive automake libtool pkgconf make clang clang-analyzer compiler-rt lldb gcc g++ valgrind gdb sudo
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: "Make sure TCP FastOpen is enabled"
         run: |
           sudo sysctl -w net.ipv4.tcp_fastopen=3

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,20 +13,23 @@ env:
   CMAKE_DEFAULT_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -G Ninja -DANDROID_PLATFORM=android-23"
   MAKE: make
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     name: "Android"
     steps:
       - name: Install packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@5513791f75b039e2a79653b1a92238d3fb8d99b4 # latest
         with:
           packages: cmake ninja-build autoconf automake libtool pkg-config
           version: 1.0
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup NDK
-        uses: nttld/setup-ndk@v1
+        uses: nttld/setup-ndk@2817442ee7c3346c1eb7d2ec60263c93206ba14f # v1
         id: setup-ndk
         with:
           ndk-version: r21e

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -15,6 +15,9 @@ env:
   CMAKE_TEST_FLAGS: "-DCARES_BUILD_TESTS=ON -DCMAKE_PREFIX_PATH=/usr/local/"
   MAKE: make
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -37,7 +40,7 @@ jobs:
           yum install -y gcc gcc-c++ make autoconf automake libtool cmake3 git ninja-build gdb
           ln -sf /usr/bin/cmake3 /usr/bin/cmake
       - name: Checkout c-ares
-        uses: actions/checkout@v1
+        uses: actions/checkout@544eadc6bf3d226fd7a7a9f0dc5b5bf7ca0675b9 # v1
       - name: Build GoogleTest
         # GoogleTest v1.10 doesn't require c++14
         run: |

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,13 +18,16 @@ concurrency:
   group: ${{ github.ref }}-codespell
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   codespell:
     runs-on: ubuntu-latest
     name: Codespell
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: install
         run: |

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -5,6 +5,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Coveralls
@@ -12,8 +15,8 @@ jobs:
     # https://www.reddit.com/r/cpp_questions/comments/1ewnv8d/lcov_geninfo_error/
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: awalsh128/cache-apt-pkgs-action@5513791f75b039e2a79653b1a92238d3fb8d99b4 # latest
         with:
           packages: lcov libgmock-dev ninja-build
           version: 1.0
@@ -34,7 +37,7 @@ jobs:
           cd build
           ninja coverage
       - name: Upload to Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@09b709cf6a16e30b0808ba050c7a6e8a5ef13f8d # master
         with:
           path-to-lcov: ${{runner.workspace}}/c-ares/build/coverage.info
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,13 +12,16 @@ concurrency:
   group: ${{ github.ref }}-coverity
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     name: Coverity
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: apt dependencies
         run: sudo apt-get install cmake ninja-build
       - name: Download Coverity Build Tool

--- a/.github/workflows/djgpp.yml
+++ b/.github/workflows/djgpp.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.ref }}-djgpp
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest
@@ -18,9 +21,9 @@ jobs:
         run: |
           choco install --yes make
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Checkout Watt-32
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: gvanem/Watt-32
           path: watt-32

--- a/.github/workflows/fedora-latest.yml
+++ b/.github/workflows/fedora-latest.yml
@@ -14,6 +14,9 @@ env:
   CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -G Ninja"
   MAKE: make
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,7 +32,7 @@ jobs:
         run: |
           yum install -y gcc gcc-c++ make autoconf automake libtool cmake git ninja-build gdb curl wget gtest-devel gmock-devel pkgconf clang clang-tools-extra clang-analyzer lldb gdb valgrind procps
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: "Make sure TCP FastOpen is enabled"
         run: |
           sudo sysctl -w net.ipv4.tcp_fastopen=3

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,6 +15,9 @@ env:
   CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_DEPLOYMENT_TARGET=10.0 -DCMAKE_OSX_ARCHITECTURES=arm64 -G Ninja"
   CMAKE_TEST_FLAGS: "-DCARES_BUILD_TESTS=OFF"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest
@@ -25,7 +28,7 @@ jobs:
           brew uninstall cmake || true
           brew install cmake googletest llvm autoconf automake libtool make ninja
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: "CMake: build and test c-ares"
         env:
           BUILD_TYPE: CMAKE

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,6 +14,9 @@ env:
   CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -G Ninja"
   MAKE: make
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest
@@ -24,7 +27,7 @@ jobs:
           brew uninstall cmake || true
           brew install cmake googletest llvm autoconf automake libtool make ninja
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: "Make sure TCP FastOpen is enabled"
         run: sudo sysctl net.inet.tcp.fastopen=3
       - name: "CMake: build and test c-ares"

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -16,6 +16,9 @@ env:
   MAKE: make
   DIST: Windows
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest
@@ -32,7 +35,7 @@ jobs:
     name: ${{ matrix.msystem }}
     steps:
       - name: Install MSYS2 and base packages
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           msystem: ${{ matrix.msystem }}
           update: true
@@ -49,7 +52,7 @@ jobs:
             mingw-w64-${{ matrix.env }}-gdb
             ${{ matrix.extra_packages }}
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: "CMake: build and test c-ares"
         env:
           BUILD_TYPE: CMAKE

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -10,15 +10,18 @@ concurrency:
   group: ${{ github.ref }}-netbsd
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     name: NetBSD
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Test
-        uses: cross-platform-actions/action@v0.24.0
+        uses: cross-platform-actions/action@0eaba0c982c4946c2410055c694efaeaa8cf33e0 # v0.24.0
         env:
           DIST: NETBSD
           BUILD_TYPE: "cmake"

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -9,14 +9,17 @@ concurrency:
   group: ${{ github.ref }}-openbsd
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     name: OpenBSD
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Test
-        uses: cross-platform-actions/action@v0.24.0
+        uses: cross-platform-actions/action@0eaba0c982c4946c2410055c694efaeaa8cf33e0 # v0.24.0
         env:
           DIST: OPENBSD
           BUILD_TYPE: "cmake"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,6 +12,9 @@ env:
   TEST_FILTER: "--gtest_filter=-*LiveSearchTXT*:*LiveSearchANY*"
   MAKE: make
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,12 +27,12 @@ jobs:
     name: "build"
     steps:
       - name: Install packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@5513791f75b039e2a79653b1a92238d3fb8d99b4 # latest
         with:
           packages: autoconf automake libtool g++ libgmock-dev pkg-config gdb
           version: 1.0
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Get Tag version
         id: version
         run: |
@@ -44,7 +47,7 @@ jobs:
           ./configure
           make dist
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "c-ares-src-tarball"
           path: 'c-ares-*.tar.gz'
@@ -52,7 +55,7 @@ jobs:
           overwrite: true
           retention-days: 7
       - name: Upload Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           body_path: RELEASE-NOTES.md
@@ -93,11 +96,11 @@ jobs:
       contents: write # To add assets to a release.
     steps:
       - name: Download the provenance
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{needs.provenance.outputs.provenance-name}}
       - name: Upload Provenance to Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         if: startsWith(github.ref, 'refs/tags/')
         id: upload-provenance
         with:

--- a/.github/workflows/qnx.yml
+++ b/.github/workflows/qnx.yml
@@ -15,13 +15,16 @@ env:
   CXXFLAGS: "-V gcc_ntox86_64"
   CPUVARDIR: "x86_64"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04
     name: "QNX"
     steps:
       - name: Install packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@5513791f75b039e2a79653b1a92238d3fb8d99b4 # latest
         with:
           packages: cmake ninja-build autoconf automake libtool qemu-user qemu-system-x86 qemu-utils bridge-utils net-tools libvirt-clients libvirt-daemon-system
           version: 1.0
@@ -45,12 +48,12 @@ jobs:
           echo "Downloading QNX SDP ..."
           ${{ github.workspace }}/qnxinstall/qnxsoftwarecenter/qnxsoftwarecenter_clt -mirror -cleanInstall -destination ${{ github.workspace }}/qnx800 -installBaseline com.qnx.qnx800 -myqnx.user="$QNX_USER" -myqnx.password="$QNX_PASSWORD"
       - name: Checkout qnx-ports build-files
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: qnx-ports/build-files
           path: build-files
       - name: Checkout qnx-ports googletest
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: qnx-ports/googletest
           path: googletest
@@ -60,7 +63,7 @@ jobs:
           env
           make -C build-files/ports/googletest PREFIX=usr install -j$(nproc)
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: c-ares
       - name: Set CMAKE_FIND_ROOT_PATH

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     name: REUSE compliance
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v1
+      uses: fsfe/reuse-action@4d31d76f16747cf196a58f1ae62f215e7cc739a9 # v1

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.ref }}-solaris
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-24.04
@@ -22,10 +25,10 @@ jobs:
       TEST_FILTER: "--gtest_filter=-*Live*"
       TEST_DEBUGGER: "gdb"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Solaris Build and Test
         id: solaris
-        uses: vmactions/solaris-vm@v1
+        uses: vmactions/solaris-vm@d30dd6c228c8661ade859e36ead7660b9a62efcc # v1
         with:
           envs: 'DIST BUILD_TYPE CMAKE_FLAGS CMAKE_TEST_FLAGS TEST_FILTER CXXFLAGS TEST_DEBUGGER'
           usesh: true

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.ref }}-sonarcloud
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,12 +23,12 @@ jobs:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     name: "SonarCloud: Build and analyze"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: "SonarCloud: Install Build-Wrapper"
-        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v7
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # v7
+      - uses: awalsh128/cache-apt-pkgs-action@5513791f75b039e2a79653b1a92238d3fb8d99b4 # latest
         with:
           packages: libgmock-dev
           version: 1.0
@@ -35,7 +38,7 @@ jobs:
           cmake -DCARES_BUILD_TESTS=ON -S . -B build
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/ --config Release
       - name: "SonareCloud: Scan"
-        uses: SonarSource/sonarqube-scan-action@v7
+        uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -14,6 +14,9 @@ env:
   CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -G Ninja"
   MAKE: make
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -31,7 +34,7 @@ jobs:
           apt-get dist-upgrade -y --assume-yes
           apt-get install -y --assume-yes sudo curl wget cmake ninja-build autoconf automake libtool g++ libgmock-dev pkg-config clang clang-tools lldb gdb valgrind
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: "Make sure TCP FastOpen is enabled"
         run: |
           sudo sysctl -w net.ipv4.tcp_fastopen=3

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -14,18 +14,21 @@ env:
   CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=DEBUG -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON -G Ninja"
   MAKE: make
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     name: "Ubuntu (latest)"
     steps:
       - name: Install packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@5513791f75b039e2a79653b1a92238d3fb8d99b4 # latest
         with:
           packages: cmake ninja-build autoconf automake libtool g++ libgmock-dev pkg-config clang clang-tools lldb gdb valgrind
           version: 1.0
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: "Make sure TCP FastOpen is enabled"
         run: |
           sudo sysctl -w net.ipv4.tcp_fastopen=3

--- a/.github/workflows/uwp.yml
+++ b/.github/workflows/uwp.yml
@@ -9,17 +9,20 @@ concurrency:
   group: ${{ github.ref }}-uwp
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest
     name: Windows UWP (Store)
     steps:
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
         with:
           arch: x64
           uwp: true
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build c-ares
         run: |
           mkdir build

--- a/.github/workflows/watcom.yml
+++ b/.github/workflows/watcom.yml
@@ -9,14 +9,17 @@ concurrency:
   group: ${{ github.ref }}-openwatcom
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest
     name: OpenWatcom
     steps:
-      - uses: open-watcom/setup-watcom@v0
+      - uses: open-watcom/setup-watcom@7ef247f4cdd25d29b7757ae9908655d253d3e13c # v0
       - name: Checkout Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: configure
         run: buildconf.bat
         shell: cmd

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.ref }}-watt32
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest
@@ -16,13 +19,13 @@ jobs:
     env:
       WATT_ROOT: "${{ github.workspace }}\\watt-32"
     steps:
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
         with:
           arch: x86
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Checkout Watt-32
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: gvanem/Watt-32
           path: watt-32


### PR DESCRIPTION
## Summary

All 23 CI workflow files were missing a top-level `permissions:` block and used mutable action tag references (`@v4`, `@latest`, `@master`, etc.). This PR addresses both across every workflow in one shot.

### Changes

**1. Add `permissions: contents: read` to all workflows**

Without an explicit `permissions` block, GitHub grants the `GITHUB_TOKEN` default access (which includes `contents: write` in some contexts). Restricting to `contents: read` follows the principle of least privilege. `reuse.yml` already had `permissions: {}` and is unchanged. `package.yml` already had job-level permissions — the workflow-level block is additive.

**2. Pin all `uses:` to full commit SHAs**

Mutable tags can be silently re-pointed to malicious commits. Pinning to the full SHA guarantees the exact reviewed code runs. Original tags are kept as comments.

| Action | Was | Now |
|--------|-----|-----|
| `actions/checkout` | `@v4` / `@v1` | `@34e114876b` / `@544eadc6bf` |
| `actions/upload-artifact` | `@v4` | `@ea165f8d65` |
| `actions/download-artifact` | `@v4` | `@d3f86a106a` |
| `awalsh128/cache-apt-pkgs-action` | `@latest` | `@5513791f75` |
| `coverallsapp/github-action` | `@master` | `@09b709cf6a` |
| `cross-platform-actions/action` | `@v0.24.0` | `@0eaba0c982` |
| `fsfe/reuse-action` | `@v1` | `@4d31d76f16` |
| `ilammy/msvc-dev-cmd` | `@v1` | `@0b201ec74f` |
| `msys2/setup-msys2` | `@v2` | `@66cd2cce69` |
| `nttld/setup-ndk` | `@v1` | `@2817442ee7` |
| `open-watcom/setup-watcom` | `@v0` | `@7ef247f4cd` |
| `softprops/action-gh-release` | `@v2` | `@3bb12739c2` |
| `SonarSource/sonarqube-scan-action` | `@v7` | `@c7ee0f9df9` |
| `vmactions/solaris-vm` | `@v1` | `@d30dd6c228` |

`slsa-framework/slsa-github-generator` uses a pinned `@v2.0.0` release tag per upstream docs and is left unchanged.

These changes qualify under the [Google Open Source Patch Rewards Program](https://bughunters.google.com/open-source-security/patch-rewards) for proactive CI/supply-chain security hardening.