### PR TITLE
enforce rfc1035 255-octet name limit when parsing dns names

### DIFF
--- a/src/lib/record/ares_dns_name.c
+++ b/src/lib/record/ares_dns_name.c
@@ -543,6 +543,7 @@ ares_status_t ares_dns_name_parse(ares_buf_t *buf, char **name,
   ares_status_t status;
   ares_buf_t   *namebuf     = NULL;
   size_t        label_start = ares_buf_get_position(buf);
+  size_t        name_len    = 0;
 
   if (buf == NULL) {
     return ARES_EFORMERR;
@@ -636,6 +637,16 @@ ares_status_t ares_dns_name_parse(ares_buf_t *buf, char **name,
     }
 
     /* New label */
+
+    /* RFC 1035 3.1 / 2.3.4: the total encoded length of a domain name is
+     * limited to 255 octets.  Enforce it here so that a compressed name
+     * pointing at a long label chain can't expand without bound, which also
+     * keeps the work done per name linear in the message size. */
+    name_len += (size_t)c + 1;
+    if (name_len > 255) {
+      status = ARES_EBADNAME;
+      goto fail;
+    }
 
     /* Labels are separated by periods */
     if (ares_buf_len(namebuf) != 0 && name != NULL) {

--- a/test/ares-test-parse.cc
+++ b/test/ares-test-parse.cc
@@ -219,5 +219,31 @@ TEST_F(LibraryTest, ParseMalformedRRCount) {
   EXPECT_EQ(nullptr, dnsrec);
 }
 
+TEST_F(LibraryTest, ParseOverlongNameRejected) {
+  std::vector<byte> data = {
+    0x12, 0x34,  // qid
+    0x84, 0x00,  // response + AA
+    0x00, 0x01,  // num questions
+    0x00, 0x00,  // num answer RRs
+    0x00, 0x00,  // num authority RRs
+    0x00, 0x00,  // num additional RRs
+  };
+  // Question name made of 5 labels of 63 octets each, i.e. 5*64+1 = 321
+  // encoded octets, beyond the RFC1035 255-octet limit.
+  for (int i = 0; i < 5; i++) {
+    data.push_back(63);
+    for (int j = 0; j < 63; j++) {
+      data.push_back('a');
+    }
+  }
+  data.push_back(0x00);        // root
+  data.push_back(0x00); data.push_back(0x01);  // type A
+  data.push_back(0x00); data.push_back(0x01);  // class IN
+
+  ares_dns_record_t *dnsrec = nullptr;
+  EXPECT_EQ(ARES_EBADNAME, ares_dns_parse(data.data(), data.size(), 0, &dnsrec));
+  EXPECT_EQ(nullptr, dnsrec);
+}
+
 }  // namespace test
 }  // namespace ares


### PR DESCRIPTION
ares_dns_name_parse decodes a name without any cap on its length, while the write side in ares_split_dns_name already rejects anything past the rfc1035 255-octet limit. a response can therefore point every resource record's owner name at one long label chain through a 2-byte compression pointer, and each record re-expands the whole chain from scratch, so a 62kb message spends ~240ms in this parser versus well under a millisecond once the limit is enforced. track the running label length in the parse loop and bail with ares_ebadname once it crosses 255, which bounds the work per name and matches the write path. added a regression case alongside parsemalformedrrcount.