### PR TITLE
ares_destroy: support being called from within a query callback

### DIFF
--- a/docs/ares_destroy.3
+++ b/docs/ares_destroy.3
@@ -21,6 +21,14 @@ channel, passing a status of \fIARES_EDESTRUCTION\fP. These calls give the
 callbacks a chance to clean up any state which might have been stored in their
 arguments. A callback must not add new requests to a channel being destroyed.
 
+As of c-ares 1.35.0, \fBares_destroy(3)\fP may be called from within a query
+callback.  In that case the channel cannot be torn down immediately, as the
+callback stack still references it, so the teardown is deferred until the
+callback returns and completes asynchronously.  The channel must not be used
+again after such a call.  Prior versions explicitly did not support this and
+doing so resulted in undefined behavior (including a deadlock when using an
+event thread).
+
 There is no ability to make this function thread-safe.  No additional calls
 using this channel may be made once this function is called.
 .SH SEE ALSO

--- a/src/lib/ares_cancel.c
+++ b/src/lib/ares_cancel.c
@@ -68,7 +68,7 @@ void ares_cancel(ares_channel_t *channel)
       query->node_all_queries = NULL;
 
       /* NOTE: its possible this may enqueue new queries */
-      query->callback(query->arg, ARES_ECANCELLED, 0, NULL);
+      ares_invoke_query_callback(query, ARES_ECANCELLED, 0, NULL);
       ares_free_query(query);
 
       node = next;
@@ -84,4 +84,11 @@ void ares_cancel(ares_channel_t *channel)
 
 done:
   ares_channel_unlock(channel);
+
+  /* If a cancel callback called ares_destroy(), it was deferred; complete it
+   * now that the callback stack has unwound.  The event thread completes its
+   * own deferred destroy in its run loop. */
+  if (!(channel->optmask & ARES_OPT_EVENT_THREAD)) {
+    ares_destroy_if_deferred(channel);
+  }
 }

