### PR TITLE
Fix recursive retry dispatch in ares_requeue_query()

### DIFF
--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -65,6 +65,10 @@ static void        end_query(ares_channel_t *channel, ares_server_t *server,
                              ares_query_t *query, ares_status_t status,
                              ares_dns_record_t *dnsrec,
                              ares_array_t **requeue);
+static ares_status_t ares_send_query_int(ares_server_t *requested_server,
+                                         ares_query_t *query,
+                                         const ares_timeval_t *now,
+                                         ares_array_t **requeue);
 
 static void        ares_query_remove_from_conn(ares_query_t *query)
 {
@@ -586,6 +590,53 @@ static ares_status_t ares_append_endqueue(ares_array_t     **requeue,
     dnsrec);
 }
 
+static ares_status_t ares_flush_requeue(ares_channel_t *channel,
+                                        ares_array_t **requeue,
+                                        const ares_timeval_t *now,
+                                        ares_status_t status)
+{
+  if (requeue == NULL || *requeue == NULL) {
+    return status;
+  }
+
+  while (ares_array_len(*requeue) > 0) {
+    ares_query_t  *query;
+    ares_requeue_t entry;
+    ares_status_t  internal_status;
+
+    internal_status = ares_array_claim_at(&entry, sizeof(entry), *requeue, 0);
+    if (internal_status != ARES_SUCCESS) {
+      break;
+    }
+
+    query = ares_htable_szvp_get_direct(channel->queries_by_qid, entry.qid);
+
+    if (entry.type == REQUEUE_REQUEUE) {
+      /* query disappeared */
+      if (query == NULL) {
+        continue;
+      }
+      internal_status = ares_send_query_int(entry.server, query, now, requeue);
+      /* We only care about ARES_ENOMEM */
+      if (internal_status == ARES_ENOMEM) {
+        status = ARES_ENOMEM;
+      }
+    } else { /* REQUEUE_ENDQUERY */
+      if (query != NULL) {
+        query->callback(query->arg, entry.status, query->timeouts, entry.dnsrec);
+        ares_free_query(query);
+      }
+      ares_dns_record_destroy(entry.dnsrec);
+    }
+  }
+  /* Don't forget to send notification if queue emptied */
+  ares_queue_notify_empty(channel);
+  ares_array_destroy(*requeue);
+  *requeue = NULL;
+
+  return status;
+}
+
 static ares_status_t read_answers(ares_conn_t *conn, const ares_timeval_t *now)
 {
   ares_status_t   status;
@@ -638,45 +689,7 @@ static ares_status_t read_answers(ares_conn_t *conn, const ares_timeval_t *now)
   }
 
 cleanup:
