### PR TITLE
size name buffers for the escaped presentation form

### DIFF
--- a/src/lib/ares_send.c
+++ b/src/lib/ares_send.c
@@ -49,8 +49,11 @@ static ares_status_t ares_apply_dns0x20(ares_channel_t    *channel,
 {
   ares_status_t status = ARES_SUCCESS;
   const char   *name   = NULL;
-  char          dns0x20name[256];
-  unsigned char randdata[256 / 8];
+  /* A name is at most 255 octets on the wire, but its presentation form
+   * escapes each non-printable/reserved octet as "\DDD" (4 chars), so a valid
+   * name can require up to ~4 bytes per octet here. */
+  char          dns0x20name[1024];
+  unsigned char randdata[1024 / 8];
   size_t        len;
   size_t        remaining_bits;
   size_t        total_bits;

--- a/src/lib/record/ares_dns_name.c
+++ b/src/lib/record/ares_dns_name.c
@@ -31,6 +31,11 @@
  * compliant name.  Shared by the read and write paths. */
 #define ARES_MAX_NAME_PRESENTATION_LEN 255
 
+/* The presentation form escapes each octet as up to "\DDD" (4 chars), so a
+ * valid name's escaped string can reach 4x its unescaped length.  Buffers and
+ * limits that hold an already-escaped name must use this, not the 255 above. */
+#define ARES_MAX_NAME_ESCAPED_LEN (ARES_MAX_NAME_PRESENTATION_LEN * 4)
+
 /* A name of <= 255 octets holds at most 128 labels, so it can never
  * legitimately require more than that many compression-pointer jumps.  Bounding
  * the number of indirections stops a name built purely from pointers (which
@@ -61,7 +66,7 @@ static ares_status_t ares_nameoffset_create(ares_llist_t **list,
   ares_nameoffset_t *off = NULL;
 
   if (list == NULL || name == NULL || ares_strlen(name) == 0 ||
-      ares_strlen(name) > ARES_MAX_NAME_PRESENTATION_LEN) {
+      ares_strlen(name) > ARES_MAX_NAME_ESCAPED_LEN) {
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
@@ -383,11 +388,17 @@ ares_status_t ares_dns_name_write(ares_buf_t *buf, ares_llist_t **list,
   size_t                   orig_name_len;
   size_t                   pos    = ares_buf_len(buf);
   ares_array_t            *labels = NULL;
-  char                     name_copy[512];
+  char                     name_copy[ARES_MAX_NAME_ESCAPED_LEN + 1];
   ares_status_t            status;
 
   if (buf == NULL || name == NULL) {
     return ARES_EFORMERR; /* LCOV_EXCL_LINE: DefensiveCoding */
+  }
+
+  /* Reject a name that wouldn't fit rather than letting ares_strcpy() silently
+   * truncate it into a different (or malformed) name */
+  if (ares_strlen(name) >= sizeof(name_copy)) {
+    return ARES_EBADNAME;
   }
 
   labels = ares_array_create(sizeof(ares_buf_t *), ares_dns_labels_free_cb);
@@ -395,8 +406,6 @@ ares_status_t ares_dns_name_write(ares_buf_t *buf, ares_llist_t **list,
     return ARES_ENOMEM;
   }
 
-  /* NOTE: due to possible escaping, name_copy buffer is > 256 to allow for
-   *       this */
   name_len      = ares_strcpy(name_copy, name, sizeof(name_copy));
   orig_name_len = name_len;
 

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -2356,6 +2356,51 @@ TEST_F(LibraryTest, DNSNameCompression14Bit) {
   ares_dns_record_destroy(dnsrec);
 }
 
+TEST_F(LibraryTest, DNSNameWriteEscapedPresentation) {
+  /* A name is at most 255 octets on the wire, but its presentation form
+   * escapes each non-printable octet as "\DDD" (4 chars).  A 3x63 octet name
+   * of 0xFF (192 wire octets, well under the 255 limit) therefore has a 758
+   * character presentation form, which overflowed the writer's fixed name
+   * buffer and made ares_dns_write() reject this valid name with
+   * ARES_EBADNAME.  It must round-trip. */
+  std::string label;
+  for (size_t i = 0; i < 63; i++) {
+    label += "\\255";
+  }
+  std::string name = label + "." + label + "." + label;
+  EXPECT_EQ(758U, name.size());
+
+  ares_dns_record_t *dnsrec = NULL;
+  ares_dns_rr_t     *rr     = NULL;
+  EXPECT_EQ(ARES_SUCCESS,
+    ares_dns_record_create(&dnsrec, 0x1234, ARES_FLAG_QR,
+      ARES_OPCODE_QUERY, ARES_RCODE_NOERROR));
+  EXPECT_EQ(ARES_SUCCESS,
+    ares_dns_record_query_add(dnsrec, "example.com", ARES_REC_TYPE_NS,
+      ARES_CLASS_IN));
+  EXPECT_EQ(ARES_SUCCESS,
+    ares_dns_record_rr_add(&rr, dnsrec, ARES_SECTION_ANSWER, "example.com",
+      ARES_REC_TYPE_NS, ARES_CLASS_IN, 0));
+  EXPECT_EQ(ARES_SUCCESS,
+    ares_dns_rr_set_str(rr, ARES_RR_NS_NSDNAME, name.c_str()));
+
+  unsigned char *msg    = NULL;
+  size_t         msglen = 0;
+  EXPECT_EQ(ARES_SUCCESS, ares_dns_write(dnsrec, &msg, &msglen));
+
+  ares_dns_record_t *parsed = NULL;
+  EXPECT_EQ(ARES_SUCCESS, ares_dns_parse(msg, msglen, 0, &parsed));
+  ASSERT_NE(nullptr, parsed);
+  const ares_dns_rr_t *nrr =
+    ares_dns_record_rr_get_const(parsed, ARES_SECTION_ANSWER, 0);
+  ASSERT_NE(nullptr, nrr);
+  EXPECT_STREQ(name.c_str(), ares_dns_rr_get_str(nrr, ARES_RR_NS_NSDNAME));
+
+  ares_dns_record_destroy(parsed);
+  ares_free_string(msg);
+  ares_dns_record_destroy(dnsrec);
+}
+
 #ifndef CARES_SYMBOL_HIDING
 /* Regression coverage for the zero-length salt/type-bitmap code paths in
 * NSEC3 and NSEC3PARAM (empty non-terminal / opt-out per RFC 5155 7.1),


### PR DESCRIPTION
A DNS name is at most 255 octets on the wire, but its presentation form escapes each non-printable/reserved octet as `\DDD` (4 chars), so a valid name's escaped string can reach ~4x that. Three sites sized against the 255-octet assumption reject such a name:
- `ares_dns_name_write`: `name_copy[512]` was silently truncated by `ares_strcpy`, so the name split/validated below was a different (or malformed) one
- `ares_nameoffset_create`: rejected an escaped name > 255 with `EFORMERR` when recording it as a compression target, which is what actually fails a full `ares_dns_write`
- `ares_apply_dns0x20`: `dns0x20name[256]` rejected the query outright

Added `ARES_MAX_NAME_ESCAPED_LEN` (4*255), sized the buffers/limit and the 0x20 randdata to it, and reject an over-long name instead of truncating.

Repro: a 3x63 octet name of `0xFF` (192 wire octets, 758-char presentation) returned `ARES_EBADNAME` from `ares_dns_write` before; the added `DNSNameWriteEscapedPresentation` test round-trips it after.