### PR TITLE
Fix UDP socket exhaustion regression: retire connections per-connection, not via server failure count

### DIFF
--- a/src/lib/ares_close_sockets.c
+++ b/src/lib/ares_close_sockets.c
@@ -112,11 +112,11 @@ void ares_check_cleanup_conns(const ares_channel_t *channel)
         do_cleanup = ARES_TRUE;
       }
 
-      /* If the associated server has failures, close it out. Resetting the
-       * connection (and specifically the source port number) can help resolve
-       * situations where packets are being dropped.
+      /* If the connection has been retired for new queries, close it out once
+       * idle.  Resetting the connection (and specifically the source port
+       * number) can help resolve situations where packets are being dropped.
        */
-      if (conn->server->consec_failures > 0) {
+      if (conn->flags & ARES_CONN_FLAG_NONEW) {
         do_cleanup = ARES_TRUE;
       }
 

--- a/src/lib/ares_conn.h
+++ b/src/lib/ares_conn.h
@@ -43,7 +43,13 @@ typedef enum {
   ARES_CONN_FLAG_TFO = 1 << 1,
   /*! TCP Fast Open has not yet sent its first packet. Gets unset on first
    *  write to a connection */
-  ARES_CONN_FLAG_TFO_INITIAL = 1 << 2
+  ARES_CONN_FLAG_TFO_INITIAL = 1 << 2,
+  /*! Connection has been retired: it must not be handed any NEW queries (e.g.
+   *  it experienced a query timeout, suggesting packets are being dropped on
+   *  it).  Its in-flight queries continue to drain and it is cleaned up once
+   *  idle.  This is a per-connection signal so that a transient failure does
+   *  not evict otherwise-healthy connections to the same server. */
+  ARES_CONN_FLAG_NONEW = 1 << 3
 } ares_conn_flags_t;
 
 typedef enum {

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -735,6 +735,12 @@ static ares_status_t process_timeouts(ares_channel_t       *channel,
     query->timeouts++;
 
     conn = query->conn;
+    /* Retire this connection for NEW queries.  A timeout suggests packets are
+     * being dropped on it, so route new queries to a fresh source port while
+     * the in-flight queries here drain (it is cleaned up once idle).  This is
+     * per-connection so a transient failure doesn't stop reuse of healthy
+     * connections to the same server. */
+    conn->flags |= ARES_CONN_FLAG_NONEW;
     server_increment_failures(conn->server, query->using_tcp);
     status = ares_requeue_query(query, now, ARES_ETIMEOUT, ARES_TRUE, NULL,
       NULL);
@@ -1236,9 +1242,13 @@ static ares_conn_t *ares_fetch_connection(const ares_channel_t *channel,
     return NULL;
   }
 
-  /* If the associated server has failures, don't use it.  It should be cleaned
-   * up later. */
-  if (conn->server->consec_failures > 0) {
+  /* Don't hand new queries to a connection that has been retired (e.g. it saw
+   * a timeout).  It keeps servicing its in-flight queries and is cleaned up
+   * once idle.  Note this is a per-connection check: a server-wide failure
+   * counter must not be used here or a single transient failure would evict
+   * every (including healthy) connection to the server and spawn a new socket
+   * per query. */
+  if (conn->flags & ARES_CONN_FLAG_NONEW) {
     return NULL;
   }
 

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -526,6 +526,69 @@ TEST_P(MockUDPMaxQueriesTest, GetHostByNameParallelLookups) {
   }
 }
 
+// Regression test for #1152.  A transient failure (a single query timeout)
+// must not force a brand new UDP socket to be opened for every subsequent
+// query to the same server.  The connection that saw the timeout is retired
+// for new queries (ARES_CONN_FLAG_NONEW) and drains, while new queries share
+// one fresh connection.  Before the fix, ares_fetch_connection() rejected
+// reuse whenever the server's consec_failures was > 0, so a single dropped
+// packet caused a new socket per query and exhausted sockets/ports under load.
+class MockUDPTransientFailureTest
+    : public MockChannelOptsTest,
+      public ::testing::WithParamInterface<int> {
+ public:
+  MockUDPTransientFailureTest()
+    : MockChannelOptsTest(1, GetParam(), false, false,
+                          FillOptions(&opts_),
+                          ARES_OPT_TIMEOUTMS | ARES_OPT_TRIES) {}
+  static struct ares_options* FillOptions(struct ares_options * opts) {
+    memset(opts, 0, sizeof(struct ares_options));
+    opts->timeout = 150; /* ms (ARES_OPT_TIMEOUTMS) - keep the test quick */
+    opts->tries   = 3;
+    return opts;
+  }
+ private:
+  struct ares_options opts_;
+};
+
+TEST_P(MockUDPTransientFailureTest, NoSocketExplosionOnTimeout) {
+  // Configure the server to never reply, so every query times out (a
+  // transient failure).  No SetReply() means ProcessRequest() drops the
+  // packet; the AnyNumber() expectation just silences uninteresting-call
+  // warnings for the many dropped requests.
+  EXPECT_CALL(server_, OnRequest("www.example.com", T_A))
+    .Times(testing::AnyNumber());
+
+  int rc = ARES_SUCCESS;
+  ares_set_socket_callback(channel_, SocketConnectCallback, &rc);
+  sock_cb_count = 0;
+
+  const size_t nqueries = 16;
+  HostResult result[nqueries];
+  for (size_t i = 0; i < nqueries; i++) {
+    ares_gethostbyname(channel_, "www.example.com.", AF_INET, HostCallback,
+                       &result[i]);
+  }
+  Process();
+
+  // All queries complete (they fail with a timeout since the server never
+  // replied).
+  for (size_t i = 0; i < nqueries; i++) {
+    EXPECT_TRUE(result[i].done_);
+  }
+
+  // The key assertion: with tries=3 the fix opens roughly one connection per
+  // retry round (the retired connection is skipped and the single replacement
+  // is reused by all queries), not one per query.  Before the fix this was on
+  // the order of nqueries*tries sockets.
+  EXPECT_LE(sock_cb_count, 6)
+    << "opened " << sock_cb_count << " sockets for " << nqueries
+    << " queries; a transient timeout must not force a new socket per query";
+}
+
+INSTANTIATE_TEST_SUITE_P(AddressFamilies, MockUDPTransientFailureTest,
+                         ::testing::ValuesIn(ares::test::families), PrintFamily);
+
 class CacheQueriesTest
     : public MockChannelOptsTest,
       public ::testing::WithParamInterface<int> {


### PR DESCRIPTION
Fixes #1152 — the v1.34.6 UDP-socket-exhaustion regression.

## Root cause

`ares_fetch_connection()` refused to reuse a UDP connection whenever the **server's** `consec_failures > 0`, and `ares_check_cleanup_conns()` keyed cleanup on the same server counter. But `consec_failures` is a **server-health** metric:

- it's set by a single transient failure (one dropped packet → one timeout) and only clears on a *successful* reply, and
- a server legitimately has **multiple** live connections (via `udp_max_queries` cycling — and, ironically, because this guard itself opens new connections while leaving the old one to drain).

So one connection's blip poisoned reuse of **every** connection to that server. Worse, after opening a replacement, the very next query re-checked the still-nonzero server counter and opened *another* — a new UDP socket per query until the next success. The reporter measured **1,651 sockets vs 13**, exhausting ephemeral ports / fds.

Introduced in **1.34.6** via #1032 (main) → backported by #1033. Present identically on `main` and `v1.34`.

## Fix

Track eligibility **on the connection**, not the server:

- New `ARES_CONN_FLAG_NONEW`. When a query times out on a connection, mark *that* connection so it takes no new queries — its in-flight queries keep draining and it's cleaned up once idle (unchanged behavior), and new queries go to a single fresh connection that is then reused.
- Both connection-decision guards (`ares_fetch_connection` reuse + `ares_check_cleanup_conns` cleanup) now test the per-connection flag.
- `server->consec_failures` stays purely a server-health/selection signal.

This preserves the #1000 fix (a bad connection is still not handed new queries) without evicting healthy connections. It also fixes a latent wart: a *healthy* idle connection was previously force-closed just because its server had an unrelated blip.

## Test (before/after verified)

`MockUDPTransientFailureTest.NoSocketExplosionOnTimeout` fires 16 parallel queries at a server that never replies and asserts the socket count stays bounded (~one per retry round):
- **before this change:** 33 sockets → test fails
- **after:** ~3 sockets → passes

Full local suite green (1081 non-live tests).
