### PR TITLE
Release prep for 1.34.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ INCLUDE (CheckCSourceCompiles)
 INCLUDE (CheckStructHasMember)
 INCLUDE (CheckLibraryExists)
 
-PROJECT (c-ares LANGUAGES C VERSION "1.34.7" )
+PROJECT (c-ares LANGUAGES C VERSION "1.34.8" )
 
 # Set this version before release
 SET (CARES_VERSION "${PROJECT_VERSION}")
@@ -30,7 +30,7 @@ INCLUDE (GNUInstallDirs) # include this *AFTER* PROJECT(), otherwise paths are w
 # For example, a version of 4:0:2 would generate output such as:
 #    libname.so   -> libname.so.2
 #    libname.so.2 -> libname.so.2.2.0
-SET (CARES_LIB_VERSIONINFO "21:6:19")
+SET (CARES_LIB_VERSIONINFO "21:7:19")
 
 
 OPTION (CARES_STATIC        "Build as a static library"                                             OFF)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,23 @@
+## c-ares version 1.34.8 - July 7 2026
+
+This is a bugfix release.
+
+Bugfixes:
+* Revert "Mark parameters in callbacks as const" which shipped in 1.34.7.
+  Changing the parameter types of the `ares_callback`, `ares_host_callback`,
+  and `ares_nameinfo_callback` function pointer typedefs was an unintended
+  API break: existing applications with the historical non-const callback
+  signatures no longer compiled, particularly in C++ where function pointer
+  types must match exactly. The read-only nature of the callback parameters
+  is now documented instead.
+  [PR #1244](https://github.com/c-ares/c-ares/pull/1244)
+
+Thanks go to these friendly people for their efforts and contributions for this
+release:
+
+* Brad House (@bradh352)
+
+
 ## c-ares version 1.34.7 - July 6 2026
 
 This is a security release.

--- a/configure.ac
+++ b/configure.ac
@@ -2,10 +2,10 @@ dnl Copyright (C) The c-ares project and its contributors
 dnl SPDX-License-Identifier: MIT
 AC_PREREQ([2.69])
 
-AC_INIT([c-ares], [1.34.7],
+AC_INIT([c-ares], [1.34.8],
   [c-ares mailing list: http://lists.haxx.se/listinfo/c-ares])
 
-CARES_VERSION_INFO="21:6:19"
+CARES_VERSION_INFO="21:7:19"
 dnl This flag accepts an argument of the form current[:revision[:age]]. So,
 dnl passing -version-info 3:12:1 sets current to 3, revision to 12, and age to
 dnl 1.

--- a/include/ares_version.h
+++ b/include/ares_version.h
@@ -32,8 +32,8 @@
 
 #define ARES_VERSION_MAJOR 1
 #define ARES_VERSION_MINOR 34
-#define ARES_VERSION_PATCH 7
-#define ARES_VERSION_STR   "1.34.7"
+#define ARES_VERSION_PATCH 8
+#define ARES_VERSION_STR   "1.34.8"
 
 /* NOTE: We cannot make the version string a C preprocessor stringify operation
  *       due to assumptions made by integrators that aren't properly using


### PR DESCRIPTION
Release preparation for **c-ares 1.34.8** on the `v1.34` branch.

## Contents
- `RELEASE-NOTES.md`: add the 1.34.8 entry.
- `configure.ac`: bump `AC_INIT` package version to 1.34.8 (names the `make dist` tarball for the release packaging workflow); bump `CARES_VERSION_INFO` `21:6:19` → `21:7:19` (revision-only — no interface changes).
- `CMakeLists.txt`: bump `PROJECT VERSION` to 1.34.8 and `CARES_LIB_VERSIONINFO` to `21:7:19`.
- `include/ares_version.h`: `ARES_VERSION_PATCH` 8, `ARES_VERSION_STR` "1.34.8".

## What's in 1.34.8
A single fix, already merged to `v1.34` (#1245): the revert of "Mark parameters in callbacks as const" (#1060, reverted on main in #1244). #1060 shipped in 1.34.7 and changed the parameter types of the `ares_callback`, `ares_host_callback`, and `ares_nameinfo_callback` function pointer typedefs — an unintended API break, since existing applications with the historical non-const callback signatures no longer compiled (especially C++, where function pointer types must match exactly).

The only other library change on main since 1.34.7 is #1247 (Win32 IOCP fallback fix), which is explicitly not applicable to any release (`main`-only code from #960); it is intentionally not backported.