### PR TITLE
RELEASE-PROCEDURE: document bumping the package version (AC_INIT / PROJECT)

### DIFF
--- a/RELEASE-PROCEDURE.md
+++ b/RELEASE-PROCEDURE.md
@@ -8,6 +8,11 @@ in the source code repo
 - edit `configure.ac`'s `CARES_VERSION_INFO`, and `CMakeLists.txt`'s
   `CARES_LIB_VERSIONINFO` set to the same value to denote the current shared
   object versioning.
+- edit the package version to the new release in both `configure.ac`'s
+  `AC_INIT([c-ares], [X.Y.Z], ...)` and `CMakeLists.txt`'s
+  `PROJECT (c-ares LANGUAGES C VERSION "X.Y.Z")`. This is the version that names
+  the generated `make dist` tarball (`c-ares-X.Y.Z.tar.gz`); if it is not bumped
+  the release packaging workflow will fail to find the expected tarball.
 - edit `include/ares_version.h` and set `ARES_VERSION_*` definitions to reflect
   the current version.
 - All release tags need to be made off a release branch named `vX.Y`, where `X`


### PR DESCRIPTION
The release version-bump checklist covered `CARES_VERSION_INFO` / `CARES_LIB_VERSIONINFO` (shared-object versioning) and `include/ares_version.h`, but not the **package version** — `configure.ac`'s `AC_INIT` and `CMakeLists.txt`'s `PROJECT (... VERSION ...)` — which is what names the `make dist` tarball (`c-ares-X.Y.Z.tar.gz`).

Missing the `AC_INIT` bump in the 1.34.7 release prep caused the "Build Release Package" workflow to fail (`Pattern 'c-ares-1.34.7.tar.gz' does not match any files`; fixed for 1.34.7 in the v1.34 branch). This adds an explicit checklist step so it can't be missed again.

Docs-only; targets `main` (the v1.34-branch fix is separate).
