### PR TITLE
[Backport v1.34] ci: restrict push builds to main/release branches; drop actions/checkout on CentOS 7 (#1198)

### DIFF
--- a/.github/workflows/alpine-latest.yml
+++ b/.github/workflows/alpine-latest.yml
@@ -3,6 +3,9 @@
 name: Alpine (latest)
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,6 +3,9 @@
 name: Android
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -3,6 +3,9 @@
 name: CentOS 7
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:
@@ -37,7 +40,16 @@ jobs:
           yum install -y gcc gcc-c++ make autoconf automake libtool cmake3 git ninja-build gdb
           ln -sf /usr/bin/cmake3 /usr/bin/cmake
       - name: Checkout c-ares
-        uses: actions/checkout@v1
+        # actions/checkout can't be used here: current versions require a newer
+        # Node.js/glibc than the CentOS 7 container provides, and the last
+        # compatible version (v1) is EOL.  Check out directly with git instead
+        # (fetch by GITHUB_REF so it works for both branch pushes and PR merge
+        # refs; CentOS 7's git is too old to fetch a bare commit SHA).
+        run: |
+          git init .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}"
+          git fetch --depth=1 origin "${GITHUB_REF}"
+          git checkout FETCH_HEAD
       - name: Build GoogleTest
         # GoogleTest v1.10 doesn't require c++14
         run: |

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -6,6 +6,9 @@ name: Codespell
 
 on:
   push:
+    branches:
+      - main
+      - 'v*'
     paths:
     - 'src/**'
     - 'include/**'

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -3,6 +3,9 @@
 name: Coveralls
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 jobs:

--- a/.github/workflows/djgpp.yml
+++ b/.github/workflows/djgpp.yml
@@ -3,6 +3,9 @@
 name: DJGPP
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/fedora-latest.yml
+++ b/.github/workflows/fedora-latest.yml
@@ -3,6 +3,9 @@
 name: Fedora Latest (bleeding edge)
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -3,6 +3,9 @@
 name: iOS
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,6 +3,9 @@
 name: MacOS
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -3,6 +3,9 @@
 name: MSYS2 (Windows)
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -4,6 +4,9 @@ name: NetBSD
 
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -3,6 +3,9 @@
 name: OpenBSD
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,6 +3,11 @@
 name: Build Release Package
 on:
   push:
+    branches:
+      - main
+      - 'v*'
+    tags:
+      - 'v*'
 
 concurrency:
   group: ${{ github.ref }}-build-release-package

--- a/.github/workflows/qnx.yml
+++ b/.github/workflows/qnx.yml
@@ -3,6 +3,9 @@
 name: QNX
 on:
   push:
+    branches:
+      - main
+      - 'v*'
 
 concurrency:
   group: ${{ github.ref }}-qnx

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -6,6 +6,9 @@ name: REUSE compliance
 
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -4,6 +4,9 @@ name: Solaris
 
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -3,6 +3,9 @@
 name: Ubuntu 20.04
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -3,6 +3,9 @@
 name: Ubuntu (latest)
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/uwp.yml
+++ b/.github/workflows/uwp.yml
@@ -3,6 +3,9 @@
 name: Windows UWP (Store)
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/watcom.yml
+++ b/.github/workflows/watcom.yml
@@ -3,6 +3,9 @@
 name: OpenWatcom
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:

--- a/.github/workflows/watt32.yml
+++ b/.github/workflows/watt32.yml
@@ -3,6 +3,9 @@
 name: WATT32
 on:
   push:
+    branches:
+      - main
+      - 'v*'
   pull_request:
 
 concurrency:


### PR DESCRIPTION
Manual backport of #1198 to `v1.34`.

Done by hand because the `/backport` GitHub App token lacks the `workflows` permission — GitHub rejects a bot pushing branches that modify `.github/workflows/*.yml` (`refusing to allow a GitHub App to create or update workflow ... without workflows permission`). The only cherry-pick conflict was `centos7.yml` (v1.34 uses `actions/checkout@v1`, main uses the SHA-pinned form); resolved to the git-checkout block.

**Why this goes in first:** QNX is a `push`-only workflow with no branch filter, so on `v1.34` it runs on every `backport-*` branch push and its flake blocks backport auto-merge. Restricting `push:` to `main`/`v*` makes QNX (and the other push-only jobs) skip backport branches entirely — including this PR's own branch — unblocking the rest of the 1.34.7 backports.
