### PR TITLE
Fix propagation of C++ flags to the test targets

### DIFF
--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -199,6 +199,10 @@ function(_int_enable_warnings_set_flags_ex langs_var configs_var)
 	endforeach()
 
 	foreach(lang C CXX)
+		if(NOT lang IN_LIST ${langs_var})
+			# do not touch FLAGS so that enable_language properly populates them
+			continue()
+		endif()
 		foreach (config IN LISTS ${configs_var})
 			string(TOUPPER "${config}" config)
 			if (config STREQUAL "NONE")


### PR DESCRIPTION
When EnableWarnings is called in the root-level CMakeLists.txt only the C language is enabled. Later for the tests the CXX langauge might be added.

The enable_language command will only populate the CXX_FLAGS variables if they have not been touched before. Therefore only conditionally touch those variables.

The bug has been found by the Debian BLHC checker that missed the hardening flags on all of the test objects.