### PR TITLE
docs: add AGENTS.md and modernize contributor documentation

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -9,7 +9,7 @@ Copyright: The c-ares project and its contributors
 License: MIT
 
 # Docs
-Files: AUTHORS BACKPORTING.md CONTRIBUTING.md GIT-INFO README.md README.msvc RELEASE-PROCEDURE.md RELEASE-NOTES.md FEATURES.md SECURITY.md DEVELOPER-NOTES.md INSTALL.md FUZZING.md test/README.md src/lib/include/README.md src/lib/thirdparty/apple/README.md
+Files: AGENTS.md AUTHORS BACKPORTING.md CONTRIBUTING.md GIT-INFO README.md README.msvc RELEASE-PROCEDURE.md RELEASE-NOTES.md FEATURES.md SECURITY.md DEVELOPER-NOTES.md INSTALL.md FUZZING.md test/README.md src/lib/include/README.md src/lib/thirdparty/apple/README.md
 Copyright: The c-ares project and its contributors
 License: MIT
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,121 @@
+# AGENTS.md — c-ares rules for coding agents
+
+c-ares is critical infrastructure (curl, Node.js, ...).  Correctness,
+portability, and interoperability beat cleverness.  Contribution policy
+(coverage >90%, API/ABI rules, commit format) lives in
+`CONTRIBUTING.md` — read it.  Build-system notes: `DEVELOPER-NOTES.md`.
+
+## Hard rules
+
+1. **C89.** Declarations before statements, `/* */` comments, no VLAs.
+   Only extension allowed: 64-bit ints.  clang/gcc won't catch
+   declaration-order mistakes; the OpenWatcom CI job will.
+2. **No API/ABI breaks** — see `CONTRIBUTING.md` for the exact policy,
+   including the limited `ares_options` extension criteria.
+3. **Never hand-roll data structures, algorithms, or parsing.**  Use
+   the internal library (table below).  If it lacks something, extend
+   it with a general, documented, tested helper — no one-offs.  All
+   parsing/serialization goes through `ares_buf_*()`.
+4. **OOM returns errors** (`ARES_ENOMEM`), never crashes.  Annotate the
+   untestable failure path: `/* LCOV_EXCL_LINE: OutOfMemory */`.
+5. **Tests required**; coverage must stay >90% (`CONTRIBUTING.md`).
+   Prefer tests that fail without your change.
+6. **clang-format** (>= 20) on changed lines, CI-enforced.  Run
+   `git clang-format` before pushing; never hand-align.
+7. **Never break interoperability.**  Parse tolerantly, emit
+   conservatively; justify any parser strictness increase.  Cite the
+   RFC section in a comment next to protocol behavior.
+
+## Build and test
+
+```sh
+cmake -DCMAKE_BUILD_TYPE=DEBUG -DCARES_BUILD_TESTS=ON -G Ninja -B build
+ninja -C build
+./build/bin/arestest -4 --gtest_filter='<Pattern>'
+```
+
+- Always filter tests (full suite is slow; `-*Live*` skips network).
+- Both CMake and autotools must keep working; add new files to
+  `src/lib/Makefile.inc`.
+- CI is wide: -Werror on modern toolchains, ASAN/UBSAN/valgrind/
+  scan-build, plus old gcc, MSVC, MinGW, OpenWatcom, DJGPP, musl,
+  Android/iOS, BSDs, Solaris, QNX.
+
+## Code conventions
+
+- `#include "ares_private.h"` first in every `src/lib` `.c`; system
+  headers after, in `#ifdef HAVE_*` guards.
+- Memory: `ares_malloc/ares_malloc_zero/ares_realloc_zero/ares_free/
+  ares_strdup` only.  Multiplied allocation sizes must be
+  overflow-checked (`ares_malloc_zero_array`, `ares_realloc_zero_array`,
+  `ares_size_t_mul_overflow`).  Never `malloc(0)`.
+- Errors: return `ares_status_t`; single-exit `goto done` cleanup.
+- Strings/ctype: `ares_str.h` helpers (`ares_streq`, `ares_strcaseeq`,
+  `ares_isdigit`, `ares_str_parse_uint`, ...).  libc `str*`, `atoi`,
+  and `<ctype.h>` are locale-sensitive — don't use them.
+- `ares_rand_bytes()` never `rand()`; `ares_tvnow()`/`ares_timeval_*`
+  for all timeout math (monotonic).
+- Types: `size_t` for sizes/counts, `unsigned char *` for bytes,
+  `ares_bool_t` for booleans; `-Wconversion -Wsign-conversion` are on.
+- Visibility: `static` by default.  `CARES_EXTERN` only in public
+  headers and the semi-public `src/lib/include/` headers.
+- Locking: public entry points take `ares_channel_lock()`; internals
+  that expect the lock held use the `*_nolock` suffix.
+- New files: MIT license header with the SPDX MIT identifier tag
+  (REUSE CI-enforced; copy the header from `src/lib/ares_cookie.c`),
+  add to `Makefile.inc` + CMake.
+- **Doxygen-style comment on every function** in headers:
+  `/*! Description \param[in] x desc \return desc */` — match
+  `src/lib/include/ares_buf.h`.
+
+## Internal library — use it or extend it
+
+| Need | Use | Never |
+|---|---|---|
+| Parse/build wire or text data | `ares_buf` (fetch/consume/tag/split/append) | pointer-walking, manual length checks |
+| Strings | `ares_str.h`, `ares_strsplit` | libc `str*`/`strtok`/`atoi` |
+| Dynamic array | `ares_array` | `realloc`-grown arrays |
+| List/queue | `ares_llist` | hand-rolled lists |
+| Sorted collection | `ares_slist` (skip list) | sorted-insert loops |
+| Hash map | `ares_htable_{strvp,szvp,asvp,dict,vpvp,vpstr}` (add a typed wrapper if your combo is missing) | linear-scan tables |
+| DNS messages | `ares_dns_record` parse/write/dup; new RR types via `ares_dns_mapping.c` tables; TXT via `ares_dns_multistring` | raw byte poking; extending `src/lib/legacy/` |
+| URIs, host:port strings | `ares_uri` | `sscanf`/`strchr` surgery |
+| Math/overflow | `ares_math.h` | unchecked multiplies |
+| Threads/events/interfaces | `ares_threads.h`, `ares_event*`, `ares_iface_ips` | direct pthread/Win32/getifaddrs |
+
+Also exists: `ares_qcache`, `ares_cookie`, `ares_metrics`,
+`ares_addrinfo*` (RFC 6724 sort).  Precedent: `ares_str_parse_uint()`
+and `ares_size_t_mul_overflow()` were added as shared helpers instead
+of open-coding — do likewise, and convert identical sibling call sites.
+
+## Tests
+
+- Placement: internal/unit → `test/ares-test-internal.cc` (wrap
+  non-`CARES_EXTERN` calls in `#ifndef CARES_SYMBOL_HIDING`); mock DNS
+  server → `ares-test-mock*.cc` (`-et` event-thread, `-ai`
+  getaddrinfo); config/init + container tests → `ares-test-init.cc`;
+  legacy parsers → `ares-test-parse-*.cc`.
+- Fixtures in `test/ares-test.h`: `LibraryTest` (has `SetAllocFail` for
+  OOM testing), `DefaultChannelTest`, `MockChannelOptsTest`, ...
+- Container tests (`CONTAINED_TEST_F`) are Linux-only.
+- LCOV exclusion tags: only `OutOfMemory`, `DefensiveCoding`,
+  `UntestablePath`, `FallbackCode` (see `CONTRIBUTING.md`).
+- Parser/writer changes: the fuzzer round-trips
+  `ares_dns_parse`→`ares_dns_write` (`test/ares-test-fuzz.c`); add
+  corpus entries in `test/fuzzinput/` for new record types.
+
+## Docs
+
+- Public API change ⇒ update `docs/` man page in the same PR.  Families
+  share a grouped page with `.so man3/<group>.3` stubs per symbol
+  (e.g. `docs/ares_dns_mapping.3`); standalone functions get their own
+  page.
+- Don't touch `RELEASE-NOTES.md`.
+
+## Security
+
+- All parsed input is untrusted; length-check via `ares_buf`.
+- In PR descriptions, distinguish remote (DNS wire) vs local
+  (config/env/API) attack surfaces honestly; local-config hardening is
+  not a "security fix".
+- Suspected vulnerabilities go through `SECURITY.md`, not public PRs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,32 @@
 Contributing to c-ares
 ======================
 