--- a/src/lib/ares_destroy.c
+++ b/src/lib/ares_destroy.c
@@ -31,11 +31,44 @@
 
 void ares_destroy(ares_channel_t *channel)
 {
+  ares_bool_t deferred = ARES_FALSE;
+
+  if (channel == NULL) {
+    return;
+  }
+
+  /* If ares_destroy() is called from within a query callback, we cannot tear
+   * the channel down right now: frames above us on the stack still reference
+   * the channel and its queries, and with an event thread we would be trying
+   * to join our own thread.  Defer the teardown; the outermost callback-
+   * dispatch frame (ares_process_fds(), ares_cancel(), or the event thread
+   * run loop) will complete it once the callback stack unwinds. */
+  ares_channel_lock(channel);
+  if (channel->callback_depth > 0) {
+    channel->destroy_pending = ARES_TRUE;
+    deferred                 = ARES_TRUE;
+  }
+  ares_channel_unlock(channel);
+
+  if (deferred) {
+    /* Nudge the event thread so it observes the pending destroy promptly even
+     * if the deferral originated on another thread. */
+    if (channel->optmask & ARES_OPT_EVENT_THREAD) {
+      ares_event_thread_wake_channel(channel);
+    }
+    return;
+  }
+
+  ares_destroy_int(channel, ARES_FALSE);
+}
+
+void ares_destroy_int(ares_channel_t *channel, ares_bool_t from_ethread)
+{
   size_t             i;
   ares_llist_node_t *node = NULL;
 
   if (channel == NULL) {
-    return;
+    return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
   /* Mark as being shutdown */
@@ -76,7 +109,7 @@ void ares_destroy(ares_channel_t *channel)
     ares_query_t      *query = ares_llist_node_claim(node);
 
     query->node_all_queries = NULL;
-    query->callback(query->arg, ARES_EDESTRUCTION, 0, NULL);
+    ares_invoke_query_callback(query, ARES_EDESTRUCTION, 0, NULL);
     ares_free_query(query);
 
     node = next;
@@ -104,7 +137,7 @@ void ares_destroy(ares_channel_t *channel)
 
   /* Shut down the event thread */
   if (channel->optmask & ARES_OPT_EVENT_THREAD) {
-    ares_event_thread_destroy(channel);
+    ares_event_thread_destroy(channel, from_ethread);
   }
 
   if (channel->domains) {

--- a/src/lib/ares_getaddrinfo.c
+++ b/src/lib/ares_getaddrinfo.c
@@ -762,8 +762,13 @@ void ares_getaddrinfo(ares_channel_t *channel, const char *name,
     return;
   }
   ares_channel_lock(channel);
+  /* Callbacks below may run synchronously; defer a reentrant destroy. */
+  ares_channel_callback_enter(channel);
   ares_getaddrinfo_int(channel, name, service, hints, callback, arg);
+  ares_channel_callback_leave(channel);
   ares_channel_unlock(channel);
+  /* Complete a destroy deferred from one of those callbacks. */
+  ares_destroy_if_deferred(channel);
 }
 
 static ares_bool_t next_dns_lookup(struct host_query *hquery)

--- a/src/lib/ares_gethostbyaddr.c
+++ b/src/lib/ares_gethostbyaddr.c
@@ -112,8 +112,13 @@ void ares_gethostbyaddr(ares_channel_t *channel, const void *addr, int addrlen,
     return;
   }
   ares_channel_lock(channel);
+  /* Callbacks below may run synchronously; defer a reentrant destroy. */
+  ares_channel_callback_enter(channel);
   ares_gethostbyaddr_nolock(channel, addr, addrlen, family, callback, arg);
+  ares_channel_callback_leave(channel);
   ares_channel_unlock(channel);
+  /* Complete a destroy deferred from one of those callbacks. */
+  ares_destroy_if_deferred(channel);
 }
 
 static void next_lookup(struct addr_query *aquery)

--- a/src/lib/ares_getnameinfo.c
+++ b/src/lib/ares_getnameinfo.c
@@ -194,8 +194,13 @@ void ares_getnameinfo(ares_channel_t *channel, const struct sockaddr *sa,
   }
 
   ares_channel_lock(channel);
+  /* Callbacks below may run synchronously; defer a reentrant destroy. */
+  ares_channel_callback_enter(channel);
   ares_getnameinfo_int(channel, sa, salen, flags_int, callback, arg);
+  ares_channel_callback_leave(channel);
   ares_channel_unlock(channel);
+  /* Complete a destroy deferred from one of those callbacks. */
+  ares_destroy_if_deferred(channel);
 }
 
 static void nameinfo_callback(void *arg, int status, int timeouts,

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -307,6 +307,18 @@ struct ares_channeldata {
    * system config changes might get triggered and we need a flag to make
    * sure we don't take action. */
   ares_bool_t                         sys_up;
+
+  /* Depth of user query callbacks currently executing on the stack.  Modified
+   * only while holding the channel lock.  Used to detect reentrant API calls
+   * (e.g. ares_destroy()) issued from within a callback. */
+  size_t                              callback_depth;
+
+  /* TRUE if ares_destroy() was invoked from within a callback and therefore
+   * had to be deferred.  The outermost callback-dispatch frame (ares_process_
+   * fds(), ares_cancel(), or the event thread loop) completes the teardown
+   * once callback_depth returns to zero.  Modified only while holding the
+   * channel lock. */
+  ares_bool_t                         destroy_pending;
 };
 
 /* Does the domain end in ".onion" or ".onion."? Case-insensitive. */
@@ -351,6 +363,24 @@ void ares_dnsrec_convert_cb(void *arg, ares_status_t status, size_t timeouts,
                             const ares_dns_record_t *dnsrec);
 
 void ares_free_query(ares_query_t *query);
+
+/*! Invoke a query's user callback, tracking callback recursion depth on the
+ *  channel so reentrant API calls (notably ares_destroy()) can be detected.
+ *  Must be called while holding the channel lock. */
+void ares_invoke_query_callback(ares_query_t *query, ares_status_t status,
+                                size_t                   timeouts,
+                                const ares_dns_record_t *dnsrec);
+
+/*! Perform the actual channel teardown.  from_ethread must be ARES_TRUE only
+ *  when the event thread is completing a deferred destroy on its own thread,
+ *  so the event thread is detached rather than join()'d. */
+void ares_destroy_int(ares_channel_t *channel, ares_bool_t from_ethread);
+
+/*! If an ares_destroy() was deferred (invoked from within a callback) and the
+ *  callback stack has now fully unwound, complete the teardown.  Must be called
+ *  with no locks held from a non-event-thread callback-dispatch frame.  Returns
+ *  ARES_TRUE if the channel was destroyed (and is now invalid). */
+ares_bool_t ares_destroy_if_deferred(ares_channel_t *channel);
 
 unsigned short ares_generate_new_id(ares_rand_state *state);
 ares_status_t ares_expand_name_validated(const unsigned char *encoded,
@@ -638,8 +668,17 @@ void ares_channel_unlock(const ares_channel_t *channel);
 struct ares_event_thread;
 typedef struct ares_event_thread ares_event_thread_t;
 
-void ares_event_thread_destroy(ares_channel_t *channel);
+/*! Destroy the event thread associated with the channel.  from_self must be
+ *  set to ARES_TRUE only when invoked from within the event thread itself
+ *  (i.e. a deferred ares_destroy() being completed by the event thread), in
+ *  which case the thread is detached rather than join()'d to avoid a
+ *  self-join deadlock. */
+void ares_event_thread_destroy(ares_channel_t *channel, ares_bool_t from_self);
 ares_status_t ares_event_thread_init(ares_channel_t *channel);
+
+/*! Wake the channel's event thread, if any, so it promptly re-evaluates its
+ *  state (used to make it observe a deferred destroy request). */
+void ares_event_thread_wake_channel(ares_channel_t *channel);
 
 
 #ifdef _WIN32

--- a/src/lib/ares_private.h
+++ b/src/lib/ares_private.h
@@ -367,6 +367,13 @@ void ares_free_query(ares_query_t *query);
 /*! Invoke a query's user callback, tracking callback recursion depth on the
  *  channel so reentrant API calls (notably ares_destroy()) can be detected.
  *  Must be called while holding the channel lock. */
+/*! Mark the start and end of a region in which the library may synchronously
+ *  invoke an application callback while frames above still need the channel.
+ *  A reentrant ares_destroy() inside such a region is deferred rather than
+ *  tearing the channel down underneath those frames.  Nesting is fine. */
+void ares_channel_callback_enter(ares_channel_t *channel);
+void ares_channel_callback_leave(ares_channel_t *channel);
+
 void ares_invoke_query_callback(ares_query_t *query, ares_status_t status,
                                 size_t                   timeouts,
                                 const ares_dns_record_t *dnsrec);

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -262,6 +262,14 @@ ares_status_t ares_process_fds(ares_channel_t         *channel,
   ares_channel_lock(channel);
   status = ares_process_fds_nolock(channel, events, nevents, flags);
   ares_channel_unlock(channel);
+
+  /* If a callback invoked during processing called ares_destroy(), it was
+   * deferred; complete it now that the callback stack has unwound.  The event
+   * thread completes its own deferred destroy in its run loop (it must detach
+   * rather than join itself), so skip that here. */
+  if (!(channel->optmask & ARES_OPT_EVENT_THREAD)) {
+    ares_destroy_if_deferred(channel);
+  }
   return status;
 }
 
@@ -382,6 +390,12 @@ done:
   ares_free(events);
   ares_free(socketlist);
   ares_channel_unlock(channel);
+
+  /* Complete a deferred ares_destroy() issued from within a callback.  This
+   * legacy entry point is not used with an event thread. */
+  if (!(channel->optmask & ARES_OPT_EVENT_THREAD)) {
+    ares_destroy_if_deferred(channel);
+  }
 }
 
 static ares_status_t process_write(ares_channel_t *channel,
@@ -444,6 +458,13 @@ void ares_process_pending_write(ares_channel_t *channel)
   }
 
   ares_channel_unlock(channel);
+
+  /* A write-flush error can fail a query, whose callback may have called
+   * ares_destroy(); complete a deferred destroy now.  The event thread
+   * completes its own deferred destroy in its run loop. */
+  if (!(channel->optmask & ARES_OPT_EVENT_THREAD)) {
+    ares_destroy_if_deferred(channel);
+  }
 }
 
 static ares_status_t read_conn_packets(ares_conn_t *conn,
@@ -653,8 +674,8 @@ static ares_status_t ares_flush_requeue(ares_channel_t       *channel,
          * find this query still linked in all_queries/queries_by_qid, free it,
          * and the ares_free_query() below would then double-free it. */
         ares_detach_query(query);
-        query->callback(query->arg, entry.status, query->timeouts,
-                        entry.dnsrec);
+        ares_invoke_query_callback(query, entry.status, query->timeouts,
+                                   entry.dnsrec);
         ares_free_query(query);
       }
       ares_dns_record_destroy(entry.dnsrec);
@@ -1603,6 +1624,42 @@ static void ares_detach_query(ares_query_t *query)
   query->node_all_queries = NULL;
 }
 
