### PR TITLE
test: pin exact message size in DNSNameCompression14Bit

### DIFF
--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -1423,10 +1423,11 @@ TEST_F(LibraryTest, DNSNameCompression14Bit) {
       ares_dns_rr_add_abin(rr, ARES_RR_TXT_DATA, txt.data(), txt.size()));
   }
 
-  /* Past byte 16383, add a repeated owner name.  Its first occurrence records a
-   * compression target at an offset that doesn't fit in 14 bits; the second
-   * occurrence must be written uncompressed rather than as a pointer to
-   * (offset & 0x3FFF), which would corrupt the message. */
+  /* Past byte 16383, add a repeated owner name.  Its first occurrence lands at
+   * an offset that doesn't fit in 14 bits, so it must not be recorded as a
+   * compression target; the second occurrence must not be emitted as a pointer
+   * to (offset & 0x3FFF), which would corrupt the message.  It instead
+   * compresses only against the in-range example.com target. */
   for (size_t i = 0; i < 2; i++) {
     EXPECT_EQ(ARES_SUCCESS,
       ares_dns_record_rr_add(&rr, dnsrec, ARES_SECTION_ANSWER,
@@ -1437,6 +1438,11 @@ TEST_F(LibraryTest, DNSNameCompression14Bit) {
 
   EXPECT_EQ(ARES_SUCCESS, ares_dns_write(dnsrec, &msg, &msglen));
   EXPECT_GT(msglen, 0x3FFFU);
+
+  /* 12 hdr + 17 question + 80*268 compressed TXT + 2*275 repeat TXT.
+   * An exact size also verifies compression remains active for names
+   * below the limit. */
+  EXPECT_EQ(22019U, msglen);
 
   /* Before the fix this parse failed / mis-parsed on the truncated pointer. */
   ares_dns_record_t *parsed = NULL;


### PR DESCRIPTION
Follow-up applying the two review nits from #1159 that landed right before the merge, so they don't get lost:

- pin the written size to exactly 22019 bytes (12 hdr + 17 question + 80*268 compressed TXT + 2*275 repeat TXT). Without this, every assertion in the test would still pass if compression got disabled entirely, so the pin also verifies compression stays active for names below the 14-bit limit.
- fix the comment on the repeated owner name: post-fix the second occurrence still suffix-compresses against the in-range example.com target at offset 12; only the out-of-range full-name target goes unrecorded.

Test-only, no library changes. Verified locally: the test passes with the exact pin.