### PR TITLE
ci: add All Checks merge-status aggregator workflow

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -1,0 +1,34 @@
+# Copyright (C) The c-ares project and its contributors
+#
+# SPDX-License-Identifier: MIT
+
+name: All Checks
+
+# Single merge-status aggregator
+# It waits for every OTHER check on the commit to pass or be skipped, so it
+# is the one check to mark required on the `main` ruleset: any workflow added
+# in the future is then automatically gated through it — fail it, and this
+# blocks the PR — with no per-check ruleset edits.
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  all-checks:
+    name: All Checks
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+    steps:
+      - name: Wait for all checks to pass or be skipped
+        uses: poseidon/wait-for-status-checks@990a77d11cde85fd8897cb1747d2701ea9565615  # v0.6.0 + #627
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Ignore:
+          #   * "All Checks" — self (we set a name, so it isn't auto-ignored).
+          ignore: "All Checks"
+          timeout: 10800


### PR DESCRIPTION
## Summary

Adds a single **All Checks** aggregator workflow that waits for every *other* check on the PR commit to pass or be skipped, using [poseidon/wait-for-status-checks](https://github.com/poseidon/wait-for-status-checks) (pinned to v0.6.0 + poseidon/wait-for-status-checks#627).

This makes it possible to mark just **All Checks** as the required status check on the `main` ruleset: any workflow added (or renamed) in the future is then automatically gated through it — if it fails, this check fails and blocks the PR — with no per-check ruleset edits ever needed.

## Notes

- The action ignores itself via `ignore: "All Checks"` (self-ignore isn't automatic once a job `name` is set).
- Skipped checks (e.g. path-filtered workflows like Codespell) count as passing.
- Timeout is 3 hours to cover the slower emulated/VM jobs (Solaris, NetBSD, OpenBSD, QNX).
- After merging, the `main` ruleset's required status checks can be reduced to just `All Checks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)