### PR TITLE
Add comment-driven backport workflow for release branches

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,125 @@
+# Copyright (C) The c-ares project and its contributors
+#
+# SPDX-License-Identifier: MIT
+
+name: Backport
+
+# Cherry-pick a merged pull request onto one or more release branches when a
+# maintainer comments "/backport <branch> [<branch> ...] [--no-automerge]".
+#
+# Because "issue_comment" workflows always execute from the default branch and
+# have access to repository secrets, authorization is enforced explicitly: only
+# users whose repository role is "maintain" or "admin" may run the command.
+on:
+  issue_comment:
+    types: [created]
+
+# The default token is not used for privileged operations (a GitHub App token
+# is minted below), so it needs no elevated permissions.
+permissions:
+  contents: read
+
+concurrency:
+  group: backport-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    # Cheap pre-filter. Real authorization happens in the "Authorize" step.
+    if: >
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/backport')
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BACKPORT_APP_ID }}
+          private-key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}
+
+      - name: Authorize commenter (maintainers only)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          role=$(gh api \
+            "repos/${{ github.repository }}/collaborators/${COMMENTER}/permission" \
+            -q '.role_name')
+          echo "${COMMENTER} has repository role '${role}'"
+          case "${role}" in
+            admin|maintain)
+              ;;
+            *)
+              gh pr comment "${{ github.event.issue.number }}" \
+                --repo "${{ github.repository }}" \
+                --body ":no_entry: \`/backport\` may only be run by project maintainers."
+              echo "::error::${COMMENTER} is not a maintainer (role: ${role})"
+              exit 1
+              ;;
+          esac
+
+      - name: Verify the pull request is merged
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          merged=$(gh pr view "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" --json mergedAt -q '.mergedAt')
+          if [ -z "${merged}" ] || [ "${merged}" = "null" ]; then
+            gh pr comment "${{ github.event.issue.number }}" \
+              --repo "${{ github.repository }}" \
+              --body ":warning: \`/backport\` only works on **merged** pull requests."
+            echo "::error::PR #${{ github.event.issue.number }} is not merged"
+            exit 1
+          fi
+
+      - name: Parse backport command
+        id: parse
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMMENT: ${{ github.event.comment.body }}
+        run: |
+          # Everything after the "/backport" token.
+          args="${COMMENT#*/backport}"
+          automerge=true
+          branches=""
+          for tok in ${args}; do
+            case "${tok}" in
+              --no-automerge)  automerge=false ;;
+              v[0-9]*.[0-9]*)  branches="${branches} ${tok}" ;;
+              *) ;;  # ignore anything else
+            esac
+          done
+          branches="$(echo "${branches}" | xargs)"
+          if [ -z "${branches}" ]; then
+            gh pr comment "${{ github.event.issue.number }}" \
+              --repo "${{ github.repository }}" \
+              --body ":warning: No target branches found. Usage: \`/backport v1.34 v1.33 [--no-automerge]\`"
+            echo "::error::No target branches parsed from comment"
+            exit 1
+          fi
+          echo "Target branches: ${branches} (auto-merge: ${automerge})"
+          echo "branches=${branches}" >> "$GITHUB_OUTPUT"
+          echo "automerge=${automerge}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Create backport pull requests
+        uses: korthout/backport-action@v4
+        with:
+          github_token:       ${{ steps.app-token.outputs.token }}
+          source_pr_number:   ${{ github.event.issue.number }}
+          target_branches:    ${{ steps.parse.outputs.branches }}
+          # On conflict, commit the conflict markers and open a *draft* PR
+          # instead of failing. Draft PRs are never auto-merged, so a human
+          # must resolve the conflict and mark it ready.
+          experimental:       '{"conflict_resolution": "draft_commit_conflicts"}'
+          # Clean cherry-picks enable auto-merge; GitHub then merges only once
+          # all required status checks on the target branch pass.
+          auto_merge_enabled: ${{ steps.parse.outputs.automerge }}
+          auto_merge_method:  squash

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -9,7 +9,7 @@ Copyright: The c-ares project and its contributors
 License: MIT
 
 # Docs
-Files: AUTHORS CONTRIBUTING.md GIT-INFO README.md README.msvc RELEASE-PROCEDURE.md RELEASE-NOTES.md FEATURES.md SECURITY.md DEVELOPER-NOTES.md INSTALL.md FUZZING.md test/README.md src/lib/include/README.md src/lib/thirdparty/apple/README.md
+Files: AUTHORS BACKPORTING.md CONTRIBUTING.md GIT-INFO README.md README.msvc RELEASE-PROCEDURE.md RELEASE-NOTES.md FEATURES.md SECURITY.md DEVELOPER-NOTES.md INSTALL.md FUZZING.md test/README.md src/lib/include/README.md src/lib/thirdparty/apple/README.md
 Copyright: The c-ares project and its contributors
 License: MIT
 

