### PR TITLE
Fix double-free in ares_requeue_queries() on connection close

### DIFF
--- a/src/lib/ares_close_sockets.c
+++ b/src/lib/ares_close_sockets.c
@@ -29,7 +29,8 @@
 #include <assert.h>
 
 static void ares_requeue_queries(ares_conn_t  *conn,
-                                 ares_status_t requeue_status)
+                                 ares_status_t requeue_status,
+                                 ares_array_t **requeue)
 {
   ares_query_t  *query;
   ares_timeval_t now;
@@ -37,11 +38,12 @@ static void ares_requeue_queries(ares_conn_t  *conn,
   ares_tvnow(&now);
 
   while ((query = ares_llist_first_val(conn->queries_to_conn)) != NULL) {
-    ares_requeue_query(query, &now, requeue_status, ARES_TRUE, NULL, NULL);
+    ares_requeue_query(query, &now, requeue_status, ARES_TRUE, NULL, requeue);
   }
 }
 
-void ares_close_connection(ares_conn_t *conn, ares_status_t requeue_status)
+void ares_close_connection(ares_conn_t *conn, ares_status_t requeue_status,
+                           ares_array_t **requeue)
 {
   ares_server_t  *server  = conn->server;
   ares_channel_t *channel = server->channel;
@@ -59,7 +61,7 @@ void ares_close_connection(ares_conn_t *conn, ares_status_t requeue_status)
   ares_buf_destroy(conn->out_buf);
 
   /* Requeue queries to other connections */
-  ares_requeue_queries(conn, requeue_status);
+  ares_requeue_queries(conn, requeue_status, requeue);
 
   ares_llist_destroy(conn->queries_to_conn);
 
@@ -76,7 +78,7 @@ void ares_close_sockets(ares_server_t *server)
 
   while ((node = ares_llist_node_first(server->connections)) != NULL) {
     ares_conn_t *conn = ares_llist_node_val(node);
-    ares_close_connection(conn, ARES_SUCCESS);
+    ares_close_connection(conn, ARES_SUCCESS, NULL);
   }
 }
 
@@ -131,7 +133,7 @@ void ares_check_cleanup_conns(const ares_channel_t *channel)
       }
 
       /* Clean it up */
-      ares_close_connection(conn, ARES_SUCCESS);
+      ares_close_connection(conn, ARES_SUCCESS, NULL);
     }
   }
 }

--- a/src/lib/ares_close_sockets.c
+++ b/src/lib/ares_close_sockets.c
@@ -28,8 +28,8 @@
 #include "ares_private.h"
 #include <assert.h>
 
