### PR TITLE
test: enlarge mock server UDP recv buffer to fix QNX MockUDPMaxQueriesTest

### DIFF
--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -477,6 +477,18 @@ MockServer::MockServer(int family, unsigned short port)
 #if defined(SO_NOSIGPIPE)
   setsockopt(udpfd_, SOL_SOCKET, SO_NOSIGPIPE, (void *)&optval, sizeof(optval));
 #endif
+  /* This harness is single-threaded and drains one datagram per event-loop
+   * iteration, but a client (e.g. MockUDPMaxQueriesTest) can burst dozens of
+   * query datagrams into this single UDP socket before we read any of them.
+   * On hosts with a small default UDP receive buffer (e.g. QNX under QEMU)
+   * the excess datagrams are silently dropped, so those queries time out and
+   * spawn extra sockets, breaking tests that assert an exact socket count.
+   * Enlarge the receive buffer so the whole burst is buffered until we drain
+   * it (the OS clamps the request to its own maximum). */
+  {
+    int rcvbuf = 1024 * 1024;
+    setsockopt(udpfd_, SOL_SOCKET, SO_RCVBUF, BYTE_CAST &rcvbuf, sizeof(rcvbuf));
+  }
 
   // Bind the sockets to the given port.
   if (family == AF_INET) {


### PR DESCRIPTION
## Problem

The post-merge **QNX** CI job fails at *"Run test cases"* on 6 tests, all the same one — `MockUDPMaxQueriesTest.GetHostByNameParallelLookups` and its event-thread twin (ipv4/ipv6 × POLL/SELECT):

```
test/ares-test-mock.cc:519: Failure
Expected equality of these values:
  32 / 8      Which is: 4
  sock_cb_count   Which is: 16
```

## Root cause — UDP datagram loss in the test harness (not a library defect)

The test fires **32 parallel UDP queries** with `udp_max_queries = 8` and asserts exactly `32/8 = 4` sockets are created. The harness is single-threaded and drains **one datagram per event-loop iteration**, but the client bursts all 32 query datagrams into the mock server's **single** UDP socket before any are read. On QNX-under-QEMU the small default UDP receive buffer overflows and **drops** some queries; those time out, which increments the server's consecutive-failure count → `ares_fetch_connection()` refuses to reuse the UDP conn (`ares_process.c`) and `ares_close_sockets()` tears it down → a fresh socket per subsequent query, inflating the count to 16. The queries are requeued and still resolve, so only the socket-count assertion failed.

## Fix

Enlarge the mock server's `udpfd_` `SO_RCVBUF` (1 MB) so the whole burst is buffered until the harness drains it. The exact-count assertion is **preserved** (not weakened), so the test still verifies the `udp_max_queries` batching it's meant to.

## Validation (on the real QNX runner)

Confirmed green on the QNX CI runner: the six `MockUDPMaxQueriesTest` variants now pass (24–47 ms each, no timeouts) and the full suite is **992/992**.

A widened query timeout (250 ms → 2000 ms) was tried first and **ruled out**: the queries still timed out, now at the 2000 ms boundary (~2016 ms test time), proving the datagrams are *lost*, not merely late — no timeout value helps.

> **Merge note:** QNX CI is `on: push` + secrets, so this PR's own checks may still trip over the flaky SDP **download** (unrelated) — that's hardened separately in #1179, which should merge first for reliable QNX CI here. The test fix itself was validated in a combined run that included #1179's download hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
