### PR TITLE
ci: pin GitHub Actions to SHAs and add Dependabot with auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Copyright (C) The c-ares project and its contributors
+# SPDX-License-Identifier: MIT
+#
+# c-ares has no external build/runtime dependencies to track, so the only
+# ecosystem Dependabot manages here is our GitHub Actions.  It keeps the
+# SHA-pinned actions (and their "# vX.Y.Z" comments) current.  All bumps are
+# grouped into a single monthly PR; a companion workflow
+# (.github/workflows/dependabot-automerge.yml) enables auto-merge so they land
+# automatically once the required "All Checks" status passes.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    # Don't bump to a release until it has been public for a week.  Since these
+    # PRs auto-merge, this avoids automatically pulling in a just-published
+    # (possibly compromised or quickly-yanked) action version.  github-actions
+    # only supports default-days (not the semver-* granular fields).
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+    open-pull-requests-limit: 5

--- a/.github/workflows/alpine-latest.yml
+++ b/.github/workflows/alpine-latest.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           apk add bash cmake samurai gtest-dev autoconf autoconf-archive automake libtool pkgconf make clang clang-analyzer compiler-rt lldb gcc g++ valgrind gdb sudo
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: "Make sure TCP FastOpen is enabled"
         run: |
           sudo sysctl -w net.ipv4.tcp_fastopen=3

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,14 +19,14 @@ jobs:
     name: "Android"
     steps:
       - name: Install packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: cmake ninja-build autoconf automake libtool pkg-config
           version: 1.0
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup NDK
-        uses: nttld/setup-ndk@v1
+        uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779 # v1.6.0
         id: setup-ndk
         with:
           ndk-version: r21e

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.BACKPORT_APP_ID }}
           private-key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}
@@ -104,13 +104,13 @@ jobs:
           echo "automerge=${automerge}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Create backport pull requests
-        uses: korthout/backport-action@v4
+        uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0
         with:
           github_token:       ${{ steps.app-token.outputs.token }}
           source_pr_number:   ${{ github.event.issue.number }}

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -37,7 +37,7 @@ jobs:
           yum install -y gcc gcc-c++ make autoconf automake libtool cmake3 git ninja-build gdb
           ln -sf /usr/bin/cmake3 /usr/bin/cmake
       - name: Checkout c-ares
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
       - name: Build GoogleTest
         # GoogleTest v1.10 doesn't require c++14
         run: |

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install latest stable clang-format from apt.llvm.org
         run: |

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -24,7 +24,7 @@ jobs:
     name: Codespell
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: install
         run: |

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -12,8 +12,8 @@ jobs:
     # https://www.reddit.com/r/cpp_questions/comments/1ewnv8d/lcov_geninfo_error/
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: lcov libgmock-dev ninja-build
           version: 1.0
@@ -34,7 +34,7 @@ jobs:
           cd build
           ninja coverage
       - name: Upload to Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           path-to-lcov: ${{runner.workspace}}/c-ares/build/coverage.info
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -18,7 +18,7 @@ jobs:
     name: Coverity
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: apt dependencies
         run: sudo apt-get install cmake ninja-build
       - name: Download Coverity Build Tool

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,27 @@
+# Copyright (C) The c-ares project and its contributors
+# SPDX-License-Identifier: MIT
+#
+# Enables GitHub's native auto-merge on Dependabot pull requests.  The PR then
+# merges by itself once the required "All Checks" status passes.  main does not
+# require a review, so no approval step is needed.  Uses only the built-in
+# GITHUB_TOKEN (no external actions, nothing to pin).
+
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    # Only act on PRs opened by Dependabot.
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "${PR_URL}"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/djgpp.yml
+++ b/.github/workflows/djgpp.yml
@@ -18,9 +18,9 @@ jobs:
         run: |
           choco install --yes make
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Checkout Watt-32
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: gvanem/Watt-32
           path: watt-32

