### PR TITLE
ares_cookie: keep dns cookies usable when source ip is unknown

### DIFF
--- a/src/lib/ares_cookie.c
+++ b/src/lib/ares_cookie.c
@@ -284,6 +284,12 @@ static ares_bool_t ares_addr_equal(const struct ares_addr *addr1,
         return ARES_TRUE;
       }
       break;
+    case AF_UNSPEC:
+      /* Both source IPs are unknown, e.g. when there's no getsockname socket
+       * callback to fetch it.  Two unspecified addresses haven't changed
+       * relative to each other, so treat them as equal to keep cookies usable
+       */
+      return ARES_TRUE;
     default:
       break; /* LCOV_EXCL_LINE */
   }

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -2278,6 +2278,60 @@ TEST_P(MockUDPChannelTest, DNSCookieServerRotate) {
   EXPECT_TRUE(memcmp(client_cookie_1, client_cookie_2, len1) == 0);
 }
 
+TEST_P(MockUDPChannelTest, DNSCookieUnknownSelfIP) {
+  /* The classic ares_set_socket_functions() API installs socket callbacks with
+   * no getsockname, so the connection source IP is unknown (AF_UNSPEC).  Per
+   * the cookie design that is still expected to work.  Both the learned server
+   * cookie and the client cookie must remain stable across queries; a source IP
+   * that never changes must not be treated as having changed. */
+  ares_socket_functions sock_funcs;
+  memset(&sock_funcs, 0, sizeof(sock_funcs));
+  ares_set_socket_functions(channel_, &sock_funcs, NULL);
+
+  std::vector<byte> server_cookie = { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+  DNSPacket reply1;
+  reply1.set_response().set_aa()
+    .add_question(new DNSQuestion("www.google.com", T_A))
+    .add_answer(new DNSARR("www.google.com", 0x0100, {0x01, 0x02, 0x03, 0x04}))
+    .add_additional(new DNSOptRR(0, 0, 0, 1280, { }, server_cookie, false));
+  /* Second reply requires the client to have echoed back the learned server
+   * cookie, proving the anti-spoofing round-trip still functions. */
+  DNSPacket reply2;
+  reply2.set_response().set_aa()
+    .add_question(new DNSQuestion("www.google.com", T_A))
+    .add_answer(new DNSARR("www.google.com", 0x0100, {0x01, 0x02, 0x03, 0x04}))
+    .add_additional(new DNSOptRR(0, 0, 0, 1280, { }, server_cookie, true));
+
+  EXPECT_CALL(server_, OnRequest("www.google.com", T_A))
+    .WillOnce(SetReply(&server_, &reply1))
+    .WillOnce(SetReply(&server_, &reply2));
+
+  QueryResult result1;
+  ares_query_dnsrec(channel_, "www.google.com", ARES_CLASS_IN, ARES_REC_TYPE_A, QueryCallback, &result1, NULL);
+  Process();
+  EXPECT_TRUE(result1.done_);
+  EXPECT_EQ(0, result1.timeouts_);
+
+  QueryResult result2;
+  ares_query_dnsrec(channel_, "www.google.com", ARES_CLASS_IN, ARES_REC_TYPE_A, QueryCallback, &result2, NULL);
+  Process();
+  EXPECT_TRUE(result2.done_);
+  EXPECT_EQ(0, result2.timeouts_);
+
+  /* Client cookie should NOT have rotated */
+  size_t len1;
+  const unsigned char *client_cookie_1 = fetch_client_cookie(result1.dnsrec_.dnsrec_, &len1);
+  size_t len2;
+  const unsigned char *client_cookie_2 = fetch_client_cookie(result2.dnsrec_.dnsrec_, &len2);
+  EXPECT_EQ(len1, 8);
+  EXPECT_EQ(len1, len2);
+  EXPECT_TRUE(client_cookie_1 != nullptr && client_cookie_2 != nullptr);
+  if (client_cookie_1 != nullptr && client_cookie_2 != nullptr) {
+    EXPECT_TRUE(memcmp(client_cookie_1, client_cookie_2, len1) == 0);
+  }
+}
+
 TEST_P(MockUDPChannelTest, DNSCookieSpoof) {
   std::vector<byte> client_cookie = { 1, 2, 3, 4, 5, 6, 7, 8 };
   std::vector<byte> server_cookie = { 1, 2, 3, 4, 5, 6, 7, 8 };


### PR DESCRIPTION
ares_addr_equal() treats two AF_UNSPEC addresses as not equal, which quietly disables DNS cookies when the connection source IP can't be determined:
- the classic ares_set_socket_functions() API installs socket callbacks with no getsockname, so ares_conn_set_self_ip() leaves conn->self_ip as AF_UNSPEC (the comment there says cookies should still work with an empty self_ip)
- ares_cookie_apply()'s source-ip-change check then fires on every query, wiping the learned server cookie and rotating the client cookie
- the server cookie is never echoed back, so the RFC 7873/9018 anti-spoofing round-trip is off and the client cookie changes every request

Compare two AF_UNSPEC addresses as equal. DNSCookieUnknownSelfIP added, which drives the unknown source-ip path and checks the server cookie is echoed and the client cookie stays stable across two queries.