+void ares_invoke_query_callback(ares_query_t *query, ares_status_t status,
+                                size_t                   timeouts,
+                                const ares_dns_record_t *dnsrec)
+{
+  ares_channel_t *channel = query->channel;
+
+  /* Track that we are executing a user callback so that a reentrant
+   * ares_destroy() from within it can be detected and deferred rather than
+   * tearing the channel down underneath the frames still using it (or, with an
+   * event thread, deadlocking on a self-join). */
+  channel->callback_depth++;
+  query->callback(query->arg, status, timeouts, dnsrec);
+  channel->callback_depth--;
+}
+
+ares_bool_t ares_destroy_if_deferred(ares_channel_t *channel)
+{
+  ares_bool_t do_destroy;
+
+  ares_channel_lock(channel);
+  do_destroy =
+    (ares_bool_t)(channel->destroy_pending && channel->callback_depth == 0);
+  /* Claim the pending destroy so a concurrent completer (another processing
+   * thread or the event thread loop) can't also tear the channel down. */
+  if (do_destroy) {
+    channel->destroy_pending = ARES_FALSE;
+  }
+  ares_channel_unlock(channel);
+
+  if (do_destroy) {
+    ares_destroy_int(channel, ARES_FALSE);
+  }
+
+  return do_destroy;
+}
+
 static void end_query(ares_channel_t *channel, ares_server_t *server,
                       ares_query_t *query, ares_status_t status,
                       ares_dns_record_t *dnsrec, ares_array_t **requeue)
@@ -1622,7 +1679,7 @@ static void end_query(ares_channel_t *channel, ares_server_t *server,
   }
 
   /* Invoke the callback. */
-  query->callback(query->arg, status, query->timeouts, dnsrec);
+  ares_invoke_query_callback(query, status, query->timeouts, dnsrec);
   ares_free_query(query);
 
   /* Check and notify if no other queries are enqueued on the channel.  This

--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -1624,6 +1624,22 @@ static void ares_detach_query(ares_query_t *query)
   query->node_all_queries = NULL;
 }
 
+void ares_channel_callback_enter(ares_channel_t *channel)
+{
+  if (channel == NULL) {
+    return; /* LCOV_EXCL_LINE: DefensiveCoding */
+  }
+  channel->callback_depth++;
+}
+
+void ares_channel_callback_leave(ares_channel_t *channel)
+{
+  if (channel == NULL || channel->callback_depth == 0) {
+    return; /* LCOV_EXCL_LINE: DefensiveCoding */
+  }
+  channel->callback_depth--;
+}
+
 void ares_invoke_query_callback(ares_query_t *query, ares_status_t status,
                                 size_t                   timeouts,
                                 const ares_dns_record_t *dnsrec)
@@ -1634,9 +1650,9 @@ void ares_invoke_query_callback(ares_query_t *query, ares_status_t status,
    * ares_destroy() from within it can be detected and deferred rather than
    * tearing the channel down underneath the frames still using it (or, with an
    * event thread, deadlocking on a self-join). */
-  channel->callback_depth++;
+  ares_channel_callback_enter(channel);
   query->callback(query->arg, status, timeouts, dnsrec);
-  channel->callback_depth--;
+  ares_channel_callback_leave(channel);
 }
 
 ares_bool_t ares_destroy_if_deferred(ares_channel_t *channel)

