### PR TITLE
Fix sticky server recovery when all servers have failures

### DIFF
--- a/src/lib/ares_init.c
+++ b/src/lib/ares_init.c
@@ -102,6 +102,20 @@ static int server_sort_cb(const void *data1, const void *data2)
   if (s1->consec_failures > s2->consec_failures) {
     return 1;
   }
+
+  /* Among servers with the same failure count, prefer the one that failed
+   * least recently so that a server that went down long ago (and may have
+   * since recovered) is tried before one that just failed.  This also keeps
+   * retries rotating across servers once the failure counts saturate at
+   * SERVER_CONSEC_FAILURES_CAP.  Healthy servers all have a zeroed retry
+   * time and fall through to configuration order. */
+  if (s1->next_retry_time.sec != s2->next_retry_time.sec) {
+    return s1->next_retry_time.sec < s2->next_retry_time.sec ? -1 : 1;
+  }
+  if (s1->next_retry_time.usec != s2->next_retry_time.usec) {
+    return s1->next_retry_time.usec < s2->next_retry_time.usec ? -1 : 1;
+  }
+
   if (s1->idx < s2->idx) {
     return -1;
   }

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -131,6 +131,13 @@ W32_FUNC const char *_w32_GetHostsFile(void);
 #define DEFAULT_SERVER_RETRY_CHANCE 10
 #define DEFAULT_SERVER_RETRY_DELAY  5000
 
