### PR TITLE
ossfuzz: cover IDNA and punycode transforms

### DIFF
--- a/test/ares-test-fuzz-name.c
+++ b/test/ares-test-fuzz-name.c
@@ -28,6 +28,8 @@
 #include <string.h>
 
 #include "ares.h"
+#include "include/ares_buf.h"
+#include "include/ares_punycode.h"
 /* Include ares internal file for DNS protocol constants */
 #include "ares_nameser.h"
 
@@ -56,12 +58,41 @@ int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
 
 #else
 
+static void fuzz_transform(const unsigned char *data, size_t size,
+                           ares_status_t (*transform)(ares_buf_t *,
+                                                      ares_buf_t *))
+{
+  ares_buf_t *input;
+  ares_buf_t *output;
+
+  if (size == 0) {
+    return;
+  }
+
+  input  = ares_buf_create_const(data, size);
+  output = ares_buf_create();
+  if (input == NULL || output == NULL) {
+    ares_buf_destroy(input);
+    ares_buf_destroy(output);
+    return;
+  }
+
+  (void)transform(input, output);
+  ares_buf_destroy(input);
+  ares_buf_destroy(output);
+}
+
 int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size)
 {
   ares_channel_t *channel = NULL;
   char           *csv;
 
   ares_library_init(ARES_LIB_INIT_ALL);
+
+  fuzz_transform(data, size, ares_idna_encode_domain_buf);
+  fuzz_transform(data, size, ares_punycode_encode_domain_buf);
+  fuzz_transform(data, size, ares_punycode_decode_domain_buf);
+
   ares_init(&channel);
 
   /* Need to null-term data */

--- a/test/fuzznames/name10
+++ b/test/fuzznames/name10
@@ -1,0 +1,1 @@
+xn--bcher-kva.de


### PR DESCRIPTION
## Summary

- exercise IDNA encoding and raw Punycode encode/decode from the existing name fuzz target
- use the size-delimited buffer APIs so embedded NUL bytes remain part of the fuzz input
- add a valid ACE seed that starts the decoder on a successful path

This follows the fuzzing work called out in the future-work section of #1031. The existing OSS-Fuzz configuration already compiles `test/ares-test-fuzz-name.c` directly, so these paths enter continuous sanitizer coverage without a separate OSS-Fuzz build change.

## Testing

- CMake build with `CARES_WERROR=ON` and tests enabled
- 1,110 non-live unit tests passed
- both corpus tests (`aresfuzz` and `aresfuzzname`) passed
- 744,659 libFuzzer executions over 151 seconds with AddressSanitizer and UndefinedBehaviorSanitizer; no project failure