### PR TITLE
ares_dns_parse: reject name compression in RDATA where not permitted (RFC 3597)

### DIFF
--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -537,10 +537,15 @@ void ares_gethostbyaddr_nolock(ares_channel_t *channel, const void *addr,
  *                         ares_free()'d by the caller.
  *  \param[in] is_hostname if ARES_TRUE, will validate the character set for
  *                         a valid hostname or will return error.
+ *  \param[in] allow_compression if ARES_FALSE, a compression pointer
+ *                         encountered while parsing the name will be rejected
+ *                         with ARES_EBADNAME.  Used for RR types (e.g. SRV)
+ *                         whose RDATA names must not use name compression.
  *  \return ARES_SUCCESS on success
  */
 ares_status_t ares_dns_name_parse(ares_buf_t *buf, char **name,
-                                  ares_bool_t is_hostname);
+                                  ares_bool_t is_hostname,
+                                  ares_bool_t allow_compression);
 
 /*! Write the DNS name to the buffer in the DNS domain-name syntax as a
  *  series of labels.  The maximum domain name length is 255 characters with

--- a/src/lib/legacy/ares_expand_name.c
+++ b/src/lib/legacy/ares_expand_name.c
@@ -69,7 +69,7 @@ ares_status_t ares_expand_name_validated(const unsigned char *encoded,
   }
 
   start_len = ares_buf_len(buf);
-  status    = ares_dns_name_parse(buf, s, is_hostname);
+  status    = ares_dns_name_parse(buf, s, is_hostname, ARES_TRUE);
   if (status != ARES_SUCCESS) {
     goto done;
   }

--- a/src/lib/record/ares_dns_name.c
+++ b/src/lib/record/ares_dns_name.c
@@ -549,7 +549,8 @@ fail:
 }
 
 ares_status_t ares_dns_name_parse(ares_buf_t *buf, char **name,
-                                  ares_bool_t is_hostname)
+                                  ares_bool_t is_hostname,
+                                  ares_bool_t allow_compression)
 {
   size_t        save_offset = 0;
   unsigned char c;
@@ -607,6 +608,13 @@ ares_status_t ares_dns_name_parse(ares_buf_t *buf, char **name,
        * of the ID field, etc.
        */
       size_t offset = (size_t)((c & 0x3F) << 8);
+
+      /* Some RR types (e.g. SRV) do not permit name compression within their
+       * RDATA.  Reject a compression pointer when it is not allowed. */
+      if (!allow_compression) {
+        status = ARES_EBADNAME;
+        goto fail;
+      }
 
       /* Fetch second byte of the redirect length */
       status = ares_buf_fetch_bytes(buf, &c, 1);

