### PR TITLE
ci: validate clang-format on PR-changed lines

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,7 +26,12 @@ AlignConsecutiveAssignments:
   AlignCompound: true
   PadOperators: true
 AlignConsecutiveBitFields: Consecutive
-AlignConsecutiveDeclarations: AcrossEmptyLinesAndComments
+# AlignFunctionDeclarations requires clang-format >= 20
+AlignConsecutiveDeclarations:
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: true
+  AlignFunctionDeclarations: false
 AlignConsecutiveMacros: Consecutive
 AlignEscapedNewlines: Left
 AlignOperands: Align

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,71 @@
+# Copyright (C) The c-ares project and its contributors
+#
+# SPDX-License-Identifier: MIT
+
+name: clang-format
+
+# Validates formatting of lines changed by the PR (and only those lines,
+# via clang-format-diff) against the repository .clang-format rules.
+#
+# Always uses the latest stable clang-format from apt.llvm.org, discovered
+# at runtime from the llvm.sh installer script.  Our configuration requires
+# at least clang-format 20 (AlignFunctionDeclarations).
+
+on:
+  pull_request:
+    paths:
+      - '**.c'
+      - '**.h'
+      - '.clang-format'
+      - '.github/workflows/clang-format.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clang-format:
+    name: clang-format
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install latest stable clang-format from apt.llvm.org
+        run: |
+          wget -q https://apt.llvm.org/llvm.sh
+          LLVM_VER=$(sed -n 's/^CURRENT_LLVM_STABLE=\([0-9]*\).*/\1/p' llvm.sh)
+          echo "Latest stable LLVM version: ${LLVM_VER}"
+          CODENAME=$(. /etc/os-release && echo "${VERSION_CODENAME}")
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | \
+            sudo tee /etc/apt/trusted.gpg.d/apt-llvm-org.asc >/dev/null
+          echo "deb http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${LLVM_VER} main" | \
+            sudo tee /etc/apt/sources.list.d/apt-llvm-org.list
+          sudo apt-get update
+          sudo apt-get install -y "clang-format-${LLVM_VER}"
+          "clang-format-${LLVM_VER}" --version
+          echo "LLVM_VER=${LLVM_VER}" >> "${GITHUB_ENV}"
+
+      - name: Check formatting of changed lines
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git fetch --quiet --depth=1 origin "${BASE_SHA}"
+          git diff -U0 --no-color "${BASE_SHA}" HEAD -- \
+              '*.c' '*.h' ':!src/lib/thirdparty' | \
+            "clang-format-diff-${LLVM_VER}" -p1 \
+              -binary "clang-format-${LLVM_VER}" > clang-format.patch || true
+          if [ -s clang-format.patch ]; then
+            echo "::error::Changed lines are not clang-format clean.  Run 'git clang-format' (clang-format >= 20 required) or apply the patch below."
+            cat clang-format.patch
+            {
+              echo '### clang-format suggested changes'
+              echo '```diff'
+              cat clang-format.patch
+              echo '```'
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 1
+          fi
+          echo "All changed lines are clang-format clean"


### PR DESCRIPTION
## Summary

Adds a `clang-format` workflow that validates formatting of **only the lines actually changed by the PR**, using `clang-format-diff` fed by `git diff -U0` against the PR base. Pre-existing style drift elsewhere in a touched file never blocks an unrelated change.

Also updates `.clang-format` to set `AlignConsecutiveDeclarations.AlignFunctionDeclarations: false` (added in clang-format 20 by llvm/llvm-project#108241), so consecutive function prototypes are no longer padded into column alignment. Variable declaration alignment is unchanged — the previous `AcrossEmptyLinesAndComments` shorthand is expanded to its equivalent explicit form with the new sub-option added.

## clang-format version

The workflow discovers the **latest stable LLVM release at runtime** by parsing `CURRENT_LLVM_STABLE` from apt.llvm.org's `llvm.sh` (currently 22), then installs just `clang-format-NN` from the matching apt repo — no toolchain bloat, and the check tracks new LLVM releases automatically. Since only changed lines are checked, a formatting-behavior change in a new release has minimal blast radius.

## Details

- Scope matches DEVELOPER-NOTES.md: `*.c` / `*.h`, excluding `src/lib/thirdparty`.
- On failure the suggested fix is printed to the log, published as a ```diff``` block in the job step summary, and surfaced via a `::error::` annotation.
- `paths` filter skips the workflow entirely for PRs not touching C sources or the format config (skips count as passing for the **All Checks** aggregator from #1182).
- `clang-format-diff` exits non-zero when it emits a diff; that's neutralized (`|| true`) so the explicit patch-size check controls failure and the diagnostics always print.
- Verified locally with clang-format 22.1.8: the updated `.clang-format` parses, and a synthetic bad-format change is flagged while untouched lines in the same file are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)