### PR TITLE
ci: diff clang-format against the PR merge commit's first parent

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -32,6 +32,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Depth 2 so the PR merge commit's first parent (the current base
+          # branch tip) is available as the diff base below.
+          fetch-depth: 2
 
       - name: Install latest stable clang-format from apt.llvm.org
         run: |
@@ -49,11 +53,15 @@ jobs:
           echo "LLVM_VER=${LLVM_VER}" >> "${GITHUB_ENV}"
 
       - name: Check formatting of changed lines
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          git fetch --quiet --depth=1 origin "${BASE_SHA}"
-          git diff -U0 --no-color "${BASE_SHA}" HEAD -- \
+          # HEAD is the PR merge commit, so HEAD^1 is the current base branch
+          # tip and the diff below is exactly the lines this PR changes.  Do
+          # NOT use github.event.pull_request.base.sha here: it is pinned to
+          # the base tip at the time the PR was opened, so on an older branch
+          # it also sweeps in unrelated base-branch changes and flags lines
+          # the PR never touched (evaluated against the current .clang-format
+          # rather than the rules they were written under).
+          git diff -U0 --no-color HEAD^1 HEAD -- \
               '*.c' '*.h' ':!src/lib/thirdparty' | \
             "clang-format-diff-${LLVM_VER}" -p1 \
               -binary "clang-format-${LLVM_VER}" > clang-format.patch || true


### PR DESCRIPTION
## Problem

The clang-format check diffs `github.event.pull_request.base.sha` against the checked-out PR **merge ref**. `base.sha` is pinned to the base-branch tip at the time the PR was opened, while the merge ref is the PR merged into the **current** base tip. For a branch opened weeks ago, the diff therefore contains every main-side change made since — and `clang-format-diff` flags lines the PR never touched.

This is amplified by #1185 having changed `.clang-format` (`AlignConsecutiveDeclarations` → `AlignFunctionDeclarations: false`) without reformatting the tree: pre-#1185 code swept into a stale diff window gets evaluated under rules it was never written for.

Observed on #1147's check run, which flagged hunks in `ares_dns_name.c`, `ares_dns_write.c`, `ares_dns_parse.c`, `ares_dns_mapping.c`, `ares_dns_private.h`, `ares_sysconfig_win.c`, and `ares_nameser.h` — none touched by that PR. Reproduced locally byte-for-byte with the workflow's exact pipeline (clang-format 22.1.8, LLVM 22 `clang-format-diff.py`, stale base), and confirmed the same PR's diff is clean when based correctly.

## Fix

Diff against `HEAD^1` instead: on the merge ref, the first parent is by definition the current base-branch tip, so the diff is exactly the lines the PR changes — regardless of branch staleness — evaluated under the base branch's current `.clang-format`. Requires `fetch-depth: 2` so the parent commit is available; the separate `git fetch` of `BASE_SHA` goes away.