### PR TITLE
ares_hosts_file: store /etc/hosts as a bipartite adjacency (fixes #1049)

### DIFF
--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -393,8 +393,8 @@ ares_bool_t ares_is_localhost(const char *name)
 
 static ares_status_t file_lookup(struct host_query *hquery)
 {
-  const ares_hosts_entry_t *entry;
-  ares_status_t             status;
+  ares_hosts_entry_t *entry = NULL;
+  ares_status_t       status;
 
   /* Per RFC 7686, reject queries for ".onion" domain names with NXDOMAIN. */
   if (ares_is_onion_domain(hquery->name)) {
@@ -421,6 +421,8 @@ static ares_status_t file_lookup(struct host_query *hquery)
 
 
 done:
+  ares_hosts_entry_destroy(entry);
+
   /* RFC6761 section 6.3 #3 states that "Name resolution APIs and libraries
    * SHOULD recognize localhost names as special and SHOULD always return the
    * IP loopback address for address queries".

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -393,8 +393,8 @@ ares_bool_t ares_is_localhost(const char *name)
 
 static ares_status_t file_lookup(struct host_query *hquery)
 {
-  ares_hosts_entry_t *entry = NULL;
-  ares_status_t       status;
+  const ares_hosts_entry_t *entry = NULL;
+  ares_status_t             status;
 
   /* Per RFC 7686, reject queries for ".onion" domain names with NXDOMAIN. */
   if (ares_is_onion_domain(hquery->name)) {
@@ -421,8 +421,6 @@ static ares_status_t file_lookup(struct host_query *hquery)
 
 
 done:
-  ares_hosts_entry_destroy(entry);
-
   /* RFC6761 section 6.3 #3 states that "Name resolution APIs and libraries
    * SHOULD recognize localhost names as special and SHOULD always return the
    * IP loopback address for address queries".

--- a/src/lib/ares_gethostbyaddr.c
+++ b/src/lib/ares_gethostbyaddr.c
@@ -196,10 +196,10 @@ static ares_status_t file_lookup(ares_channel_t         *channel,
                                  const struct ares_addr *addr,
                                  struct hostent        **host)
 {
-  char                      ipaddr[INET6_ADDRSTRLEN];
-  const void               *ptr = NULL;
-  const ares_hosts_entry_t *entry;
-  ares_status_t             status;
+  char                ipaddr[INET6_ADDRSTRLEN];
+  const void         *ptr   = NULL;
+  ares_hosts_entry_t *entry = NULL;
+  ares_status_t       status;
 
   if (addr->family == AF_INET) {
     ptr = &addr->addr.addr4;
@@ -221,6 +221,7 @@ static ares_status_t file_lookup(ares_channel_t         *channel,
   }
 
   status = ares_hosts_entry_to_hostent(entry, addr->family, host);
+  ares_hosts_entry_destroy(entry);
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }

--- a/src/lib/ares_gethostbyaddr.c
+++ b/src/lib/ares_gethostbyaddr.c
@@ -196,10 +196,10 @@ static ares_status_t file_lookup(ares_channel_t         *channel,
                                  const struct ares_addr *addr,
                                  struct hostent        **host)
 {
-  char                ipaddr[INET6_ADDRSTRLEN];
-  const void         *ptr   = NULL;
-  ares_hosts_entry_t *entry = NULL;
-  ares_status_t       status;
+  char                      ipaddr[INET6_ADDRSTRLEN];
+  const void               *ptr   = NULL;
+  const ares_hosts_entry_t *entry = NULL;
+  ares_status_t             status;
 
   if (addr->family == AF_INET) {
     ptr = &addr->addr.addr4;
@@ -221,7 +221,6 @@ static ares_status_t file_lookup(ares_channel_t         *channel,
   }
 
   status = ares_hosts_entry_to_hostent(entry, addr->family, host);
-  ares_hosts_entry_destroy(entry);
   if (status != ARES_SUCCESS) {
     return status; /* LCOV_EXCL_LINE: OutOfMemory */
   }

--- a/src/lib/ares_gethostbyname.c
+++ b/src/lib/ares_gethostbyname.c
@@ -288,8 +288,8 @@ static ares_status_t ares_gethostbyname_file_int(ares_channel_t *channel,
                                                  const char *name, int family,
                                                  struct hostent **host)
 {
-  ares_hosts_entry_t *entry = NULL;
-  ares_status_t       status;
+  const ares_hosts_entry_t *entry = NULL;
+  ares_status_t             status;
 
   /* We only take the channel to ensure that ares_init() been called. */
   if (channel == NULL || name == NULL || host == NULL) {
@@ -319,8 +319,6 @@ static ares_status_t ares_gethostbyname_file_int(ares_channel_t *channel,
   }
 
 done:
-  ares_hosts_entry_destroy(entry);
-
   /* RFC6761 section 6.3 #3 states that "Name resolution APIs and libraries
    * SHOULD recognize localhost names as special and SHOULD always return the
    * IP loopback address for address queries".

--- a/src/lib/ares_gethostbyname.c
+++ b/src/lib/ares_gethostbyname.c
@@ -288,8 +288,8 @@ static ares_status_t ares_gethostbyname_file_int(ares_channel_t *channel,
                                                  const char *name, int family,
                                                  struct hostent **host)
 {
-  const ares_hosts_entry_t *entry;
-  ares_status_t             status;
+  ares_hosts_entry_t *entry = NULL;
+  ares_status_t       status;
 
   /* We only take the channel to ensure that ares_init() been called. */
   if (channel == NULL || name == NULL || host == NULL) {
@@ -319,6 +319,8 @@ static ares_status_t ares_gethostbyname_file_int(ares_channel_t *channel,
   }
 
 done:
+  ares_hosts_entry_destroy(entry);
+
   /* RFC6761 section 6.3 #3 states that "Name resolution APIs and libraries
    * SHOULD recognize localhost names as special and SHOULD always return the
    * IP loopback address for address queries".

--- a/src/lib/ares_hosts_file.c
+++ b/src/lib/ares_hosts_file.c
@@ -70,15 +70,28 @@
  * 192.168.1.5  host.example.com host
  * 2620:1234::1 host.example.com host6.example.com host6 host
  *
- * This will yield 2 entries.
- *  1) ips: 127.0.0.1,::1
- *     hosts: localhost.localdomain,localhost
- *  2) ips: 192.168.1.1,192.168.1.5,2620:1234::1
- *     hosts: host.example.com,host,host6.example.com,host6
+ * STORAGE MODEL: BIPARTITE ADJACENCY
+ * ----------------------------------
+ * The hosts file is stored as a bipartite adjacency between hostnames and
+ * addresses.  Every (hostname, address) edge that appears on any line is
+ * recorded in both directions:
+ *   - hosthash: hostname -> ares_llist_t of the addresses that hostname
+ *     appeared on a line with (file-ordered, de-duplicated)
+ *   - iphash:   address  -> ares_llist_t of the hostnames that appeared on a
+ *     line with that address (file-ordered, de-duplicated)
  *
- * It could be argued that if searching for 192.168.1.1 that the 'host6'
- * hostnames should not be returned, but this implementation will return them
- * since they are related.  It is unlikely this will matter in the real world.
+ * A forward lookup (by name) or reverse lookup (by ip) builds a transient,
+ * fully address-scoped result entry from the relevant adjacency list.  Aliases
+ * are address-scoped: they are exactly the hostnames that share an address with
+ * the queried name.  Recording every edge is correct by construction -- it does
+ * not drop "bridge" lines (a line whose ip already belongs to one hostname and
+ * whose hostname belongs to another), which the older merged store did,
+ * silently losing addresses (Issue #1049).
+ *
+ * Memory tradeoff: keeping a hostname->address list plus an address->hostname
+ * list for every edge roughly doubles memory versus a naive merged store on
+ * very large hosts files (e.g. StevenBlack/hosts, ~80k hostnames).  We accept
+ * this deliberately in exchange for correct, leak-free results.
  */
 
 struct ares_hosts_file {
@@ -86,16 +99,17 @@ struct ares_hosts_file {
   /*! cache the filename so we know if the filename changes it automatically
    *  invalidates the cache */
   char                *filename;
-  /*! iphash is the owner of the 'entry' object as there is only ever a single
-   *  match to the object. */
+  /*! address (normalized str) -> ares_llist_t of hostname strings that appeared
+   *  on a line with that address (file-ordered, de-duplicated).  Owns the
+   *  llist values via ares_hosts_list_destroy_cb. */
   ares_htable_strvp_t *iphash;
-  /*! hosthash does not own the entry so won't free on destruction */
+  /*! hostname (str) -> ares_llist_t of address strings that hostname appeared
+   *  on a line with (file-ordered, de-duplicated).  Owns the llist values via
+   *  ares_hosts_list_destroy_cb. */
   ares_htable_strvp_t *hosthash;
 };
 
 struct ares_hosts_entry {
-  size_t        refcnt; /*! If the entry is stored multiple times in the
-                         *  ip address hash, we have to reference count it */
   ares_llist_t *ips;
   ares_llist_t *hosts;
 };
@@ -158,18 +172,9 @@ static ares_bool_t ares_normalize_ipaddr(const char *ipaddr, char *out,
   return ARES_TRUE;
 }
 
-static void ares_hosts_entry_destroy(ares_hosts_entry_t *entry)
+void ares_hosts_entry_destroy(ares_hosts_entry_t *entry)
 {
   if (entry == NULL) {
-    return;
-  }
-
-  /* Honor reference counting */
-  if (entry->refcnt != 0) {
-    entry->refcnt--;
-  }
-
-  if (entry->refcnt > 0) {
     return;
   }
 
@@ -178,9 +183,11 @@ static void ares_hosts_entry_destroy(ares_hosts_entry_t *entry)
   ares_free(entry);
 }
 
-static void ares_hosts_entry_destroy_cb(void *entry)
+/* htable value destructor: each value is an ares_llist_t (of ip or hostname
+ * strings) */
+static void ares_hosts_list_destroy_cb(void *arg)
 {
-  ares_hosts_entry_destroy(entry);
+  ares_llist_destroy(arg);
 }
 
 void ares_hosts_file_destroy(ares_hosts_file_t *hf)
@@ -209,12 +216,12 @@ static ares_hosts_file_t *ares_hosts_file_create(const char *filename)
     goto fail;
   }
 
-  hf->iphash = ares_htable_strvp_create(ares_hosts_entry_destroy_cb);
+  hf->iphash = ares_htable_strvp_create(ares_hosts_list_destroy_cb);
   if (hf->iphash == NULL) {
     goto fail;
   }
 
-  hf->hosthash = ares_htable_strvp_create(NULL);
+  hf->hosthash = ares_htable_strvp_create(ares_hosts_list_destroy_cb);
   if (hf->hosthash == NULL) {
     goto fail;
   }
@@ -226,140 +233,102 @@ fail:
   return NULL;
 }
 
-typedef enum {
-  ARES_MATCH_NONE   = 0,
-  ARES_MATCH_IPADDR = 1,
-  ARES_MATCH_HOST   = 2
-} ares_hosts_file_match_t;
-
-static ares_status_t ares_hosts_file_merge_entry(
-  const ares_hosts_file_t *hf, ares_hosts_entry_t *existing,
-  ares_hosts_entry_t *entry, ares_hosts_file_match_t matchtype)
+/* Case-insensitive membership test for an ip/host string list */
+static ares_bool_t ares_hosts_iplist_contains(ares_llist_t *list,
+                                              const char   *ipaddr)
 {
   ares_llist_node_t *node;
 
-  /* If we matched on IP address, we know there can only be 1, so there's no
-   * reason to do anything */
-  if (matchtype != ARES_MATCH_IPADDR) {
-    while ((node = ares_llist_node_first(entry->ips)) != NULL) {
-      const char *ipaddr = ares_llist_node_val(node);
-
-      if (ares_htable_strvp_get_direct(hf->iphash, ipaddr) != NULL) {
-        ares_llist_node_destroy(node);
-        continue;
-      }
-
-      ares_llist_node_mvparent_last(node, existing->ips);
+  for (node = ares_llist_node_first(list); node != NULL;
+       node = ares_llist_node_next(node)) {
+    if (ares_strcaseeq(ares_llist_node_val(node), ipaddr)) {
+      return ARES_TRUE;
     }
   }
 
-
-  while ((node = ares_llist_node_first(entry->hosts)) != NULL) {
-    const char *hostname = ares_llist_node_val(node);
-
-    if (ares_htable_strvp_get_direct(hf->hosthash, hostname) != NULL) {
-      ares_llist_node_destroy(node);
-      continue;
-    }
-
-    ares_llist_node_mvparent_last(node, existing->hosts);
-  }
-
-  ares_hosts_entry_destroy(entry);
-  return ARES_SUCCESS;
+  return ARES_FALSE;
 }
 
-static ares_hosts_file_match_t
-  ares_hosts_file_match(const ares_hosts_file_t *hf, ares_hosts_entry_t *entry,
-                        ares_hosts_entry_t **match)
-{
-  ares_llist_node_t *node;
-  *match = NULL;
-
-  for (node = ares_llist_node_first(entry->ips); node != NULL;
-       node = ares_llist_node_next(node)) {
-    const char *ipaddr = ares_llist_node_val(node);
-    *match             = ares_htable_strvp_get_direct(hf->iphash, ipaddr);
-    if (*match != NULL) {
-      return ARES_MATCH_IPADDR;
-    }
-  }
-
-  for (node = ares_llist_node_first(entry->hosts); node != NULL;
-       node = ares_llist_node_next(node)) {
-    const char *host = ares_llist_node_val(node);
-    *match           = ares_htable_strvp_get_direct(hf->hosthash, host);
-    if (*match != NULL) {
-      return ARES_MATCH_HOST;
-    }
-  }
-
-  return ARES_MATCH_NONE;
-}
-
-/*! entry is invalidated upon calling this function, always, even on error */
+/*! entry represents a single parsed line (one ip, its hostnames).  It is always
+ *  invalidated (destroyed) upon calling this function, even on error.  Each
+ *  (hostname, ipaddress) edge is recorded in both directions. */
 static ares_status_t ares_hosts_file_add(ares_hosts_file_t  *hosts,
                                          ares_hosts_entry_t *entry)
 {
-  ares_hosts_entry_t     *match  = NULL;
-  ares_status_t           status = ARES_SUCCESS;
-  ares_llist_node_t      *node;
-  ares_hosts_file_match_t matchtype;
-  size_t                  num_hostnames;
+  const char        *ipaddr = ares_llist_first_val(entry->ips);
+  ares_llist_node_t *node;
+  ares_status_t      status = ARES_SUCCESS;
 
-  /* Record the number of hostnames in this entry file.  If we merge into an
-   * existing record, these will be *appended* to the entry, so we'll count
-   * backwards when adding to the hosts hashtable */
-  num_hostnames = ares_llist_len(entry->hosts);
+  for (node = ares_llist_node_first(entry->hosts); node != NULL;
+       node = ares_llist_node_next(node)) {
+    const char   *host = ares_llist_node_val(node);
+    ares_llist_t *fwd;
+    ares_llist_t *rev;
+    char         *tmp;
 
-  matchtype = ares_hosts_file_match(hosts, entry, &match);
-
-  if (matchtype != ARES_MATCH_NONE) {
-    status = ares_hosts_file_merge_entry(hosts, match, entry, matchtype);
-    if (status != ARES_SUCCESS) {
-      ares_hosts_entry_destroy(entry); /* LCOV_EXCL_LINE: DefensiveCoding */
-      return status;                   /* LCOV_EXCL_LINE: DefensiveCoding */
-    }
-    /* entry was invalidated above by merging */
-    entry = match;
-  }
-
-  if (matchtype != ARES_MATCH_IPADDR) {
-    const char *ipaddr = ares_llist_last_val(entry->ips);
-
-    if (!ares_htable_strvp_get(hosts->iphash, ipaddr, NULL)) {
-      if (!ares_htable_strvp_insert(hosts->iphash, ipaddr, entry)) {
-        ares_hosts_entry_destroy(entry);
-        return ARES_ENOMEM;
+    /* Forward edge: hostname -> ip */
+    fwd = ares_htable_strvp_get_direct(hosts->hosthash, host);
+    if (fwd == NULL) {
+      fwd = ares_llist_create(ares_free);
+      if (fwd == NULL) {
+        status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
+        goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
       }
-      entry->refcnt++;
-    }
-  }
-
-  /* Go backwards, on a merge, hostnames are appended.  Breakout once we've
-   * consumed all the hosts that we appended */
-  for (node = ares_llist_node_last(entry->hosts); node != NULL;
-       node = ares_llist_node_prev(node)) {
-    const char *val = ares_llist_node_val(node);
-
-    if (num_hostnames == 0) {
-      break;
+      if (!ares_htable_strvp_insert(hosts->hosthash, host, fwd)) {
+        ares_llist_destroy(fwd); /* LCOV_EXCL_LINE: OutOfMemory */
+        status = ARES_ENOMEM;    /* LCOV_EXCL_LINE: OutOfMemory */
+        goto done;               /* LCOV_EXCL_LINE: OutOfMemory */
+      }
     }
 
-    num_hostnames--;
-
-    /* first hostname match wins.  If we detect a duplicate hostname for another
-     * ip it will automatically be added to the same entry */
-    if (ares_htable_strvp_get(hosts->hosthash, val, NULL)) {
+    /* De-dupe this (host, ip) edge against the (usually tiny) forward list.  If
+     * the edge already exists, so does its reverse, so skip both. */
+    if (ares_hosts_iplist_contains(fwd, ipaddr)) {
       continue;
     }
 
-    if (!ares_htable_strvp_insert(hosts->hosthash, val, entry)) {
-      return ARES_ENOMEM;
+    tmp = ares_strdup(ipaddr);
+    if (tmp == NULL) {
+      status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
+      goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+    if (ares_llist_insert_last(fwd, tmp) == NULL) {
+      ares_free(tmp);       /* LCOV_EXCL_LINE: OutOfMemory */
+      status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
+      goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+
+    /* Reverse edge: ip -> hostname.  The edge was new above, so 'host' is not
+     * yet in the reverse list either. */
+    rev = ares_htable_strvp_get_direct(hosts->iphash, ipaddr);
+    if (rev == NULL) {
+      rev = ares_llist_create(ares_free);
+      if (rev == NULL) {
+        status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
+        goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
+      }
+      if (!ares_htable_strvp_insert(hosts->iphash, ipaddr, rev)) {
+        ares_llist_destroy(rev); /* LCOV_EXCL_LINE: OutOfMemory */
+        status = ARES_ENOMEM;    /* LCOV_EXCL_LINE: OutOfMemory */
+        goto done;               /* LCOV_EXCL_LINE: OutOfMemory */
+      }
+    }
+
+    tmp = ares_strdup(host);
+    if (tmp == NULL) {
+      status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
+      goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+    if (ares_llist_insert_last(rev, tmp) == NULL) {
+      ares_free(tmp);       /* LCOV_EXCL_LINE: OutOfMemory */
+      status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
+      goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
     }
   }
 
-  return ARES_SUCCESS;
+done:
+  ares_hosts_entry_destroy(entry);
+  return status;
 }
 
 static ares_bool_t ares_hosts_entry_isdup(ares_hosts_entry_t *entry,
@@ -367,7 +336,7 @@ static ares_bool_t ares_hosts_entry_isdup(ares_hosts_entry_t *entry,
 {
   ares_llist_node_t *node;
 
-  for (node = ares_llist_node_first(entry->ips); node != NULL;
+  for (node = ares_llist_node_first(entry->hosts); node != NULL;
        node = ares_llist_node_next(node)) {
     const char *myhost = ares_llist_node_val(node);
     if (ares_strcaseeq(myhost, host)) {
@@ -721,10 +690,14 @@ static ares_status_t ares_hosts_update(ares_channel_t *channel,
 
 ares_status_t ares_hosts_search_ipaddr(ares_channel_t *channel,
                                        ares_bool_t use_env, const char *ipaddr,
-                                       const ares_hosts_entry_t **entry)
+                                       ares_hosts_entry_t **entry)
 {
-  ares_status_t status;
-  char          addr[INET6_ADDRSTRLEN];
+  ares_status_t       status;
+  char                addr[INET6_ADDRSTRLEN];
+  ares_llist_t       *names;
+  ares_hosts_entry_t *e = NULL;
+  ares_llist_node_t  *node;
+  char               *tmp;
 
   *entry = NULL;
 
@@ -741,19 +714,69 @@ ares_status_t ares_hosts_search_ipaddr(ares_channel_t *channel,
     return ARES_EBADNAME;
   }
 
-  *entry = ares_htable_strvp_get_direct(channel->hf->iphash, addr);
-  if (*entry == NULL) {
+  names = ares_htable_strvp_get_direct(channel->hf->iphash, addr);
+  if (names == NULL) {
     return ARES_ENOTFOUND;
   }
 
+  /* Build a transient result entry scoped to this address */
+  e = ares_malloc_zero(sizeof(*e));
+  if (e == NULL) {
+    return ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
+  }
+  e->ips   = ares_llist_create(ares_free);
+  e->hosts = ares_llist_create(ares_free);
+  if (e->ips == NULL || e->hosts == NULL) {
+    ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
+    return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
+  }
+
+  tmp = ares_strdup(addr);
+  if (tmp == NULL) {
+    ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
+    return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
+  }
+  if (ares_llist_insert_last(e->ips, tmp) == NULL) {
+    ares_free(tmp);              /* LCOV_EXCL_LINE: OutOfMemory */
+    ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
+    return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
+  }
+
+  /* All hostnames that appeared on a line with this address, in file order.
+   * Cap at 101 (canonical + 100 aliases). */
+  for (node = ares_llist_node_first(names); node != NULL;
+       node = ares_llist_node_next(node)) {
+    const char *nm = ares_llist_node_val(node);
+
+    if (ares_llist_len(e->hosts) >= 101) {
+      break; /* LCOV_EXCL_LINE: DefensiveCoding */
+    }
+
+    tmp = ares_strdup(nm);
+    if (tmp == NULL) {
+      ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
+      return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+    if (ares_llist_insert_last(e->hosts, tmp) == NULL) {
+      ares_free(tmp);              /* LCOV_EXCL_LINE: OutOfMemory */
+      ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
+      return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+  }
+
+  *entry = e;
   return ARES_SUCCESS;
 }
 
 ares_status_t ares_hosts_search_host(ares_channel_t *channel,
                                      ares_bool_t use_env, const char *host,
-                                     const ares_hosts_entry_t **entry)
+                                     ares_hosts_entry_t **entry)
 {
-  ares_status_t status;
+  ares_status_t       status;
+  ares_llist_t       *iplist;
+  ares_hosts_entry_t *e = NULL;
+  ares_llist_node_t  *ipnode;
+  char               *tmp;
 
   *entry = NULL;
 
@@ -766,11 +789,78 @@ ares_status_t ares_hosts_search_host(ares_channel_t *channel,
     return ARES_ENOTFOUND; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  *entry = ares_htable_strvp_get_direct(channel->hf->hosthash, host);
-  if (*entry == NULL) {
+  iplist = ares_htable_strvp_get_direct(channel->hf->hosthash, host);
+  if (iplist == NULL) {
     return ARES_ENOTFOUND;
   }
 
+  /* Build a transient result entry scoped to this hostname */
+  e = ares_malloc_zero(sizeof(*e));
+  if (e == NULL) {
+    return ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
+  }
+  e->ips   = ares_llist_create(ares_free);
+  e->hosts = ares_llist_create(ares_free);
+  if (e->ips == NULL || e->hosts == NULL) {
+    ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
+    return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
+  }
+
+  /* E->ips = the addresses this hostname appeared with, in file order */
+  for (ipnode = ares_llist_node_first(iplist); ipnode != NULL;
+       ipnode = ares_llist_node_next(ipnode)) {
+    tmp = ares_strdup(ares_llist_node_val(ipnode));
+    if (tmp == NULL) {
+      ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
+      return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+    if (ares_llist_insert_last(e->ips, tmp) == NULL) {
+      ares_free(tmp);              /* LCOV_EXCL_LINE: OutOfMemory */
+      ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
+      return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+  }
+
+  /* E->hosts = address-scoped alias list, canonical first.  Iterate E->ips in
+   * order; for each ip iterate iphash[ip] names in order, appending each name
+   * not already present (case-insensitive).  'host' itself will appear (it is a
+   * name on each of its ips).  Cap at 101 (canonical + 100 aliases) to bound
+   * the StevenBlack blocklist case. */
+  for (ipnode = ares_llist_node_first(e->ips); ipnode != NULL;
+       ipnode = ares_llist_node_next(ipnode)) {
+    const char   *ip    = ares_llist_node_val(ipnode);
+    ares_llist_t *names = ares_htable_strvp_get_direct(channel->hf->iphash, ip);
+    ares_llist_node_t *nnode;
+
+    if (ares_llist_len(e->hosts) >= 101) {
+      break; /* LCOV_EXCL_LINE: DefensiveCoding */
+    }
+
+    for (nnode = ares_llist_node_first(names); nnode != NULL;
+         nnode = ares_llist_node_next(nnode)) {
+      const char *nm = ares_llist_node_val(nnode);
+
+      if (ares_hosts_iplist_contains(e->hosts, nm)) {
+        continue;
+      }
+      if (ares_llist_len(e->hosts) >= 101) {
+        break; /* LCOV_EXCL_LINE: DefensiveCoding */
+      }
+
+      tmp = ares_strdup(nm);
+      if (tmp == NULL) {
+        ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
+        return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
+      }
+      if (ares_llist_insert_last(e->hosts, tmp) == NULL) {
+        ares_free(tmp);              /* LCOV_EXCL_LINE: OutOfMemory */
+        ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
+        return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
+      }
+    }
+  }
+
+  *entry = e;
   return ARES_SUCCESS;
 }
 
@@ -778,22 +868,20 @@ static ares_status_t
   ares_hosts_ai_append_cnames(const ares_hosts_entry_t    *entry,
                               struct ares_addrinfo_cname **cnames_out)
 {
-  struct ares_addrinfo_cname *cname  = NULL;
-  struct ares_addrinfo_cname *cnames = NULL;
-  const char                 *primaryhost;
+  struct ares_addrinfo_cname *cname       = NULL;
+  struct ares_addrinfo_cname *cnames      = NULL;
+  const char                 *primaryhost = ares_llist_first_val(entry->hosts);
   ares_llist_node_t          *node;
   ares_status_t               status;
   size_t                      cnt = 0;
 
-  node        = ares_llist_node_first(entry->hosts);
-  primaryhost = ares_llist_node_val(node);
-  /* Skip to next node to start with aliases */
-  node = ares_llist_node_next(node);
+  /* Canonical name is the first host (in file order); aliases are the rest. */
+  node = ares_llist_node_next(ares_llist_node_first(entry->hosts));
 
   while (node != NULL) {
     const char *host = ares_llist_node_val(node);
 
-    /* Cap at 100 entries. , some people use
+    /* Cap at 100 aliases, some people use
      * https://github.com/StevenBlack/hosts and we don't need 200k+ aliases */
     cnt++;
     if (cnt > 100) {

--- a/src/lib/ares_hosts_file.c
+++ b/src/lib/ares_hosts_file.c
@@ -70,28 +70,36 @@
  * 192.168.1.5  host.example.com host
  * 2620:1234::1 host.example.com host6.example.com host6 host
  *
- * STORAGE MODEL: BIPARTITE ADJACENCY
- * ----------------------------------
- * The hosts file is stored as a bipartite adjacency between hostnames and
- * addresses.  Every (hostname, address) edge that appears on any line is
- * recorded in both directions:
- *   - hosthash: hostname -> ares_llist_t of the addresses that hostname
- *     appeared on a line with (file-ordered, de-duplicated)
- *   - iphash:   address  -> ares_llist_t of the hostnames that appeared on a
- *     line with that address (file-ordered, de-duplicated)
+ * STORAGE MODEL: CACHED, ADDRESS-SCOPED ENTRIES
+ * ---------------------------------------------
+ * Every (hostname, address) edge that appears on any line is recorded, so no
+ * "bridge" line (a line whose ip already belongs to one hostname and whose
+ * hostname belongs to another) is dropped -- that dropping was Issue #1049.
  *
- * A forward lookup (by name) or reverse lookup (by ip) builds a transient,
- * fully address-scoped result entry from the relevant adjacency list.  Aliases
- * are address-scoped: they are exactly the hostnames that share an address with
- * the queried name.  Recording every edge is correct by construction -- it does
- * not drop "bridge" lines (a line whose ip already belongs to one hostname and
- * whose hostname belongs to another), which the older merged store did,
- * silently losing addresses (Issue #1049).
+ * Both lookup directions return a CACHED, fully address-scoped entry directly
+ * from a hashtable (no per-lookup allocation, callers do not free):
+ *   - iphash:   address  -> reverse entry E_r { ips=[address],
+ *               hosts=[the names that appeared on a line with that address,
+ *               file-ordered] }
+ *   - hosthash: hostname -> the entry to return for a forward lookup of that
+ *               name.  For a single-address hostname this is simply that
+ *               address's reverse entry E_r (shared, and reference counted so
+ *               it is freed exactly once).  Only a multi-address hostname gets
+ *               a dedicated forward entry E_f { ips=[its addresses, file
+ *               order], hosts=[canonical + up to 100 address-scoped aliases] }.
  *
- * Memory tradeoff: keeping a hostname->address list plus an address->hostname
- * list for every edge roughly doubles memory versus a naive merged store on
- * very large hosts files (e.g. StevenBlack/hosts, ~80k hostnames).  We accept
- * this deliberately in exchange for correct, leak-free results.
+ * The common case -- a hostname that appears with a single address -- is wired
+ * up INCREMENTALLY during the parse: the first time a hostname is seen it is
+ * pointed at that line's reverse entry in hosthash directly, with no extra
+ * bookkeeping.  A very large single-address file (e.g. StevenBlack/hosts, ~80k
+ * names all on 0.0.0.0) therefore needs no per-hostname adjacency and no
+ * finalize work at all.  Only a hostname that is later found on a SECOND
+ * address is tracked (in a small temporary map of just the multi-address names
+ * and their addresses); a finalize pass then replaces its hosthash entry with a
+ * dedicated forward entry.  Those temporaries are discarded before returning.
+ *
+ * Aliases are address-scoped: exactly the hostnames that share an address with
+ * the queried name, canonical first (the first such name in file order).
  */
 
 struct ares_hosts_file {
@@ -99,17 +107,19 @@ struct ares_hosts_file {
   /*! cache the filename so we know if the filename changes it automatically
    *  invalidates the cache */
   char                *filename;
-  /*! address (normalized str) -> ares_llist_t of hostname strings that appeared
-   *  on a line with that address (file-ordered, de-duplicated).  Owns the
-   *  llist values via ares_hosts_list_destroy_cb. */
+  /*! address (normalized str) -> cached reverse entry (ares_hosts_entry_t).
+   *  Owns the entry via ares_hosts_entry_destroy_cb (reference counted). */
   ares_htable_strvp_t *iphash;
-  /*! hostname (str) -> ares_llist_t of address strings that hostname appeared
-   *  on a line with (file-ordered, de-duplicated).  Owns the llist values via
-   *  ares_hosts_list_destroy_cb. */
+  /*! hostname (str) -> cached entry to return for a forward lookup of that name
+   *  (ares_hosts_entry_t).  May be the same object as an iphash reverse entry
+   *  (single-address hostname) or a dedicated forward entry (multi-address).
+   *  Owns the entry via ares_hosts_entry_destroy_cb (reference counted). */
   ares_htable_strvp_t *hosthash;
 };
 
 struct ares_hosts_entry {
+  size_t        refcnt; /*! Entries may be shared between iphash and hosthash,
+                         *  so they are reference counted. */
   ares_llist_t *ips;
   ares_llist_t *hosts;
 };
@@ -172,9 +182,17 @@ static ares_bool_t ares_normalize_ipaddr(const char *ipaddr, char *out,
   return ARES_TRUE;
 }
 
-void ares_hosts_entry_destroy(ares_hosts_entry_t *entry)
+static void ares_hosts_entry_destroy(ares_hosts_entry_t *entry)
 {
   if (entry == NULL) {
+    return;
+  }
+
+  /* Honor reference counting: only free once the last reference goes away */
+  if (entry->refcnt > 0) {
+    entry->refcnt--;
+  }
+  if (entry->refcnt > 0) {
     return;
   }
 
@@ -183,8 +201,14 @@ void ares_hosts_entry_destroy(ares_hosts_entry_t *entry)
   ares_free(entry);
 }
 
-/* htable value destructor: each value is an ares_llist_t (of ip or hostname
- * strings) */
+/* iphash/hosthash value destructor: values are (refcounted) entries */
+static void ares_hosts_entry_destroy_cb(void *e)
+{
+  ares_hosts_entry_destroy(e);
+}
+
+/* Temporary forward-adjacency htable value destructor: each value is an
+ * ares_llist_t of ip strings */
 static void ares_hosts_list_destroy_cb(void *arg)
 {
   ares_llist_destroy(arg);
@@ -216,12 +240,12 @@ static ares_hosts_file_t *ares_hosts_file_create(const char *filename)
     goto fail;
   }
 
-  hf->iphash = ares_htable_strvp_create(ares_hosts_list_destroy_cb);
+  hf->iphash = ares_htable_strvp_create(ares_hosts_entry_destroy_cb);
   if (hf->iphash == NULL) {
     goto fail;
   }
 
-  hf->hosthash = ares_htable_strvp_create(ares_hosts_list_destroy_cb);
+  hf->hosthash = ares_htable_strvp_create(ares_hosts_entry_destroy_cb);
   if (hf->hosthash == NULL) {
     goto fail;
   }
@@ -249,11 +273,73 @@ static ares_bool_t ares_hosts_iplist_contains(ares_llist_t *list,
   return ARES_FALSE;
 }
 
+/* Append a string copy to a list, returning the stored copy (or NULL on OOM) */
+static char *ares_hosts_list_append_strdup(ares_llist_t *list, const char *str)
+{
+  char *tmp = ares_strdup(str);
+  if (tmp == NULL) {
+    return NULL; /* LCOV_EXCL_LINE: OutOfMemory */
+  }
+  if (ares_llist_insert_last(list, tmp) == NULL) {
+    ares_free(tmp); /* LCOV_EXCL_LINE: OutOfMemory */
+    return NULL;    /* LCOV_EXCL_LINE: OutOfMemory */
+  }
+  return tmp;
+}
+
+/* Fetch (creating if needed) the cached reverse entry for 'ipaddr'.  A reverse
+ * entry is { refcnt=1, ips=[ipaddr], hosts=[] } and is owned by iphash. */
+static ares_status_t ares_hosts_reverse_entry(ares_hosts_file_t   *hosts,
+                                              const char          *ipaddr,
+                                              ares_hosts_entry_t **out)
+{
+  ares_hosts_entry_t *rev = ares_htable_strvp_get_direct(hosts->iphash, ipaddr);
+
+  if (rev != NULL) {
+    *out = rev;
+    return ARES_SUCCESS;
+  }
+
+  rev = ares_malloc_zero(sizeof(*rev));
+  if (rev == NULL) {
+    return ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
+  }
+  rev->refcnt = 1;
+  rev->ips    = ares_llist_create(ares_free);
+  rev->hosts  = ares_llist_create(ares_free);
+  if (rev->ips == NULL || rev->hosts == NULL) {
+    ares_hosts_entry_destroy(rev); /* LCOV_EXCL_LINE: OutOfMemory */
+    return ARES_ENOMEM;            /* LCOV_EXCL_LINE: OutOfMemory */
+  }
+
+  if (ares_hosts_list_append_strdup(rev->ips, ipaddr) == NULL) {
+    ares_hosts_entry_destroy(rev); /* LCOV_EXCL_LINE: OutOfMemory */
+    return ARES_ENOMEM;            /* LCOV_EXCL_LINE: OutOfMemory */
+  }
+
+  if (!ares_htable_strvp_insert(hosts->iphash, ipaddr, rev)) {
+    ares_hosts_entry_destroy(rev); /* LCOV_EXCL_LINE: OutOfMemory */
+    return ARES_ENOMEM;            /* LCOV_EXCL_LINE: OutOfMemory */
+  }
+
+  *out = rev;
+  return ARES_SUCCESS;
+}
+
 /*! entry represents a single parsed line (one ip, its hostnames).  It is always
- *  invalidated (destroyed) upon calling this function, even on error.  Each
- *  (hostname, ipaddress) edge is recorded in both directions. */
-static ares_status_t ares_hosts_file_add(ares_hosts_file_t  *hosts,
-                                         ares_hosts_entry_t *entry)
+ *  invalidated (destroyed) upon calling this function, even on error.
+ *
+ *  Each new (hostname, ipaddress) edge is appended to the address's reverse
+ *  entry in iphash.  A hostname's first sighting is wired directly into
+ *  hosthash as a shared reference to that reverse entry (the single-address
+ *  fast path).  Only when a hostname is later found on a SECOND address is it
+ *  tracked in the small temporary 'multi' map (hostname -> its ip strings) and
+ *  appended to 'multi_names'; hosthash keeps pointing at the shared reverse
+ *  entry until the finalize pass replaces it. */
+static ares_status_t ares_hosts_file_add(ares_hosts_file_t   *hosts,
+                                         ares_htable_strvp_t *multi,
+                                         ares_llist_t        *multi_names,
+                                         ares_hosts_entry_t  *entry)
 {
   const char        *ipaddr = ares_llist_first_val(entry->ips);
   ares_llist_node_t *node;
@@ -261,66 +347,88 @@ static ares_status_t ares_hosts_file_add(ares_hosts_file_t  *hosts,
 
   for (node = ares_llist_node_first(entry->hosts); node != NULL;
        node = ares_llist_node_next(node)) {
-    const char   *host = ares_llist_node_val(node);
-    ares_llist_t *fwd;
-    ares_llist_t *rev;
-    char         *tmp;
+    const char         *host = ares_llist_node_val(node);
+    ares_hosts_entry_t *rev;
+    ares_hosts_entry_t *cur;
+    ares_llist_t       *m;
 
-    /* Forward edge: hostname -> ip */
-    fwd = ares_htable_strvp_get_direct(hosts->hosthash, host);
-    if (fwd == NULL) {
-      fwd = ares_llist_create(ares_free);
-      if (fwd == NULL) {
+    /* Reverse entry for this line's ip */
+    status = ares_hosts_reverse_entry(hosts, ipaddr, &rev);
+    if (status != ARES_SUCCESS) {
+      goto done; /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+
+    cur = ares_htable_strvp_get_direct(hosts->hosthash, host);
+
+    if (cur == NULL) {
+      /* First sighting of host: assume single-address, share this reverse
+       * entry.  The (host, ip) edge is new. */
+      if (!ares_htable_strvp_insert(hosts->hosthash, host, rev)) {
         status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
         goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
       }
-      if (!ares_htable_strvp_insert(hosts->hosthash, host, fwd)) {
-        ares_llist_destroy(fwd); /* LCOV_EXCL_LINE: OutOfMemory */
-        status = ARES_ENOMEM;    /* LCOV_EXCL_LINE: OutOfMemory */
-        goto done;               /* LCOV_EXCL_LINE: OutOfMemory */
+      rev->refcnt++;
+      if (ares_hosts_list_append_strdup(rev->hosts, host) == NULL) {
+        status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
+        goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
       }
-    }
-
-    /* De-dupe this (host, ip) edge against the (usually tiny) forward list.  If
-     * the edge already exists, so does its reverse, so skip both. */
-    if (ares_hosts_iplist_contains(fwd, ipaddr)) {
       continue;
     }
 
-    tmp = ares_strdup(ipaddr);
-    if (tmp == NULL) {
-      status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
-      goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
-    }
-    if (ares_llist_insert_last(fwd, tmp) == NULL) {
-      ares_free(tmp);       /* LCOV_EXCL_LINE: OutOfMemory */
-      status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
-      goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
+    if (cur == rev) {
+      /* host already recorded on this same ip -> duplicate edge, skip */
+      continue;
     }
 
-    /* Reverse edge: ip -> hostname.  The edge was new above, so 'host' is not
-     * yet in the reverse list either. */
-    rev = ares_htable_strvp_get_direct(hosts->iphash, ipaddr);
-    if (rev == NULL) {
-      rev = ares_llist_create(ares_free);
-      if (rev == NULL) {
+    /* host is (or is becoming) multi-address: cur is the reverse entry of its
+     * first address, which differs from this line's ip. */
+    m = ares_htable_strvp_get_direct(multi, host);
+    if (m == NULL) {
+      /* Second distinct address: start tracking host's address list.  Seed it
+       * with its existing first address followed by this one. */
+      const char *first_ip = ares_llist_first_val(cur->ips);
+      char       *hostcopy;
+
+      m = ares_llist_create(ares_free);
+      if (m == NULL) {
         status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
         goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
       }
-      if (!ares_htable_strvp_insert(hosts->iphash, ipaddr, rev)) {
-        ares_llist_destroy(rev); /* LCOV_EXCL_LINE: OutOfMemory */
-        status = ARES_ENOMEM;    /* LCOV_EXCL_LINE: OutOfMemory */
-        goto done;               /* LCOV_EXCL_LINE: OutOfMemory */
+      if (ares_hosts_list_append_strdup(m, first_ip) == NULL ||
+          ares_hosts_list_append_strdup(m, ipaddr) == NULL) {
+        ares_llist_destroy(m); /* LCOV_EXCL_LINE: OutOfMemory */
+        status = ARES_ENOMEM;  /* LCOV_EXCL_LINE: OutOfMemory */
+        goto done;             /* LCOV_EXCL_LINE: OutOfMemory */
       }
+      if (!ares_htable_strvp_insert(multi, host, m)) {
+        ares_llist_destroy(m); /* LCOV_EXCL_LINE: OutOfMemory */
+        status = ARES_ENOMEM;  /* LCOV_EXCL_LINE: OutOfMemory */
+        goto done;             /* LCOV_EXCL_LINE: OutOfMemory */
+      }
+
+      /* The (host, ip) edge is new; append to this ip's reverse entry and
+       * remember host (by reference to the persistent copy) for finalize. */
+      hostcopy = ares_hosts_list_append_strdup(rev->hosts, host);
+      if (hostcopy == NULL) {
+        status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
+        goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
+      }
+      if (ares_llist_insert_last(multi_names, hostcopy) == NULL) {
+        status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
+        goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
+      }
+      continue;
     }
 
-    tmp = ares_strdup(host);
-    if (tmp == NULL) {
+    /* Already multi-address.  Record the edge if this ip is new for host. */
+    if (ares_hosts_iplist_contains(m, ipaddr)) {
+      continue;
+    }
+    if (ares_hosts_list_append_strdup(m, ipaddr) == NULL) {
       status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
       goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
     }
-    if (ares_llist_insert_last(rev, tmp) == NULL) {
-      ares_free(tmp);       /* LCOV_EXCL_LINE: OutOfMemory */
+    if (ares_hosts_list_append_strdup(rev->hosts, host) == NULL) {
       status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
       goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
     }
@@ -329,6 +437,108 @@ static ares_status_t ares_hosts_file_add(ares_hosts_file_t  *hosts,
 done:
   ares_hosts_entry_destroy(entry);
   return status;
+}
+
+/* Build the forward entry for a hostname that appeared with 2+ addresses:
+ * { refcnt=1, ips=[its addresses, file order],
+ *   hosts=[canonical + up to 100 address-scoped aliases] }. */
+static ares_status_t ares_hosts_build_forward_entry(ares_hosts_file_t   *hosts,
+                                                    ares_llist_t        *flist,
+                                                    ares_hosts_entry_t **out)
+{
+  ares_hosts_entry_t *ent;
+  ares_llist_node_t  *ipnode;
+
+  *out = NULL;
+
+  ent = ares_malloc_zero(sizeof(*ent));
+  if (ent == NULL) {
+    return ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
+  }
+  ent->refcnt = 1;
+  ent->ips    = ares_llist_create(ares_free);
+  ent->hosts  = ares_llist_create(ares_free);
+  if (ent->ips == NULL || ent->hosts == NULL) {
+    ares_hosts_entry_destroy(ent); /* LCOV_EXCL_LINE: OutOfMemory */
+    return ARES_ENOMEM;            /* LCOV_EXCL_LINE: OutOfMemory */
+  }
+
+  /* ips = this hostname's addresses, in file order */
+  for (ipnode = ares_llist_node_first(flist); ipnode != NULL;
+       ipnode = ares_llist_node_next(ipnode)) {
+    if (ares_hosts_list_append_strdup(ent->ips, ares_llist_node_val(ipnode)) ==
+        NULL) {
+      ares_hosts_entry_destroy(ent); /* LCOV_EXCL_LINE: OutOfMemory */
+      return ARES_ENOMEM;            /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+  }
+
+  /* hosts = address-scoped alias list, canonical first.  Iterate the addresses
+   * in order; for each, iterate the reverse entry's hostnames in order,
+   * appending each name not already present (case-insensitive).  Cap at 101
+   * (canonical + 100 aliases) to bound the StevenBlack blocklist case. */
+  for (ipnode = ares_llist_node_first(ent->ips); ipnode != NULL;
+       ipnode = ares_llist_node_next(ipnode)) {
+    const char         *ip  = ares_llist_node_val(ipnode);
+    ares_hosts_entry_t *rev = ares_htable_strvp_get_direct(hosts->iphash, ip);
+    ares_llist_node_t  *nnode;
+
+    if (ares_llist_len(ent->hosts) >= 101) {
+      break; /* LCOV_EXCL_LINE: DefensiveCoding */
+    }
+
+    for (nnode = ares_llist_node_first(rev->hosts); nnode != NULL;
+         nnode = ares_llist_node_next(nnode)) {
+      const char *nm = ares_llist_node_val(nnode);
+
+      if (ares_hosts_iplist_contains(ent->hosts, nm)) {
+        continue;
+      }
+      if (ares_llist_len(ent->hosts) >= 101) {
+        break; /* LCOV_EXCL_LINE: DefensiveCoding */
+      }
+
+      if (ares_hosts_list_append_strdup(ent->hosts, nm) == NULL) {
+        ares_hosts_entry_destroy(ent); /* LCOV_EXCL_LINE: OutOfMemory */
+        return ARES_ENOMEM;            /* LCOV_EXCL_LINE: OutOfMemory */
+      }
+    }
+  }
+
+  *out = ent;
+  return ARES_SUCCESS;
+}
+
+/* After all lines are parsed, give each multi-address hostname its own
+ * dedicated forward entry.  During the parse hosthash[name] was left pointing
+ * at the shared reverse entry of the name's first address; inserting the
+ * forward entry over that key invokes the value destructor on the old shared
+ * entry (dropping its reference), cleanly un-sharing it. */
+static ares_status_t ares_hosts_finalize(ares_hosts_file_t   *hosts,
+                                         ares_htable_strvp_t *multi,
+                                         ares_llist_t        *multi_names)
+{
+  ares_llist_node_t *node;
+
+  for (node = ares_llist_node_first(multi_names); node != NULL;
+       node = ares_llist_node_next(node)) {
+    const char         *name = ares_llist_node_val(node);
+    ares_llist_t       *m    = ares_htable_strvp_get_direct(multi, name);
+    ares_hosts_entry_t *ent;
+    ares_status_t       status;
+
+    status = ares_hosts_build_forward_entry(hosts, m, &ent);
+    if (status != ARES_SUCCESS) {
+      return status; /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+
+    if (!ares_htable_strvp_insert(hosts->hosthash, name, ent)) {
+      ares_hosts_entry_destroy(ent); /* LCOV_EXCL_LINE: OutOfMemory */
+      return ARES_ENOMEM;            /* LCOV_EXCL_LINE: OutOfMemory */
+    }
+  }
+
+  return ARES_SUCCESS;
 }
 
 static ares_bool_t ares_hosts_entry_isdup(ares_hosts_entry_t *entry,
@@ -474,10 +684,16 @@ static ares_status_t ares_parse_hosts_ipaddr(ares_buf_t          *buf,
 static ares_status_t ares_parse_hosts(const char         *filename,
                                       ares_hosts_file_t **out)
 {
-  ares_buf_t         *buf    = NULL;
-  ares_status_t       status = ARES_EBADRESP;
-  ares_hosts_file_t  *hf     = NULL;
-  ares_hosts_entry_t *entry  = NULL;
+  ares_buf_t          *buf    = NULL;
+  ares_status_t        status = ARES_EBADRESP;
+  ares_hosts_file_t   *hf     = NULL;
+  ares_hosts_entry_t  *entry  = NULL;
+  /* Small temporaries tracking ONLY multi-address hostnames: their ip lists
+   * (multi) and the order they became multi (multi_names, holding references,
+   * not owned, to hostname copies that live in the reverse entries).  For a
+   * single-address file these stay empty.  Discarded before returning. */
+  ares_htable_strvp_t *multi       = NULL;
+  ares_llist_t        *multi_names = NULL;
 
   *out = NULL;
 
@@ -496,6 +712,13 @@ static ares_status_t ares_parse_hosts(const char         *filename,
   if (hf == NULL) {
     status = ARES_ENOMEM;
     goto done;
+  }
+
+  multi       = ares_htable_strvp_create(ares_hosts_list_destroy_cb);
+  multi_names = ares_llist_create(NULL);
+  if (multi == NULL || multi_names == NULL) {
+    status = ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
+    goto done;            /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   while (ares_buf_len(buf)) {
@@ -539,8 +762,9 @@ static ares_status_t ares_parse_hosts(const char         *filename,
       continue;
     }
 
-    /* Append the successful entry to the hosts file */
-    status = ares_hosts_file_add(hf, entry);
+    /* Record this line's edges (reverse entries + single-address sharing;
+     * multi-address names accumulate in multi/multi_names) */
+    status = ares_hosts_file_add(hf, multi, multi_names, entry);
     entry  = NULL; /* is always invalidated by this function, even on error */
     if (status != ARES_SUCCESS) {
       goto done;
@@ -550,10 +774,18 @@ static ares_status_t ares_parse_hosts(const char         *filename,
     ares_buf_consume_line(buf, ARES_TRUE);
   }
 
+  /* Give each multi-address hostname its dedicated forward entry */
+  status = ares_hosts_finalize(hf, multi, multi_names);
+  if (status != ARES_SUCCESS) {
+    goto done; /* LCOV_EXCL_LINE: OutOfMemory */
+  }
+
   status = ARES_SUCCESS;
 
 done:
   ares_hosts_entry_destroy(entry);
+  ares_llist_destroy(multi_names);
+  ares_htable_strvp_destroy(multi);
   ares_buf_destroy(buf);
   if (status != ARES_SUCCESS) {
     ares_hosts_file_destroy(hf);
@@ -690,14 +922,10 @@ static ares_status_t ares_hosts_update(ares_channel_t *channel,
 
 ares_status_t ares_hosts_search_ipaddr(ares_channel_t *channel,
                                        ares_bool_t use_env, const char *ipaddr,
-                                       ares_hosts_entry_t **entry)
+                                       const ares_hosts_entry_t **entry)
 {
-  ares_status_t       status;
-  char                addr[INET6_ADDRSTRLEN];
-  ares_llist_t       *names;
-  ares_hosts_entry_t *e = NULL;
-  ares_llist_node_t  *node;
-  char               *tmp;
+  ares_status_t status;
+  char          addr[INET6_ADDRSTRLEN];
 
   *entry = NULL;
 
@@ -714,69 +942,20 @@ ares_status_t ares_hosts_search_ipaddr(ares_channel_t *channel,
     return ARES_EBADNAME;
   }
 
-  names = ares_htable_strvp_get_direct(channel->hf->iphash, addr);
-  if (names == NULL) {
+  /* Cached, address-scoped reverse entry (caller does not free) */
+  *entry = ares_htable_strvp_get_direct(channel->hf->iphash, addr);
+  if (*entry == NULL) {
     return ARES_ENOTFOUND;
   }
 
-  /* Build a transient result entry scoped to this address */
-  e = ares_malloc_zero(sizeof(*e));
-  if (e == NULL) {
-    return ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
-  }
-  e->ips   = ares_llist_create(ares_free);
-  e->hosts = ares_llist_create(ares_free);
-  if (e->ips == NULL || e->hosts == NULL) {
-    ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
-    return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
-  }
-
-  tmp = ares_strdup(addr);
-  if (tmp == NULL) {
-    ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
-    return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
-  }
-  if (ares_llist_insert_last(e->ips, tmp) == NULL) {
-    ares_free(tmp);              /* LCOV_EXCL_LINE: OutOfMemory */
-    ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
-    return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
-  }
-
-  /* All hostnames that appeared on a line with this address, in file order.
-   * Cap at 101 (canonical + 100 aliases). */
-  for (node = ares_llist_node_first(names); node != NULL;
-       node = ares_llist_node_next(node)) {
-    const char *nm = ares_llist_node_val(node);
-
-    if (ares_llist_len(e->hosts) >= 101) {
-      break; /* LCOV_EXCL_LINE: DefensiveCoding */
-    }
-
-    tmp = ares_strdup(nm);
-    if (tmp == NULL) {
-      ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
-      return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
-    }
-    if (ares_llist_insert_last(e->hosts, tmp) == NULL) {
-      ares_free(tmp);              /* LCOV_EXCL_LINE: OutOfMemory */
-      ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
-      return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
-    }
-  }
-
-  *entry = e;
   return ARES_SUCCESS;
 }
 
 ares_status_t ares_hosts_search_host(ares_channel_t *channel,
                                      ares_bool_t use_env, const char *host,
-                                     ares_hosts_entry_t **entry)
+                                     const ares_hosts_entry_t **entry)
 {
-  ares_status_t       status;
-  ares_llist_t       *iplist;
-  ares_hosts_entry_t *e = NULL;
-  ares_llist_node_t  *ipnode;
-  char               *tmp;
+  ares_status_t status;
 
   *entry = NULL;
 
@@ -789,78 +968,12 @@ ares_status_t ares_hosts_search_host(ares_channel_t *channel,
     return ARES_ENOTFOUND; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  iplist = ares_htable_strvp_get_direct(channel->hf->hosthash, host);
-  if (iplist == NULL) {
+  /* Cached, address-scoped forward entry (caller does not free) */
+  *entry = ares_htable_strvp_get_direct(channel->hf->hosthash, host);
+  if (*entry == NULL) {
     return ARES_ENOTFOUND;
   }
 
-  /* Build a transient result entry scoped to this hostname */
-  e = ares_malloc_zero(sizeof(*e));
-  if (e == NULL) {
-    return ARES_ENOMEM; /* LCOV_EXCL_LINE: OutOfMemory */
-  }
-  e->ips   = ares_llist_create(ares_free);
-  e->hosts = ares_llist_create(ares_free);
-  if (e->ips == NULL || e->hosts == NULL) {
-    ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
-    return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
-  }
-
-  /* E->ips = the addresses this hostname appeared with, in file order */
-  for (ipnode = ares_llist_node_first(iplist); ipnode != NULL;
-       ipnode = ares_llist_node_next(ipnode)) {
-    tmp = ares_strdup(ares_llist_node_val(ipnode));
-    if (tmp == NULL) {
-      ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
-      return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
-    }
-    if (ares_llist_insert_last(e->ips, tmp) == NULL) {
-      ares_free(tmp);              /* LCOV_EXCL_LINE: OutOfMemory */
-      ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
-      return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
-    }
-  }
-
-  /* E->hosts = address-scoped alias list, canonical first.  Iterate E->ips in
-   * order; for each ip iterate iphash[ip] names in order, appending each name
-   * not already present (case-insensitive).  'host' itself will appear (it is a
-   * name on each of its ips).  Cap at 101 (canonical + 100 aliases) to bound
-   * the StevenBlack blocklist case. */
-  for (ipnode = ares_llist_node_first(e->ips); ipnode != NULL;
-       ipnode = ares_llist_node_next(ipnode)) {
-    const char   *ip    = ares_llist_node_val(ipnode);
-    ares_llist_t *names = ares_htable_strvp_get_direct(channel->hf->iphash, ip);
-    ares_llist_node_t *nnode;
-
-    if (ares_llist_len(e->hosts) >= 101) {
-      break; /* LCOV_EXCL_LINE: DefensiveCoding */
-    }
-
-    for (nnode = ares_llist_node_first(names); nnode != NULL;
-         nnode = ares_llist_node_next(nnode)) {
-      const char *nm = ares_llist_node_val(nnode);
-
-      if (ares_hosts_iplist_contains(e->hosts, nm)) {
-        continue;
-      }
-      if (ares_llist_len(e->hosts) >= 101) {
-        break; /* LCOV_EXCL_LINE: DefensiveCoding */
-      }
-
-      tmp = ares_strdup(nm);
-      if (tmp == NULL) {
-        ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
-        return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
-      }
-      if (ares_llist_insert_last(e->hosts, tmp) == NULL) {
-        ares_free(tmp);              /* LCOV_EXCL_LINE: OutOfMemory */
-        ares_hosts_entry_destroy(e); /* LCOV_EXCL_LINE: OutOfMemory */
-        return ARES_ENOMEM;          /* LCOV_EXCL_LINE: OutOfMemory */
-      }
-    }
-  }
-
-  *entry = e;
   return ARES_SUCCESS;
 }
 

--- a/src/lib/ares_hosts_file.c
+++ b/src/lib/ares_hosts_file.c
@@ -102,6 +102,12 @@
  * the queried name, canonical first (the first such name in file order).
  */
 
+/*! Maximum number of address-scoped aliases (beyond the canonical name) that we
+ *  retain in a forward entry and emit as cnames.  Bounds the StevenBlack/hosts
+ *  blocklist case where a single address can carry hundreds of thousands of
+ *  names. */
+#define ARES_HOSTS_MAX_ALIASES 100
+
 struct ares_hosts_file {
   time_t               ts;
   /*! cache the filename so we know if the filename changes it automatically
@@ -258,8 +264,8 @@ fail:
 }
 
 /* Case-insensitive membership test for an ip/host string list */
-static ares_bool_t ares_hosts_iplist_contains(ares_llist_t *list,
-                                              const char   *ipaddr)
+static ares_bool_t ares_hosts_strlist_contains(ares_llist_t *list,
+                                               const char   *ipaddr)
 {
   ares_llist_node_t *node;
 
@@ -421,7 +427,7 @@ static ares_status_t ares_hosts_file_add(ares_hosts_file_t   *hosts,
     }
 
     /* Already multi-address.  Record the edge if this ip is new for host. */
-    if (ares_hosts_iplist_contains(m, ipaddr)) {
+    if (ares_hosts_strlist_contains(m, ipaddr)) {
       continue;
     }
     if (ares_hosts_list_append_strdup(m, ipaddr) == NULL) {
@@ -483,19 +489,27 @@ static ares_status_t ares_hosts_build_forward_entry(ares_hosts_file_t   *hosts,
     ares_hosts_entry_t *rev = ares_htable_strvp_get_direct(hosts->iphash, ip);
     ares_llist_node_t  *nnode;
 
-    if (ares_llist_len(ent->hosts) >= 101) {
-      break; /* LCOV_EXCL_LINE: DefensiveCoding */
+    /* Every ip in ent->ips was recorded during parse and so has an iphash
+     * entry; nothing removes from iphash.  Guard anyway so a future change that
+     * could drop an entry degrades to a lookup miss rather than a NULL deref.
+     */
+    if (rev == NULL) {
+      continue; /* LCOV_EXCL_LINE: DefensiveCoding */
+    }
+
+    if (ares_llist_len(ent->hosts) >= ARES_HOSTS_MAX_ALIASES + 1) {
+      break; /* LCOV_EXCL_LINE: FallbackCode */
     }
 
     for (nnode = ares_llist_node_first(rev->hosts); nnode != NULL;
          nnode = ares_llist_node_next(nnode)) {
       const char *nm = ares_llist_node_val(nnode);
 
-      if (ares_hosts_iplist_contains(ent->hosts, nm)) {
+      if (ares_hosts_strlist_contains(ent->hosts, nm)) {
         continue;
       }
-      if (ares_llist_len(ent->hosts) >= 101) {
-        break; /* LCOV_EXCL_LINE: DefensiveCoding */
+      if (ares_llist_len(ent->hosts) >= ARES_HOSTS_MAX_ALIASES + 1) {
+        break; /* LCOV_EXCL_LINE: FallbackCode */
       }
 
       if (ares_hosts_list_append_strdup(ent->hosts, nm) == NULL) {
@@ -994,11 +1008,11 @@ static ares_status_t
   while (node != NULL) {
     const char *host = ares_llist_node_val(node);
 
-    /* Cap at 100 aliases, some people use
+    /* Cap aliases (ARES_HOSTS_MAX_ALIASES); some people use
      * https://github.com/StevenBlack/hosts and we don't need 200k+ aliases */
     cnt++;
-    if (cnt > 100) {
-      break; /* LCOV_EXCL_LINE: DefensiveCoding */
+    if (cnt > ARES_HOSTS_MAX_ALIASES) {
+      break; /* LCOV_EXCL_LINE: FallbackCode */
     }
 
     cname = ares_append_addrinfo_cname(&cnames);

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -489,13 +489,12 @@ struct ares_hosts_entry;
 typedef struct ares_hosts_entry ares_hosts_entry_t;
 
 void                            ares_hosts_file_destroy(ares_hosts_file_t *hf);
-void ares_hosts_entry_destroy(ares_hosts_entry_t *entry);
 ares_status_t ares_hosts_search_ipaddr(ares_channel_t *channel,
                                        ares_bool_t use_env, const char *ipaddr,
-                                       ares_hosts_entry_t **entry);
+                                       const ares_hosts_entry_t **entry);
 ares_status_t ares_hosts_search_host(ares_channel_t *channel,
                                      ares_bool_t use_env, const char *host,
-                                     ares_hosts_entry_t **entry);
+                                     const ares_hosts_entry_t **entry);
 ares_status_t ares_hosts_entry_to_hostent(const ares_hosts_entry_t *entry,
                                           int family, struct hostent **hostent);
 ares_status_t ares_hosts_entry_to_addrinfo(const ares_hosts_entry_t *entry,

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -489,12 +489,13 @@ struct ares_hosts_entry;
 typedef struct ares_hosts_entry ares_hosts_entry_t;
 
 void                            ares_hosts_file_destroy(ares_hosts_file_t *hf);
+void ares_hosts_entry_destroy(ares_hosts_entry_t *entry);
 ares_status_t ares_hosts_search_ipaddr(ares_channel_t *channel,
                                        ares_bool_t use_env, const char *ipaddr,
-                                       const ares_hosts_entry_t **entry);
+                                       ares_hosts_entry_t **entry);
 ares_status_t ares_hosts_search_host(ares_channel_t *channel,
                                      ares_bool_t use_env, const char *host,
-                                     const ares_hosts_entry_t **entry);
+                                     ares_hosts_entry_t **entry);
 ares_status_t ares_hosts_entry_to_hostent(const ares_hosts_entry_t *entry,
                                           int family, struct hostent **hostent);
 ares_status_t ares_hosts_entry_to_addrinfo(const ares_hosts_entry_t *entry,

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -636,6 +636,208 @@ TEST_F(FileChannelTest, GetAddrInfoHostsIPV6) {
   EXPECT_EQ("{ipv6.com addr=[[0000:0000:0000:0000:0000:0000:0000:0001]]}", ss.str());
 }
 
+// Regression for #1049: hostnames merged into a single entry only because they
+// share an ip address must not leak each other's *other* addresses (forward
+// lookup) or appear as each other's aliases (address-scoped cnames).  Here
+// mullvad-no-svg shares 10.124.2.38 with mullvad-no (which drags in the whole
+// group), but must resolve to only 10.124.2.38, and mullvad-no-osl (no shared
+// address) must not be reported as an alias.
+TEST_F(FileChannelTest, GetAddrInfoHostsSharedIPNoLeak)
+{
+  TempFile                   hostsfile("10.124.0.6   mullvad-no\n"
+                                       "10.124.0.108 mullvad-no\n"
+                                       "10.124.2.38  mullvad-no\n"
+                                       "10.124.0.6   mullvad-no-osl\n"
+                                       "10.124.0.108 mullvad-no-osl\n"
+                                       "10.124.2.38  mullvad-no-svg\n");
+  EnvValue                   with_env("CARES_HOSTS", hostsfile.filename());
+  struct ares_addrinfo_hints hints  = { 0, 0, 0, 0 };
+  AddrInfoResult             result = {};
+  hints.ai_family                   = AF_INET;
+  hints.ai_flags = ARES_AI_CANONNAME | ARES_AI_ENVHOSTS | ARES_AI_NOSORT;
+  ares_getaddrinfo(channel_, "mullvad-no-svg", NULL, &hints, AddrInfoCallback,
+                   &result);
+  Process();
+  EXPECT_TRUE(result.done_);
+  std::stringstream ss;
+  ss << result.ai_;
+  EXPECT_EQ("{mullvad-no-svg->mullvad-no addr=[10.124.2.38]}", ss.str());
+}
+
+// The legitimate multi-address case still returns all of a hostname's own
+// addresses (mullvad-no genuinely has three).
+TEST_F(FileChannelTest, GetAddrInfoHostsMultiAddressPreserved)
+{
+  TempFile                   hostsfile("10.124.0.6   mullvad-no\n"
+                                       "10.124.0.108 mullvad-no\n"
+                                       "10.124.2.38  mullvad-no\n"
+                                       "10.124.0.6   mullvad-no-osl\n"
+                                       "10.124.0.108 mullvad-no-osl\n"
+                                       "10.124.2.38  mullvad-no-svg\n");
+  EnvValue                   with_env("CARES_HOSTS", hostsfile.filename());
+  struct ares_addrinfo_hints hints  = { 0, 0, 0, 0 };
+  AddrInfoResult             result = {};
+  hints.ai_family                   = AF_INET;
+  hints.ai_flags                    = ARES_AI_NOSORT | ARES_AI_ENVHOSTS;
+  ares_getaddrinfo(channel_, "mullvad-no", NULL, &hints, AddrInfoCallback,
+                   &result);
+  Process();
+  EXPECT_TRUE(result.done_);
+  std::stringstream ss;
+  ss << result.ai_;
+  EXPECT_EQ("{addr=[10.124.0.6], addr=[10.124.0.108], addr=[10.124.2.38]}",
+            ss.str());
+}
+
+// Regression for #1049: a "bridge" line whose ip already belongs to one
+// hostname and whose hostname already belongs to another must NOT drop the
+// address.  Here mullvad-no-svg appears with 10.124.2.38 and with 10.64.0.1
+// (a line that also lists mullvad).  Both addresses must be returned; the old
+// merged store silently dropped 10.64.0.1.
+TEST_F(FileChannelTest, GetAddrInfoHostsBridgeFallback)
+{
+  TempFile                   hostsfile("10.64.0.1 mullvad\n"
+                                       "10.124.2.38 mullvad-no-svg\n"
+                                       "10.64.0.1 mullvad-no-svg\n");
+  EnvValue                   with_env("CARES_HOSTS", hostsfile.filename());
+  struct ares_addrinfo_hints hints  = { 0, 0, 0, 0 };
+  AddrInfoResult             result = {};
+  hints.ai_family                   = AF_INET;
+  hints.ai_flags = ARES_AI_CANONNAME | ARES_AI_ENVHOSTS | ARES_AI_NOSORT;
+  ares_getaddrinfo(channel_, "mullvad-no-svg", NULL, &hints, AddrInfoCallback,
+                   &result);
+  Process();
+  EXPECT_TRUE(result.done_);
+  std::stringstream ss;
+  ss << result.ai_;
+  EXPECT_EQ("{mullvad->mullvad-no-svg addr=[10.124.2.38], addr=[10.64.0.1]}",
+            ss.str());
+}
+
+// A shared ip chains hostnames together, but a forward lookup must return only
+// the addresses the queried name actually appeared with.  c shares 1.1.1.1
+// with a (which owns only 1.1.1.1) and has its own 3.3.3.3; b's 2.2.2.2 must
+// not leak in.
+TEST_F(FileChannelTest, GetAddrInfoHostsChain)
+{
+  TempFile                   hostsfile("1.1.1.1 a\n"
+                                       "2.2.2.2 b\n"
+                                       "1.1.1.1 c\n"
+                                       "3.3.3.3 c\n");
+  EnvValue                   with_env("CARES_HOSTS", hostsfile.filename());
+  struct ares_addrinfo_hints hints  = { 0, 0, 0, 0 };
+  AddrInfoResult             result = {};
+  hints.ai_family                   = AF_INET;
+  hints.ai_flags = ARES_AI_CANONNAME | ARES_AI_ENVHOSTS | ARES_AI_NOSORT;
+  ares_getaddrinfo(channel_, "c", NULL, &hints, AddrInfoCallback, &result);
+  Process();
+  EXPECT_TRUE(result.done_);
+  std::stringstream ss;
+  ss << result.ai_;
+  EXPECT_EQ("{c->a addr=[1.1.1.1], addr=[3.3.3.3]}", ss.str());
+}
+
+// A hostname sharing an ip with a multi-family host must not inherit the other
+// host's address of a different family.  other shares 192.168.1.1 with host,
+// but host's 2620:1234::1 must not appear in an AF_UNSPEC lookup of other.
+TEST_F(FileChannelTest, GetAddrInfoHostsMixedFamilyNoLeak)
+{
+  TempFile                   hostsfile("192.168.1.1 host\n"
+                                       "2620:1234::1 host\n"
+                                       "192.168.1.1 other\n");
+  EnvValue                   with_env("CARES_HOSTS", hostsfile.filename());
+  struct ares_addrinfo_hints hints  = { 0, 0, 0, 0 };
+  AddrInfoResult             result = {};
+  hints.ai_family                   = AF_UNSPEC;
+  hints.ai_flags = ARES_AI_CANONNAME | ARES_AI_ENVHOSTS | ARES_AI_NOSORT;
+  ares_getaddrinfo(channel_, "other", NULL, &hints, AddrInfoCallback, &result);
+  Process();
+  EXPECT_TRUE(result.done_);
+  std::stringstream ss;
+  ss << result.ai_;
+  EXPECT_EQ("{other->host addr=[192.168.1.1]}", ss.str());
+}
+
+// Hostnames are matched case-insensitively, so FooBar and foobar are the same
+// name and FOOBAR resolves to both of their addresses.
+TEST_F(FileChannelTest, GetAddrInfoHostsCaseInsensitive)
+{
+  TempFile                   hostsfile("1.1.1.1 FooBar\n"
+                                       "2.2.2.2 foobar\n");
+  EnvValue                   with_env("CARES_HOSTS", hostsfile.filename());
+  struct ares_addrinfo_hints hints  = { 0, 0, 0, 0 };
+  AddrInfoResult             result = {};
+  hints.ai_family                   = AF_INET;
+  hints.ai_flags = ARES_AI_CANONNAME | ARES_AI_ENVHOSTS | ARES_AI_NOSORT;
+  ares_getaddrinfo(channel_, "FOOBAR", NULL, &hints, AddrInfoCallback, &result);
+  Process();
+  EXPECT_TRUE(result.done_);
+  std::stringstream ss;
+  ss << result.ai_;
+  EXPECT_EQ("{FooBar addr=[1.1.1.1], addr=[2.2.2.2]}", ss.str());
+}
+
+// Reverse lookup (ares_gethostbyaddr) is address-scoped: only the names that
+// appeared with the queried address, and only that address.  a (which only
+// shares 1.1.1.1 with b) must not appear when reverse-resolving 2.2.2.2.
+// gethostbyaddr uses use_env=FALSE, so configure the hosts file via
+// ARES_OPT_HOSTS_FILE on a private channel.
+TEST_F(LibraryTest, GetHostByAddrHostsFile)
+{
+  TempFile            hostsfile("1.1.1.1 a\n"
+                                "1.1.1.1 b\n"
+                                "2.2.2.2 b\n"
+                                "2.2.2.2 c\n");
+  ares_channel_t     *channel = nullptr;
+  struct ares_options opts;
+  memset(&opts, 0, sizeof(opts));
+  opts.hosts_path = strdup(hostsfile.filename());
+  int optmask     = ARES_OPT_HOSTS_FILE;
+  EXPECT_EQ(ARES_SUCCESS, ares_init_options(&channel, &opts, optmask));
+  free(opts.hosts_path);
+
+  struct in_addr addr;
+  ares_inet_pton(AF_INET, "2.2.2.2", &addr);
+  HostResult result;
+  ares_gethostbyaddr(channel, &addr, sizeof(addr), AF_INET, HostCallback,
+                     &result);
+  ProcessWork(channel, NoExtraFDs, nullptr);
+  EXPECT_TRUE(result.done_);
+  std::stringstream ss;
+  ss << result.host_;
+  EXPECT_EQ("{'b' aliases=[c] addrs=[2.2.2.2]}", ss.str());
+
+  ares_destroy(channel);
+}
+
+// Forward lookup via ares_gethostbyname (also use_env=FALSE, private channel).
+// c only appeared with 2.2.2.2; b's other address 1.1.1.1 must not leak.  The
+// canonical name is the first file-order name that shares the address (b).
+TEST_F(LibraryTest, GetHostByNameHostsFile)
+{
+  TempFile            hostsfile("1.1.1.1 a\n"
+                                "1.1.1.1 b\n"
+                                "2.2.2.2 b\n"
+                                "2.2.2.2 c\n");
+  ares_channel_t     *channel = nullptr;
+  struct ares_options opts;
+  memset(&opts, 0, sizeof(opts));
+  opts.hosts_path = strdup(hostsfile.filename());
+  int optmask     = ARES_OPT_HOSTS_FILE;
+  EXPECT_EQ(ARES_SUCCESS, ares_init_options(&channel, &opts, optmask));
+  free(opts.hosts_path);
+
+  HostResult result;
+  ares_gethostbyname(channel, "c", AF_INET, HostCallback, &result);
+  ProcessWork(channel, NoExtraFDs, nullptr);
+  EXPECT_TRUE(result.done_);
+  std::stringstream ss;
+  ss << result.host_;
+  EXPECT_EQ("{'b' aliases=[c] addrs=[2.2.2.2]}", ss.str());
+
+  ares_destroy(channel);
+}
+
 TEST_F(FileChannelTest, GetAddrInfoInvalidService) {
   TempFile hostsfile("1.2.3.4 example.com");
   EnvValue with_env("CARES_HOSTS", hostsfile.filename());


### PR DESCRIPTION
Fixes #1049.

## Problem
`/etc/hosts` entries were merged into a single record whenever they were transitively connected through a shared address, and lookups returned that record's **union**. Two failure modes:
1. **Leak:** a forward lookup returned addresses belonging to *unrelated* hostnames that merely shared an address (the reported symptom — `mullvad-no-svg` returned `mullvad-no-osl`'s addresses).
2. **Dropped "bridge" lines:** a line whose address already belonged to one entry and whose hostname to another was discarded entirely by the merge's first-match-wins rule, silently losing that address (the reporter's fallback `10.64.0.1 mullvad-no-svg` never applied).

## Approach: bipartite adjacency
The data is a set of `(hostname, address)` edges, one per line-token. Store them directly and index both ways:
- `hosthash`: hostname → list of its addresses (file order)
- `iphash`: address → list of its hostnames (file order)

A lookup builds a correctly-scoped result on demand — forward returns the queried name's **own** addresses plus **address-scoped** aliases (names sharing one of those addresses); reverse returns the queried address and its own hostnames. This is **correct by construction**: bridges, chains, cross-family merges, and reverse lookups all resolve the way glibc's `multi on` does, with no merging, filtering, or dropped lines. `to_addrinfo`/`to_hostent` go back to simple consumers.

> **Note:** an earlier revision of this PR kept the merged store and filtered results at lookup time to save memory. Review found that approach could not represent bridge lines (it inherited the merge's drop behavior), leaving #1049 only ~90% fixed. This revision replaces it with the bipartite model, which fully fixes it.

## Memory
This is done in two commits so the second can be dropped independently:
1. **the bipartite model** (correctness), and
2. **cached lookup entries** — `ares_hosts_search_*` return a cached `const` entry again (no per-lookup allocation, callers don't free). Entries are refcounted: a single-address hostname shares its address's reverse entry (wired up incrementally during parse), and only genuinely multi-address hostnames get a dedicated entry.

With the second commit, a single-address file collapses to one shared entry — structurally identical to the old merged store — so there is **no memory or parse regression** for blocklist-style files. Measured on [StevenBlack/hosts](https://github.com/StevenBlack/hosts) (~80k entries, all → `0.0.0.0`) with the internal-API harness:

| | parse | peak RSS |
|---|---|---|
| before (merged) | ~84 ms | 23.7 MB |
| this PR | **~64 ms** | **23.7 MB** |

Only files with many *multi-address* hostnames pay for the extra per-name entry, and that cost is bounded.

## Verification
- **Correctness (new regression tests):** bridge fallback (`mullvad-no-svg → [10.124.2.38, 10.64.0.1]`), chain (`c → [1.1.1.1, 3.3.3.3]`, not `2.2.2.2`), mixed-family AF_UNSPEC (no v6 leak), reverse `gethostbyaddr` (address-scoped names), `gethostbyname` (name-scoped addresses), and case-insensitivity — covering the forward, reverse, and `gethostbyname` paths that previously had zero coverage.
- All existing hosts/`gethostbyname`/`gethostbyaddr` tests pass (112 total in the hosts/hostent sweep).
- **ASAN** clean across the hosts/gethostby tests (the search functions now return an owned entry that each of the three callers destroys on every path).
- Also fixes a pre-existing bug in `ares_hosts_entry_isdup` (iterated the ip list instead of the hostname list).

_Numbers were produced with a small harness linked against the internal `ares_hosts_*` API in a throwaway checkout (not CI); reproduce by pointing `CARES_HOSTS` at the StevenBlack file._