-
-  /* Flush requeue */
-  while (ares_array_len(requeue) > 0) {
-    ares_query_t  *query;
-    ares_requeue_t entry;
-    ares_status_t  internal_status;
-
-    internal_status = ares_array_claim_at(&entry, sizeof(entry), requeue, 0);
-    if (internal_status != ARES_SUCCESS) {
-      break;
-    }
-
-    query = ares_htable_szvp_get_direct(channel->queries_by_qid, entry.qid);
-
-    if (entry.type == REQUEUE_REQUEUE) {
-      /* query disappeared */
-      if (query == NULL) {
-        continue;
-      }
-      internal_status = ares_send_query(entry.server, query, now);
-      /* We only care about ARES_ENOMEM */
-      if (internal_status == ARES_ENOMEM) {
-        status = ARES_ENOMEM;
-      }
-    } else { /* REQUEUE_ENDQUERY */
-      if (query != NULL) {
-        query->callback(query->arg, entry.status, query->timeouts, entry.dnsrec);
-        ares_free_query(query);
-      }
-      ares_dns_record_destroy(entry.dnsrec);
-    }
-  }
-  /* Don't forget to send notification if queue emptied */
-  if (requeue != NULL) {
-    ares_queue_notify_empty(channel);
-  }
-  ares_array_destroy(requeue);
-
-  return status;
+  return ares_flush_requeue(channel, &requeue, now, status);
 }
 
 static ares_status_t process_read(ares_channel_t       *channel,
@@ -985,9 +998,9 @@ static void handle_conn_error(ares_conn_t *conn, ares_bool_t critical_failure,
   ares_close_connection(conn, failure_status);
 }
 
-/* Requeue query will normally call ares_send_query() but in some circumstances
- * this needs to be delayed, so if requeue is not NULL, it will add the query
- * to the queue instead */
+/* Requeue query will normally queue another send attempt. If a caller is already
+ * collecting requeues, append to its queue; otherwise drain a local queue
+ * iteratively before returning. */
 ares_status_t ares_requeue_query(ares_query_t *query, const ares_timeval_t *now,
                                  ares_status_t            status,
                                  ares_bool_t              inc_try_count,
@@ -1017,7 +1030,11 @@ ares_status_t ares_requeue_query(ares_query_t *query, const ares_timeval_t *now,
     if (requeue != NULL) {
       return ares_append_requeue(requeue, query, NULL);
     }
-    return ares_send_query(NULL, query, now);
+    {
+      ares_array_t *local_requeue = NULL;
+      status = ares_append_requeue(&local_requeue, query, NULL);
+      return ares_flush_requeue(channel, &local_requeue, now, status);
+    }
   }
 
   /* If we are here, all attempts to perform query failed. */
@@ -1293,8 +1310,10 @@ static ares_status_t ares_conn_query_write(ares_conn_t          *conn,
   return ares_conn_flush(conn);
 }
 
-ares_status_t ares_send_query(ares_server_t *requested_server,
-                              ares_query_t *query, const ares_timeval_t *now)
+static ares_status_t ares_send_query_int(ares_server_t *requested_server,
+                                         ares_query_t *query,
+                                         const ares_timeval_t *now,
+                                         ares_array_t **requeue)
 {
   ares_channel_t *channel = query->channel;
   ares_server_t  *server;
@@ -1341,7 +1360,7 @@ ares_status_t ares_send_query(ares_server_t *requested_server,
       case ARES_ECONNREFUSED:
       case ARES_EBADFAMILY:
         server_increment_failures(server, query->using_tcp);
-        return ares_requeue_query(query, now, status, ARES_TRUE, NULL, NULL);
+        return ares_requeue_query(query, now, status, ARES_TRUE, NULL, requeue);
 
       /* Anything else is not retryable, likely ENOMEM */
       default:
@@ -1367,7 +1386,7 @@ ares_status_t ares_send_query(ares_server_t *requested_server,
     case ARES_ECONNREFUSED:
     case ARES_EBADFAMILY:
       handle_conn_error(conn, ARES_TRUE, status);
-      status = ares_requeue_query(query, now, status, ARES_TRUE, NULL, NULL);
+      status = ares_requeue_query(query, now, status, ARES_TRUE, NULL, requeue);
       if (status == ARES_ETIMEOUT) {
         status = ARES_ECONNREFUSED;
       }
@@ -1375,7 +1394,7 @@ ares_status_t ares_send_query(ares_server_t *requested_server,
 
     default:
       server_increment_failures(server, query->using_tcp);
-      status = ares_requeue_query(query, now, status, ARES_TRUE, NULL, NULL);
+      status = ares_requeue_query(query, now, status, ARES_TRUE, NULL, requeue);
       return status;
   }
 
@@ -1423,6 +1442,17 @@ ares_status_t ares_send_query(ares_server_t *requested_server,
   }
 
   return ARES_SUCCESS;
+}
+
+ares_status_t ares_send_query(ares_server_t *requested_server,
+                              ares_query_t *query, const ares_timeval_t *now)
+{
+  ares_array_t   *requeue = NULL;
+  ares_status_t   status;
+  ares_channel_t *channel = query->channel;
+
+  status = ares_send_query_int(requested_server, query, now, &requeue);
+  return ares_flush_requeue(channel, &requeue, now, status);
 }
 
 static ares_bool_t same_questions(const ares_query_t      *query,

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -1903,6 +1903,51 @@ TEST_P(MockChannelTest, VerifySocketFunctionCallback) {
 
 }
 
+class MockHighRetrySocketFailTest : public MockChannelOptsTest {
+ public:
+  MockHighRetrySocketFailTest()
+    : MockChannelOptsTest(1, AF_INET, false, false, FillOptions(&opts_),
+                          ARES_OPT_TRIES) {}
+
+  static struct ares_options *FillOptions(struct ares_options *opts) {
+    memset(opts, 0, sizeof(struct ares_options));
+    opts->tries = 100000;
+    return opts;
+  }
+
+ private:
+  struct ares_options opts_;
+};
+
+TEST_F(MockHighRetrySocketFailTest, SocketOpenFailuresDoNotRecurse) {
+  ares_socket_functions sock_funcs;
+  memset(&sock_funcs, 0, sizeof(sock_funcs));
+
+  size_t count = 0;
+
+  sock_funcs.asocket =
+    [](int af, int type, int protocol, void *p) -> ares_socket_t {
+    (void)af;
+    (void)type;
+    (void)protocol;
+    EXPECT_NE(nullptr, p);
+    (*reinterpret_cast<size_t *>(p))++;
+    return ARES_SOCKET_BAD;
+  };
+
+  ares_set_socket_functions(channel_, &sock_funcs, &count);
+
+  QueryResult result;
+  ares_status_t status =
+    ares_query_dnsrec(channel_, "www.google.com.", ARES_CLASS_IN,
+                      ARES_REC_TYPE_A, QueryCallback, &result, NULL);
+
+  EXPECT_EQ(ARES_SUCCESS, status);
+  EXPECT_TRUE(result.done_);
+  EXPECT_EQ(ARES_ECONNREFUSED, result.status_);
+  EXPECT_EQ(100000U, count);
+}
+
 static const unsigned char *
   fetch_server_cookie(const ares_dns_record_t *dnsrec, size_t *len)
 {


### PR DESCRIPTION
﻿## Summary

Fixes c-ares/c-ares#1145.
Related to c-ares/c-ares#1043.

`ares_requeue_query()` can currently call `ares_send_query()` directly when it needs to retry a query and no deferred requeue list is provided. When socket creation or connection setup fails synchronously with a retryable error, this creates mutual recursion:

```text
ares_send_query()
  -> ares_requeue_query()
     -> ares_send_query()
        -> ...
```

The recursion depth is bounded by `num_servers * channel->tries`, but `ARES_OPT_TRIES` accepts large positive values. With a sufficiently large retry budget, the process exhausts its stack before the retry limit is reached.

This change routes retry dispatch through the existing requeue mechanism and drains retries iteratively, avoiding one C stack frame per retry.

## Reachability

The issue is reachable through public c-ares APIs:

- `ares_init_options()` accepts `ARES_OPT_TRIES`.
- `ares_set_socket_functions()` or `ares_set_socket_functions_ex()` can provide a socket implementation whose `asocket` fails synchronously.
- `ares_query()` / `ares_query_dnsrec()` dispatches the query.
- `ares_send_query()` treats synchronous `ARES_ECONNREFUSED` / `ARES_EBADFAMILY` from `ares_open_connection()` as retryable.
- The old `ares_requeue_query(..., requeue == NULL)` path immediately re-entered `ares_send_query()`.

The same control-flow shape can also occur when real socket setup fails synchronously in a retryable way.

## Impact

The confirmed impact is uncontrolled recursion leading to stack exhaustion and process termination. This is best described conservatively as an availability issue / denial of service in callers that allow a large retry budget or many configured servers.

## Fix

- Add an internal `ares_send_query_int()` helper that accepts an optional requeue list.
- Reuse the existing `ares_requeue_t` array machinery for retry dispatch.
- Add `ares_flush_requeue()` so top-level callers without an existing queue can still process retries iteratively.
- Update retryable send/open failure paths to append to the active requeue list instead of recursing directly.
- Add a regression test that configures a high retry count and forces synchronous socket-open failures.

## Duplicate PR Check

Checked GitHub PR search before preparing this patch:

```text
repo:c-ares/c-ares is:pr requeue_query send_query recursion stack overflow
=> total_count: 0

repo:c-ares/c-ares is:pr ARES_OPT_TRIES recursion requeue
=> total_count: 0

repo:c-ares/c-ares is:pr stack overflow socket failure
=> only c-ares/c-ares#257, an unrelated 2019 getaddrinfo PR
```

I did not find an existing PR fixing this issue.

## Verification

Performed locally:

```text
cmake -S c-ares -B c-ares/build-notests \
  -DCARES_BUILD_TESTS=OFF -DCARES_STATIC=ON -DCARES_SHARED=OFF
cmake --build c-ares/build-notests --parallel 2
```

Result: patched production build completed successfully.

Standalone ASan reproducer against an unpatched worktree at the same base commit:

```text
env ASAN_OPTIONS=abort_on_error=1:detect_leaks=0 \
  c-ares-unpatched/build-notests/repro_requeue_recursion 100000
```

Result: reproduced `AddressSanitizer: stack-overflow`; stack trace alternates `ares_send_query()` and `ares_requeue_query()`.

Same reproducer against the patched build:

```text
env ASAN_OPTIONS=abort_on_error=1:detect_leaks=0 \
  c-ares/build-notests/repro_requeue_recursion 100000
```

Result:

```text
callback_done=1 callback_status=11 socket_calls=100000
```

Also performed:

```text
git diff --check
```

Result: clean.

Not performed:

Full c-ares test suite. The local machine is missing GMock (`LIBGMOCK` not found), so `CARES_BUILD_TESTS=ON` configure does not complete here. The regression test is included for upstream CI.
