### PR TITLE
reject rdata larger than the 16-bit rdlength field on write

### DIFF
--- a/src/lib/record/ares_dns_write.c
+++ b/src/lib/record/ares_dns_write.c
@@ -1393,12 +1393,19 @@ static ares_status_t ares_dns_write_rr(const ares_dns_record_t *dnsrec,
     end_length = ares_buf_len(buf);
     rdlength   = end_length - pos_len - 2;
 
+    /* RDLENGTH is a 16-bit field.  A record whose assembled rdata is larger
+     * can't be represented on the wire; emitting a truncated length would
+     * desync the framing of everything after it, so reject the record. */
+    if (rdlength > 0xFFFF) {
+      return ARES_EBADQUERY;
+    }
+
     status = ares_buf_set_length(buf, pos_len);
     if (status != ARES_SUCCESS) {
       return status;
     }
 
-    status = ares_buf_append_be16(buf, (unsigned short)(rdlength & 0xFFFF));
+    status = ares_buf_append_be16(buf, (unsigned short)rdlength);
     if (status != ARES_SUCCESS) {
       return status; /* LCOV_EXCL_LINE: OutOfMemory */
     }

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -2482,6 +2482,41 @@ TEST_F(LibraryTest, DNSRecordRejectsInvalidBinaryInput) {
   ares_dns_record_destroy(dnsrec);
 }
 
+TEST_F(LibraryTest, DNSRecordRejectsOversizedRdata) {
+  ares_dns_record_t         *dnsrec = NULL;
+  ares_dns_rr_t             *rr     = NULL;
+  unsigned char             *msg    = NULL;
+  size_t                     msglen = 0;
+  std::vector<unsigned char> big(70000, 0xAB);
+
+  EXPECT_EQ(ARES_SUCCESS,
+    ares_dns_record_create(&dnsrec, 0x1234, ARES_FLAG_RD,
+      ARES_OPCODE_QUERY, ARES_RCODE_NOERROR));
+
+  EXPECT_EQ(ARES_SUCCESS,
+    ares_dns_record_rr_add(&rr, dnsrec, ARES_SECTION_ANSWER, "example.com",
+      ARES_REC_TYPE_RAW_RR, ARES_CLASS_IN, 0));
+  EXPECT_EQ(ARES_SUCCESS,
+    ares_dns_rr_set_u16(rr, ARES_RR_RAW_RR_TYPE, 40000));
+
+  /* rdata larger than the 16-bit RDLENGTH field is accepted by the setter but
+   * cannot be represented on the wire; writing it must fail rather than emit a
+   * packet whose length field is truncated and mis-frames the rdata. */
+  EXPECT_EQ(ARES_SUCCESS,
+    ares_dns_rr_set_bin(rr, ARES_RR_RAW_RR_DATA, big.data(), big.size()));
+  EXPECT_EQ(ARES_EBADQUERY, ares_dns_write(dnsrec, &msg, &msglen));
+  EXPECT_EQ(nullptr, msg);
+
+  /* An rdata that exactly fills the field still writes */
+  big.resize(65535);
+  EXPECT_EQ(ARES_SUCCESS,
+    ares_dns_rr_set_bin(rr, ARES_RR_RAW_RR_DATA, big.data(), big.size()));
+  EXPECT_EQ(ARES_SUCCESS, ares_dns_write(dnsrec, &msg, &msglen));
+  ares_free_string(msg);
+
+  ares_dns_record_destroy(dnsrec);
+}
+
 TEST_F(LibraryTest, DNSParseFlags) {
   ares_dns_record_t   *dnsrec = NULL;
   ares_dns_rr_t       *rr     = NULL;


### PR DESCRIPTION
ares_dns_write_rr() narrows the assembled rdata length into the 16-bit RDLENGTH field without checking it fits:
- rdata is appended to the buffer first, then RDLENGTH is written as (unsigned short)(rdlength & 0xFFFF)
- the record setters accept lengths well past 65535 (#1168 only guards the SIZE_MAX allocation), so a record can hold oversized rdata
- ares_dns_write() then returns success but emits a truncated RDLENGTH that mis-frames every following record

Reject the record with ARES_EBADQUERY instead, matching the oversized-message check already in ares_dns_write_buf_tcp. Added DNSRecordRejectsOversizedRdata.