### PR TITLE
detach query before synchronous callback in end_query

### DIFF
--- a/src/lib/ares_process.c
+++ b/src/lib/ares_process.c
@@ -1621,6 +1621,13 @@ static void end_query(ares_channel_t *channel, ares_server_t *server,
     return;
   }
 
+  /* Detach from all lookup lists before the callback, otherwise a reentrant
+   * ares_cancel() from within it would find this query still linked, free it,
+   * and the ares_free_query() below would double-free.  Mirrors
+   * ares_flush_requeue() for the synchronous teardown path
+   * (ares_close_connection() requeues with a NULL requeue). */
+  ares_detach_query(query);
+
   /* Invoke the callback. */
   query->callback(query->arg, status, query->timeouts, dnsrec);
   ares_free_query(query);

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -1946,6 +1946,48 @@ TEST_P(MockUDPChannelTest, CancelInCallbackNoDoubleFree) {
   EXPECT_TRUE(data.done);
 }
 
+// Sibling of CancelInCallbackNoDoubleFree for the connection-teardown path.  A
+// malformed response makes process_answer() return EBADRESP, tearing down the
+// connection.  ares_close_connection() requeues its queries synchronously
+// (requeue==NULL), and with tries=1 the query is not retried but ended right
+// there via end_query().  That synchronous branch must detach the query before
+// invoking the callback so a reentrant ares_cancel() cannot find and free it a
+// second time.  The read-path flush was fixed for CVE-2026-33630; this
+// synchronous teardown path was not, so it double-freed the query.
+class MockUDPSingleTryTest : public MockChannelOptsTest,
+                             public ::testing::WithParamInterface<int> {
+ public:
+  MockUDPSingleTryTest()
+    : MockChannelOptsTest(1, GetParam(), false, false, FillOptions(&opts_),
+                          ARES_OPT_TRIES) {}
+  static struct ares_options *FillOptions(struct ares_options *opts) {
+    memset(opts, 0, sizeof(struct ares_options));
+    opts->tries = 1; /* max_tries==1: first connection error ends the query */
+    return opts;
+  }
+ private:
+  struct ares_options opts_;
+};
+
+TEST_P(MockUDPSingleTryTest, CancelInCallbackConnTeardownNoDoubleFree) {
+  /* A reply too short to be a DNS header fails to parse, so process_answer()
+   * returns EBADRESP and the connection is torn down. */
+  std::vector<byte> malformed = {0x00, 0x00, 0x00, 0x00};
+  ON_CALL(server_, OnRequest("www.google.com", T_A))
+    .WillByDefault(SetReplyData(&server_, malformed));
+
+  CancelInCbData data;
+  data.channel = channel_;
+  data.done    = false;
+  ares_query_dnsrec(channel_, "www.google.com", ARES_CLASS_IN, ARES_REC_TYPE_A,
+                    CancelChannelCallback, &data, NULL);
+  Process();
+  EXPECT_TRUE(data.done);
+}
+
+INSTANTIATE_TEST_SUITE_P(AddressFamilies, MockUDPSingleTryTest,
+                         ::testing::ValuesIn(ares::test::families), PrintFamily);
+
 TEST_P(MockUDPChannelTest, GetSock) {
   DNSPacket reply;
   reply.set_response().set_aa()


### PR DESCRIPTION
end_query()'s synchronous branch runs the query callback before detaching the query, so a reentrant ares_cancel() from that callback double-frees it:
- reached when ares_close_connection() requeues a query with a NULL requeue array: a malformed response makes process_answer() return EBADRESP, handle_conn_error() tears the connection down, and a retry-exhausted query on it is ended right there
- the callback's ares_cancel() finds the still-linked query (still in all_queries/queries_by_qid) and frees it, then the ares_free_query() below frees it again
- the CVE-2026-33630 fix added detach-before-callback only to the deferred ares_flush_requeue() path, not this synchronous one

Detach before the callback here too, mirroring ares_flush_requeue(). The added test CancelInCallbackConnTeardownNoDoubleFree double-frees on the current code under ASAN and passes with the fix.