### PR TITLE
ci(qnx): fix flaky SDP download + MockUDPMaxQueriesTest datagram loss

### DIFF
--- a/.github/workflows/qnx.yml
+++ b/.github/workflows/qnx.yml
@@ -33,17 +33,39 @@ jobs:
           QNX_PASSWORD: ${{ secrets.QNX_PASSWORD }}
         run: |
           [ -z "${QNX_USER}" -o -z "${QNX_PASSWORD}" -o -z "${QNX_LICENSE_KEY}" ] && echo "Must set QNX_USER, QNX_PASSWORD, and QNX_LICENSE_KEY" && /bin/false
+
+          # QNX's download/licensing servers intermittently time out (curl exit
+          # 28), which fails this ~11 minute job during setup before any c-ares
+          # code is even built.  Retry the network-facing steps a few times so a
+          # transient blip doesn't fail the whole run.  curl gets its own
+          # --retry plus a bounded --connect-timeout (the observed hang was
+          # ~136s per attempt); the Java installer is wrapped in a shell retry.
+          retry() {
+            local n=1 max=4 delay=20
+            while true; do
+              "$@" && return 0
+              if [ "$n" -ge "$max" ]; then
+                echo "  * Command still failing after $n attempts, giving up: $*" >&2
+                return 1
+              fi
+              echo "  * Attempt $n failed, retrying in ${delay}s: $*" >&2
+              n=$((n + 1))
+              sleep "$delay"
+            done
+          }
+          CURL_RETRY="--connect-timeout 60 --retry 5 --retry-delay 10 --retry-connrefused"
+
           echo "Downloading QNX Software Center ..."
           mkdir ${{ github.workspace }}/.qnx
-          curl --cookie-jar ${{ github.workspace }}/.qnx/myqnxcookies.auth --form "userlogin=$QNX_USER" --form "password=$QNX_PASSWORD" -X POST https://www.qnx.com/account/login.html > login_response.html
-          curl -L --cookie ${{ github.workspace }}/.qnx/myqnxcookies.auth https://www.qnx.com/download/download/79441/qnx-setup-2.0.4-202501021438-linux.run > qnx-setup-lin.run
+          retry curl $CURL_RETRY --cookie-jar ${{ github.workspace }}/.qnx/myqnxcookies.auth --form "userlogin=$QNX_USER" --form "password=$QNX_PASSWORD" -X POST https://www.qnx.com/account/login.html -o login_response.html
+          retry curl $CURL_RETRY -L --cookie ${{ github.workspace }}/.qnx/myqnxcookies.auth https://www.qnx.com/download/download/79441/qnx-setup-2.0.4-202501021438-linux.run -o qnx-setup-lin.run
           chmod a+x qnx-setup-lin.run
           ./qnx-setup-lin.run force-override disable-auto-start agree-to-license-terms ${{ github.workspace }}/qnxinstall
           echo "Installing License ..."
-          ${{ github.workspace }}/qnxinstall/qnxsoftwarecenter/qnxsoftwarecenter_clt -syncLicenseKeys -myqnx.user="$QNX_USER" -myqnx.password="$QNX_PASSWORD" -addLicenseKey $QNX_LICENSE_KEY
+          retry ${{ github.workspace }}/qnxinstall/qnxsoftwarecenter/qnxsoftwarecenter_clt -syncLicenseKeys -myqnx.user="$QNX_USER" -myqnx.password="$QNX_PASSWORD" -addLicenseKey $QNX_LICENSE_KEY
           cp -r ~/.qnx/license ${{ github.workspace }}/.qnx
           echo "Downloading QNX SDP ..."