--- a/src/lib/ares_query.c
+++ b/src/lib/ares_query.c
@@ -125,8 +125,13 @@ ares_status_t ares_query_dnsrec(ares_channel_t *channel, const char *name,
   }
 
   ares_channel_lock(channel);
+  /* Callbacks below may run synchronously; defer a reentrant destroy. */
+  ares_channel_callback_enter(channel);
   status = ares_query_nolock(channel, name, dnsclass, type, callback, arg, qid);
+  ares_channel_callback_leave(channel);
   ares_channel_unlock(channel);
+  /* Complete a destroy deferred from one of those callbacks. */
+  ares_destroy_if_deferred(channel);
   return status;
 }
 

--- a/src/lib/ares_search.c
+++ b/src/lib/ares_search.c
@@ -463,8 +463,13 @@ void ares_search(ares_channel_t *channel, const char *name, int dnsclass,
   }
 
   ares_channel_lock(channel);
+  /* Callbacks below may run synchronously; defer a reentrant destroy. */
+  ares_channel_callback_enter(channel);
   ares_search_int(channel, dnsrec, ares_dnsrec_convert_cb, carg);
+  ares_channel_callback_leave(channel);
   ares_channel_unlock(channel);
+  /* Complete a destroy deferred from one of those callbacks. */
+  ares_destroy_if_deferred(channel);
 
   ares_dns_record_destroy(dnsrec);
 }
@@ -481,8 +486,13 @@ ares_status_t ares_search_dnsrec(ares_channel_t          *channel,
   }
 
   ares_channel_lock(channel);
+  /* Callbacks below may run synchronously; defer a reentrant destroy. */
+  ares_channel_callback_enter(channel);
   status = ares_search_int(channel, dnsrec, callback, arg);
+  ares_channel_callback_leave(channel);
   ares_channel_unlock(channel);
+  /* Complete a destroy deferred from one of those callbacks. */
+  ares_destroy_if_deferred(channel);
 
   return status;
 }

--- a/src/lib/ares_send.c
+++ b/src/lib/ares_send.c
@@ -237,9 +237,15 @@ ares_status_t ares_send_dnsrec(ares_channel_t          *channel,
 
   ares_channel_lock(channel);
 
+  /* A cache hit dispatches the callback synchronously from here, so defer a
+   * reentrant destroy rather than tearing the channel down under us. */
+  ares_channel_callback_enter(channel);
   status = ares_send_nolock(channel, NULL, 0, dnsrec, callback, arg, qid);
+  ares_channel_callback_leave(channel);
 
   ares_channel_unlock(channel);
+  /* Complete a destroy deferred from one of those callbacks. */
+  ares_destroy_if_deferred(channel);
 
   return status;
 }

--- a/src/lib/event/ares_event_thread.c
+++ b/src/lib/event/ares_event_thread.c
@@ -328,7 +328,10 @@ static void ares_event_thread_cleanup(ares_event_thread_t *e)
 
 static void *ares_event_thread(void *arg)
 {
-  ares_event_thread_t *e = arg;
+  ares_event_thread_t *e            = arg;
+  ares_channel_t      *channel      = e->channel;
+  ares_bool_t          self_destroy = ARES_FALSE;
+
   ares_thread_mutex_lock(e->mutex);
 
   while (e->isup) {
@@ -368,9 +371,33 @@ static void *ares_event_thread(void *arg)
      * that may not have been performed */
     if (e->isup) {
       ares_thread_mutex_unlock(e->mutex);
-      ares_process_fds(e->channel, NULL, 0, ARES_PROCESS_FLAG_NONE);
+      ares_process_fds(channel, NULL, 0, ARES_PROCESS_FLAG_NONE);
       ares_thread_mutex_lock(e->mutex);
     }
+
+    /* A callback invoked during processing may have called ares_destroy().
+     * That couldn't tear down (or join) this very thread, so it was deferred
+     * to us.  Claim it and break out to complete the teardown ourselves.  We
+     * take the channel lock without holding e->mutex to preserve lock order. */
+    ares_thread_mutex_unlock(e->mutex);
+    ares_channel_lock(channel);
+    if (channel->destroy_pending && channel->callback_depth == 0) {
+      channel->destroy_pending = ARES_FALSE;
+      self_destroy             = ARES_TRUE;
+    }
+    ares_channel_unlock(channel);
+    if (self_destroy) {
+      break; /* NOTE: e->mutex is unlocked here */
+    }
+    ares_thread_mutex_lock(e->mutex);
+  }
+
+  if (self_destroy) {
+    /* e->mutex is not held here (see break above).  Complete the deferred
+     * ares_destroy() on our own thread; ares_destroy_int() will detach rather
+     * than join this thread to avoid a self-join deadlock. */
+    ares_destroy_int(channel, ARES_TRUE);
+    return NULL;
   }
 
   /* Lets cleanup while we're in the thread itself */
@@ -381,26 +408,38 @@ static void *ares_event_thread(void *arg)
   return NULL;
 }
 