--- a/BACKPORTING.md
+++ b/BACKPORTING.md
@@ -1,0 +1,90 @@
+Backporting fixes to release branches
+=====================================
+
+Fixes are developed against `main` and then cherry-picked ("backported") onto
+the relevant release branches (e.g. `v1.34`, `v1.33`). This is automated by the
+`Backport` GitHub Actions workflow (`.github/workflows/backport.yml`).
+
+Release branches are protected and cannot be pushed to directly, so the
+workflow always proposes changes as a **pull request** against the release
+branch rather than pushing to it.
+
+Usage
+-----
+
+Comment on a **merged** pull request:
+
+```
+/backport <branch> [<branch> ...] [--no-automerge]
+```
+
+Examples:
+
+```
+/backport v1.34
+/backport v1.34 v1.33
+/backport v1.34 --no-automerge
+```
+
+- One backport pull request is opened per target branch.
+- Only users with the `maintain` or `admin` repository role may run the
+  command; anyone else gets a polite refusal.
+- The command only operates on pull requests that have already been merged.
+- Target branches are recognized by the `vMAJOR.MINOR` naming pattern; any other
+  tokens in the comment (aside from `--no-automerge`) are ignored.
+
+What happens on a clean cherry-pick
+-----------------------------------
+
+The backport pull request is opened and **auto-merge is enabled by default**.
+GitHub will merge it automatically once **all required status checks on the
+target branch pass** (this is why the CI checks must be marked as *required* in
+the branch protection rules — see setup below). Add `--no-automerge` to open the
+pull request without enabling auto-merge.
+
+What happens on a conflict
+--------------------------
+
+If the cherry-pick hits a merge conflict, the workflow still opens a pull
+request, but:
+
+- the conflict markers are committed, and
+- the pull request is opened as a **draft**.
+
+Draft pull requests are never auto-merged, so a maintainer must resolve the
+conflict, push the resolution, and mark the pull request ready for review.
+
+One-time repository setup
+-------------------------
+
+The workflow requires the following to be configured by a repository
+administrator:
+
+1. **GitHub App** (recommended over a personal access token so that backport
+   pull requests are attributed to a bot and so that CI runs on them). Create or
+   reuse a GitHub App with these repository permissions:
+   - Contents: Read and write
+   - Pull requests: Read and write
+
+   Install the App on this repository, then add two repository secrets:
+   - `BACKPORT_APP_ID` — the App's ID
+   - `BACKPORT_APP_PRIVATE_KEY` — a generated private key for the App
+
+2. **Allow auto-merge** must be enabled in the repository settings
+   (Settings → General → Pull Requests → Allow auto-merge).
+
+3. **Branch protection on the release branches** (e.g. a rule matching `v*`):
+   - Require a pull request before merging (blocks direct pushes).
+   - Require status checks to pass before merging, and mark the CI checks as
+     *required*. Without required checks, auto-merge merges immediately rather
+     than waiting for CI.
+   - If pull request approvals are also required, auto-merge will wait for an
+     approval before merging; grant the backport App an exception or adjust the
+     required-approval count as appropriate for your workflow.
+
+Notes
+-----
+
+- The list of authorized roles (`maintain`, `admin`) is enforced in the
+  workflow's "Authorize" step. Adjust it there if your maintainers use a
+  different repository role.


### PR DESCRIPTION
## Summary

Adds a `Backport` GitHub Actions workflow so maintainers can cherry-pick a merged pull request onto one or more protected release branches (e.g. `v1.34`, `v1.33`) by commenting on the PR:

```
/backport <branch> [<branch> ...] [--no-automerge]
```

One backport PR is opened per target branch. Because release branches are protected, changes are always proposed as a **pull request** against the release branch — never pushed directly.

## Behavior

- **Trigger:** `/backport` comment on a **merged** PR (works retroactively on already-merged PRs).
- **Maintainers only:** authorized to users whose repository role is `maintain` or `admin`; anyone else gets a polite refusal. (Uses the `role_name` field, since the legacy `permission` field collapses `maintain`→`write`.)
- **Auth:** mints a **GitHub App token** so backport PRs trigger CI and work with branch protection.
- **Clean cherry-pick:** the backport PR is opened with **auto-merge enabled by default**, so GitHub merges it once all *required* status checks on the target branch pass. Opt out per-invocation with `--no-automerge`.
- **Conflict:** the conflict markers are committed and a **draft** PR is opened for manual resolution. Draft PRs are never auto-merged.

Engine is [`korthout/backport-action`](https://github.com/korthout/backport-action) (`@v4`), with `experimental: {"conflict_resolution": "draft_commit_conflicts"}` for the conflict behavior.

## One-time setup required (repo admin)

Documented in `BACKPORTING.md`:

1. A **GitHub App** with *Contents: R/W* and *Pull requests: R/W*, installed on the repo; secrets `BACKPORT_APP_ID` and `BACKPORT_APP_PRIVATE_KEY`.
2. **Allow auto-merge** enabled in repository settings.
3. **Branch protection on `v*`** requiring a PR and requiring the CI status checks (so auto-merge waits for CI instead of merging immediately).

## Files

- `.github/workflows/backport.yml` — the workflow.
- `BACKPORTING.md` — maintainer usage + setup docs (registered in `.reuse/dep5` for REUSE compliance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)