### PR TITLE
Regression: Query removal after random qid reuse

### DIFF
--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -1598,7 +1598,12 @@ static void ares_detach_query(ares_query_t *query)
 {
   /* Remove the query from all the lists in which it is linked */
   ares_query_remove_from_conn(query);
-  ares_htable_szvp_remove(query->channel->queries_by_qid, query->qid);
+  /* A callback may queue a new query that reuses this ID. Only remove the
+   * entry if it still points to this query. */
+  if (ares_htable_szvp_get_direct(query->channel->queries_by_qid, query->qid) ==
+      query) {
+    ares_htable_szvp_remove(query->channel->queries_by_qid, query->qid);
+  }
   ares_llist_node_destroy(query->node_all_queries);
   query->node_all_queries = NULL;
 }


### PR DESCRIPTION
This PR fixes a regression in main and 1.34.8 that causes a serious issue. If a reentrant query is sent on the same channel with the same qid (yes selected by random, yes till will happen at some point, yes it done so), the query is removed without being executed, resulting in a stale execution flow. The behaviour and regression can be seen if

Make a test-program that from its result callback send another query

```
#include <ares.h>
#include <string.h>
#include <stdio.h>

ares_channel_t *channel;
ares_dns_record_t *query;

static void result_cb(void *arg, ares_status_t status, size_t timeouts,
                      const ares_dns_record_t *answer)
{
  printf("woop!\n");
  ares_send_dnsrec(channel, query, result_cb, 0x0, 0x0);
}

int main(int argc, char **argv)
{
  struct ares_options options;
  memset(&options, 0, sizeof(options));
  options.qcache_max_ttl = 0;
  options.evsys = ARES_EVSYS_DEFAULT;

  ares_library_init(ARES_LIB_INIT_ALL);
  ares_dns_record_create(&query, 0, ARES_FLAG_RD,
                         ARES_OPCODE_QUERY, ARES_RCODE_NOERROR);
  ares_dns_record_query_add(query, "example.com",
                            ARES_REC_TYPE_A, ARES_CLASS_IN);
  ares_init_options(&channel, &options, ARES_OPT_QUERY_CACHE | ARES_OPT_EVENT_THREAD);
  ares_send_dnsrec(channel, query, result_cb, 0x0, 0x0);
  while (ares_queue_wait_empty(channel, 1000) == ARES_ETIMEOUT)
    ;
  ares_destroy(channel);
  ares_dns_record_destroy(query);
  ares_library_cleanup();
  return 0;
}
```

Make the ```generate_unique_qid```/```ares_generate_new_id``` always generate the same number (eg id = 42).

```
unsigned short ares_generate_new_id(ares_rand_state *state)
{
  return 42;
}
```

In 1.34.6 generate_unique_qid would fail in this case (since the qid would exist) and it would loop forever, in main and 1.34.7/.8 generate_unique_qid happily returns 42 and ares_detach_query removes the query twice and the new query callback is never executed. With this patch, "woop" is printed again and again as one would expect.