### PR TITLE
ares_sysconfig_files: recognize AIX netsvc.conf bind4/local4 tokens

### DIFF
--- a/src/lib/ares_sysconfig_files.c
+++ b/src/lib/ares_sysconfig_files.c
@@ -348,12 +348,17 @@ static ares_status_t config_lookup(ares_sysconfig_t *sysconfig, ares_buf_t *buf,
     const char *value = lookups[i];
     char        ch;
 
+    /* AIX /etc/netsvc.conf uses address-family-suffixed tokens such as
+     * "bind4"/"bind6" and "local4"/"local6" in addition to the bare forms. */
     if (ares_strcaseeq(value, "dns") || ares_strcaseeq(value, "bind") ||
+        ares_strcaseeq(value, "bind4") || ares_strcaseeq(value, "bind6") ||
         ares_strcaseeq(value, "resolv") || ares_strcaseeq(value, "resolve")) {
       ch = 'b';
     } else if (ares_strcaseeq(value, "files") ||
                ares_strcaseeq(value, "file") ||
-               ares_strcaseeq(value, "local")) {
+               ares_strcaseeq(value, "local") ||
+               ares_strcaseeq(value, "local4") ||
+               ares_strcaseeq(value, "local6")) {
       ch = 'f';
     } else {
       continue;

--- a/test/ares-test-init.cc
+++ b/test/ares-test-init.cc
@@ -523,6 +523,24 @@ CONTAINED_TEST_F(LibraryTest, ContainerSvcConfInit,
   return HasFailure();
 }
 
+// AIX /etc/netsvc.conf uses address-family-suffixed tokens (bind4/bind6,
+// local4/local6).  Ensure these are recognized rather than dropped.
+NameContentList netsvcconf = {
+  {"/etc/resolv.conf", "nameserver 1.2.3.4\n"
+                       "search first.com second.com\n"},
+  {"/etc/netsvc.conf", "hosts = bind4, local4\n"}};
+CONTAINED_TEST_F(LibraryTest, ContainerNetsvcConfAIXSuffix,
+                 "myhostname", "mydomainname.org", netsvcconf) {
+  ares_channel_t *channel = nullptr;
+  EXPECT_EQ(ARES_SUCCESS, ares_init(&channel));
+
+  /* "bf" (not the default "fb") proves the bind4/local4 tokens were parsed. */
+  EXPECT_EQ(std::string("bf"), std::string(channel->lookups));
+
+  ares_destroy(channel);
+  return HasFailure();
+}
+
 NameContentList malformedresolvconflookup = {
   {"/etc/resolv.conf", "nameserver 1.2.3.4\n"
                        "lookup garbage\n"}};  // malformed line


### PR DESCRIPTION
`config_lookup()` only matched the bare `bind`/`dns`/`resolv` and `files`/`file`/`local` tokens. AIX `/etc/netsvc.conf` uses address-family-suffixed variants — `bind4`/`bind6` and `local4`/`local6` (e.g. `hosts = local, bind4`).

Those suffixed tokens fell through to the ignore branch, so a configuration like `hosts = local, bind4` recorded only the `files` source and **never attempted DNS** — the reported regression (#986).

### Change
- Match the suffixed forms in addition to the bare ones in `config_lookup()`.

### Test
Adds a container test injecting `/etc/netsvc.conf` with `hosts = bind4, local4` and asserting the resulting lookup order is `"bf"`. This differs from the default `"fb"`, so the test fails if the suffixed tokens are ignored (pre-fix) and passes only when they are parsed.

Note: the functional test is a `CONTAINED_TEST_F` (Linux user-namespace container), mirroring the existing `ContainerSvcConfInit` test — `config_lookup()` is only reached on the file-based sysconfig path (Linux/AIX/etc.); macOS and several other platforms use native config readers that bypass it, so this cannot be exercised outside the container harness.

Fixes #986