--- a/.github/workflows/fedora-latest.yml
+++ b/.github/workflows/fedora-latest.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           yum install -y gcc gcc-c++ make autoconf automake libtool cmake git ninja-build gdb curl wget gtest-devel gmock-devel pkgconf clang clang-tools-extra clang-analyzer lldb gdb valgrind procps
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: "Make sure TCP FastOpen is enabled"
         run: |
           sudo sysctl -w net.ipv4.tcp_fastopen=3

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -25,7 +25,7 @@ jobs:
           brew uninstall cmake || true
           brew install cmake googletest llvm autoconf automake libtool make ninja
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: "CMake: build and test c-ares"
         env:
           BUILD_TYPE: CMAKE

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,7 @@ jobs:
           brew uninstall cmake || true
           brew install cmake googletest llvm autoconf automake libtool make ninja
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: "Make sure TCP FastOpen is enabled"
         run: sudo sysctl net.inet.tcp.fastopen=3
       - name: "CMake: build and test c-ares"

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -32,7 +32,7 @@ jobs:
     name: ${{ matrix.msystem }}
     steps:
       - name: Install MSYS2 and base packages
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
           msystem: ${{ matrix.msystem }}
           update: true
@@ -49,7 +49,7 @@ jobs:
             mingw-w64-${{ matrix.env }}-gdb
             ${{ matrix.extra_packages }}
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: "CMake: build and test c-ares"
         env:
           BUILD_TYPE: CMAKE

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     name: NetBSD
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Test
-        uses: cross-platform-actions/action@v0.24.0
+        uses: cross-platform-actions/action@b2e15da1e667187766fff4945d20b98ac7055576 # v0.24.0
         env:
           DIST: NETBSD
           BUILD_TYPE: "cmake"

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     name: OpenBSD
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Test
-        uses: cross-platform-actions/action@v0.24.0
+        uses: cross-platform-actions/action@b2e15da1e667187766fff4945d20b98ac7055576 # v0.24.0
         env:
           DIST: OPENBSD
           BUILD_TYPE: "cmake"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -24,12 +24,12 @@ jobs:
     name: "build"
     steps:
       - name: Install packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: autoconf automake libtool g++ libgmock-dev pkg-config gdb
           version: 1.0
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Get Tag version
         id: version
         run: |
@@ -44,7 +44,7 @@ jobs:
           ./configure
           make dist
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: "c-ares-src-tarball"
           path: 'c-ares-*.tar.gz'
@@ -52,7 +52,7 @@ jobs:
           overwrite: true
           retention-days: 7
       - name: Upload Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           body_path: RELEASE-NOTES.md
@@ -93,11 +93,11 @@ jobs:
       contents: write # To add assets to a release.
     steps:
       - name: Download the provenance
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{needs.provenance.outputs.provenance-name}}
       - name: Upload Provenance to Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         if: startsWith(github.ref, 'refs/tags/')
         id: upload-provenance
         with:

--- a/.github/workflows/qnx.yml
+++ b/.github/workflows/qnx.yml
@@ -21,7 +21,7 @@ jobs:
     name: "QNX"
     steps:
       - name: Install packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: cmake ninja-build autoconf automake libtool qemu-user qemu-system-x86 qemu-utils bridge-utils net-tools libvirt-clients libvirt-daemon-system
           version: 1.0
@@ -67,12 +67,12 @@ jobs:
           echo "Downloading QNX SDP ..."
           retry ${{ github.workspace }}/qnxinstall/qnxsoftwarecenter/qnxsoftwarecenter_clt -mirror -cleanInstall -destination ${{ github.workspace }}/qnx800 -installBaseline com.qnx.qnx800 -myqnx.user="$QNX_USER" -myqnx.password="$QNX_PASSWORD"
       - name: Checkout qnx-ports build-files
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: qnx-ports/build-files
           path: build-files
       - name: Checkout qnx-ports googletest
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: qnx-ports/googletest
           path: googletest
@@ -82,7 +82,7 @@ jobs:
           env
           make -C build-files/ports/googletest PREFIX=usr install -j$(nproc)
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: c-ares
       - name: Set CMAKE_FIND_ROOT_PATH

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     name: REUSE compliance
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v1
+      uses: fsfe/reuse-action@28cf8f33bc50f4c306f52e38fe3826717dea63dc # v1.3.0

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -22,10 +22,10 @@ jobs:
       TEST_FILTER: "--gtest_filter=-*Live*"
       TEST_DEBUGGER: "gdb"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Solaris Build and Test
         id: solaris
-        uses: vmactions/solaris-vm@v1
+        uses: vmactions/solaris-vm@d30dd6c228c8661ade859e36ead7660b9a62efcc # v1.3.7
         with:
           envs: 'DIST BUILD_TYPE CMAKE_FLAGS CMAKE_TEST_FLAGS TEST_FILTER CXXFLAGS TEST_DEBUGGER'
           usesh: true

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -20,12 +20,12 @@ jobs:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     name: "SonarCloud: Build and analyze"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: "SonarCloud: Install Build-Wrapper"
-        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v7
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # v7.2.1
+      - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: libgmock-dev
           version: 1.0
