### PR TITLE
ci: exclude Coveralls from the All Checks aggregator

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -30,5 +30,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Ignore:
           #   * "All Checks" — self (we set a name, so it isn't auto-ignored).
-          ignore: "All Checks"
+          #   * "Coveralls"  — coverage reporting flakes intermittently (upload
+          #     failures) and must not gate merges; it is informational only.
+          ignore: "All Checks,Coveralls"
           timeout: 10800


### PR DESCRIPTION
Coveralls intermittently fails on transient coverage-upload errors. Because the "All Checks" aggregator waits for every non-ignored check, a Coveralls flake blocks merges and auto-merge — even though coverage reporting is informational, not a correctness signal (it surfaced repeatedly during the 1.34.7 backport sweep). Add `Coveralls` to the aggregator's `ignore` list so it no longer gates.