### PR TITLE
docs: correct availability version for ares_dns_record_rr_get_const

### DIFF
--- a/docs/ares_dns_rr.3
+++ b/docs/ares_dns_rr.3
@@ -942,7 +942,11 @@ return the requested resource record pointer or NULL on failure (misuse).
 found, otherwise ARES_FALSE if not found (or misuse).
 
 .SH AVAILABILITY
-These functions were first introduced in c-ares version 1.22.0.
+These functions were first introduced in c-ares version 1.22.0, except
+\fIares_dns_record_rr_get_const(3)\fP which was introduced in version 1.28.0, and
+\fIares_dns_rr_get_abin_cnt(3)\fP, \fIares_dns_rr_get_abin(3)\fP,
+\fIares_dns_rr_add_abin(3)\fP and \fIares_dns_rr_del_abin(3)\fP which were
+introduced in version 1.32.0.
 .SH SEE ALSO
 .BR ares_dns_mapping (3),
 .BR ares_dns_record (3),


### PR DESCRIPTION
The AVAILABILITY section of `ares_dns_rr.3` claimed all documented functions were first introduced in c-ares 1.22.0. That is wrong for:

- `ares_dns_record_rr_get_const()` — added in **1.28.0**
- `ares_dns_rr_get_abin_cnt()` / `ares_dns_rr_get_abin()` / `ares_dns_rr_add_abin()` / `ares_dns_rr_del_abin()` — added in **1.32.0**

This corrects the note. Documentation only.

Fixes #970