-static void ares_event_thread_destroy_int(ares_event_thread_t *e)
+static void ares_event_thread_destroy_int(ares_event_thread_t *e,
+                                          ares_bool_t          from_self)
 {
-  /* Wake thread and tell it to shutdown if it exists */
-  ares_thread_mutex_lock(e->mutex);
-  if (e->isup) {
-    e->isup = ARES_FALSE;
-    ares_event_thread_wake(e);
-  }
-  ares_thread_mutex_unlock(e->mutex);
+  if (from_self) {
+    /* We are running on the event thread itself, completing a deferred
+     * ares_destroy().  The run loop has already exited, so we just clean up
+     * our own resources.  We cannot join ourselves, so detach instead. */
+    ares_event_thread_cleanup(e);
+    if (e->thread) {
+      ares_thread_detach(e->thread);
+      e->thread = NULL;
+    }
+  } else {
+    /* Wake thread and tell it to shutdown if it exists */
+    ares_thread_mutex_lock(e->mutex);
+    if (e->isup) {
+      e->isup = ARES_FALSE;
+      ares_event_thread_wake(e);
+    }
+    ares_thread_mutex_unlock(e->mutex);
 
-  /* Wait for thread to shutdown */
-  if (e->thread) {
-    void *rv = NULL;
-    ares_thread_join(e->thread, &rv);
-    e->thread = NULL;
-  }
+    /* Wait for thread to shutdown */
+    if (e->thread) {
+      void *rv = NULL;
+      ares_thread_join(e->thread, &rv);
+      e->thread = NULL;
+    }
 
-  /* If the event thread ever got to the point of starting, this is a no-op
-   * as it runs this same cleanup when it shuts down */
-  ares_event_thread_cleanup(e);
+    /* If the event thread ever got to the point of starting, this is a no-op
+     * as it runs this same cleanup when it shuts down */
+    ares_event_thread_cleanup(e);
+  }
 
   ares_thread_mutex_destroy(e->mutex);
   e->mutex = NULL;
@@ -408,7 +447,7 @@ static void ares_event_thread_destroy_int(ares_event_thread_t *e)
   ares_free(e);
 }
 
-void ares_event_thread_destroy(ares_channel_t *channel)
+void ares_event_thread_destroy(ares_channel_t *channel, ares_bool_t from_self)
 {
   ares_event_thread_t *e = channel->sock_state_cb_data;
 
@@ -416,12 +455,23 @@ void ares_event_thread_destroy(ares_channel_t *channel)
     return; /* LCOV_EXCL_LINE: DefensiveCoding */
   }
 
-  ares_event_thread_destroy_int(e);
+  ares_event_thread_destroy_int(e, from_self);
   channel->sock_state_cb_data           = NULL;
   channel->sock_state_cb                = NULL;
   channel->notify_pending_write_cb      = NULL;
   channel->notify_pending_write_cb_data = NULL;
   ares_set_query_enqueue_cb(channel, NULL, NULL);
+}
+
+void ares_event_thread_wake_channel(ares_channel_t *channel)
+{
+  ares_event_thread_t *e = channel->sock_state_cb_data;
+
+  if (e == NULL) {
+    return; /* LCOV_EXCL_LINE: DefensiveCoding */
+  }
+
+  ares_event_thread_wake(e);
 }
 
 static const ares_event_sys_t *ares_event_fetch_sys(ares_evsys_t evsys)
