### PR TITLE
test: fix OpenBSD CI hang in MockTCPChannelTest.ReadFullFrameThenDisconnect

### DIFF
--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -644,6 +644,17 @@ void MockServer::ProcessFD(ares_socket_t fd) {
     if (connfd == ARES_SOCKET_BAD) {
       std::cerr << "Error accepting connection on fd " << fd << std::endl;
     } else {
+      /* This test harness is single-threaded: the mock server runs in the same
+       * thread as the c-ares client, so the client can only drain a socket
+       * between our (blocking) sends, never during one.  A full-size TCP reply
+       * (MakeMaxReadTcpAReply() is a 65535-octet frame) therefore deadlocks a
+       * blocking send() on platforms whose default socket buffers can't hold
+       * the whole frame -- e.g. OpenBSD's ~16k default -- because send() waits
+       * for a reader that cannot run.  Enlarge the send buffer so the entire
+       * frame fits locally and send() returns without a concurrent reader. */
+      int sndbuf = 128 * 1024;
+      setsockopt(connfd, SOL_SOCKET, SO_SNDBUF, BYTE_CAST &sndbuf,
+                 sizeof(sndbuf));
       connfds_.insert(connfd);
     }
     return;


### PR DESCRIPTION
## Problem

Every OpenBSD CI job hangs and is killed at GitHub's 6-hour ceiling. The hang is deterministic and identical across every branch (including `main`): `arestest` prints

```
[ RUN      ] AddressFamilies/MockTCPChannelTest.ReadFullFrameThenDisconnect/ipv4
```

and never returns. NetBSD, macOS and Linux all pass, so this is OpenBSD-specific, not BSD-wide. (The `WARNING: clock gained 810 days` in the OpenBSD logs is unrelated — it's just the VM image noticing the host clock.)

## Root cause — a single-threaded test-harness deadlock, not a library bug

The mock DNS server runs **synchronously in the same thread** as the c-ares client: `ProcessWork` → `select()` → `ProcessFD` → `ProcessRequest`. The client's `ares_process` only runs *after* `ProcessFD` returns, so the client can drain a socket *between* the server's sends, never *during* one.

`MakeMaxReadTcpAReply()` (added in #1138, and used by this one test only) builds a reply whose TCP frame is exactly **65535 octets** to exercise the `read_again` path. The mock server writes it with a **single blocking `sendto()`** on a **blocking** `accept()`ed socket that has no `SO_SNDBUF` tuning.

`send()` returns only once the data is copied into the kernel send buffer, which requires `server_sndbuf + client_rcvbuf ≥ 65535`. c-ares tunes neither buffer, so:

- **Linux / macOS / NetBSD** — large default loopback buffers hold the whole frame → `send()` returns → test passes.
- **OpenBSD** — ~16k default buffers can't hold 65535 bytes → `send()` blocks waiting for the client to drain — but the client can't run because it's the same thread stuck in `send()`. **Permanent deadlock** → 6h timeout.

The `#1138` deferred disconnect-handling change that introduced this test is correct; only the harness's assumption that a full-size reply can be written in one blocking `send()` is wrong on small-socket-buffer platforms.

## Fix

Enlarge the accepted connection's send buffer (128k) so the entire 65535-octet frame fits locally and the blocking `send()` returns without needing a concurrent reader. Test-only change.

```c
int sndbuf = 128 * 1024;
setsockopt(connfd, SOL_SOCKET, SO_SNDBUF, BYTE_CAST &sndbuf, sizeof(sndbuf));
```

## Validation

- Compiles clean; `MockTCPChannelTest.*` (incl. `ReadFullFrameThenDisconnect`, `GetHostByNameParallelLookups`, `MalformedResponse`) pass locally on macOS.
- Draft until the **OpenBSD** runner confirms the hang is gone — that's the platform this can't be reproduced on locally, and the whole point of the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
