### PR TITLE
event: deliver failed-I/O completions in Win32 IOCP fallback (x86 event-thread hang)

### DIFF
--- a/src/lib/event/ares_event_win32.c
+++ b/src/lib/event/ares_event_win32.c
@@ -937,12 +937,24 @@ static BOOL
   (*ulNumEntriesRemoved) = 0;
 
   for (i = 0; i < ulCount; i++) {
-    if (!GetQueuedCompletionStatus(
-          CompletionPort,
-          &lpCompletionPortEntries[i].dwNumberOfBytesTransferred,
-          &lpCompletionPortEntries[i].lpCompletionKey,
-          &lpCompletionPortEntries[i].lpOverlapped,
-          (i == 0) ? dwMilliseconds : 0)) {
+    BOOL success = GetQueuedCompletionStatus(
+      CompletionPort, &lpCompletionPortEntries[i].dwNumberOfBytesTransferred,
+      &lpCompletionPortEntries[i].lpCompletionKey,
+      &lpCompletionPortEntries[i].lpOverlapped, (i == 0) ? dwMilliseconds : 0);
+
+    /* GetQueuedCompletionStatus() returns FALSE in two very different
+     * situations that we must distinguish, otherwise we silently lose events:
+     *   1. No completion packet was dequeued (timeout, or the port failed).
+     *      In this case lpOverlapped is set to NULL and we should stop.
+     *   2. A completion packet WAS dequeued, but it is for a *failed* I/O
+     *      operation (lpOverlapped is non-NULL).  This is exactly what an
+     *      outstanding AFD POLL request delivers when the underlying socket is
+     *      reset or closed, and it must still be handled so the socket's poll
+     *      state is cleaned up / re-armed -- otherwise that socket's events are
+     *      never delivered again and any query waiting on it hangs forever.
+     * GetQueuedCompletionStatusEx() returns these failed-I/O entries in its
+     * output array, so emulate that behavior here rather than dropping them. */
+    if (!success && lpCompletionPortEntries[i].lpOverlapped == NULL) {
       break;
     }
 


### PR DESCRIPTION
## Problem

The 32-bit Windows CI job (`MSVC x86 (CMake)`, built with `-D_WIN32_WINNT=0x0501`) intermittently **hangs** on `MockEventThreadTest.BulkCancel/WIN32_ipv4_ForceTCP` — it ran 2h06m before being cancelled in run [28809396229 attempt 1](https://github.com/c-ares/c-ares/actions/runs/28809396229), while `MSVC x64 (CMake)` passed in 4m. It is **x86-only** and rare (one hang in 33 Windows runs; the only run ever re-run).

## Root cause

On builds where `_WIN32_WINNT < 0x0600` (the XP-compatible 32-bit build), `GetQueuedCompletionStatusEx()` is unavailable and `ares_event_win32.c` emulates it with a loop over `GetQueuedCompletionStatus()`. That loop stops on **any** `FALSE` return, but `GetQueuedCompletionStatus()` returns `FALSE` in two different situations:

1. **No packet dequeued** (`lpOverlapped == NULL`) — timeout; stopping is correct.
2. **A packet WAS dequeued for a *failed* I/O** (`lpOverlapped != NULL`) — this is what an outstanding AFD POLL request delivers when its socket is torn down (rapid connection cancel/reset). It must still be handled.

Dropping case 2 means `process_socket_event()` never runs for that socket, so its AFD poll is never re-armed or cleaned up — stranding a query waiting on it and hanging the event thread. `GetQueuedCompletionStatusEx()` returns these failed-I/O entries in its output array, which is why the 64-bit build never hangs.

## Regression scope — unreleased

The `GetQueuedCompletionStatus()` emulation was introduced with Windows XP support in #960. That work is on **`main` only** and has **not shipped in any release** (all releases are `v1.34.x`, built at the Vista floor `0x0600`, which use the real `GetQueuedCompletionStatusEx()`). **No released version is affected.**

## Fix

Distinguish the two `FALSE` cases via `lpOverlapped`, matching `GetQueuedCompletionStatusEx()` semantics: deliver a dequeued packet even when the I/O failed, and only stop when nothing was dequeued.

## Validation

- x86 and x64 CMake jobs both stay green with the fix.
- The hang could not be reproduced on demand (it is very rare — ~1 in 33 runs — and does not reproduce on non-Win32 event backends), so this ships without a dedicated regression test. The change is correct by parity with the `GetQueuedCompletionStatusEx()` path that the 64-bit build already uses without issue.
