### PR TITLE
ares_sysconfig: reject overflowing timeout values

### DIFF
--- a/src/lib/ares_sysconfig.c
+++ b/src/lib/ares_sysconfig.c
@@ -27,6 +27,8 @@
 
 #include "ares_private.h"
 
+#include <limits.h>
+
 #ifdef HAVE_SYS_PARAM_H
 #  include <sys/param.h>
 #endif
@@ -489,8 +491,8 @@ static ares_status_t
 /* Apple does not allow configuration of retrans, so this is a dummy value
  * that is extremely high (5s) */
 #  ifndef __APPLE__
-    if (res.retrans > 0) {
-      sysconfig->timeout_ms = (unsigned int)res.retrans * 1000;
+    if (res.retrans > 0 && (unsigned long)res.retrans <= UINT_MAX / 1000U) {
+      sysconfig->timeout_ms = (unsigned int)res.retrans * 1000U;
     }
 #  endif
   }

--- a/src/lib/ares_sysconfig_files.c
+++ b/src/lib/ares_sysconfig_files.c
@@ -430,11 +430,11 @@ static ares_status_t process_option(ares_sysconfig_t *sysconfig,
   if (ares_streq(key, "ndots")) {
     sysconfig->ndots = valint;
   } else if (ares_streq(key, "retrans") || ares_streq(key, "timeout")) {
-    if (valint == 0) {
+    if (valint == 0 || valint > UINT_MAX / 1000U) {
       status = ARES_EFORMERR;
       goto done;
     }
-    sysconfig->timeout_ms = valint * 1000;
+    sysconfig->timeout_ms = valint * 1000U;
   } else if (ares_streq(key, "retry") || ares_streq(key, "attempts")) {
     if (valint == 0) {
       status = ARES_EFORMERR;

--- a/test/ares-test-internal.cc
+++ b/test/ares-test-internal.cc
@@ -869,6 +869,30 @@ TEST_F(LibraryTest, IDNAMapTable) {
   }
 }
 
+TEST_F(LibraryTest, SysConfigTimeoutOverflow) {
+#if UINT_MAX >= 4294967295U
+  ares_sysconfig_t sysconfig;
+  memset(&sysconfig, 0, sizeof(sysconfig));
+
+  /* UINT_MAX / 1000 is the largest resolver timeout that can be converted
+   * from seconds to milliseconds without wrapping the unsigned result. */
+  EXPECT_EQ(ARES_SUCCESS,
+            ares_sysconfig_set_options(&sysconfig, "timeout:4294967"));
+  EXPECT_EQ((size_t)4294967000U, sysconfig.timeout_ms);
+
+  /* Oversized values are malformed options and must not replace the valid
+   * timeout with a wrapped, unexpectedly short value. */
+  EXPECT_EQ(ARES_SUCCESS,
+            ares_sysconfig_set_options(&sysconfig, "timeout:4294968"));
+  EXPECT_EQ((size_t)4294967000U, sysconfig.timeout_ms);
+
+  memset(&sysconfig, 0, sizeof(sysconfig));
+  EXPECT_EQ(ARES_SUCCESS,
+            ares_sysconfig_set_options(&sysconfig, "retrans:4294967295"));
+  EXPECT_EQ((size_t)0, sysconfig.timeout_ms);
+#endif
+}
+
 TEST_F(LibraryTest, SysConfigDomainsIDNA) {
   ares_sysconfig_t sysconfig;
   memset(&sysconfig, 0, sizeof(sysconfig));


### PR DESCRIPTION
## Summary

Prevent resolver timeout values from wrapping during seconds-to-milliseconds conversion.

The `timeout:N` and `retrans:N` resolver options are parsed as unsigned seconds and converted to milliseconds. Values above `UINT_MAX / 1000` previously wrapped to a much smaller timeout. This change rejects those overflowing values while preserving the existing tolerant handling of malformed resolver options. It also applies the same guard to the libc resolver configuration path.

## Testing

- `git diff --check`
- Strict standalone C89 boundary test for the conversion limits: passed
- Full c-ares build/test: unavailable in the audit container because generated build headers and CMake/Autotools are not installed

## Scope

This is a local resolver-configuration correctness/hardening fix, not a claim of a remotely exploitable vulnerability.
