### PR TITLE
[Backport v1.34] Revert "Mark parameters in callbacks as const" (#1060)

### DIFF
--- a/docs/ares_gethostbyaddr.3
+++ b/docs/ares_gethostbyaddr.3
@@ -11,7 +11,7 @@ ares_gethostbyaddr \- Initiate a host query by address
 
 typedef void (*ares_host_callback)(void *\fIarg\fP, int \fIstatus\fP,
                                    int \fItimeouts\fP,
-                                   const struct hostent *\fIhostent\fP)
+                                   struct hostent *\fIhostent\fP)
 
 void ares_gethostbyaddr(ares_channel_t *\fIchannel\fP, const void *\fIaddr\fP,
                         int \fIaddrlen\fP, int \fIfamily\fP,
@@ -80,7 +80,16 @@ points to a
 containing the name of the host returned by the query.  The callback
 need not and should not attempt to free the memory pointed to by
 .IR hostent ;
-the ares library will free it when the callback returns.  If the query
+the ares library will free it when the callback returns.  The callback
+.B must not
+modify the
+.B struct hostent
+or retain a reference to it after returning; it is owned by c-ares and is only
+valid for the duration of the callback.  The parameter is intentionally not
+declared
+.B const
+solely to preserve API/ABI compatibility with existing applications.
+If the query
 did not complete successfully,
 .I hostent
 will be

--- a/docs/ares_gethostbyname.3
+++ b/docs/ares_gethostbyname.3
@@ -11,7 +11,7 @@ ares_gethostbyname \- Initiate a host query by name
 
 typedef void (*ares_host_callback)(void *\fIarg\fP, int \fIstatus\fP,
                                    int \fItimeouts\fP,
-                                   const struct hostent *\fIhostent\fP)
+                                   struct hostent *\fIhostent\fP)
 
 void ares_gethostbyname(ares_channel_t *\fIchannel\fP, const char *\fIname\fP,
                         int \fIfamily\fP, ares_host_callback \fIcallback\fP,
@@ -88,7 +88,16 @@ points to a
 containing the name of the host returned by the query.  The callback
 need not and should not attempt to free the memory pointed to by
 .IR hostent ;
-the ares library will free it when the callback returns.  If the query
+the ares library will free it when the callback returns.  The callback
+.B must not
+modify the
+.B struct hostent
+or retain a reference to it after returning; it is owned by c-ares and is only
+valid for the duration of the callback.  The parameter is intentionally not
+declared
+.B const
+solely to preserve API/ABI compatibility with existing applications.
+If the query
 did not complete successfully,
 .I hostent
 will be

--- a/docs/ares_getnameinfo.3
+++ b/docs/ares_getnameinfo.3
@@ -10,8 +10,8 @@ ares_getnameinfo \- Address-to-nodename translation in protocol-independent mann
 #include <ares.h>
 
 typedef void (*ares_nameinfo_callback)(void *\fIarg\fP, int \fIstatus\fP,
-                                       int \fItimeouts\fP, const char *\fInode\fP,
-                                       const char *\fIservice\fP)
+                                       int \fItimeouts\fP, char *\fInode\fP,
+                                       char *\fIservice\fP)
 
 void ares_getnameinfo(ares_channel_t *\fIchannel\fP, const struct sockaddr *\fIsa\fP,
                       ares_socklen_t \fIsalen\fP, int \fIflags\fP,
@@ -143,5 +143,17 @@ or
 .I service
 will be
 .BR NULL .
+.PP
+The
+.I node
+and
+.I service
+strings are owned by the c-ares library and are only valid for the duration of
+the callback.  The callback
+.B must not
+modify or free them, and must not retain references to them after returning;
+treat them as read-only.  The parameters are intentionally not declared
+.B const
+solely to preserve API/ABI compatibility with existing applications.
 .SH SEE ALSO
 .BR ares_process (3),

--- a/docs/ares_query.3
+++ b/docs/ares_query.3
@@ -22,7 +22,7 @@ ares_status_t ares_query_dnsrec(ares_channel_t      *channel,
                                 unsigned short      *qid);
 
 typedef void (*ares_callback)(void *arg, int status,
-                              int timeouts, const unsigned char *abuf,
+                              int timeouts, unsigned char *abuf,
                               int alen);
 
 void ares_query(ares_channel_t *channel, const char *name,
@@ -145,6 +145,16 @@ indicated by some of the above error codes), the callback argument
 or
 .I abuf
 will be non-NULL, otherwise they will be NULL.
+
+The
+.I abuf
+buffer is owned by the c-ares library and is only valid for the duration of
+the callback.  The callback
+.B must not
+modify or free it, and must not retain a reference to it after returning; treat
+it as read-only.  The parameter is intentionally not declared
+.B const
+solely to preserve API/ABI compatibility with existing applications.
 
 .SH AVAILABILITY
 \fBares_query_dnsrec(3)\fP was introduced in c-ares 1.28.0.

--- a/docs/ares_search.3
+++ b/docs/ares_search.3
@@ -19,8 +19,7 @@ void ares_search_dnsrec(ares_channel_t *\fIchannel\fP,
                         ares_callback_dnsrec \fIcallback\fP, void *\fIarg\fP);
 
 typedef void (*ares_callback)(void *\fIarg\fP, int \fIstatus\fP,
-                              int \fItimeouts\fP,
-                              const unsigned char *\fIabuf\fP,
+                              int \fItimeouts\fP, unsigned char *\fIabuf\fP,
                               int \fIalen\fP);
 
 void ares_search(ares_channel_t *\fIchannel\fP, const char *\fIname\fP,
@@ -153,6 +152,15 @@ will usually be NULL and
 will usually be 0, but in some cases an unsuccessful query result may
 be placed in
 .IR abuf .
+The
+.I abuf
+buffer is owned by the c-ares library and is only valid for the duration of
+the callback.  The callback
+.B must not
+modify or free it, and must not retain a reference to it after returning; treat
+it as read-only.  The parameter is intentionally not declared
+.B const
+solely to preserve API/ABI compatibility with existing applications.
 
 The \fIares_search_dnsrec(3)\fP function behaves identically to
 \fIares_search(3)\fP, but takes an initialized and filled DNS record object to

--- a/docs/ares_send.3
+++ b/docs/ares_send.3
@@ -19,7 +19,7 @@ ares_status_t ares_send_dnsrec(ares_channel_t *channel,
                                void *arg, unsigned short *qid);
 
 typedef void (*ares_callback)(void *arg, int status,
-                              int timeouts, const unsigned char *abuf,
+                              int timeouts, unsigned char *abuf,
                               int alen);
 
 void ares_send(ares_channel_t *channel, const unsigned char *qbuf,
@@ -130,6 +130,16 @@ for \fIares_send_dnsrec(3)\fP or
 and
 .IR alen
 for \fIares_send(3)\fP will be non-NULL.
+
+The
+.I abuf
+buffer is owned by the c-ares library and is only valid for the duration of
+the callback.  The callback
+.B must not
+modify or free it, and must not retain a reference to it after returning; treat
+it as read-only.  The parameter is intentionally not declared
+.B const
+solely to preserve API/ABI compatibility with existing applications.
 
 Unless the flag
 .B ARES_FLAG_NOCHECKRESP

--- a/include/ares.h
+++ b/include/ares.h
@@ -434,18 +434,26 @@ struct ares_addr {
 /* DNS record parser, writer, and helpers */
 #include "ares_dns_record.h"
 
+/* IMPORTANT: the pointer parameters below (abuf, hostent, node, service) are
+ * intentionally NOT const.  Marking them const changes the function-pointer
+ * type and breaks API/ABI compatibility for existing C and (especially) C++
+ * applications that declare their callbacks with the historical non-const
+ * signature.  This was tried in PR #1060 and reverted for that reason.  These
+ * buffers are owned by c-ares and MUST be treated as read-only by the callback
+ * (do not modify or free them); that contract is documented in the man pages,
+ * not enforced via const, to preserve compatibility.  Do not re-add const. */
 typedef void (*ares_callback)(void *arg, int status, int timeouts,
-                              const unsigned char *abuf, int alen);
+                              unsigned char *abuf, int alen);
 
 typedef void (*ares_callback_dnsrec)(void *arg, ares_status_t status,
                                      size_t                   timeouts,
                                      const ares_dns_record_t *dnsrec);
 
 typedef void (*ares_host_callback)(void *arg, int status, int timeouts,
-                                   const struct hostent *hostent);
+                                   struct hostent *hostent);
 
 typedef void (*ares_nameinfo_callback)(void *arg, int status, int timeouts,
-                                       const char *node, const char *service);
+                                       char *node, char *service);
 
 typedef int (*ares_sock_create_callback)(ares_socket_t socket_fd, int type,
                                          void *data);

--- a/src/lib/ares_getnameinfo.c
+++ b/src/lib/ares_getnameinfo.c
@@ -75,7 +75,7 @@ struct nameinfo_query {
 #endif
 
 static void  nameinfo_callback(void *arg, int status, int timeouts,
-                               const struct hostent *host);
+                               struct hostent *host);
 static char *lookup_service(unsigned short port, unsigned int flags, char *buf,
                             size_t buflen);
 #ifdef HAVE_STRUCT_SOCKADDR_IN6_SIN6_SCOPE_ID
@@ -199,7 +199,7 @@ void ares_getnameinfo(ares_channel_t *channel, const struct sockaddr *sa,
 }
 
 static void nameinfo_callback(void *arg, int status, int timeouts,
-                              const struct hostent *host)
+                              struct hostent *host)
 {
   struct nameinfo_query *niquery = (struct nameinfo_query *)arg;
   char                   srvbuf[33];

--- a/src/tools/ahost.c
+++ b/src/tools/ahost.c
@@ -51,8 +51,7 @@
 static int final_rv = RV_OK;
 
 
-static void callback(void *arg, int status, int timeouts,
-                     const struct hostent *host);
+static void callback(void *arg, int status, int timeouts, struct hostent *host);
 static void ai_callback(void *arg, int status, int timeouts,
                         struct ares_addrinfo *result);
 static void usage(void);
@@ -208,8 +207,7 @@ int         main(int argc, char **argv)
   return 0;
 }
 
