### PR TITLE
ares_getaddrinfo: handle NULL node per POSIX and implement ARES_AI_PASSIVE

### DIFF
--- a/docs/ares_getaddrinfo.3
+++ b/docs/ares_getaddrinfo.3
@@ -27,6 +27,19 @@ The
 and
 .I service
 parameters give the hostname and service as NULL-terminated C strings.
+Either
+.I name
+or
+.I service
+may be NULL, but not both.  If
+.I name
+is NULL, the returned addresses are synthesized from
+.IR service :
+the wildcard address (0.0.0.0 or ::) is returned when
+.B ARES_AI_PASSIVE
+is set in
+.IR ai_flags ,
+otherwise the loopback address (127.0.0.1 or ::1) is returned.
 The
 .I hints
 parameter is an
@@ -62,6 +75,16 @@ Specifies additional options, see below.
 If this option is set
 .I service
 field will be treated as a numeric value.
+.TP 19
+.B ARES_AI_PASSIVE
+If this option is set and
+.I name
+is NULL, the returned addresses will use the wildcard address (0.0.0.0 or ::),
+suitable for
+.BR bind (2)ing
+a socket that will accept connections.  If not set and
+.I name
+is NULL, the loopback address (127.0.0.1 or ::1) is returned instead.
 .TP 19
 .B ARES_AI_CANONNAME
 The ares_addrinfo structure will return a canonical names list.

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -242,6 +242,11 @@ static ares_bool_t fake_addrinfo(const char *name, unsigned short port,
   ares_status_t               status = ARES_SUCCESS;
   ares_bool_t                 result = ARES_FALSE;
   int                         family = hints->ai_family;
+
+  if (name == NULL) {
+    return ARES_FALSE; /* LCOV_EXCL_LINE: DefensiveCoding */
+  }
+
   if (family == AF_INET || family == AF_INET6 || family == AF_UNSPEC) {
     /* It only looks like an IP address if it's all numbers and dots. */
     size_t      numdots = 0;
@@ -594,6 +599,57 @@ static ares_bool_t numeric_service_to_port(const char *service,
   return ARES_FALSE;
 }
 
+/* Per POSIX getaddrinfo(), when no node/hostname is provided the returned
+ * addresses are synthesized from the service: the wildcard address when
+ * ARES_AI_PASSIVE is set (suitable for bind()ing a listening socket),
+ * otherwise the loopback address (suitable for connect()ing to a peer on the
+ * local host). */
+static ares_status_t
+  ares_append_nulladdr(unsigned short                    port,
+                       const struct ares_addrinfo_hints *hints,
+                       struct ares_addrinfo             *ai)
+{
+  int                        family  = hints->ai_family;
+  ares_bool_t                passive = ARES_FALSE;
+  ares_status_t              status;
+  struct ares_addrinfo_node *node;
+
+  if (hints->ai_flags & ARES_AI_PASSIVE) {
+    passive = ARES_TRUE;
+  }
+
+  if (family == AF_INET6 || family == AF_UNSPEC) {
+    struct ares_in6_addr addr6;
+    memset(&addr6, 0, sizeof(addr6)); /* wildcard "::" */
+    if (!passive) {
+      ares_inet_pton(AF_INET6, "::1", &addr6);
+    }
+    status = ares_append_ai_node(AF_INET6, port, 0, &addr6, &ai->nodes);
+    if (status != ARES_SUCCESS) {
+      return status; /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+  }
+
+  if (family == AF_INET || family == AF_UNSPEC) {
+    struct in_addr addr4;
+    memset(&addr4, 0, sizeof(addr4)); /* wildcard "0.0.0.0" */
+    if (!passive) {
+      ares_inet_pton(AF_INET, "127.0.0.1", &addr4);
+    }
+    status = ares_append_ai_node(AF_INET, port, 0, &addr4, &ai->nodes);
+    if (status != ARES_SUCCESS) {
+      return status; /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+  }
+
+  for (node = ai->nodes; node != NULL; node = node->ai_next) {
+    node->ai_socktype = hints->ai_socktype;
+    node->ai_protocol = hints->ai_protocol;
+  }
+
+  return ARES_SUCCESS;
+}
+
 static void ares_getaddrinfo_int(ares_channel_t *channel, const char *name,
                                  const char                       *service,
                                  const struct ares_addrinfo_hints *hints,
@@ -615,6 +671,13 @@ static void ares_getaddrinfo_int(ares_channel_t *channel, const char *name,
      and unspec means try both basically. */
   if (family != AF_INET && family != AF_INET6 && family != AF_UNSPEC) {
     callback(arg, ARES_ENOTIMP, 0, NULL);
+    return;
+  }
+
+  /* POSIX getaddrinfo() requires that at least one of node (name) or service
+   * be provided. */
+  if (name == NULL && service == NULL) {
+    callback(arg, ARES_ENOTFOUND, 0, NULL);
     return;
   }
 
@@ -643,6 +706,19 @@ static void ares_getaddrinfo_int(ares_channel_t *channel, const char *name,
   ai = ares_malloc_zero(sizeof(*ai));
   if (!ai) {
     callback(arg, ARES_ENOMEM, 0, NULL);
+    return;
+  }
+
+  /* No node/hostname was provided (service-only lookup): synthesize wildcard
+   * or loopback addresses from the resolved port instead of issuing a query. */
+  if (name == NULL) {
+    status = ares_append_nulladdr(port, hints, ai);
+    if (status != ARES_SUCCESS) {
+      ares_freeaddrinfo(ai);               /* LCOV_EXCL_LINE: OutOfMemory */
+      callback(arg, (int)status, 0, NULL); /* LCOV_EXCL_LINE: OutOfMemory */
+      return;                              /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+    callback(arg, ARES_SUCCESS, 0, ai);
     return;
   }
 

--- a/test/ares-test-misc.cc
+++ b/test/ares-test-misc.cc
@@ -26,6 +26,8 @@
 #include "ares-test.h"
 #include "dns-proto.h"
 
+#include <set>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -343,6 +345,95 @@ TEST_F(DefaultChannelTest, GetAddrinfoOnionDomain) {
   struct ares_addrinfo_hints hints = {0, 0, 0, 0};
   hints.ai_family = AF_UNSPEC;
   ares_getaddrinfo(channel_, "dontleak.onion", NULL, &hints, AddrInfoCallback, &result);
+  EXPECT_TRUE(result.done_);
+  EXPECT_EQ(ARES_ENOTFOUND, result.status_);
+}
+
+// Collect the resolved nodes of an AddrInfoResult as "addr:port" strings.
+static std::set<std::string> AddrInfoNodeStrings(const AddrInfoResult &result) {
+  std::set<std::string> out;
+  if (result.ai_ == nullptr) {
+    return out;
+  }
+  for (struct ares_addrinfo_node *n = result.ai_->nodes; n != NULL;
+       n = n->ai_next) {
+    std::stringstream ss;
+    if (n->ai_family == AF_INET) {
+      sockaddr_in *sin = reinterpret_cast<sockaddr_in *>(
+        reinterpret_cast<void *>(n->ai_addr));
+      ss << AddressToString(&sin->sin_addr, 4) << ":" << ntohs(sin->sin_port);
+    } else if (n->ai_family == AF_INET6) {
+      sockaddr_in6 *sin6 = reinterpret_cast<sockaddr_in6 *>(
+        reinterpret_cast<void *>(n->ai_addr));
+      ss << "[" << AddressToString(&sin6->sin6_addr, 16)
+         << "]:" << ntohs(sin6->sin6_port);
+    }
+    out.insert(ss.str());
+  }
+  return out;
+}
+
+// A NULL node/hostname with a service is a valid POSIX getaddrinfo() request;
+// it must not crash and, without ARES_AI_PASSIVE, returns loopback addresses.
+TEST_F(DefaultChannelTest, GetAddrinfoNullNameLoopback) {
+  AddrInfoResult result;
+  struct ares_addrinfo_hints hints = {0, 0, 0, 0};
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_flags  = ARES_AI_NUMERICSERV;
+  ares_getaddrinfo(channel_, NULL, "80", &hints, AddrInfoCallback, &result);
+  EXPECT_TRUE(result.done_);
+  EXPECT_EQ(ARES_SUCCESS, result.status_);
+  std::set<std::string> expected = {
+      "127.0.0.1:80", "[0000:0000:0000:0000:0000:0000:0000:0001]:80"};
+  EXPECT_EQ(expected, AddrInfoNodeStrings(result));
+}
+
+// With ARES_AI_PASSIVE a NULL node returns wildcard addresses (for bind()).
+TEST_F(DefaultChannelTest, GetAddrinfoNullNamePassiveWildcard) {
+  AddrInfoResult result;
+  struct ares_addrinfo_hints hints = {0, 0, 0, 0};
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_flags  = ARES_AI_NUMERICSERV | ARES_AI_PASSIVE;
+  ares_getaddrinfo(channel_, NULL, "80", &hints, AddrInfoCallback, &result);
+  EXPECT_TRUE(result.done_);
+  EXPECT_EQ(ARES_SUCCESS, result.status_);
+  std::set<std::string> expected = {
+      "0.0.0.0:80", "[0000:0000:0000:0000:0000:0000:0000:0000]:80"};
+  EXPECT_EQ(expected, AddrInfoNodeStrings(result));
+}
+
+// ai_family is honored for NULL-node synthesis.
+TEST_F(DefaultChannelTest, GetAddrinfoNullNameInetOnly) {
+  AddrInfoResult result;
+  struct ares_addrinfo_hints hints = {0, 0, 0, 0};
+  hints.ai_family = AF_INET;
+  hints.ai_flags  = ARES_AI_NUMERICSERV;
+  ares_getaddrinfo(channel_, NULL, "80", &hints, AddrInfoCallback, &result);
+  EXPECT_TRUE(result.done_);
+  EXPECT_EQ(ARES_SUCCESS, result.status_);
+  std::set<std::string> expected = {"127.0.0.1:80"};
+  EXPECT_EQ(expected, AddrInfoNodeStrings(result));
+}
+
+TEST_F(DefaultChannelTest, GetAddrinfoNullNameInet6Passive) {
+  AddrInfoResult result;
+  struct ares_addrinfo_hints hints = {0, 0, 0, 0};
+  hints.ai_family = AF_INET6;
+  hints.ai_flags  = ARES_AI_NUMERICSERV | ARES_AI_PASSIVE;
+  ares_getaddrinfo(channel_, NULL, "80", &hints, AddrInfoCallback, &result);
+  EXPECT_TRUE(result.done_);
+  EXPECT_EQ(ARES_SUCCESS, result.status_);
+  std::set<std::string> expected = {
+      "[0000:0000:0000:0000:0000:0000:0000:0000]:80"};
+  EXPECT_EQ(expected, AddrInfoNodeStrings(result));
+}
+
+// Both node and service NULL is invalid per POSIX; must error, not crash.
+TEST_F(DefaultChannelTest, GetAddrinfoNullNameNullService) {
+  AddrInfoResult result;
+  struct ares_addrinfo_hints hints = {0, 0, 0, 0};
+  hints.ai_family = AF_UNSPEC;
+  ares_getaddrinfo(channel_, NULL, NULL, &hints, AddrInfoCallback, &result);
   EXPECT_TRUE(result.done_);
   EXPECT_EQ(ARES_ENOTFOUND, result.status_);
 }


### PR DESCRIPTION
`ares_getaddrinfo()` dereferenced the `name` (node) argument with no NULL check, so calling it with a NULL name crashed in `fake_addrinfo()` (issue #1035).

Per POSIX, a NULL node is valid as long as a service is provided — the returned addresses are then synthesized from the service:

- **`ARES_AI_PASSIVE` set** → wildcard address (`0.0.0.0` / `::`), suitable for `bind()`ing a listening socket.
- **not set** → loopback address (`127.0.0.1` / `::1`), for connecting to a peer on the local host.
- **both node and service NULL** → `ARES_ENOTFOUND` (POSIX `EAI_NONAME`).

`ARES_AI_PASSIVE` was already declared in the public API and included in `ARES_AI_MASK`, but had no implementation. It is now honored.

### Changes
- Guard the both-NULL case with `ARES_ENOTFOUND`.
- Synthesize wildcard/loopback nodes honoring `ai_family`, `ai_socktype`, `ai_protocol` when `name` is NULL.
- Defensive NULL guard in `fake_addrinfo()`.
- Document NULL-node behavior and the `ARES_AI_PASSIVE` flag in `ares_getaddrinfo.3`.
- Tests: loopback, passive/wildcard, `AF_INET`/`AF_INET6` selection, and the both-NULL error case.

All 1074 non-live tests pass locally.

Fixes #1035
