### PR TITLE
getaddrinfo: ignore non-loopback localhost hosts entries

### DIFF
--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -401,6 +401,16 @@ static ares_status_t file_lookup(struct host_query *hquery)
     return ARES_ENOTFOUND;
   }
 
+  /* RFC6761 section 6.3 #3 states that "Name resolution APIs and libraries
+   * SHOULD recognize localhost names as special and SHOULD always return the
+   * IP loopback address for address queries".
+   * We will also ignore ALL errors when trying to resolve localhost, such
+   * as permissions errors reading /etc/hosts or a malformed /etc/hosts. */
+  if (ares_is_localhost(hquery->name)) {
+    return ares_addrinfo_localhost(hquery->name, hquery->port, &hquery->hints,
+                                   hquery->ai);
+  }
+
   status = ares_hosts_search_host(
     hquery->channel,
     (hquery->hints.ai_flags & ARES_AI_ENVHOSTS) ? ARES_TRUE : ARES_FALSE,
@@ -421,21 +431,6 @@ static ares_status_t file_lookup(struct host_query *hquery)
 
 
 done:
-  /* RFC6761 section 6.3 #3 states that "Name resolution APIs and libraries
-   * SHOULD recognize localhost names as special and SHOULD always return the
-   * IP loopback address for address queries".
-   * We will also ignore ALL errors when trying to resolve localhost, such
-   * as permissions errors reading /etc/hosts or a malformed /etc/hosts.
-   *
-   * Also, just because the query itself returned success from /etc/hosts
-   * lookup doesn't mean it returned everything it needed to for all requested
-   * address families. As long as we're not on a critical out of memory
-   * condition pass it through to fill in any other address classes. */
-  if (status != ARES_ENOMEM && ares_is_localhost(hquery->name)) {
-    return ares_addrinfo_localhost(hquery->name, hquery->port, &hquery->hints,
-                                   hquery->ai);
-  }
-
   return status;
 }
 

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -1530,6 +1530,23 @@ TEST_F(LibraryTest, GetHostByNameHostsFile)
   ares_destroy(channel);
 }
 
+TEST_F(FileChannelTest, GetAddrInfoHostsLocalhostIgnoresNonLoopback) {
+  TempFile hostsfile("192.0.2.10 localhost\n");
+  EnvValue with_env("CARES_HOSTS", hostsfile.filename());
+  struct ares_addrinfo_hints hints = {0, 0, 0, 0};
+  AddrInfoResult result = {};
+  hints.ai_family = AF_INET;
+  hints.ai_flags = ARES_AI_ENVHOSTS | ARES_AI_NOSORT;
+  ares_getaddrinfo(channel_, "localhost", NULL, &hints, AddrInfoCallback,
+                   &result);
+  Process();
+  EXPECT_TRUE(result.done_);
+  EXPECT_EQ(result.status_, ARES_SUCCESS);
+  std::stringstream ss;
+  ss << result.ai_;
+  EXPECT_EQ("{addr=[127.0.0.1]}", ss.str());
+}
+
 TEST_F(FileChannelTest, GetAddrInfoInvalidService) {
   TempFile hostsfile("1.2.3.4 example.com");
   EnvValue with_env("CARES_HOSTS", hostsfile.filename());


### PR DESCRIPTION
## Summary

- Synthesize localhost loopback results before consulting hosts-file entries in the getaddrinfo hosts-file lookup path.
- Add a regression covering a `CARES_HOSTS` file that maps `localhost` to a documentation-only non-loopback IPv4 address.
- Leave `.onion` rejection and ordinary non-localhost hosts-file lookups unchanged.

Fixes #976.

## Test Plan

- Red check before the fix: `./build-make/bin/arestest -4 --gtest_filter=FileChannelTest.GetAddrInfoHostsLocalhostIgnoresNonLoopback` failed with `{addr=[192.0.2.10]}` instead of `{addr=[127.0.0.1]}`.
- `cmake -S . -B build-make -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=DEBUG -DCARES_BUILD_TESTS=ON -DGTEST_ROOT=/tmp/c-ares-gtest-install`
- `cmake --build build-make --target arestest -j2`
- `./build-make/bin/arestest -4 --gtest_filter=FileChannelTest.GetAddrInfoHostsLocalhostIgnoresNonLoopback`
- `./build-make/bin/arestest -4 --gtest_filter='FileChannelTest.GetAddrInfoHosts*'`
- `./build-make/bin/arestest -4 --gtest_filter='*Localhost*:*LocalHost*'`
- `./build-make/bin/arestest -4 --gtest_filter='-*LiveSearchTXT*:*LiveSearchANY*'`