@@ -35,7 +35,7 @@ jobs:
           cmake -DCARES_BUILD_TESTS=ON -S . -B build
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/ --config Release
       - name: "SonareCloud: Scan"
-        uses: SonarSource/sonarqube-scan-action@v7
+        uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # v7.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -31,7 +31,7 @@ jobs:
           apt-get dist-upgrade -y --assume-yes
           apt-get install -y --assume-yes sudo curl wget cmake ninja-build autoconf automake libtool g++ libgmock-dev pkg-config clang clang-tools lldb gdb valgrind
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: "Make sure TCP FastOpen is enabled"
         run: |
           sudo sysctl -w net.ipv4.tcp_fastopen=3

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -20,12 +20,12 @@ jobs:
     name: "Ubuntu (latest)"
     steps:
       - name: Install packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: cmake ninja-build autoconf automake libtool g++ libgmock-dev pkg-config clang clang-tools lldb gdb valgrind
           version: 1.0
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: "Make sure TCP FastOpen is enabled"
         run: |
           sudo sysctl -w net.ipv4.tcp_fastopen=3

--- a/.github/workflows/uwp.yml
+++ b/.github/workflows/uwp.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: windows-latest
     name: Windows UWP (Store)
     steps:
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
           arch: x64
           uwp: true
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Build c-ares
         run: |
           mkdir build

--- a/.github/workflows/watcom.yml
+++ b/.github/workflows/watcom.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: windows-latest
     name: OpenWatcom
     steps:
-      - uses: open-watcom/setup-watcom@v0
+      - uses: open-watcom/setup-watcom@7ef247f4cdd25d29b7757ae9908655d253d3e13c # v0
       - name: Checkout Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: configure
         run: buildconf.bat
         shell: cmd

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -16,13 +16,13 @@ jobs:
     env:
       WATT_ROOT: "${{ github.workspace }}\\watt-32"
     steps:
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
           arch: x86
       - name: Checkout c-ares
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Checkout Watt-32
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: gvanem/Watt-32
           path: watt-32


### PR DESCRIPTION
Pins all third-party GitHub Actions to immutable commit SHAs and sets up Dependabot to keep them current, with grouped monthly PRs that auto-merge on green.

## What's here

**1. SHA-pin every action** (`@<sha> # vX.Y.Z`). This converts the remaining floating tag refs and — more importantly — the two **mutable** refs (`coverallsapp/github-action@master`, `awalsh128/cache-apt-pkgs-action@latest`) to immutable digests, closing the supply-chain gap where a moved tag/branch could inject code into CI.

Two references are intentionally left unpinned:
- `poseidon/wait-for-status-checks` — already SHA-pinned.
- `slsa-framework/slsa-github-generator` — **must** be referenced by a full `@vX.Y.Z` tag; `slsa-verifier` can't verify a hash-pinned trusted reusable workflow ([slsa-verifier#12](https://github.com/slsa-framework/slsa-verifier/issues/12)). Stays at `@v2.0.0`; Dependabot will still bump the tag.

**2. `.github/dependabot.yml`** — one grouped, **monthly** PR for all `github-actions` updates (the only ecosystem c-ares has to track). Keeps the SHAs *and* the `# vX.Y.Z` comments current. A **7-day `cooldown`** (`default-days: 7`) means a release must be public for a week before it's auto-merged — a supply-chain safety window since these PRs merge automatically. (github-actions only supports `default-days`, not the semver-granular cooldown fields.)

**3. `.github/workflows/dependabot-automerge.yml`** — enables GitHub-native auto-merge on Dependabot PRs so grouped bumps land automatically once the required **All Checks** status passes. `main` requires no review, so no approval step is needed; uses only the built-in `GITHUB_TOKEN` (no external actions to pin).

## Notes
- Auto-merge is already permitted on the repo (`allow_auto_merge` is on) and squash is enabled, so the workflow uses `--squash`.
- The single required **All Checks** aggregator means an actions-only PR still runs full CI and only merges green — no path-filter deadlock.
- Trade-off left as-is per request: **all** bumps grouped into one auto-merged PR. If you'd rather not let a breaking *major* block the batch, split majors into their own non-automerged group later.

Activation steps (and ordering) are in the follow-up comment / handed off separately.