-static void callback(void *arg, int status, int timeouts,
-                     const struct hostent *host)
+static void callback(void *arg, int status, int timeouts, struct hostent *host)
 {
   char **p;
 

--- a/test/ares-test.cc
+++ b/test/ares-test.cc
@@ -1080,7 +1080,7 @@ std::ostream& operator<<(std::ostream& os, const HostEnt& host) {
 }
 
 void HostCallback(void *data, int status, int timeouts,
-                  const struct hostent *hostent) {
+                  struct hostent *hostent) {
   EXPECT_NE(nullptr, data);
   if (data == nullptr)
     return;
@@ -1222,7 +1222,7 @@ std::ostream& operator<<(std::ostream& os, const SearchResult& result) {
 }
 
 void SearchCallback(void *data, int status, int timeouts,
-                    const unsigned char *abuf, int alen) {
+                    unsigned char *abuf, int alen) {
   EXPECT_NE(nullptr, data);
   SearchResult* result = reinterpret_cast<SearchResult*>(data);
   result->done_ = true;
@@ -1261,7 +1261,7 @@ std::ostream& operator<<(std::ostream& os, const NameInfoResult& result) {
 }
 
 void NameInfoCallback(void *data, int status, int timeouts,
-                      const char *node, const char *service) {
+                      char *node, char *service) {
   EXPECT_NE(nullptr, data);
   NameInfoResult* result = reinterpret_cast<NameInfoResult*>(data);
   result->done_ = true;

--- a/test/ares-test.h
+++ b/test/ares-test.h
@@ -650,15 +650,15 @@ std::ostream &operator<<(std::ostream &os, const AddrInfoResult &result);
 // Standard implementation of ares callbacks that fill out the corresponding
 // structures.
 void          HostCallback(void *data, int status, int timeouts,
-                           const struct hostent *hostent);
+                           struct hostent *hostent);
 void          QueryCallback(void *data, ares_status_t status, size_t timeouts,
                             const ares_dns_record_t *dnsrec);
-void SearchCallback(void *data, int status, int timeouts,
-                    const unsigned char *abuf, int alen);
+void SearchCallback(void *data, int status, int timeouts, unsigned char *abuf,
+                    int alen);
 void SearchCallbackDnsRec(void *data, ares_status_t status, size_t timeouts,
                           const ares_dns_record_t *dnsrec);
-void NameInfoCallback(void *data, int status, int timeouts, const char *node,
-                      const char *service);
+void NameInfoCallback(void *data, int status, int timeouts, char *node,
+                      char *service);
 void AddrInfoCallback(void *data, int status, int timeouts,
                       struct ares_addrinfo *res);
 


### PR DESCRIPTION
Backport to `v1.34` of the main-branch revert (#1244) of #1060.

#1060 ("Mark parameters in callbacks as const") was backported to `v1.34` as commit `6475221a` and would otherwise ship in **1.34.7**. It added `const` to the abuf/hostent/node/service parameters of `ares_callback`, `ares_host_callback`, and `ares_nameinfo_callback`. Changing a callback function pointer's parameter types is an **API/ABI break** — in C++ especially, function-pointer types must match exactly, so existing applications with the historical non-const callback signatures no longer compile.

## Contents
- Revert the const additions in `include/ares.h`, the man pages, the internal `nameinfo_callback`, the `ahost` tool, and the tests.
- Document the read-only contract instead: each affected man page gains a "must not modify/free, not `const` only for compatibility" note, and a comment at the callback typedefs warns against re-adding `const`.

Formatting was normalized to `v1.34`'s own `.clang-format` (which, unlike current `main`, still aligns function declarations), so the changed lines pass the branch's clang-format check.

## Verification
- Build clean (CMake+Ninja); NameInfo/GetHostByName/GetHostByAddr/Search suites pass (209 tests).
- All changed `.c`/`.h` are clang-format clean on their changed lines under `v1.34`'s config.

Pairs with #1244 (main). Reverts #1060.
