### PR TITLE
ci(qnx): retry SDP download/licensing steps to survive transient timeouts

### DIFF
--- a/.github/workflows/qnx.yml
+++ b/.github/workflows/qnx.yml
@@ -33,17 +33,39 @@ jobs:
           QNX_PASSWORD: ${{ secrets.QNX_PASSWORD }}
         run: |
           [ -z "${QNX_USER}" -o -z "${QNX_PASSWORD}" -o -z "${QNX_LICENSE_KEY}" ] && echo "Must set QNX_USER, QNX_PASSWORD, and QNX_LICENSE_KEY" && /bin/false
+
+          # QNX's download/licensing servers intermittently time out (curl exit
+          # 28), which fails this ~11 minute job during setup before any c-ares
+          # code is even built.  Retry the network-facing steps a few times so a
+          # transient blip doesn't fail the whole run.  curl gets its own
+          # --retry plus a bounded --connect-timeout (the observed hang was
+          # ~136s per attempt); the Java installer is wrapped in a shell retry.
+          retry() {
+            local n=1 max=4 delay=20
+            while true; do
+              "$@" && return 0
+              if [ "$n" -ge "$max" ]; then
+                echo "  * Command still failing after $n attempts, giving up: $*" >&2
+                return 1
+              fi
+              echo "  * Attempt $n failed, retrying in ${delay}s: $*" >&2
+              n=$((n + 1))
+              sleep "$delay"
+            done
+          }
+          CURL_RETRY="--connect-timeout 60 --retry 5 --retry-delay 10 --retry-connrefused"
+
           echo "Downloading QNX Software Center ..."
           mkdir ${{ github.workspace }}/.qnx
-          curl --cookie-jar ${{ github.workspace }}/.qnx/myqnxcookies.auth --form "userlogin=$QNX_USER" --form "password=$QNX_PASSWORD" -X POST https://www.qnx.com/account/login.html > login_response.html
-          curl -L --cookie ${{ github.workspace }}/.qnx/myqnxcookies.auth https://www.qnx.com/download/download/79441/qnx-setup-2.0.4-202501021438-linux.run > qnx-setup-lin.run
+          retry curl $CURL_RETRY --cookie-jar ${{ github.workspace }}/.qnx/myqnxcookies.auth --form "userlogin=$QNX_USER" --form "password=$QNX_PASSWORD" -X POST https://www.qnx.com/account/login.html -o login_response.html
+          retry curl $CURL_RETRY -L --cookie ${{ github.workspace }}/.qnx/myqnxcookies.auth https://www.qnx.com/download/download/79441/qnx-setup-2.0.4-202501021438-linux.run -o qnx-setup-lin.run
           chmod a+x qnx-setup-lin.run
           ./qnx-setup-lin.run force-override disable-auto-start agree-to-license-terms ${{ github.workspace }}/qnxinstall
           echo "Installing License ..."
-          ${{ github.workspace }}/qnxinstall/qnxsoftwarecenter/qnxsoftwarecenter_clt -syncLicenseKeys -myqnx.user="$QNX_USER" -myqnx.password="$QNX_PASSWORD" -addLicenseKey $QNX_LICENSE_KEY
+          retry ${{ github.workspace }}/qnxinstall/qnxsoftwarecenter/qnxsoftwarecenter_clt -syncLicenseKeys -myqnx.user="$QNX_USER" -myqnx.password="$QNX_PASSWORD" -addLicenseKey $QNX_LICENSE_KEY
           cp -r ~/.qnx/license ${{ github.workspace }}/.qnx
           echo "Downloading QNX SDP ..."
-          ${{ github.workspace }}/qnxinstall/qnxsoftwarecenter/qnxsoftwarecenter_clt -mirror -cleanInstall -destination ${{ github.workspace }}/qnx800 -installBaseline com.qnx.qnx800 -myqnx.user="$QNX_USER" -myqnx.password="$QNX_PASSWORD"
+          retry ${{ github.workspace }}/qnxinstall/qnxsoftwarecenter/qnxsoftwarecenter_clt -mirror -cleanInstall -destination ${{ github.workspace }}/qnx800 -installBaseline com.qnx.qnx800 -myqnx.user="$QNX_USER" -myqnx.password="$QNX_PASSWORD"
       - name: Checkout qnx-ports build-files
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Problem

The QNX job regularly fails in the **"Download SDP 8.0"** setup step with:

```
curl: (28) Failed to connect to support7.qnx.com port 443 after 136498 ms: Connection timed out
##[error]Process completed with exit code 28.
```

QNX's download/licensing servers are intermittently unreachable from the runner. Because this happens during setup, an ~11-minute run is thrown away before any c-ares code is even built. (This is separate from the test-level QNX failure fixed in #1178.)

## Change

Harden only the network-facing setup steps so a transient blip retries instead of failing the whole job — no behavioral change on success:

- A small shell `retry()` helper (4 attempts, 20s apart) wraps the two `qnxsoftwarecenter_clt` invocations (license sync, SDP mirror install).
- Both `curl` calls get `--connect-timeout 60` (the observed hangs ran ~136s per attempt, so an unbounded connect wastes time) plus `--retry 5 --retry-delay 10 --retry-connrefused`.

The actual c-ares CMake/autotools builds are deliberately **not** retried — only the flaky third-party downloads are.

## Notes

- Caching the SDP was considered and rejected: it's proprietary, license-gated content, and an `actions/cache` entry on a public repo can be read by fork-PR workflows (exfiltration risk). Retry-hardening is the safe lever; a self-hosted runner with the SDP pre-installed (as qnx-ports uses) would be the longer-term fix.

## Validation

- YAML parses; the embedded script passes `bash -n`; the `retry()` helper was unit-tested (retries a flaky command to success, gives up non-zero after max so `set -e` fails the step, passes through immediate success).
- QNX runs on `push`, so the branch push triggers a real QNX run that exercises this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
