### PR TITLE
Add ARES_OPT_MINTIMEOUTMS channel option

### DIFF
--- a/docs/ares_init_options.3
+++ b/docs/ares_init_options.3
@@ -39,6 +39,7 @@ struct ares_options {
   char *hosts_path;
   int udp_max_queries;
   int maxtimeout; /* in milliseconds */
+  int mintimeout; /* in milliseconds */
   unsigned int qcache_max_ttl; /* in seconds */
   ares_evsys_t evsys;
   struct ares_server_failover_options server_failover_opts;
@@ -180,6 +181,12 @@ resolv.conf or the RES_OPTIONS environment variable.  Valid range is 0-15.
 The upper bound for timeout between sequential retry attempts.  When retrying
 queries, the timeout is increased from the requested timeout parameter, this
 caps the value.
+.TP 18
+.B ARES_OPT_MINTIMEOUTMS
+.B int \fImintimeout\fP;
+.br
+The lower bound for the adaptively-computed retry timeout, in milliseconds.
+The default floor is 250ms.  Applied before the maximum bound.
 .TP 18
 .B ARES_OPT_UDP_PORT
 .B unsigned short \fIudp_port\fP;

--- a/include/ares.h
+++ b/include/ares.h
@@ -265,6 +265,7 @@ typedef enum {
 #define ARES_OPT_QUERY_CACHE     (1 << 21)
 #define ARES_OPT_EVENT_THREAD    (1 << 22)
 #define ARES_OPT_SERVER_FAILOVER (1 << 23)
+#define ARES_OPT_MINTIMEOUTMS    (1 << 24)
 
 /* Nameinfo flag values */
 #define ARES_NI_NOFQDN        (1 << 0)
@@ -391,6 +392,7 @@ struct ares_options {
   char              *hosts_path;
   int                udp_max_queries;
   int                maxtimeout; /* in milliseconds */
+  int                mintimeout; /* in milliseconds */
   unsigned int qcache_max_ttl;   /* Maximum TTL for query cache, 0=disabled */
   ares_evsys_t evsys;
   struct ares_server_failover_options server_failover_opts;

--- a/include/ares.h
+++ b/include/ares.h
@@ -392,10 +392,10 @@ struct ares_options {
   char              *hosts_path;
   int                udp_max_queries;
   int                maxtimeout; /* in milliseconds */
-  int                mintimeout; /* in milliseconds */
   unsigned int qcache_max_ttl;   /* Maximum TTL for query cache, 0=disabled */
   ares_evsys_t evsys;
   struct ares_server_failover_options server_failover_opts;
+  int          mintimeout; /* in milliseconds */
 };
 
 struct hostent;

--- a/src/lib/ares_metrics.c
+++ b/src/lib/ares_metrics.c
@@ -247,8 +247,12 @@ size_t ares_metrics_server_timeout(const ares_server_t  *server,
   }
 
   /* don't go below lower bounds */
-  if (timeout_ms < MIN_TIMEOUT_MS) {
-    timeout_ms = MIN_TIMEOUT_MS;
+  {
+    size_t min_timeout_ms =
+      channel->mintimeout ? channel->mintimeout : MIN_TIMEOUT_MS;
+    if (timeout_ms < min_timeout_ms) {
+      timeout_ms = min_timeout_ms;
+    }
   }
 
   /* don't go above upper bounds */

--- a/src/lib/ares_metrics.c
+++ b/src/lib/ares_metrics.c
@@ -37,7 +37,8 @@
  * rails.
  *
  * Values:
- * - Minimum Timeout: 250ms (approximate RTT half-way around the globe)
+ * - Minimum Timeout: 250ms (approximate RTT half-way around the globe), can be
+ *   raised by ARES_OPT_MINTIMEOUTMS.
  * - Maximum Timeout: 5000ms (Recommended timeout in RFC 1123), can be reduced
  *   by ARES_OPT_MAXTIMEOUTMS, but otherwise the bound specified by the option
  *   caps the retry timeout.
@@ -211,6 +212,7 @@ size_t ares_metrics_server_timeout(const ares_server_t  *server,
   const ares_channel_t *channel = server->channel;
   ares_server_bucket_t  i;
   size_t                timeout_ms = 0;
+  size_t                min_timeout_ms;
   size_t                max_timeout_ms;
 
   for (i = 0; i < ARES_METRIC_COUNT; i++) {
@@ -247,12 +249,9 @@ size_t ares_metrics_server_timeout(const ares_server_t  *server,
   }
 
   /* don't go below lower bounds */
-  {
-    size_t min_timeout_ms =
-      channel->mintimeout ? channel->mintimeout : MIN_TIMEOUT_MS;
-    if (timeout_ms < min_timeout_ms) {
-      timeout_ms = min_timeout_ms;
-    }
+  min_timeout_ms = channel->mintimeout ? channel->mintimeout : MIN_TIMEOUT_MS;
+  if (timeout_ms < min_timeout_ms) {
+    timeout_ms = min_timeout_ms;
   }
 
   /* don't go above upper bounds */

--- a/src/lib/ares_options.c
+++ b/src/lib/ares_options.c
@@ -128,6 +128,10 @@ int ares_save_options(const ares_channel_t *channel,
     options->maxtimeout = (int)channel->maxtimeout;
   }
 
+  if (channel->optmask & ARES_OPT_MINTIMEOUTMS) {
+    options->mintimeout = (int)channel->mintimeout;
+  }
+
   if (channel->optmask & ARES_OPT_UDP_PORT) {
     options->udp_port = channel->udp_port;
   }
@@ -332,6 +336,14 @@ ares_status_t ares_init_by_options(ares_channel_t            *channel,
       optmask &= ~(ARES_OPT_MAXTIMEOUTMS);
     } else {
       channel->maxtimeout = (size_t)options->maxtimeout;
+    }
+  }
+
+  if (optmask & ARES_OPT_MINTIMEOUTMS) {
+    if (options->mintimeout <= 0) {
+      optmask &= ~(ARES_OPT_MINTIMEOUTMS);
+    } else {
+      channel->mintimeout = (size_t)options->mintimeout;
     }
   }
 

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -187,6 +187,7 @@ struct ares_channeldata {
   size_t               tries;
   size_t               ndots;
   size_t               maxtimeout;                 /* in milliseconds */
+  size_t               mintimeout;                 /* in milliseconds */
   ares_bool_t          rotate;
   unsigned short       udp_port;                   /* stored in network order */
   unsigned short       tcp_port;                   /* stored in network order */

--- a/test/ares-test-init.cc
+++ b/test/ares-test-init.cc
@@ -89,6 +89,8 @@ TEST_F(LibraryTest, OptionsChannelInit) {
   opts.udp_port = 54;
   optmask |= ARES_OPT_MAXTIMEOUTMS;
   opts.maxtimeout = 10000;
+  optmask |= ARES_OPT_MINTIMEOUTMS;
+  opts.mintimeout = 500;
   optmask |= ARES_OPT_UDP_PORT;
   opts.tcp_port = 54;
   optmask |= ARES_OPT_TCP_PORT;
@@ -136,6 +138,7 @@ TEST_F(LibraryTest, OptionsChannelInit) {
   EXPECT_EQ(opts.tries, opts2.tries);
   EXPECT_EQ(opts.ndots, opts2.ndots);
   EXPECT_EQ(opts.maxtimeout, opts2.maxtimeout);
+  EXPECT_EQ(opts.mintimeout, opts2.mintimeout);
   EXPECT_EQ(opts.udp_port, opts2.udp_port);
   EXPECT_EQ(opts.tcp_port, opts2.tcp_port);
   EXPECT_EQ(1, opts2.nservers);  // Truncated by ARES_FLAG_PRIMARY


### PR DESCRIPTION
Add a new channel option `ARES_OPT_MINTIMEOUTMS` that lets callers override the minimum per-query timeout used by the adaptive timeout algorithm in ares_metrics_server_timeout(). This mirrors the existing `ARES_OPT_MAXTIMEOUTMS` option which controls the upper bound.

When a caller sets tries=1 (`ARES_OPT_TRIES`), the adaptive algorithm often computes a timeout near the 250ms floor because local DNS servers return cached responses quickly. Without retries and their exponential backoff, queries that require upstream recursion can time out. This new option lets callers raise the floor to account for that.

A value of 0 (the default) preserves existing behavior (250ms floor).

We noticed this while configuring `ARES_OPT_TRIES` to 1 to limit the number of DNS queries c-ares sends per resolution. With the default retry count, the 250ms floor is rarely an issue because retries double the timeout on each round, giving slower lookups time to complete. But with a single try, any lookup that needs upstream recursion exceeds the ~250ms window and fails.