-static void ares_requeue_queries(ares_conn_t  *conn,
-                                 ares_status_t requeue_status,
+static void ares_requeue_queries(ares_conn_t   *conn,
+                                 ares_status_t  requeue_status,
                                  ares_array_t **requeue)
 {
   ares_query_t  *query;

--- a/src/lib/ares_conn.h
+++ b/src/lib/ares_conn.h
@@ -170,7 +170,8 @@ struct ares_server {
   ares_channel_t       *channel;
 };
 
-void ares_close_connection(ares_conn_t *conn, ares_status_t requeue_status);
+void ares_close_connection(ares_conn_t *conn, ares_status_t requeue_status,
+                           ares_array_t **requeue);
 void ares_close_sockets(ares_server_t *server);
 void ares_check_cleanup_conns(const ares_channel_t *channel);
 

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -58,7 +58,7 @@ static ares_status_t process_answer(ares_channel_t      *channel,
                                     const ares_timeval_t *now,
                                     ares_array_t        **requeue);
 static void handle_conn_error(ares_conn_t *conn, ares_bool_t critical_failure,
-                              ares_status_t failure_status,
+                              ares_status_t  failure_status,
                               ares_array_t **requeue);
 static ares_bool_t same_questions(const ares_query_t      *query,
                                   const ares_dns_record_t *arec);
@@ -1037,13 +1037,13 @@ cleanup:
 }
 
 static void handle_conn_error(ares_conn_t *conn, ares_bool_t critical_failure,
-                              ares_status_t failure_status,
+                              ares_status_t  failure_status,
                               ares_array_t **requeue)
 {
-  ares_server_t  *server         = conn->server;
-  ares_channel_t *channel        = server->channel;
-  ares_array_t   *local_requeue  = NULL;
-  ares_array_t  **use_requeue    = requeue != NULL ? requeue : &local_requeue;
+  ares_server_t  *server        = conn->server;
+  ares_channel_t *channel       = server->channel;
+  ares_array_t   *local_requeue = NULL;
+  ares_array_t  **use_requeue   = requeue != NULL ? requeue : &local_requeue;
 
   /* Increment failures first before requeue so it is unlikely to requeue
    * to the same server */

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -58,7 +58,8 @@ static ares_status_t process_answer(ares_channel_t      *channel,
                                     const ares_timeval_t *now,
                                     ares_array_t        **requeue);
 static void handle_conn_error(ares_conn_t *conn, ares_bool_t critical_failure,
-                              ares_status_t failure_status);
+                              ares_status_t failure_status,
+                              ares_array_t **requeue);
 static ares_bool_t same_questions(const ares_query_t      *query,
                                   const ares_dns_record_t *arec);
 static void end_query(ares_channel_t *channel, ares_server_t *server,
@@ -401,7 +402,7 @@ static ares_status_t process_write(ares_channel_t *channel,
 
   status = ares_conn_flush(conn);
   if (status != ARES_SUCCESS) {
-    handle_conn_error(conn, ARES_TRUE, status);
+    handle_conn_error(conn, ARES_TRUE, status, NULL);
   }
   return status;
 }
@@ -439,7 +440,7 @@ void ares_process_pending_write(ares_channel_t *channel)
     /* Enqueue any pending data if there is any */
     status = ares_conn_flush(conn);
     if (status != ARES_SUCCESS) {
-      handle_conn_error(conn, ARES_TRUE, status);
+      handle_conn_error(conn, ARES_TRUE, status, NULL);
     }
   }
 
@@ -469,7 +470,7 @@ static ares_status_t read_conn_packets(ares_conn_t *conn,
     if (!(conn->flags & ARES_CONN_FLAG_TCP) &&
         ares_buf_append_be16(conn->in_buf, 0) != ARES_SUCCESS) {
       handle_conn_error(conn, ARES_FALSE /* not critical to connection */,
-                        ARES_SUCCESS);
+                        ARES_SUCCESS, NULL);
       return ARES_ENOMEM;
     }
 
@@ -478,7 +479,7 @@ static ares_status_t read_conn_packets(ares_conn_t *conn,
 
     if (ptr == NULL) {
       handle_conn_error(conn, ARES_FALSE /* not critical to connection */,
-                        ARES_SUCCESS);
+                        ARES_SUCCESS, NULL);
       return ARES_ENOMEM;
     }
 
@@ -532,7 +533,7 @@ static ares_status_t read_conn_packets(ares_conn_t *conn,
      * immediate connection-failure behavior so retries happen promptly.
      * Only defer if there is buffered data to parse first. */
     if (ares_buf_len(conn->in_buf) == 0) {
-      handle_conn_error(conn, ARES_TRUE, ARES_ECONNREFUSED);
+      handle_conn_error(conn, ARES_TRUE, ARES_ECONNREFUSED, NULL);
       return ARES_ECONNREFUSED;
     }
 
@@ -714,7 +715,7 @@ static ares_status_t read_answers(ares_conn_t *conn, const ares_timeval_t *now)
     /* We finished reading this answer; process it */
     status = process_answer(channel, data, data_len, conn, now, &requeue);
     if (status != ARES_SUCCESS) {
-      handle_conn_error(conn, ARES_TRUE, status);
+      handle_conn_error(conn, ARES_TRUE, status, &requeue);
       goto cleanup;
     }
 
@@ -758,7 +759,7 @@ static ares_status_t process_read(ares_channel_t       *channel,
   if (conn_error) {
     conn = ares_conn_from_fd(channel, read_fd);
     if (conn != NULL) {
-      handle_conn_error(conn, ARES_TRUE, ARES_ECONNREFUSED);
+      handle_conn_error(conn, ARES_TRUE, ARES_ECONNREFUSED, NULL);
     }
   }
 
@@ -1036,9 +1037,13 @@ cleanup:
 }
 
 static void handle_conn_error(ares_conn_t *conn, ares_bool_t critical_failure,
-                              ares_status_t failure_status)
+                              ares_status_t failure_status,
+                              ares_array_t **requeue)
 {
-  ares_server_t *server = conn->server;
+  ares_server_t  *server         = conn->server;
+  ares_channel_t *channel        = server->channel;
+  ares_array_t   *local_requeue  = NULL;
+  ares_array_t  **use_requeue    = requeue != NULL ? requeue : &local_requeue;
 
   /* Increment failures first before requeue so it is unlikely to requeue
    * to the same server */
@@ -1048,7 +1053,13 @@ static void handle_conn_error(ares_conn_t *conn, ares_bool_t critical_failure,
   }
 
   /* This will requeue any connections automatically */
-  ares_close_connection(conn, failure_status);
+  ares_close_connection(conn, failure_status, use_requeue);
+
+  if (requeue == NULL) {
+    ares_timeval_t now;
+    ares_tvnow(&now);
+    ares_flush_requeue(channel, &now, &local_requeue);
+  }
 }
 
 /* Requeue query will normally call ares_send_query() but in some circumstances
@@ -1475,7 +1486,7 @@ static ares_status_t ares_send_query_int(ares_server_t        *requested_server,
      * error codes */
     case ARES_ECONNREFUSED:
     case ARES_EBADFAMILY:
-      handle_conn_error(conn, ARES_TRUE, status);
+      handle_conn_error(conn, ARES_TRUE, status, requeue);
       status = ares_requeue_query(query, now, status, ARES_TRUE, NULL, requeue);
       if (status == ARES_ETIMEOUT) {
         status = ARES_ECONNREFUSED;

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -1946,6 +1946,41 @@ TEST_P(MockUDPChannelTest, CancelInCallbackNoDoubleFree) {
   EXPECT_TRUE(data.done);
 }
 
+// Same root cause as CancelInCallbackNoDoubleFree above, but reached via
+// ares_close_sockets.c's ares_requeue_queries() (connection close/error)
+// instead of read_answers().  Every attempt is disconnected so retries are
+// exhausted on a closed connection; the completion callback calls
+// ares_cancel() reentrantly and must fire exactly once.
+struct CancelInCbConnErrorData {
+  ares_channel_t *channel;
+  int             ncalls;
+};
+
+static void CancelChannelConnErrorCallback(void *arg, ares_status_t status,
+                                           size_t timeouts,
+                                           const ares_dns_record_t *dnsrec)
+{
+  CancelInCbConnErrorData *data = static_cast<CancelInCbConnErrorData *>(arg);
+  (void)status;
+  (void)timeouts;
+  (void)dnsrec;
+  data->ncalls++;
+  ares_cancel(data->channel);
+}
+
+TEST_P(MockChannelTest, CancelInCallbackNoDoubleFreeOnConnError) {
+  ON_CALL(server_, OnRequest("www.google.com", T_A))
+    .WillByDefault(Disconnect(&server_));
+
+  CancelInCbConnErrorData data;
+  data.channel = channel_;
+  data.ncalls  = 0;
+  ares_query_dnsrec(channel_, "www.google.com", ARES_CLASS_IN, ARES_REC_TYPE_A,
+                    CancelChannelConnErrorCallback, &data, NULL);
+  Process();
+  EXPECT_EQ(1, data.ncalls);
+}
+
 TEST_P(MockUDPChannelTest, GetSock) {
   DNSPacket reply;
   reply.set_response().set_aa()


### PR DESCRIPTION
## Summary

`ares_close_sockets.c`'s `ares_requeue_queries()` called `ares_requeue_query()` with `requeue=NULL`. On retry exhaustion, this hit `end_query()`'s legacy direct-callback path, invoking the query's callback before detaching it from `channel->all_queries`/`queries_by_qid`. A reentrant `ares_cancel()` from that callback — an ordinary pattern, not misuse — would find the same still-linked query, invoke its callback again, and free it, causing the original `end_query()` call to free it a second time on return.

This is the same root cause as CVE-2026-33630 / GHSA-6wfj-rwm7-3542. That fix (#1237) hardened `process_timeouts()` and `read_answers()` via `ares_flush_requeue()`, but never touched `ares_close_sockets.c`, so the identical bug remained reachable through any connection close/error while a query was on its final retry — no malformed traffic required.

## What changed

`ares_close_connection()` and the internal `ares_requeue_queries()` now take an `ares_array_t **requeue` parameter and thread it down to `ares_requeue_query()`, mirroring the existing pattern used by `read_answers()` / `process_timeouts()` / `ares_send_query()`.

`handle_conn_error()` — the sole caller of `ares_close_connection()` that can reach a connection with live queries attached — now also takes `requeue`. When called with a non-NULL `requeue` (currently only from `read_answers()`, which already owns one), it appends into that scope. When called with `NULL` (all its other 6 call sites, none of which previously had an active requeue scope), it creates a local one and flushes it before returning, so every existing caller keeps working unchanged.

The other two callers of `ares_close_connection()` (`ares_close_sockets()` and `ares_check_cleanup_conns()`) now explicitly pass `NULL`. Both only ever close connections with an empty `queries_to_conn` list in every current call path (`ares_check_cleanup_conns()` skips connections with any attached queries via its own guard; `ares_destroy()` drains all queries before tearing down servers), so this is unchanged behavior made explicit, not a new gap.

## Testing

- Added `MockChannelTest.CancelInCallbackNoDoubleFreeOnConnError`, mirroring the existing `CancelInCallbackNoDoubleFree` regression test for #1237 but reached via `Disconnect()` (connection close) instead of a normal answer, across all 4 address-family/transport variants.
- Verified this test reproduces the double-free on the pre-fix code: `___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED` through `ares_requeue_queries → ares_close_connection → handle_conn_error → end_query → ares_free`, matching the reported stack exactly.
- Full existing suite (1102 tests) plus the 4 new variants (1106 total) pass clean with the fix applied.
- Also independently verified with two standalone reproducers (C+ASan, Python+ctypes) against a live channel: pre-fix, the query callback fires twice for one query and the process aborts on double-free; post-fix, it fires exactly once and exits cleanly.

Reported privately per SECURITY.md; opening this publicly with the security team's go-ahead.