### PR TITLE
ares_dns_parse: reject responses with more than one OPT record (RFC 6891)

### DIFF
--- a/src/lib/record/ares_dns_parse.c
+++ b/src/lib/record/ares_dns_parse.c
@@ -1690,6 +1690,22 @@ static ares_status_t ares_dns_parse_buf(ares_buf_t *buf, unsigned int flags,
     }
   }
 
+  /* RFC 6891 6.1.1: a message MUST NOT contain more than one OPT RR.  Reject
+   * any response carrying multiple OPT records in the additional section. */
+  {
+    size_t rr_cnt  = ares_dns_record_rr_cnt(*dnsrec, ARES_SECTION_ADDITIONAL);
+    size_t opt_cnt = 0;
+    size_t j;
+    for (j = 0; j < rr_cnt; j++) {
+      const ares_dns_rr_t *rr =
+        ares_dns_record_rr_get_const(*dnsrec, ARES_SECTION_ADDITIONAL, j);
+      if (ares_dns_rr_get_type(rr) == ARES_REC_TYPE_OPT && ++opt_cnt > 1) {
+        status = ARES_EBADRESP;
+        goto fail;
+      }
+    }
+  }
+
   /* Finalize rcode now that if we have OPT it is processed */
   if (!ares_dns_rcode_isvalid((*dnsrec)->raw_rcode)) {
     (*dnsrec)->rcode = ARES_RCODE_SERVFAIL;

--- a/test/ares-test-parse.cc
+++ b/test/ares-test-parse.cc
@@ -395,5 +395,33 @@ TEST_F(LibraryTest, ParseRejectsName256) {
   EXPECT_EQ(nullptr, dnsrec);
 }
 
+// A single OPT record in the additional section is valid (EDNS0).
+TEST_F(LibraryTest, ParseSingleOpt) {
+  DNSPacket pkt;
+  pkt.set_qid(0x1234).set_response()
+    .add_question(new DNSQuestion("example.com", T_A))
+    .add_additional(new DNSOptRR(0, 0, 0, 1280, {}, {}, false));
+  std::vector<byte> data = pkt.data();
+
+  ares_dns_record_t *dnsrec = NULL;
+  EXPECT_EQ(ARES_SUCCESS, ares_dns_parse(data.data(), data.size(), 0, &dnsrec));
+  EXPECT_NE(nullptr, dnsrec);
+  ares_dns_record_destroy(dnsrec);
+}
+
+// RFC 6891 6.1.1: more than one OPT record in a message is a format error.
+TEST_F(LibraryTest, ParseMultipleOptRejected) {
+  DNSPacket pkt;
+  pkt.set_qid(0x1234).set_response()
+    .add_question(new DNSQuestion("example.com", T_A))
+    .add_additional(new DNSOptRR(0, 0, 0, 1280, {}, {}, false))
+    .add_additional(new DNSOptRR(0, 0, 0, 1280, {}, {}, false));
+  std::vector<byte> data = pkt.data();
+
+  ares_dns_record_t *dnsrec = NULL;
+  EXPECT_EQ(ARES_EBADRESP, ares_dns_parse(data.data(), data.size(), 0, &dnsrec));
+  EXPECT_EQ(nullptr, dnsrec);
+}
+
 }  // namespace test
 }  // namespace ares


### PR DESCRIPTION
RFC 6891 §6.1.1 states a message MUST NOT contain more than one OPT resource record. The parser accepted any number of OPT RRs in the additional section without complaint.

### Change
After parsing the additional section in `ares_dns_parse_buf`, count the OPT records and return `ARES_EBADRESP` (format error) if more than one is present.

### Tests
- `ParseSingleOpt` — a single OPT still parses successfully (regression guard).
- `ParseMultipleOptRejected` — a response carrying two OPT records is rejected with `ARES_EBADRESP`. (Verified the test fails without the fix.)

Fixes #1137