-To contribute patches to c-ares, please generate a GitHub pull request
-and follow these guidelines:
+Submit patches as GitHub pull requests.  Requirements:
 
- - Check that the CI/CD builds are green for your pull request.
- - Please update the test suite to add a test case for any new functionality.
- - Build the library on your own machine and ensure there are no new warnings.
+ - CI must be green ("All Checks") with no new warnings on any platform.
+ - Add tests for any new functionality or behavior change; prefer tests
+   that fail without your change.
+ - **Coverage must stay above 90%** (lcov/Coveralls).  New reachable
+   logic needs tests.
+ - Allocation failures must return an error (`ARES_ENOMEM`), never
+   crash.  Those paths are untestable, so annotate them:
+   `/* LCOV_EXCL_LINE: OutOfMemory */`.  Other allowed tags:
+   `DefensiveCoding` (can't-happen guards), `UntestablePath`
+   (OS-dependent), `FallbackCode` (platform fallbacks; use
+   `LCOV_EXCL_START`/`STOP` for blocks).  Never use annotations to skip
+   testing reachable logic.
+ - **No API or ABI breaks.**  `include/ares*.h` is additive-only;
+   deprecate with `CARES_DEPRECATED_FOR()`, never remove.  New members
+   may be appended to `struct ares_options` (with an `ARES_OPT_*` bit)
+   only if they need no allocation/deallocation —
+   `ares_destroy_options()` cannot free them.  Anything else gets
+   `ares_set_*()`/`ares_get_*()` functions.  Update `ares_dup()` either
+   way.
+ - Public API changes update the man pages in `docs/` in the same PR.
+   Do not edit `RELEASE-NOTES.md` (written at release time).
+ - Commit subject `subsystem: summary` (e.g. `ares_dns_parse: ...`,
+   `test: ...`), explanatory body, ending with
+   `Signed-off-by: Your Name <email>`.  PRs are squash-merged.
+
+Coding conventions: see `AGENTS.md` (applies to humans too) and
+`DEVELOPER-NOTES.md` (build systems, C89 requirement).

--- a/DEVELOPER-NOTES.md
+++ b/DEVELOPER-NOTES.md
@@ -43,5 +43,7 @@ Developer Notes
 * Comments must be written in the old-style `/* unnested C-fashion */`
 
 * Try to keep line lengths below 80 columns and formatted as the existing code.
-  There is a `.clang-format` in the repository that can be used to run the
-  automated code formatter as such: `clang-format -i */*.c */*.h */*/*.c */*/*.h`
+  Formatting is defined by the `.clang-format` in the repository root
+  (clang-format >= 20 required) and validated by CI on the lines each pull
+  request changes.  Run `git clang-format` before committing to format only
+  your changed lines.

--- a/test/README.md
+++ b/test/README.md
@@ -1,75 +1,62 @@
 c-ares Unit Test Suite
 ======================
 
-This directory holds unit tests for the c-ares library.  To build the tests:
+This directory holds the c-ares test suite (C++14, GoogleTest).
 
- - Build the main c-ares library first, in the directory above this.  To
-   enable tests of internal functions, configure the library build to expose
-   hidden symbols with `./configure --disable-symbol-hiding`.
- - Generate a `configure` file by running `autoreconf -iv` (which requires
-   a local installation of
-   [autotools](https://www.gnu.org/software/automake/manual/html_node/Autotools-Introduction.html)).
- - `./configure`
- - `make`
- - Run the tests with `./arestest`, or `./arestest -v` for extra debug info.
+Building and running
+--------------------
 
-Points to note:
+```sh
+cmake -DCMAKE_BUILD_TYPE=DEBUG -DCARES_BUILD_TESTS=ON -G Ninja -B build
+ninja -C build
+./build/bin/arestest -4 --gtest_filter='<Pattern>'
+```
 
- - The tests are written in C++11, and so need a C++ compiler that supports
-   this.  To avoid adding this as a requirement for the library, the
-   configuration and build of the tests is independent from the library.
- - The tests include some live queries, which will fail when run on a machine
-   without internet connectivity.  To skip live tests, run with
-   `./arestest --gtest_filter=-*.Live*`.
- - The tests include queries of a mock DNS server.  This server listens on port
-   5300 by default, but the port can be changed with the `-p 5300` option to
-   `arestest`.
+Autotools works too: `./configure --enable-tests && make`.
 
+ - Always filter; the full suite is slow and includes live-network
+   tests.  Skip those with `--gtest_filter=-*Live*`.
+ - `arestest` flags: `-v` verbose, `-4`/`-6` address family,
+   `-p <port>` mock server port; all other args pass through to
+   GoogleTest.
+ - Container tests (resolv.conf/hosts scenarios via `CONTAINED_TEST_F`)
+   are Linux-only: `-DCARES_BUILD_CONTAINER_TESTS=ON`.
+ - Tests of internal (non-`CARES_EXTERN`) functions are excluded when
+   the library is built with symbol hiding; they are wrapped in
+   `#ifndef CARES_SYMBOL_HIDING`.
 
-Test Types
+Test types
 ----------
 
-The test suite includes various different types of test.
+ - `ares-test-internal.cc` — unit tests of internal helpers (buffers,
+   strings, data structures, DNS record internals).
+ - `ares-test-mock.cc`, `ares-test-mock-et.cc` (event thread),
+   `ares-test-mock-ai.cc` (getaddrinfo) — integration tests against a
+   mock DNS server with crafted responses; `dns-proto.h` provides C++
+   packet-builder helpers.
+ - `ares-test-init.cc` — configuration/init, including the container
+   tests.
+ - `ares-test-parse-*.cc` — legacy `ares_parse_*_reply` API tests.
+ - `ares-test-live.cc` — real DNS queries; requires connectivity.
+ - Fixtures live in `ares-test.h`; `LibraryTest::SetAllocFail` injects
+   allocation failures for OOM-path testing.
 
- - There are live tests (`ares-test-live.cc`), which assume that the
-   current machine has a valid DNS setup and connection to the
-   internet; these tests issue queries for real domains but don't
-   particularly check what gets returned.  The tests will fail on
-   an offline machine.
- - There are some mock tests (`ares-test-mock.cc`) that set up a fake DNS
-   server and inject its port into the c-ares library configuration.
-   These tests allow specific response messages to be crafted and
-   injected, and so are likely to be used for many more tests in
-   future.
-    - To make this generation/injection easier, the `dns-proto.h`
-      file includes C++ helper classes for building DNS packets.
- - Other library entrypoints that don't require network activity
-   (e.g. `ares_parse_*_reply`) are tested directly.
- - A couple of the tests use a helper method of the test fixture to
-   inject memory allocation failures, using a recent change to the
-   c-ares library that allows override of `malloc`/`free`.
- - There are some tests of the internal entrypoints of the library
-   (`ares-test-internal.c`), but these are only enabled if the library
-   was configured with `--disable-symbol-hiding` and/or
-   `--enable-expose-statics`.
- - There is also an entrypoint to allow Clang's
-   [libfuzzer](http://llvm.org/docs/LibFuzzer.html) to drive
-   the packet parsing code in `ares_parse_*_reply`, together with a
-   standalone wrapper for it (`./aresfuzz`) to allow use of command
-   line fuzzers (such as [afl-fuzz](http://lcamtuf.coredump.cx/afl/))
-   for further [fuzz testing](#fuzzing).
+Fuzzing
+-------
 
+`aresfuzz` drives `ares_dns_parse` and round-trips through
+`ares_dns_write`; `aresfuzzname` fuzzes name parsing.  The corpora in
+`fuzzinput/` and `fuzznames/` are executed on every CI run — add
+corpus entries when introducing new record types or wire-format
+handling.  See `../FUZZING.md` for libFuzzer/AFL instructions.
 
-Code Coverage Information
--------------------------
+Code coverage
+-------------
 
-To generate code coverage information:
+```sh
+cmake -DCMAKE_BUILD_TYPE=DEBUG -DCARES_BUILD_TESTS=ON -DCARES_COVERAGE=ON -G Ninja -B build
+ninja -C build && ./build/bin/arestest && ninja -C build coverage
+```
 
- - Configure both the library and the tests with `./configure
-   --enable-code-coverage` before building. This requires the relevant code
-   coverage tools ([gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html),
-   [lcov](http://ltp.sourceforge.net/coverage/lcov.php)) to be installed locally.
- - Run the tests with `test/arestest`.
- - Generate code coverage output with `make code-coverage-capture` in the
-   library directory (i.e. not in `test/`).
-
+Requires `gcov`/`lcov`.  Coverage policy (>90%, exclusion annotation
+tags) is documented in `../CONTRIBUTING.md`.


### PR DESCRIPTION
## Summary

Adds a root `AGENTS.md` with the project's coding rules, written for AI coding agents but applicable to all contributors, and promotes `CONTRIBUTING.md` to the canonical contribution policy it references. Also fixes stale documentation discovered while researching the rules.

## AGENTS.md

Seven hard rules up front (C89; no API/ABI breaks; internal-library-first — extend it, never hand-roll; OOM returns errors with LCOV annotations; tests + coverage; clang-format on changed lines; never break interoperability), followed by compact build/test commands, code conventions, a need→module table for the internal library, test placement, docs, and security posture. Rules were extracted from actual source/CI behavior with each verified against current main — most existed only as tribal knowledge.

## CONTRIBUTING.md

Now the single written home for policy that was previously unwritten: the >90% coverage requirement, the four canonical LCOV exclusion tags (`OutOfMemory`, `DefensiveCoding`, `UntestablePath`, `FallbackCode`) and when they're allowed, the API/ABI additive-only rule including the current `ares_options` extension criteria (non-allocating members appended with an `ARES_OPT_*` bit only; `ares_dup()` updated either way), commit format with `Signed-off-by`, and man-pages-in-same-PR.

## Stale doc fixes

- `test/README.md`: rewritten — CMake+Ninja instructions, current test-file layout (`-et`/`-ai`/container/symbol-hiding), correct fuzzer description (`ares_dns_parse`→`ares_dns_write` round-trip + corpus rule), modern coverage flow, C++14 (verified against `test/CMakeLists.txt`). Removes references to `--enable-expose-statics`, `ares-test-internal.c`, and `make code-coverage-capture`.
- `DEVELOPER-NOTES.md`: the `clang-format -i */*.c ...` glob (misses nested dirs) replaced with `git clang-format` + the CI changed-lines gate.
- `.reuse/dep5`: AGENTS.md added to the docs license block for REUSE compliance.

No `CLAUDE.md`/`copilot-instructions.md` aliases — `AGENTS.md` is the emerging cross-tool standard and stands alone.