+/* Upper bound on the consecutive failure count tracked per server.  Only the
+ * relative order of the counts is used for server selection, so magnitude
+ * beyond "clearly down" carries no additional signal.  Capping it bounds how
+ * long a server that failed for an extended period sorts behind other failed
+ * servers once it comes back online. */
+#define SERVER_CONSEC_FAILURES_CAP 16
+
 struct ares_query;
 typedef struct ares_query ares_query_t;
 

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -123,12 +123,21 @@ static void server_increment_failures(ares_server_t *server,
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  server->consec_failures++;
-  ares_slist_node_reinsert(node);
+  /* Cap the failure count.  Only the relative order matters for server
+   * selection, and an uncapped count would require an unbounded number of
+   * failures on other servers before a server that failed during an
+   * extended outage could be selected again. */
+  if (server->consec_failures < SERVER_CONSEC_FAILURES_CAP) {
+    server->consec_failures++;
+  }
 
+  /* Must update the retry time before reinserting since the sort uses it to
+   * order servers with the same failure count */
   ares_tvnow(&next_retry_time);
   ares_timeval_add(&next_retry_time, channel->server_retry_delay);
   server->next_retry_time = next_retry_time;
+
+  ares_slist_node_reinsert(node);
 
   invoke_server_state_cb(server, ARES_FALSE,
                          used_tcp == ARES_TRUE ? ARES_SERV_STATE_TCP
@@ -147,11 +156,12 @@ static void server_set_good(ares_server_t *server, ares_bool_t used_tcp)
 
   if (server->consec_failures > 0) {
     server->consec_failures = 0;
+    /* Must update the retry time before reinserting since the sort uses it
+     * to order servers with the same failure count */
+    server->next_retry_time.sec  = 0;
+    server->next_retry_time.usec = 0;
     ares_slist_node_reinsert(node);
   }
-
-  server->next_retry_time.sec  = 0;
-  server->next_retry_time.usec = 0;
 
   invoke_server_state_cb(server, ARES_TRUE,
                          used_tcp == ARES_TRUE ? ARES_SERV_STATE_TCP
@@ -1128,22 +1138,23 @@ static void ares_probe_failed_server(ares_channel_t      *channel,
   }
 
   /* Select the first server with failures to retry that has passed the retry
-   * timeout and doesn't already have a pending probe */
+   * timeout and doesn't already have a pending probe.  Skip the server the
+   * triggering query was just sent to since that query is already exercising
+   * it. */
   ares_tvnow(&now);
   for (node = ares_slist_node_first(channel->servers); node != NULL;
        node = ares_slist_node_next(node)) {
     ares_server_t *node_val = ares_slist_node_val(node);
-    if (node_val != NULL && node_val->consec_failures > 0 &&
-        !node_val->probe_pending &&
+    if (node_val != NULL && node_val != server &&
+        node_val->consec_failures > 0 && !node_val->probe_pending &&
         ares_timedout(&now, &node_val->next_retry_time)) {
       probe_server = node_val;
       break;
     }
   }
 
-  /* Either nothing to probe or the query was enqueud to the same server
-   * we were going to probe. Do nothing. */
-  if (probe_server == NULL || server == probe_server) {
+  /* Nothing to probe */
+  if (probe_server == NULL) {
     return;
   }
 
@@ -1321,10 +1332,12 @@ ares_status_t ares_send_query(ares_server_t *requested_server,
     return ARES_ENOSERVER;
   }
 
-  /* If a query is directed to a specific query, or the server chosen has
-   * failures, or the query is being retried, don't probe for downed servers */
-  if (requested_server != NULL || server->consec_failures > 0 ||
-      query->try_count != 0) {
+  /* If a query is directed to a specific server, or the query is being
+   * retried, don't probe for downed servers.  Note that the chosen server
+   * having failures itself does NOT disable probing: when every server has
+   * failures (e.g. during an extended outage), probes are the only way a
+   * recovered server that sorts behind the current best can be noticed. */
+  if (requested_server != NULL || query->try_count != 0) {
     probe_downed_server = ARES_FALSE;
   }
 

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -2647,6 +2647,178 @@ TEST_P(ServerFailoverOptsMultiMockTest, ProbeAfterProbeTimeout) {
   EXPECT_TRUE(result3.done_);
 }
 
+class ServerRecoveryMultiMockTest
+  : public MockChannelOptsTest,
+    public ::testing::WithParamInterface< std::pair<int, bool> > {
+ public:
+  ServerRecoveryMultiMockTest()
+    : MockChannelOptsTest(2, GetParam().first, GetParam().second, false,
+                          FillOptions(&opts_),
+                          ARES_OPT_SERVER_FAILOVER | ARES_OPT_NOROTATE) {}
+
+  static struct ares_options* FillOptions(struct ares_options *opts) {
+    memset(opts, 0, sizeof(struct ares_options));
+    opts->server_failover_opts.retry_chance = 1;
+    opts->server_failover_opts.retry_delay = SERVER_FAILOVER_RETRY_DELAY;
+    return opts;
+  }
+ private:
+  struct ares_options opts_;
+};
+
+// Test that when every server has failures, a query sent to a failed server
+// still spawns a probe of another failed server.  Without this, a server
+// that recovers from an extended outage while another (better-sorted) server
+// is still failing is never noticed until the failure counts catch up
+// ("sticky recovery").
+TEST_P(ServerRecoveryMultiMockTest, StickyRecoveryProbe) {
+  DNSPacket servfailrsp;
+  servfailrsp.set_response().set_aa().set_rcode(SERVFAIL)
+    .add_question(new DNSQuestion("www.example.com", T_A));
+  DNSPacket okrsp;
+  okrsp.set_response().set_aa()
+    .add_question(new DNSQuestion("www.example.com", T_A))
+    .add_answer(new DNSARR("www.example.com", 100, {2,3,4,5}));
+  unsigned int delay_ms = SERVER_FAILOVER_RETRY_DELAY +
+                          (SERVER_FAILOVER_RETRY_DELAY / 10);
+
+  // Fail all attempts of the first query so both servers end up failed.
+  // Attempts alternate between the servers as each failure re-sorts the
+  // list, so each server sees 3 requests (2 servers x 3 tries).  No probes
+  // are spawned: retries never probe, and the initial attempt is sent while
+  // all servers are still healthy.
+  EXPECT_CALL(*servers_[0], OnRequest("www.example.com", T_A))
+    .WillOnce(SetReply(servers_[0].get(), &servfailrsp))
+    .WillOnce(SetReply(servers_[0].get(), &servfailrsp))
+    .WillOnce(SetReply(servers_[0].get(), &servfailrsp));
+  EXPECT_CALL(*servers_[1], OnRequest("www.example.com", T_A))
+    .WillOnce(SetReply(servers_[1].get(), &servfailrsp))
+    .WillOnce(SetReply(servers_[1].get(), &servfailrsp))
+    .WillOnce(SetReply(servers_[1].get(), &servfailrsp));
+  HostResult result1;
+  ares_gethostbyname(channel_, "www.example.com.", AF_INET, HostCallback,
+                     &result1);
+  Process();
+  EXPECT_TRUE(result1.done_);
+  EXPECT_EQ(ARES_ESERVFAIL, result1.status_);
+
+  // Sleep past the retry delay so both servers are eligible for probing.
+  ares_sleep_time(delay_ms);
+
+  // Server #0 recovers.  The query is sent to server #0 (both servers have
+  // equal failure counts and #0 failed least recently).  Even though the
+  // chosen server has failures, a probe must be spawned to the other failed
+  // server (#1), which is still down.
+  EXPECT_CALL(*servers_[0], OnRequest("www.example.com", T_A))
+    .WillOnce(SetReply(servers_[0].get(), &okrsp));
+  EXPECT_CALL(*servers_[1], OnRequest("www.example.com", T_A))
+    .WillOnce(SetReply(servers_[1].get(), &servfailrsp));
+  HostResult result2;
+  ares_gethostbyname(channel_, "www.example.com.", AF_INET, HostCallback,
+                     &result2);
+  Process();
+  EXPECT_TRUE(result2.done_);
+  EXPECT_EQ(ARES_SUCCESS, result2.status_);
+
+  // Sleep past the retry delay again so server #1 is once more eligible for
+  // probing.
+  ares_sleep_time(delay_ms);
+
+  // Server #1 has now recovered.  The query goes to healthy server #0 and a
+  // probe is spawned to server #1 which succeeds, marking it healthy again.
+  EXPECT_CALL(*servers_[0], OnRequest("www.example.com", T_A))
+    .WillOnce(SetReply(servers_[0].get(), &okrsp));
+  EXPECT_CALL(*servers_[1], OnRequest("www.example.com", T_A))
+    .WillOnce(SetReply(servers_[1].get(), &okrsp));
+  HostResult result3;
+  ares_gethostbyname(channel_, "www.example.com.", AF_INET, HostCallback,
+                     &result3);
+  Process();
+  EXPECT_TRUE(result3.done_);
+  EXPECT_EQ(ARES_SUCCESS, result3.status_);
+}
+
+class ServerRecoveryNoProbeMultiMockTest
+  : public MockChannelOptsTest,
+    public ::testing::WithParamInterface< std::pair<int, bool> > {
+ public:
+  ServerRecoveryNoProbeMultiMockTest()
+    : MockChannelOptsTest(2, GetParam().first, GetParam().second, false,
+                          FillOptions(&opts_),
+                          ARES_OPT_SERVER_FAILOVER | ARES_OPT_NOROTATE) {}
+
+  static struct ares_options* FillOptions(struct ares_options *opts) {
+    memset(opts, 0, sizeof(struct ares_options));
+    // Probing disabled: recovery must come from server selection alone
+    opts->server_failover_opts.retry_chance = 0;
+    opts->server_failover_opts.retry_delay = SERVER_FAILOVER_RETRY_DELAY;
+    return opts;
+  }
+ private:
+  struct ares_options opts_;
+};
+
+// Test that with probing disabled, a server whose failure count went stale
+// during an outage is still retried once an actively-failing server reaches
+// the same count: servers with equal failure counts are tried
+// least-recently-failed first rather than in configuration order.
+TEST_P(ServerRecoveryNoProbeMultiMockTest, StickyRecoveryTieBreak) {
+  DNSPacket servfailrsp;
+  servfailrsp.set_response().set_aa().set_rcode(SERVFAIL)
+    .add_question(new DNSQuestion("www.example.com", T_A));
+  DNSPacket okrsp;
+  okrsp.set_response().set_aa()
+    .add_question(new DNSQuestion("www.example.com", T_A))
+    .add_answer(new DNSARR("www.example.com", 100, {2,3,4,5}));
+
+  // Fail all attempts of the first query so both servers end up failed with
+  // a failure count of 3 (2 servers x 3 tries, alternating).
+  EXPECT_CALL(*servers_[0], OnRequest("www.example.com", T_A))
+    .WillOnce(SetReply(servers_[0].get(), &servfailrsp))
+    .WillOnce(SetReply(servers_[0].get(), &servfailrsp))
+    .WillOnce(SetReply(servers_[0].get(), &servfailrsp));
+  EXPECT_CALL(*servers_[1], OnRequest("www.example.com", T_A))
+    .WillOnce(SetReply(servers_[1].get(), &servfailrsp))
+    .WillOnce(SetReply(servers_[1].get(), &servfailrsp))
+    .WillOnce(SetReply(servers_[1].get(), &servfailrsp));
+  HostResult result1;
+  ares_gethostbyname(channel_, "www.example.com.", AF_INET, HostCallback,
+                     &result1);
+  Process();
+  EXPECT_TRUE(result1.done_);
+  EXPECT_EQ(ARES_ESERVFAIL, result1.status_);
+
+  // Server #0 recovers briefly: the next query succeeds and resets its
+  // failure count, while server #1 stays failed with its count frozen at 3.
+  EXPECT_CALL(*servers_[0], OnRequest("www.example.com", T_A))
+    .WillOnce(SetReply(servers_[0].get(), &okrsp));
+  HostResult result2;
+  ares_gethostbyname(channel_, "www.example.com.", AF_INET, HostCallback,
+                     &result2);
+  Process();
+  EXPECT_TRUE(result2.done_);
+  EXPECT_EQ(ARES_SUCCESS, result2.status_);
+
+  // Server #0 starts failing again while server #1 has (unnoticed)
+  // recovered.  The query retries server #0 until its failure count catches
+  // up to server #1's stale count of 3.  At that point server #1 must sort
+  // first (it failed least recently) and answer successfully.  Without the
+  // tie-break the remaining attempts would all go to server #0 and the query
+  // would fail without server #1 ever being tried.
+  EXPECT_CALL(*servers_[0], OnRequest("www.example.com", T_A))
+    .WillOnce(SetReply(servers_[0].get(), &servfailrsp))
+    .WillOnce(SetReply(servers_[0].get(), &servfailrsp))
+    .WillOnce(SetReply(servers_[0].get(), &servfailrsp));
+  EXPECT_CALL(*servers_[1], OnRequest("www.example.com", T_A))
+    .WillOnce(SetReply(servers_[1].get(), &okrsp));
+  HostResult result3;
+  ares_gethostbyname(channel_, "www.example.com.", AF_INET, HostCallback,
+                     &result3);
+  Process();
+  EXPECT_TRUE(result3.done_);
+  EXPECT_EQ(ARES_SUCCESS, result3.status_);
+}
+
 const char *af_tostr(int af)
 {
   switch (af) {
@@ -2706,6 +2878,10 @@ INSTANTIATE_TEST_SUITE_P(AddressFamilies, MockEDNSChannelTest, ::testing::Values
 INSTANTIATE_TEST_SUITE_P(TransportModes, NoRotateMultiMockTest, ::testing::ValuesIn(ares::test::families_modes), PrintFamilyMode);
 
 INSTANTIATE_TEST_SUITE_P(TransportModes, ServerFailoverOptsMultiMockTest, ::testing::ValuesIn(ares::test::families_modes), PrintFamilyMode);
+
+INSTANTIATE_TEST_SUITE_P(TransportModes, ServerRecoveryMultiMockTest, ::testing::ValuesIn(ares::test::families_modes), PrintFamilyMode);
+
+INSTANTIATE_TEST_SUITE_P(TransportModes, ServerRecoveryNoProbeMultiMockTest, ::testing::ValuesIn(ares::test::families_modes), PrintFamilyMode);
 
 }  // namespace test
 }  // namespace ares


### PR DESCRIPTION
## Problem

In the review discussion on #992, @DavidMcNallyAlianza and @Flynnzaa identified a failure mode they named **"sticky recovery"**: when every configured server is failing, a server that recovers from an extended outage can go unnoticed for an unbounded amount of time. Credit to them for the analysis and the timeline diagram that made this concrete.

Their scenario (2 servers, 1 qps): both servers fail for 10 minutes (both counters reach 600). Server A briefly recovers — resetting its counter to 0 — then starts failing again, while server B's counter stays frozen at 600 because no traffic reaches it. When B actually recovers moments later, nothing notices: all queries keep going to A (count ~60 and climbing) until A's counter climbs past B's frozen 600. That's ~9 minutes of avoidable downtime in their example, and in general the blindness window scales with the length of the original outage, at any query rate.

Two root causes in the current code:

1. **Probing is gated off exactly when it's needed most.** `ares_send_query()` only considers spawning a probe when the triggering query was sent to a server with *no* failures. During a total outage every query necessarily goes to a failed server, so no probes are ever sent, and the "auto-rotate on each attempt" property of the sorted server list only holds while failure counts stay within ±1 of each other — a recovery blip breaks that symmetry permanently.
2. **The consecutive-failure count is unbounded and freezes when traffic stops.** Only the *relative order* of the counts is used for selection, so magnitude beyond "clearly down" carries no signal — but a huge frozen count means an equally huge number of failures elsewhere before the server is ever consulted again.

## Fix (three small changes, no new state, no new options)

1. **Relax the probe trigger** (`ares_process.c`): a fresh query sent to a failed server can now spawn a probe of a *different* failed server; the probe-selection scan skips the triggering server since the query itself already exercises it. All existing throttles are unchanged (1-in-`retry_chance` dice, per-server `next_retry_time` cooldown, `probe_pending` single-flight), so probe load remains bounded during an outage. In the scenario above, B now gets probed within ~`retry_chance` queries of recovering (~10s at 1 qps with defaults) instead of ~9 minutes.
2. **Cap `consec_failures` at 16** (`SERVER_CONSEC_FAILURES_CAP`): bounds how far a stale counter can diverge, as a backstop for configurations where probing is disabled.
3. **Break sort ties by `next_retry_time`** (`ares_init.c`): among servers with equal failure counts, the least-recently-failed sorts first. This keeps retries rotating across servers once counts saturate at the cap (previously the `idx` tiebreak would pin all retries to the lowest-index server), and it means a stale failed server — which may have silently recovered — is retried before one that just failed. This resolves the sticky-recovery scenario even with probing disabled (`retry_chance = 0`). Healthy servers all have a zeroed retry time and continue to be used in configuration order, so behavior with no failures is unchanged.

`server_increment_failures()`/`server_set_good()` now update `next_retry_time` *before* reinserting into the sorted list, since the sort depends on it.

## Tests

Two new mock tests, both verified to **fail against the previous code** and pass with this change:

- `ServerRecoveryMultiMockTest.StickyRecoveryProbe` — all servers fail; a query to a still-failed server must spawn a probe of the other failed server, which is how its later recovery is detected.
- `ServerRecoveryNoProbeMultiMockTest.StickyRecoveryTieBreak` — probing disabled; after a recovery blip on server 0, a query's retries must reach the stale-failed (recovered) server 1 once the counts tie, rather than burning every attempt on server 0.

The existing `ServerFailoverOpts` and `ProbeAfterProbeTimeout` tests pass unchanged, as do the broader mock suites (120 tests run locally, CMake+Ninja, no new warnings, clang-format clean on changed lines).

## Relation to #992

This addresses the "sticky recovery" concern (concern 1 of 3) from that discussion in isolation, since it's a bug in current behavior independent of the rise/fall threshold feature. The rise/fall thresholds (#987) and the per-request retry-distribution question (concerns 2/3) remain under discussion in #992 — notably, once rise thresholds exist, the probe path here is what delivers the N consecutive successes a recovered server needs, so the two changes compose.
