### PR TITLE
ares_uri: roll back the ':' probe when it lands past the '@'

### DIFF
--- a/src/lib/util/ares_uri.c
+++ b/src/lib/util/ares_uri.c
@@ -1138,6 +1138,11 @@ static ares_status_t ares_uri_parse_userinfo(ares_uri_t *uri, ares_buf_t *buf)
 
     /* Consume : */
     ares_buf_consume(buf, 1);
+  } else {
+    /* The ':' is absent or belongs to the host:port that follows the '@', but
+     * the search above has already consumed up to it, so rewind to the start
+     * of the userinfo */
+    ares_buf_tag_rollback(buf);
   }
 
   ares_buf_tag(buf);

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -421,6 +421,9 @@ TEST_F(LibraryTest, URI) {
     { ARES_TRUE,  "https://user%25:password@www.example.com",                                              NULL },
     { ARES_TRUE,  "https://user:password%25@www.example.com",                                              NULL },
     { ARES_TRUE,  "https://user@www.example.com",                                                          NULL },
+    { ARES_TRUE,  "https://user@www.example.com:8443",                                                     NULL },
+    { ARES_TRUE,  "dns://user@[fe80::1]:53",                                                               NULL },
+    { ARES_FALSE, "https://user@www.example.com:8443@evil.example.com",                                    NULL }, /* ambiguous authority, '@' not valid in host */
     { ARES_TRUE,  "https://www.example.com/path",                                                          NULL },
     { ARES_TRUE,  "https://www.example.com/path/",                                                         NULL },
     { ARES_TRUE,  "https://www.example.com/a/../",                                                         "https://www.example.com/" },


### PR DESCRIPTION
`ares_uri_parse_userinfo()` probes for `:` to decide whether the userinfo carries a password, but `ares_buf_consume_until_charset()` consumes up to the match and only the password branch rewinds:

- `dns://user@127.0.0.1:53` is rejected, the offset is left inside the host so the username fetch spans zero bytes
- `dns://user@[fe80::1]:53` fails the same way, and `parse_nameserver_uri()` drops the server
- `https://user@www.example.com:8443@evil.example.com` parses with host `evil.example.com`, since the scan restarts mid-host and takes the trailing `@` as the delimiter

Roll back to the tag when the `:` isn't inside the userinfo, matching the probe-then-rollback already used in `ares_update_servers.c`. Cases added to the existing URI table.