### PR TITLE
ares_qcache: replace duplicate entries instead of orphaning them

### DIFF
--- a/src/lib/ares_qcache.c
+++ b/src/lib/ares_qcache.c
@@ -36,6 +36,9 @@ typedef struct {
   ares_dns_record_t *dnsrec;
   time_t             expire_ts;
   time_t             insert_ts;
+  /*! Node owning this entry in ares_qcache_t.expire, so a duplicate insert can
+   *  drop the entry it replaces instead of orphaning it. */
+  ares_slist_node_t *node;
 } ares_qcache_entry_t;
 
 static char *ares_qcache_calc_key(const ares_dns_record_t *dnsrec)
@@ -154,7 +157,12 @@ static void ares_qcache_expire(ares_qcache_t *cache, const ares_timeval_t *now)
       break;
     }
 
-    ares_htable_strvp_remove(cache->cache, entry->key);
+    /* Only drop the hashtable slot if it still refers to this entry.  A
+     * duplicate insert can have replaced it with a newer one under the same
+     * key, and evicting that would throw away a live entry. */
+    if (ares_htable_strvp_get_direct(cache->cache, entry->key) == entry) {
+      ares_htable_strvp_remove(cache->cache, entry->key);
+    }
     ares_slist_node_destroy(node);
   }
 }
@@ -359,11 +367,26 @@ static ares_status_t ares_qcache_insert_int(ares_qcache_t           *qcache,
     goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
+  /* Concurrent identical queries are not merged, so the same key can be
+   * inserted more than once.  The hashtable holds no value destructor -- the
+   * expire list owns the entries -- so replacing a slot used to leave the
+   * previous entry unreachable but still retained until its TTL ran out.
+   * Drop it explicitly instead. */
+  {
+    ares_qcache_entry_t *old_entry =
+      ares_htable_strvp_get_direct(qcache->cache, entry->key);
+
+    if (old_entry != NULL && old_entry->node != NULL) {
+      ares_slist_node_destroy(old_entry->node);
+    }
+  }
+
   if (!ares_htable_strvp_insert(qcache->cache, entry->key, entry)) {
     goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 
-  if (ares_slist_insert(qcache->expire, entry) == NULL) {
+  entry->node = ares_slist_insert(qcache->expire, entry);
+  if (entry->node == NULL) {
     goto fail; /* LCOV_EXCL_LINE: OutOfMemory */
   }
 

--- a/test/ares-test-mock.cc
+++ b/test/ares-test-mock.cc
@@ -606,6 +606,55 @@ class CacheQueriesTest
   struct ares_options opts_;
 };
 
+// Concurrent identical queries are not merged, so the same cache key can be
+// inserted twice.  The hashtable holds no value destructor -- the expire list
+// owns the entries -- so the second insert used to replace the slot and leave
+// the first entry unreachable but still retained.  Worse, when that orphan
+// later expired it removed the slot by key, evicting the *newer* entry that
+// had replaced it.
+//
+// Two answers with different TTLs make that visible: the short-lived orphan
+// expires first and takes the long-lived entry with it, so a later lookup that
+// should have been a cache hit goes back to the server.
+TEST_P(CacheQueriesTest, DuplicateInsertDoesNotEvictNewerEntry) {
+  DNSPacket shortttl;
+  shortttl.set_response().set_aa()
+    .add_question(new DNSQuestion("www.google.com", T_A))
+    .add_answer(new DNSARR("www.google.com", 1, {2, 3, 4, 5}));
+  DNSPacket longttl;
+  longttl.set_response().set_aa()
+    .add_question(new DNSQuestion("www.google.com", T_A))
+    .add_answer(new DNSARR("www.google.com", 100, {2, 3, 4, 5}));
+
+  /* Exactly two: the third lookup below must be served from the cache. */
+  EXPECT_CALL(server_, OnRequest("www.google.com", T_A))
+    .Times(2)
+    .WillOnce(SetReply(&server_, &shortttl))
+    .WillOnce(SetReply(&server_, &longttl));
+
+  /* Both issued before either completes, so neither can be served from the
+   * cache and both reach the server -- giving two entries on one key. */
+  QueryResult r1;
+  QueryResult r2;
+  ares_query_dnsrec(channel_, "www.google.com", ARES_CLASS_IN, ARES_REC_TYPE_A,
+                    QueryCallback, &r1, NULL);
+  ares_query_dnsrec(channel_, "www.google.com", ARES_CLASS_IN, ARES_REC_TYPE_A,
+                    QueryCallback, &r2, NULL);
+  Process();
+  EXPECT_TRUE(r1.done_);
+  EXPECT_TRUE(r2.done_);
+
+  /* Outlive the 1s entry but not the 100s one. */
+  ares_sleep_time(2100);
+
+  QueryResult r3;
+  ares_query_dnsrec(channel_, "www.google.com", ARES_CLASS_IN, ARES_REC_TYPE_A,
+                    QueryCallback, &r3, NULL);
+  Process();
+  EXPECT_TRUE(r3.done_);
+  EXPECT_EQ(ARES_SUCCESS, r3.status_);
+}
+
 TEST_P(CacheQueriesTest, GetHostByNameCache) {
   DNSPacket rsp;
   rsp.set_response().set_aa()


### PR DESCRIPTION
## Problem

Concurrent identical queries are not merged (cf. #835), so the same cache key can be inserted more than once. `ares_qcache_t.cache` is created with **no value destructor** — the expire list owns the entries — so a second insert replaced the hashtable slot and left the first entry unreachable but still retained until its TTL expired.

That also causes a **wrong eviction**. When the orphan expires:

```c
ares_htable_strvp_remove(cache->cache, entry->key);
```

removes the slot by key — and by then that slot belongs to the *newer* entry which replaced it. A later lookup that should have been a cache hit goes back to the server.

## Fix

- Drop the entry being replaced at insert time rather than orphaning it.
- Entries remember their expire-list node, so that is a direct removal rather than a scan.
- Expiry checks the slot still refers to the entry being expired before removing it (belt and braces once duplicates cannot accumulate).

## Test

`DuplicateInsertDoesNotEvictNewerEntry` issues two identical queries before either completes, so both reach the server and produce two entries on one key — answered with TTL 1 and TTL 100. After the short one expires, the long one must still serve a third lookup.

Unpatched:

```
Expected: to be called twice
  Actual: called 3 times
```

Full mock suite 1112/1112.

## Not addressed here

The cache still has no entry or byte cap, only `qcache_max_ttl`. Bounding it needs a policy decision — what limit, and what eviction order — rather than a bug fix, so I have left it out. Happy to follow up separately if you want a cap.