-          ${{ github.workspace }}/qnxinstall/qnxsoftwarecenter/qnxsoftwarecenter_clt -mirror -cleanInstall -destination ${{ github.workspace }}/qnx800 -installBaseline com.qnx.qnx800 -myqnx.user="$QNX_USER" -myqnx.password="$QNX_PASSWORD"
+          retry ${{ github.workspace }}/qnxinstall/qnxsoftwarecenter/qnxsoftwarecenter_clt -mirror -cleanInstall -destination ${{ github.workspace }}/qnx800 -installBaseline com.qnx.qnx800 -myqnx.user="$QNX_USER" -myqnx.password="$QNX_PASSWORD"
       - name: Checkout qnx-ports build-files
         uses: actions/checkout@v4
         with:

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -477,6 +477,18 @@ MockServer::MockServer(int family, unsigned short port)
 #if defined(SO_NOSIGPIPE)
   setsockopt(udpfd_, SOL_SOCKET, SO_NOSIGPIPE, (void *)&optval, sizeof(optval));
 #endif
+  /* This harness is single-threaded and drains one datagram per event-loop
+   * iteration, but a client (e.g. MockUDPMaxQueriesTest) can burst dozens of
+   * query datagrams into this single UDP socket before we read any of them.
+   * On hosts with a small default UDP receive buffer (e.g. QNX under QEMU)
+   * the excess datagrams are silently dropped, so those queries time out and
+   * spawn extra sockets, breaking tests that assert an exact socket count.
+   * Enlarge the receive buffer so the whole burst is buffered until we drain
+   * it (the OS clamps the request to its own maximum). */
+  {
+    int rcvbuf = 1024 * 1024;
+    setsockopt(udpfd_, SOL_SOCKET, SO_RCVBUF, BYTE_CAST &rcvbuf, sizeof(rcvbuf));
+  }
 
   // Bind the sockets to the given port.
   if (family == AF_INET) {


### PR DESCRIPTION
Two independent fixes for the QNX CI job, which fails both at setup (flaky download) and at the test step. Consolidated from #1178 + #1179 into one PR. Both were validated together on the real QNX runner (all steps green, suite **992/992**).

## 1. `test:` enlarge mock server UDP recv buffer — fixes `MockUDPMaxQueriesTest`

The QNX test step failed on 6 tests, all `MockUDPMaxQueriesTest.GetHostByNameParallelLookups` (+ event-thread twin):

```
Expected equality of these values:
  32 / 8      Which is: 4
  sock_cb_count   Which is: 16
```

**Root cause — UDP datagram loss in the test harness, not a library defect.** The test fires 32 parallel UDP queries with `udp_max_queries = 8` and asserts exactly `32/8 = 4` sockets. The harness is single-threaded and drains one datagram per event-loop iteration, but the client bursts all 32 query datagrams into the mock server's **single** UDP socket before any are read. On QNX-under-QEMU the small default UDP receive buffer overflows and drops some queries; those time out, which bumps the server's consecutive-failure count → `ares_fetch_connection()` refuses to reuse the UDP conn and `ares_close_sockets()` tears it down → a fresh socket per subsequent query (16 instead of 4). The queries requeue and still resolve, so only the socket-count assertion failed.

**Fix:** enlarge the mock server's `udpfd_` `SO_RCVBUF` (1 MB) so the burst is buffered until drained. The exact-count assertion is **preserved**. (A widened query timeout was tried first and ruled out — queries still timed out at the new boundary, proving the datagrams are lost, not late.)

## 2. `ci(qnx):` retry SDP download/licensing steps

The job frequently failed in *"Download SDP 8.0"* with `curl: (28) ... Connection timed out` when QNX's servers were briefly unreachable — wasting an ~11-minute run during setup. A small `retry()` helper wraps the licensing/mirror steps, and both `curl` calls get `--connect-timeout 60 --retry 5 --retry-delay 10 --retry-connrefused`. (Observed rescuing a run where the SDP mirror failed on attempt 1 and succeeded on retry.)

Caching the SDP was considered and rejected: it's proprietary/license-gated and an `actions/cache` entry on a public repo is readable by fork-PR workflows (exfiltration risk).

## Validation

Confirmed green on the QNX CI runner (`on: push`, secrets on the fork): download step passes (with a retry), and the six `MockUDPMaxQueriesTest` variants pass in 24–47 ms — full suite **992/992**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
