### PR TITLE
ci: restrict push builds to main/release branches; drop actions/checkout on CentOS 7

### DIFF
--- a/.github/workflows/alpine-latest.yml
+++ b/.github/workflows/alpine-latest.yml
@@ -3,6 +3,9 @@
 name: Alpine (latest)
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,6 +3,9 @@
 name: Android
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -3,6 +3,9 @@
 name: CentOS 7
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:
@@ -37,7 +40,16 @@ jobs:
           yum install -y gcc gcc-c++ make autoconf automake libtool cmake3 git ninja-build gdb
           ln -sf /usr/bin/cmake3 /usr/bin/cmake
       - name: Checkout c-ares
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
+        # actions/checkout can't be used here: current versions require a newer
+        # Node.js/glibc than the CentOS 7 container provides, and the last
+        # compatible version (v1) is EOL.  Check out directly with git instead
+        # (fetch by GITHUB_REF so it works for both branch pushes and PR merge
+        # refs; CentOS 7's git is too old to fetch a bare commit SHA).
+        run: |
+          git init .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}"
+          git fetch --depth=1 origin "${GITHUB_REF}"
+          git checkout FETCH_HEAD
       - name: Build GoogleTest
         # GoogleTest v1.10 doesn't require c++14
         run: |

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -6,6 +6,9 @@ name: Codespell
 
 on:
   push:
+    branches:
+      - main
+      - 'v*'
     paths:
     - 'src/**'
     - 'include/**'

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -3,6 +3,9 @@
 name: Coveralls
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 jobs:

--- a/.github/workflows/djgpp.yml
+++ b/.github/workflows/djgpp.yml
@@ -3,6 +3,9 @@
 name: DJGPP
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/fedora-latest.yml
+++ b/.github/workflows/fedora-latest.yml
@@ -3,6 +3,9 @@
 name: Fedora Latest (bleeding edge)
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -3,6 +3,9 @@
 name: iOS
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,6 +3,9 @@
 name: MacOS
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -3,6 +3,9 @@
 name: MSYS2 (Windows)
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -4,6 +4,9 @@ name: NetBSD
 
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -3,6 +3,9 @@
 name: OpenBSD
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,6 +3,11 @@
 name: Build Release Package
 on:
   push:
+    branches:
+      - main
+      - 'v*'
+    tags:
+      - 'v*'
 
 concurrency:
   group: ${{ github.ref }}-build-release-package

--- a/.github/workflows/qnx.yml
+++ b/.github/workflows/qnx.yml
@@ -3,6 +3,9 @@
 name: QNX
 on:
   push:
+    branches:
+      - main
+      - 'v*'
 
 concurrency:
   group: ${{ github.ref }}-qnx

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -6,6 +6,9 @@ name: REUSE compliance
 
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -4,6 +4,9 @@ name: Solaris
 
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -3,6 +3,9 @@
 name: Ubuntu 20.04
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -3,6 +3,9 @@
 name: Ubuntu (latest)
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/uwp.yml
+++ b/.github/workflows/uwp.yml
@@ -3,6 +3,9 @@
 name: Windows UWP (Store)
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/watcom.yml
+++ b/.github/workflows/watcom.yml
@@ -3,6 +3,9 @@
 name: OpenWatcom
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -3,6 +3,9 @@
 name: WATT32
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:


### PR DESCRIPTION
Addresses the two observations from the first Dependabot run (#1196).

## 1. Restrict `push:` builds to `main` + release branches

The build/test/lint workflows triggered on `push:` for **every** branch. Since c-ares develops in forks/PRs (not in-repo branches), those per-branch push runs were redundant — `pull_request` already covers development. Each affected workflow's `push:` now filters to:

```yaml
  push:
    branches:
      - main
      - 'v*'
```

- **`package.yml`** additionally keeps `tags: ['v*']` so release builds still fire on version tags.
- **Unchanged:** `sonarcloud` (already `main`-only), `coverity` (`coverity_scan`), and the non-`push` workflows (`clang-format`, `all-checks`, `dependabot-automerge`, `backport`).

## 2. Drop `actions/checkout` on CentOS 7

CentOS 7 runs its steps inside a `centos:7` container, so `actions/checkout` executes in that ancient-glibc environment. Current checkout versions need Node 20/24 (newer glibc than CentOS 7 has), and the last compatible version (v1) is EOL — so Dependabot couldn't bump it, and a grouped bump would have broken the job.

Replaced with a direct `git` checkout (git is already installed in the container). It fetches by `GITHUB_REF` so it works for both branch pushes and PR merge refs (CentOS 7's git is too old to fetch a bare commit SHA), and uses `--depth=1` to match the prior shallow behavior. This removes the checkout action dependency from that workflow entirely, so Dependabot no longer has to reconcile it.

All workflow YAML validated.
