### PR TITLE
Release prep for 1.34.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ INCLUDE (CheckCSourceCompiles)
 INCLUDE (CheckStructHasMember)
 INCLUDE (CheckLibraryExists)
 
-PROJECT (c-ares LANGUAGES C VERSION "1.34.6" )
+PROJECT (c-ares LANGUAGES C VERSION "1.34.7" )
 
 # Set this version before release
 SET (CARES_VERSION "${PROJECT_VERSION}")
@@ -30,7 +30,7 @@ INCLUDE (GNUInstallDirs) # include this *AFTER* PROJECT(), otherwise paths are w
 # For example, a version of 4:0:2 would generate output such as:
 #    libname.so   -> libname.so.2
 #    libname.so.2 -> libname.so.2.2.0
-SET (CARES_LIB_VERSIONINFO "21:5:19")
+SET (CARES_LIB_VERSIONINFO "21:6:19")
 
 
 OPTION (CARES_STATIC        "Build as a static library"                                             OFF)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,93 @@
+## c-ares version 1.34.7 - July 6 2026
+
+This is a security release.
+
+Security:
+* CVE-2026-33630. Use-after-free / double-free in c-ares' query-completion
+  handling, remotely triggerable via ares_getaddrinfo() over TCP. Please see
+  https://github.com/c-ares/c-ares/security/advisories/GHSA-6wfj-rwm7-3542
+* CPU-exhaustion denial of service via unbounded DNS name compression pointer
+  chains. Please see
+  https://github.com/c-ares/c-ares/security/advisories/GHSA-pjmc-gx33-gc76
+* Memory-amplification denial of service via unvalidated DNS header record
+  counts. Please see
+  https://github.com/c-ares/c-ares/security/advisories/GHSA-jv8r-gqr9-68wj
+
+Changes:
+* `ares_getaddrinfo()`: handle a NULL node per POSIX and implement
+  `ARES_AI_PASSIVE`. [PR #1186](https://github.com/c-ares/c-ares/pull/1186)
+* Mark parameters in callbacks as const.
+  [PR #1060](https://github.com/c-ares/c-ares/pull/1060)
+* Correct `ARES_CLASS_HESOID` misspelling to `ARES_CLASS_HESIOD`.
+  [PR #1092](https://github.com/c-ares/c-ares/pull/1092)
+
+Bugfixes:
+* Fix sticky server recovery when all servers have failures. [PR #1192](https://github.com/c-ares/c-ares/pull/1192)
+* Fix UDP socket exhaustion regression: retire connections per-connection, not via server failure count. [PR #1197](https://github.com/c-ares/c-ares/pull/1197)
+* Guard DNS record binary length overflow. [PR #1168](https://github.com/c-ares/c-ares/pull/1168)
+* Prevent integer overflow in allocation size calculations. [PR #1147](https://github.com/c-ares/c-ares/pull/1147)
+* Prevent overflow in ares_array allocation size calculations. [PR #1117](https://github.com/c-ares/c-ares/pull/1117)
+* Prevent integer overflow in buffer size calculation. [PR #1116](https://github.com/c-ares/c-ares/pull/1116)
+* Add overflow checks to ares_buf_ensure_space(). [PR #1094](https://github.com/c-ares/c-ares/pull/1094)
+* Skip name compression offsets beyond the 14-bit pointer limit. [PR #1159](https://github.com/c-ares/c-ares/pull/1159)
+* ares_dns_parse: reject name compression in RDATA where not permitted (RFC 3597). [PR #1190](https://github.com/c-ares/c-ares/pull/1190)
+* ares_dns_parse: reject responses with more than one OPT record (RFC 6891). [PR #1189](https://github.com/c-ares/c-ares/pull/1189)
+* Discard oversized UDP datagrams instead of truncating the length frame. [PR #1161](https://github.com/c-ares/c-ares/pull/1161)
+* Route numeric config parsing through range-checked ares_str_parse_uint. [PR #1158](https://github.com/c-ares/c-ares/pull/1158)
+* Replace atoi-based port parsing with validated helper. [PR #1097](https://github.com/c-ares/c-ares/pull/1097)
+* Defer TCP connection error handling until DNS responses are parsed. [PR #1138](https://github.com/c-ares/c-ares/pull/1138)
+* Prevent undefined-behavior left shift in ares_calc_query_timeout(). [PR #1151](https://github.com/c-ares/c-ares/pull/1151)
+* Use unsigned type for ares_round_up_pow2_u64 to avoid undefined behavior. [PR #1107](https://github.com/c-ares/c-ares/pull/1107)
+* Fix undefined behavior in ares_buf_replace() pointer arithmetic. [PR #1099](https://github.com/c-ares/c-ares/pull/1099)
+* ares_array: reset offset when array becomes empty. [PR #1165](https://github.com/c-ares/c-ares/pull/1165)
+* ares_iface_ips: add ARES_IFACE_IP_NONE zero enum value. [PR #1187](https://github.com/c-ares/c-ares/pull/1187)
+* ares_sysconfig_files: recognize AIX netsvc.conf bind4/local4 tokens. [PR #1188](https://github.com/c-ares/c-ares/pull/1188)
+* Use safe string construction in Windows sysconfig join path. [PR #1143](https://github.com/c-ares/c-ares/pull/1143)
+* Fix zero-length RAW_RR losing type metadata during parsing. [PR #1129](https://github.com/c-ares/c-ares/pull/1129)
+* Fix RAW_RR type tostr/fromstr roundtrip mismatch. [PR #1123](https://github.com/c-ares/c-ares/pull/1123)
+* Fix NULL dereference for ifa netmask. [PR #1120](https://github.com/c-ares/c-ares/pull/1120)
+* adig: fix negated option prefix parsing. [PR #1135](https://github.com/c-ares/c-ares/pull/1135)
+* Use UnregisterWaitEx to prevent use-after-free on Win32. [PR #1111](https://github.com/c-ares/c-ares/pull/1111)
+* Add NULL check after ares_malloc_zero in Windows UTF8 conversion. [PR #1121](https://github.com/c-ares/c-ares/pull/1121)
+* Fix NULL dereference after ares_malloc_zero in Win32 IOCP event add. [PR #1132](https://github.com/c-ares/c-ares/pull/1132)
+* Fix microsecond overflow in ares_queue_wait_empty timeout. [PR #1122](https://github.com/c-ares/c-ares/pull/1122)
+* Fix NULL dereference in ares_buf_replace() on NULL buf. [PR #1124](https://github.com/c-ares/c-ares/pull/1124)
+* Initialize *read_bytes in ares_socket_recvfrom(). [PR #1125](https://github.com/c-ares/c-ares/pull/1125)
+* Fix memory leak of binbuf in ares_buf_parse_dns_binstr_int. [PR #1126](https://github.com/c-ares/c-ares/pull/1126)
+* Fix memory leak of qcache entry on key allocation failure. [PR #1127](https://github.com/c-ares/c-ares/pull/1127)
+* Fix memory leak of buf in ares_dns_multistring_combined() on OOM. [PR #1110](https://github.com/c-ares/c-ares/pull/1110)
+* Fix memory leaks on error paths in two functions. [PR #1109](https://github.com/c-ares/c-ares/pull/1109)
+* Fix memory leak of buckets in ares_htable_dict_keys() error path. [PR #1108](https://github.com/c-ares/c-ares/pull/1108)
+* Fix memory leak of bucket->key in ares_htable_dict_insert error path. [PR #1105](https://github.com/c-ares/c-ares/pull/1105)
+* Fix additional memory leaks. [PR #1091](https://github.com/c-ares/c-ares/pull/1091) [PR #1078](https://github.com/c-ares/c-ares/pull/1078)
+* Prevent corrupt addrinfo nodes on sockaddr allocation failure. [PR #1112](https://github.com/c-ares/c-ares/pull/1112)
+* Fix two logic bugs in DNS cookie handling. [PR #1103](https://github.com/c-ares/c-ares/pull/1103)
+* Fix linked list INSERT_BEFORE corruption and array insertdata_first ordering. [PR #1101](https://github.com/c-ares/c-ares/pull/1101)
+* Fix HASH_IDX macro missing parentheses. [PR #1128](https://github.com/c-ares/c-ares/pull/1128)
+* Fix malloc(0) in ares_htable_all_buckets on empty table. [PR #1131](https://github.com/c-ares/c-ares/pull/1131)
+* Fix wrong sizeof in QNX confstr() call truncating domain names. [PR #1130](https://github.com/c-ares/c-ares/pull/1130)
+* Clear probe pending flag after timeout. [PR #1059](https://github.com/c-ares/c-ares/pull/1059)
+* Fix incorrect check for empty wide string. [PR #1064](https://github.com/c-ares/c-ares/pull/1064)
+* Handle strdup failure. [PR #1077](https://github.com/c-ares/c-ares/pull/1077)
+* doc: reference ares_free_string(), not ares_free(). [PR #1084](https://github.com/c-ares/c-ares/pull/1084)
+
+Thanks go to these friendly people for their efforts and contributions for this
+release:
+
+* (@Alb3e3)
+* Brad House (@bradh352)
+* (@dankmeme01)
+* David Hotham (@dimbleby)
+* Tom Flynn (@Flynnzaa)
+* (@jmestwa-coder)
+* (@kodareef5)
+* Kaixuan Li (@MarkLee131)
+* (@lifenjoiner)
+* (@metsw24-max)
+* Song Li (@SongTonyLi)
+* (@uwezkhan)
+
+
 ## c-ares version 1.34.6 - December 8 2025
 
 This is a security release.

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.69])
 AC_INIT([c-ares], [1.34.6],
   [c-ares mailing list: http://lists.haxx.se/listinfo/c-ares])
 
-CARES_VERSION_INFO="21:5:19"
+CARES_VERSION_INFO="21:6:19"
 dnl This flag accepts an argument of the form current[:revision[:age]]. So,
 dnl passing -version-info 3:12:1 sets current to 3, revision to 12, and age to
 dnl 1.

--- a/include/ares_version.h
+++ b/include/ares_version.h
@@ -32,8 +32,8 @@
 
 #define ARES_VERSION_MAJOR 1
 #define ARES_VERSION_MINOR 34
-#define ARES_VERSION_PATCH 6
-#define ARES_VERSION_STR "1.34.6"
+#define ARES_VERSION_PATCH 7
+#define ARES_VERSION_STR   "1.34.7"
 
 /* NOTE: We cannot make the version string a C preprocessor stringify operation
  *       due to assumptions made by integrators that aren't properly using


### PR DESCRIPTION
Release preparation for **v1.34.7** against the `v1.34` branch, per `RELEASE-PROCEDURE.md`.

## Contents
- `RELEASE-NOTES.md`: the 1.34.7 entry (security release), covering all non-CI/CD changes between v1.34.6 and current `v1.34` (65 commits evaluated).
- Version bump:
  - `include/ares_version.h` → `1.34.7`
  - `configure.ac` `CARES_VERSION_INFO` and `CMakeLists.txt` `CARES_LIB_VERSIONINFO` → `21:6:19` (revision bump only — no exported-symbol/ABI change since 1.34.6; header additions are enum values only)
  - `CMakeLists.txt` project version → `1.34.7`

## Security
This is a security release. The notes reference three advisories:
- **CVE-2026-33630** — GHSA-6wfj-rwm7-3542 (UAF/double-free in query completion, TCP `ares_getaddrinfo()`; came in via the private security fork merge, no public PR)
- GHSA-pjmc-gx33-gc76 (name-compression CPU DoS; fix #1164)
- GHSA-jv8r-gqr9-68wj (record-count memory-amplification DoS; fix #1134)

> ⚠️ These three advisories are **still private/unpublished** — the links in RELEASE-NOTES.md will 404 until they are published as part of this release. Those fix PRs are intentionally represented only in the Security section (not duplicated under Bugfixes), matching the existing format.

## Notes for the reviewer
- Release date is set to **July 6 2026** — adjust to the actual publish date before tagging.
- CI/build/test-only changes were omitted from the notes (they don't affect the release tarball): #1234, #1226, #1228, #1222, #1191, #1177, #1198, #1182, #1063.
- After merge, follow the remaining RELEASE-PROCEDURE.md steps (empty commit, signed tag `v1.34.7`, package workflow, GPG-signed tarball, www repo update).