@@ -494,34 +544,39 @@ ares_status_t ares_event_thread_init(ares_channel_t *channel)
 
   e->mutex = ares_thread_mutex_create();
   if (e->mutex == NULL) {
-    ares_event_thread_destroy_int(e); /* LCOV_EXCL_LINE: OutOfMemory */
-    return ARES_ENOMEM;               /* LCOV_EXCL_LINE: OutOfMemory */
+    ares_event_thread_destroy_int(e,
+                                  ARES_FALSE); /* LCOV_EXCL_LINE: OutOfMemory */
+    return ARES_ENOMEM;                        /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   e->ev_updates = ares_llist_create(NULL);
   if (e->ev_updates == NULL) {
-    ares_event_thread_destroy_int(e); /* LCOV_EXCL_LINE: OutOfMemory */
-    return ARES_ENOMEM;               /* LCOV_EXCL_LINE: OutOfMemory */
+    ares_event_thread_destroy_int(e,
+                                  ARES_FALSE); /* LCOV_EXCL_LINE: OutOfMemory */
+    return ARES_ENOMEM;                        /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   e->ev_sock_handles = ares_htable_asvp_create(ares_event_destroy_cb);
   if (e->ev_sock_handles == NULL) {
-    ares_event_thread_destroy_int(e); /* LCOV_EXCL_LINE: OutOfMemory */
-    return ARES_ENOMEM;               /* LCOV_EXCL_LINE: OutOfMemory */
+    ares_event_thread_destroy_int(e,
+                                  ARES_FALSE); /* LCOV_EXCL_LINE: OutOfMemory */
+    return ARES_ENOMEM;                        /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   e->ev_cust_handles = ares_htable_vpvp_create(NULL, ares_event_destroy_cb);
   if (e->ev_cust_handles == NULL) {
-    ares_event_thread_destroy_int(e); /* LCOV_EXCL_LINE: OutOfMemory */
-    return ARES_ENOMEM;               /* LCOV_EXCL_LINE: OutOfMemory */
+    ares_event_thread_destroy_int(e,
+                                  ARES_FALSE); /* LCOV_EXCL_LINE: OutOfMemory */
+    return ARES_ENOMEM;                        /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
   e->channel = channel;
   e->isup    = ARES_TRUE;
   e->ev_sys  = ares_event_fetch_sys(channel->evsys);
   if (e->ev_sys == NULL) {
-    ares_event_thread_destroy_int(e); /* LCOV_EXCL_LINE: UntestablePath */
-    return ARES_ENOTIMP;              /* LCOV_EXCL_LINE: UntestablePath */
+    ares_event_thread_destroy_int(
+      e, ARES_FALSE);    /* LCOV_EXCL_LINE: UntestablePath */
+    return ARES_ENOTIMP; /* LCOV_EXCL_LINE: UntestablePath */
   }
 
   channel->sock_state_cb                = ares_event_thread_sockstate_cb;
@@ -532,7 +587,7 @@ ares_status_t ares_event_thread_init(ares_channel_t *channel)
 
   if (!e->ev_sys->init(e)) {
     /* LCOV_EXCL_START: UntestablePath */
-    ares_event_thread_destroy_int(e);
+    ares_event_thread_destroy_int(e, ARES_FALSE);
     channel->sock_state_cb      = NULL;
     channel->sock_state_cb_data = NULL;
     return ARES_ESERVFAIL;
@@ -549,7 +604,7 @@ ares_status_t ares_event_thread_init(ares_channel_t *channel)
   /* Start thread */
   if (ares_thread_create(&e->thread, ares_event_thread, e) != ARES_SUCCESS) {
     /* LCOV_EXCL_START: UntestablePath */
-    ares_event_thread_destroy_int(e);
+    ares_event_thread_destroy_int(e, ARES_FALSE);
     channel->sock_state_cb      = NULL;
     channel->sock_state_cb_data = NULL;
     return ARES_ESERVFAIL;
@@ -567,7 +622,13 @@ ares_status_t ares_event_thread_init(ares_channel_t *channel)
   return ARES_ENOTIMP;
 }
 
-void ares_event_thread_destroy(ares_channel_t *channel)
+void ares_event_thread_destroy(ares_channel_t *channel, ares_bool_t from_self)
+{
+  (void)channel;
+  (void)from_self;
+}
+
+void ares_event_thread_wake_channel(ares_channel_t *channel)
 {
   (void)channel;
 }

--- a/src/lib/util/ares_threads.c
+++ b/src/lib/util/ares_threads.c
@@ -351,8 +351,12 @@ struct ares_thread {
   DWORD  id;
 
   void *(*func)(void *arg);
-  void *arg;
-  void *rv;
+  void       *arg;
+  void       *rv;
+  /* Set by ares_thread_detach() when the thread detaches itself.  The struct
+   * cannot be freed by detach in that case because this wrapper still writes
+   * ->rv after func() returns, so the wrapper frees it instead. */
+  ares_bool_t detached;
 };
 
 /* Wrap for pthread compatibility */
@@ -361,6 +365,9 @@ static DWORD WINAPI ares_thread_func(LPVOID lpParameter)
   ares_thread_t *thread = lpParameter;
 
   thread->rv = thread->func(thread->arg);
+  if (thread->detached) {
+    ares_free(thread);
+  }
   return 0;
 }
 
@@ -410,6 +417,20 @@ ares_status_t ares_thread_join(ares_thread_t *thread, void **rv)
   ares_free(thread);
 
   return status;
+}
+
+ares_status_t ares_thread_detach(ares_thread_t *thread)
+{
+  if (thread == NULL) {
+    return ARES_EFORMERR;
+  }
+
+  /* Only ever called by the thread on itself.  Release the OS handle now, but
+   * defer freeing the struct to ares_thread_func(), which still writes ->rv
+   * once func() returns. */
+  CloseHandle(thread->thread);
+  thread->detached = ARES_TRUE;
+  return ARES_SUCCESS;
 }
 
 #  else /* !WIN32 == PTHREAD */
@@ -628,6 +649,21 @@ ares_status_t ares_thread_join(ares_thread_t *thread, void **rv)
   return status;
 }
 
+ares_status_t ares_thread_detach(ares_thread_t *thread)
+{
+  ares_status_t status = ARES_SUCCESS;
+
+  if (thread == NULL) {
+    return ARES_EFORMERR;
+  }
+
+  if (pthread_detach(thread->thread) != 0) {
+    status = ARES_ENOTFOUND; /* LCOV_EXCL_LINE: UntestablePath */
+  }
+  ares_free(thread);
+  return status;
+}
+
 #  endif
 
 ares_bool_t ares_threadsafety(void)
@@ -709,6 +745,12 @@ ares_status_t ares_thread_join(ares_thread_t *thread, void **rv)
 {
   (void)thread;
   (void)rv;
+  return ARES_ENOTIMP;
+}
+
+ares_status_t ares_thread_detach(ares_thread_t *thread)
+{
+  (void)thread;
   return ARES_ENOTIMP;
 }
 

--- a/src/lib/util/ares_threads.h
+++ b/src/lib/util/ares_threads.h
@@ -59,4 +59,10 @@ ares_status_t ares_thread_create(ares_thread_t    **thread,
                                  ares_thread_func_t func, void *arg);
 ares_status_t ares_thread_join(ares_thread_t *thread, void **rv);
 
+/*! Detach a thread so its resources are released automatically on exit without
+ *  another thread join()'ing it.  Used when a thread must tear itself down and
+ *  therefore cannot be joined (e.g. the event thread destroying its own
+ *  channel from within a callback).  After this call the handle is invalid. */
+ares_status_t ares_thread_detach(ares_thread_t *thread);
+
 #endif

--- a/test/ares-test-mock-et.cc
+++ b/test/ares-test-mock-et.cc
@@ -35,6 +35,7 @@
 
 #include <sstream>
 #include <vector>
+#include <atomic>
 
 using testing::InvokeWithoutArgs;
 using testing::DoAll;
@@ -1750,6 +1751,88 @@ static std::string PrintEvsysFamily(const testing::TestParamInfo<std::tuple<ares
   name += "_";
   name += af_tostr(std::get<1>(info.param));
   return name;
+}
+
+// Invoking ares_destroy() from within a query callback that is running on the
+// event thread must not deadlock: the event thread cannot join itself.  The
+// destroy is deferred; once the callback returns, the event thread breaks its
+// run loop and tears the channel down itself (detaching rather than joining).
+// Under ASAN/valgrind this also validates there is no leak or use-after-free.
+struct DestroyInCbETData {
+  ares_channel_t   *channel;
+  std::atomic<bool> done;
+};
+
+static void DestroyChannelCallbackET(void *arg, ares_status_t status,
+                                     size_t                    timeouts,
+                                     const ares_dns_record_t  *dnsrec)
+{
+  DestroyInCbETData *data = static_cast<DestroyInCbETData *>(arg);
+  (void)status;
+  (void)timeouts;
+  (void)dnsrec;
+  /* Reentrant destroy from within a callback on the event thread.  Deferred;
+   * the event thread completes teardown after we return.  Must not deadlock. */
+  ares_destroy(data->channel);
+  data->done = true;
+}
+
+TEST_P(MockUDPEventThreadTest, DestroyInCallback) {
+  DNSPacket reply;
+  reply.set_response().set_aa()
+    .add_question(new DNSQuestion("www.google.com", T_A))
+    .add_answer(new DNSARR("www.google.com", 0x0100, {0x01, 0x02, 0x03, 0x04}));
+  ON_CALL(server_, OnRequest("www.google.com", T_A))
+    .WillByDefault(SetReply(&server_, &reply));
+
+  DestroyInCbETData data;
+  data.channel = channel_;
+  data.done    = false;
+  ares_query_dnsrec(channel_, "www.google.com", ARES_CLASS_IN, ARES_REC_TYPE_A,
+                    DestroyChannelCallbackET, &data, NULL);
+
+  // Service the mock server so the query is answered promptly.  We must not use
+  // Process() (it polls the channel, which the event thread is tearing down),
+  // but servicing the mock server's own fds only ever touches the server, never
+  // the channel, so it is safe.  If the self-join bug were present, the event
+  // thread would deadlock in ares_destroy() and data.done would never be set.
+  auto tv_begin = std::chrono::high_resolution_clock::now();
+  while (!data.done) {
+    std::set<ares_socket_t> serverfds = fds();
+    fd_set                  readers;
+    int                     nfds = 0;
+    FD_ZERO(&readers);
+    for (ares_socket_t fd : serverfds) {
+      FD_SET(fd, &readers);
+      if (fd >= (ares_socket_t)nfds) {
+        nfds = (int)fd + 1;
+      }
+    }
+    struct timeval tv;
+    tv.tv_sec  = 0;
+    tv.tv_usec = 50 * 1000;
+    if (select(nfds, &readers, nullptr, nullptr, &tv) > 0) {
+      for (ares_socket_t fd : serverfds) {
+        if (FD_ISSET(fd, &readers)) {
+          ProcessFD(fd);
+        }
+      }
+    }
+    auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                     std::chrono::high_resolution_clock::now() - tv_begin)
+                     .count();
+    ASSERT_LT(elapsed, 10) << "callback never fired (possible self-join "
+                              "deadlock in ares_destroy())";
+  }
+
+  // The event thread completes teardown asynchronously after the callback
+  // returns; give it a moment to detach and free the channel.  Under ASAN /
+  // valgrind this validates there is no leak or use-after-free.
+  std::this_thread::sleep_for(std::chrono::milliseconds(250));
+
+  // Channel destroyed from within the callback; don't destroy it again.
+  channel_ = nullptr;
+  EXPECT_TRUE(data.done);
 }
 
 INSTANTIATE_TEST_SUITE_P(AddressFamilies, MockEventThreadTest, ::testing::ValuesIn(ares::test::evsys_families_modes), ares::test::PrintEvsysFamilyMode);

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -1946,6 +1946,81 @@ TEST_P(MockUDPChannelTest, CancelInCallbackNoDoubleFree) {
   EXPECT_TRUE(data.done);
 }
 
+// Invoking ares_destroy() from within a query callback is not allowed to run
+// synchronously: frames above the callback still reference the channel and its
+// queries.  Instead the destroy is deferred and completed once the callback
+// stack unwinds back out of the processing entrypoint.  This exercises the
+// non-event-thread path, where completion happens at the end of ares_process().
+struct DestroyInCbData {
+  ares_channel_t *channel;
+  bool            done;
+};
+
+static void DestroyChannelCallback(void *arg, ares_status_t status,
+                                   size_t                    timeouts,
+                                   const ares_dns_record_t  *dnsrec)
+{
+  DestroyInCbData *data = static_cast<DestroyInCbData *>(arg);
+  (void)status;
+  (void)timeouts;
+  (void)dnsrec;
+  data->done = true;
+  /* Reentrant destroy from within the callback.  Must not crash or
+   * use-after-free; the teardown is deferred until the callback returns. */
+  ares_destroy(data->channel);
+}
+
+TEST_P(MockUDPChannelTest, DestroyInCallback) {
+  DNSPacket reply;
+  reply.set_response().set_aa()
+    .add_question(new DNSQuestion("www.google.com", T_A))
+    .add_answer(new DNSARR("www.google.com", 0x0100, {0x01, 0x02, 0x03, 0x04}));
+  ON_CALL(server_, OnRequest("www.google.com", T_A))
+    .WillByDefault(SetReply(&server_, &reply));
+
+  DestroyInCbData data;
+  data.channel = channel_;
+  data.done    = false;
+  ares_query_dnsrec(channel_, "www.google.com", ARES_CLASS_IN, ARES_REC_TYPE_A,
+                    DestroyChannelCallback, &data, NULL);
+
+  // Drive processing manually.  We can't use Process() here because the channel
+  // is destroyed from within the callback and Process() would touch the freed
+  // channel on its next loop iteration.  Stop the moment the callback fires.
+  while (!data.done) {
+    fd_set readers, writers;
+    int    nfds;
+    FD_ZERO(&readers);
+    FD_ZERO(&writers);
+    nfds = ares_fds(channel_, &readers, &writers);
+    for (ares_socket_t fd : fds()) {
+      FD_SET(fd, &readers);
+      if (fd >= (ares_socket_t)nfds) {
+        nfds = (int)fd + 1;
+      }
+    }
+    struct timeval tv;
+    tv.tv_sec  = 1;
+    tv.tv_usec = 0;
+    int count = select(nfds, &readers, &writers, nullptr, &tv);
+    ASSERT_GE(count, 0);
+    // Let the mock server reply first, then let c-ares process.  The callback
+    // (and the deferred destroy) fires inside ares_process(); afterwards the
+    // channel is gone, so we must not touch it again this iteration.
+    for (ares_socket_t fd : fds()) {
+      if (FD_ISSET(fd, &readers)) {
+        ProcessFD(fd);
+      }
+    }
+    ares_process(channel_, &readers, &writers);
+  }
+
+  // The channel was destroyed from within the callback; make sure the fixture
+  // does not try to destroy it a second time.
+  channel_ = nullptr;
+  EXPECT_TRUE(data.done);
+}
+
 TEST_P(MockUDPChannelTest, GetSock) {
   DNSPacket reply;
   reply.set_response().set_aa()

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -1970,6 +1970,40 @@ static void DestroyChannelCallback(void *arg, ares_status_t status,
   ares_destroy(data->channel);
 }
 
+// ares_getaddrinfo() can finish without any DNS at all -- a literal address is
+// answered from inside the call itself.  The callback then runs with the
+// channel lock held and no query callback on the stack, so callback_depth was
+// zero and a reentrant ares_destroy() tore the channel down while
+// ares_getaddrinfo() was still about to unlock it.
+//
+// Only callbacks routed through ares_invoke_query_callback() were counted; the
+// synchronous paths dispatch directly.
+static void DestroyAiCallback(void *arg, int status, int timeouts,
+                              struct ares_addrinfo *result) {
+  DestroyInCbData *data = static_cast<DestroyInCbData *>(arg);
+  (void)status;
+  (void)timeouts;
+  if (result != nullptr) {
+    ares_freeaddrinfo(result);
+  }
+  data->done = true;
+  ares_destroy(data->channel);
+}
+
+TEST_P(MockUDPChannelTest, DestroyInSynchronousCallback) {
+  DestroyInCbData data;
+  data.channel = channel_;
+  data.done    = false;
+
+  /* A literal address never reaches the network, so the callback fires from
+   * inside this call. */
+  ares_getaddrinfo(channel_, "127.0.0.1", NULL, NULL, DestroyAiCallback,
+                   &data);
+
+  EXPECT_TRUE(data.done);
+  channel_ = nullptr; /* destroyed above; don't let the fixture repeat it */
+}
+
 TEST_P(MockUDPChannelTest, DestroyInCallback) {
   DNSPacket reply;
   reply.set_response().set_aa()


### PR DESCRIPTION
## Summary

Rescoped from a documentation-only change to actually **supporting** `ares_destroy()` being called from within a query callback.

Previously this was undefined behavior:
- In the non-event-thread case, frames above the callback on the stack still reference the channel and its queries, so tearing the channel down immediately is a use-after-free.
- In the event-thread case, `ares_destroy()` tries to join the very thread the callback is running on — a self-join **deadlock**.

## Approach

Detect the reentrant call by tracking user-callback recursion depth on the channel (`callback_depth`), maintained under the channel lock around every query-callback dispatch. When `ares_destroy()` is invoked while a callback is on the stack, teardown can't run synchronously, so it is **deferred** (`destroy_pending`) and completed once the callback stack unwinds, at the outermost callback-dispatch frame:

- **Non-event-thread:** `ares_process()` / `ares_process_fds()` / `ares_cancel()` / `ares_process_pending_write()` complete the deferred destroy after processing returns (normal join-based teardown).
- **Event thread:** the run loop observes `destroy_pending` after processing, breaks out, and tears the channel down on its own thread — **detaching** rather than joining itself to avoid the self-join deadlock (new `ares_thread_detach()` primitive).

A claim flag guards against two completers racing.

Because a channel whose callback is still on the stack cannot be freed synchronously, reentrant destroy is **asynchronous**: `ares_destroy()` returns while the callback finishes, and the actual teardown completes afterward. The channel must not be used again after such a call. This is documented in the `ares_destroy(3)` manpage as supported **as of 1.35.0**; prior versions explicitly did not support it.

## Tests

Adds regression tests exercising destroy-from-callback in both modes:
- `MockUDPChannelTest.DestroyInCallback` (non-event-thread)
- `MockUDPEventThreadTest.DestroyInCallback` (event thread, all evsys backends)

Both pass cleanly under ASAN/UBSAN. The event-thread test would deadlock/time out if the self-join bug were reintroduced.
