### PR TITLE
ares_iface_ips: add ARES_IFACE_IP_NONE zero enum value

### DIFF
--- a/src/lib/util/ares_iface_ips.c
+++ b/src/lib/util/ares_iface_ips.c
@@ -256,12 +256,12 @@ ares_iface_ip_flags_t ares_iface_ips_get_flags(const ares_iface_ips_t *ips,
   const ares_iface_ip_t *ip;
 
   if (ips == NULL) {
-    return 0;
+    return ARES_IFACE_IP_NONE;
   }
 
   ip = ares_array_at_const(ips->ips, idx);
   if (ip == NULL) {
-    return 0;
+    return ARES_IFACE_IP_NONE;
   }
 
   return ip->flags;
@@ -376,7 +376,7 @@ static ares_status_t ares_iface_ips_enumerate(ares_iface_ips_t *ips,
 
   for (address = addresses; address != NULL; address = address->Next) {
     IP_ADAPTER_UNICAST_ADDRESS *ipaddr     = NULL;
-    ares_iface_ip_flags_t       addrflag   = 0;
+    ares_iface_ip_flags_t       addrflag   = ARES_IFACE_IP_NONE;
     char                        ifname[64] = "";
 
 #  if defined(HAVE_CONVERTINTERFACEINDEXTOLUID) && \
@@ -477,7 +477,7 @@ static ares_status_t ares_iface_ips_enumerate(ares_iface_ips_t *ips,
   }
 
   for (ifa = ifap; ifa != NULL; ifa = ifa->ifa_next) {
-    ares_iface_ip_flags_t addrflag = 0;
+    ares_iface_ip_flags_t addrflag = ARES_IFACE_IP_NONE;
     struct ares_addr      addr;
     unsigned char         netmask  = 0;
     unsigned int          ll_scope = 0;

--- a/src/lib/util/ares_iface_ips.h
+++ b/src/lib/util/ares_iface_ips.h
@@ -28,6 +28,7 @@
 
 /*! Flags for interface ip addresses. */
 typedef enum {
+  ARES_IFACE_IP_NONE      = 0,             /*!< No flags set / unspecified */
   ARES_IFACE_IP_V4 = 1 << 0,        /*!< IPv4 address. During enumeration if
                                      *   this flag is set ARES_IFACE_IP_V6
                                      *   is not, will only enumerate v4


### PR DESCRIPTION
`ares_iface_ip_flags_t` had no member with the value `0`, yet the code assigns and returns a literal `0` to that enum type in several places — `ares_iface_ips_get_flags()` error returns, and the `addrflag` accumulators during interface enumeration.

This adds an explicit `ARES_IFACE_IP_NONE = 0` member and uses it at those sites, so no out-of-enum value is used.

Note: this addresses the literal-`0` usage. The `-Wassign-enum` warning reported when OR-combining flag values is a non-standard compiler diagnostic and is not affected by this change.

Fixes #723
