### PR TITLE
configure.ac: bump AC_INIT package version to 1.34.7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl Copyright (C) The c-ares project and its contributors
 dnl SPDX-License-Identifier: MIT
 AC_PREREQ([2.69])
 
-AC_INIT([c-ares], [1.34.6],
+AC_INIT([c-ares], [1.34.7],
   [c-ares mailing list: http://lists.haxx.se/listinfo/c-ares])
 
 CARES_VERSION_INFO="21:6:19"


### PR DESCRIPTION
Fixes the failed release "Build Release Package" workflow for the `v1.34.7` tag ([run](https://github.com/c-ares/c-ares/actions/runs/28808920559/job/85431480291)).

The 1.34.7 release prep (#1239) bumped `CARES_VERSION_INFO`, `ares_version.h`, and the CMake version, but **missed `AC_INIT([c-ares], [1.34.6], …)`** on line 5. `AC_INIT` is the autotools *package* version that names the `make dist` tarball, so the release build produced `c-ares-1.34.6.tar.gz` while the upload step looked for `c-ares-1.34.7.tar.gz`:

```
⚠️  Pattern 'c-ares-1.34.7.tar.gz' does not match any files.
```

This bumps `AC_INIT` to `1.34.7`. It is the only remaining stale version reference in the build (`git grep 1.34.6` in the tree is otherwise clean).

> After this merges, the `v1.34.7` tag needs to be moved to the new commit (delete + re-create the signed tag) so the package workflow re-runs and builds `c-ares-1.34.7.tar.gz`.