--- a/src/lib/record/ares_dns_parse.c
+++ b/src/lib/record/ares_dns_parse.c
@@ -46,8 +46,14 @@ static ares_status_t ares_dns_parse_and_set_dns_name(ares_buf_t    *buf,
 {
   ares_status_t status;
   char         *name = NULL;
+  /* Only RR types defined in RFC1035 may use name compression within their
+   * RDATA (RFC3597).  Reject compression pointers for any other type (e.g.
+   * SRV per RFC2782) to match the write-side policy and avoid following
+   * pointers that a non-understanding nameserver could not have rewritten. */
+  ares_bool_t   allow_compression =
+    ares_dns_rec_allow_name_comp(ares_dns_rr_get_type(rr));
 
-  status = ares_dns_name_parse(buf, &name, is_hostname);
+  status = ares_dns_name_parse(buf, &name, is_hostname, allow_compression);
   if (status != ARES_SUCCESS) {
     return status;
   }
@@ -1399,7 +1405,7 @@ static ares_status_t ares_dns_parse_qd(ares_buf_t        *buf,
    */
 
   /* Name */
-  status = ares_dns_name_parse(buf, &name, ARES_FALSE);
+  status = ares_dns_name_parse(buf, &name, ARES_FALSE, ARES_TRUE);
   if (status != ARES_SUCCESS) {
     goto done;
   }
@@ -1470,7 +1476,7 @@ static ares_status_t ares_dns_parse_rr(ares_buf_t *buf, unsigned int flags,
    */
 
   /* Name */
-  status = ares_dns_name_parse(buf, &name, ARES_FALSE);
+  status = ares_dns_name_parse(buf, &name, ARES_FALSE, ARES_TRUE);
   if (status != ARES_SUCCESS) {
     goto done;
   }

--- a/test/ares-test-parse-srv.cc
+++ b/test/ares-test-parse-srv.cc
@@ -312,5 +312,38 @@ TEST_F(LibraryTest, ParseSrvReplyAllocFail) {
   }
 }
 
+// RFC 2782: the SRV TARGET must not use name compression.  A response whose
+// SRV target is a compression pointer must be rejected rather than followed.
+TEST_F(LibraryTest, ParseSrvRejectsCompressedTarget) {
+  const unsigned char data[] = {
+    0x12, 0x34,              // qid
+    0x84, 0x00,              // response + AA, rcode NOERROR
+    0x00, 0x01,              // qdcount
+    0x00, 0x01,              // ancount
+    0x00, 0x00,              // nscount
+    0x00, 0x00,              // arcount
+    // Question (name starts at offset 0x0c)
+    0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+    0x03, 'c', 'o', 'm',
+    0x00,
+    0x00, 0x21,              // type SRV (33)
+    0x00, 0x01,              // class IN
+    // Answer
+    0xc0, 0x0c,              // name -> pointer to example.com
+    0x00, 0x21,              // type SRV
+    0x00, 0x01,              // class IN
+    0x00, 0x00, 0x00, 0x3c,  // TTL
+    0x00, 0x08,              // rdlength
+    0x00, 0x0a,              // priority
+    0x00, 0x14,              // weight
+    0x00, 0x1e,              // port
+    0xc0, 0x0c,              // TARGET -> compression pointer (illegal for SRV)
+  };
+
+  ares_dns_record_t *dnsrec = NULL;
+  EXPECT_EQ(ARES_EBADNAME, ares_dns_parse(data, sizeof(data), 0, &dnsrec));
+  EXPECT_EQ(nullptr, dnsrec);
+}
+
 }  // namespace test
 }  // namespace ares

--- a/test/ares-test-parse.cc
+++ b/test/ares-test-parse.cc
@@ -423,5 +423,37 @@ TEST_F(LibraryTest, ParseMultipleOptRejected) {
   EXPECT_EQ(nullptr, dnsrec);
 }
 
+// RFC 3597: only RR types defined in RFC 1035 may use name compression within
+// their RDATA.  A modern type such as SVCB must reject a compressed target,
+// same as SRV -- this exercises the shared policy, not an SRV special case.
+TEST_F(LibraryTest, ParseSvcbRejectsCompressedTarget) {
+  const unsigned char data[] = {
+    0x12, 0x34,              // qid
+    0x84, 0x00,              // response + AA
+    0x00, 0x01,              // qdcount
+    0x00, 0x01,              // ancount
+    0x00, 0x00,              // nscount
+    0x00, 0x00,              // arcount
+    // Question (name at offset 0x0c)
+    0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+    0x03, 'c', 'o', 'm',
+    0x00,
+    0x00, 0x40,              // type SVCB (64)
+    0x00, 0x01,              // class IN
+    // Answer
+    0xc0, 0x0c,              // name -> pointer to example.com
+    0x00, 0x40,              // type SVCB
+    0x00, 0x01,              // class IN
+    0x00, 0x00, 0x00, 0x3c,  // TTL
+    0x00, 0x04,              // rdlength
+    0x00, 0x01,              // SvcPriority
+    0xc0, 0x0c,              // TargetName -> compression pointer (illegal)
+  };
+
+  ares_dns_record_t *dnsrec = NULL;
+  EXPECT_EQ(ARES_EBADNAME, ares_dns_parse(data, sizeof(data), 0, &dnsrec));
+  EXPECT_EQ(nullptr, dnsrec);
+}
+
 }  // namespace test
 }  // namespace ares


### PR DESCRIPTION
`ares_dns_name_parse()` unconditionally followed DNS name-compression pointers, even for RR types whose RDATA names may not use compression. Per RFC 3597, only the RR types defined in RFC 1035 may use name compression within their RDATA; other types (e.g. SRV per RFC 2782, and NAPTR, SVCB, HTTPS, SIG, RRSIG, NSEC, …) must not. c-ares would instead silently follow the pointer (#1181).

### Change
- Add an `allow_compression` argument to `ares_dns_name_parse()`. When `ARES_FALSE`, a compression pointer encountered while parsing the name is rejected with `ARES_EBADNAME`.
- The RDATA name parser (`ares_dns_parse_and_set_dns_name`) derives this from the existing **`ares_dns_rec_allow_name_comp()`** policy keyed on the record type — the same function the write side already uses. So parse and write behavior now match and cannot drift, and the restriction applies uniformly to **all** RR types where compression is not permitted, not just SRV.
- Owner-name parsing (question + RR owner names) and `ares_expand_name()` continue to allow compression (`ARES_TRUE`).

### Tests
- `ParseSrvRejectsCompressedTarget` — SRV target that is a compression pointer is rejected.
- `ParseSvcbRejectsCompressedTarget` — same for a SVCB target, exercising the shared policy rather than an SRV special case.

Both verified to fail before the change (they previously parsed successfully by following the pointer). All existing SRV/SOA/MX/CNAME/NS parsing (RFC 1035 types, which legitimately use compression) still passes — full local test suite green.

Fixes #1181
